### PR TITLE
Add ci to check validation for modified models.

### DIFF
--- a/.github/workflows/Codestyle-Check.yml
+++ b/.github/workflows/Codestyle-Check.yml
@@ -2,14 +2,13 @@ name: Codestyle-Check
 
 on:
   pull_request:
-    branches: ["develop"]
+    branches:
+      - develop
 
 jobs:
   pre-commit:
     name: Pre Commit
-    if: ${{ github.repository_owner == 'PaddlePaddle' }}
-    runs-on:
-      group: APPROVAL
+    runs-on: ubuntu-latest
     env:
       PR_ID: ${{ github.event.pull_request.number }}
       BRANCH: develop
@@ -38,22 +37,20 @@ jobs:
           git fetch origin pull/${PR_ID}/merge
           git checkout -b test FETCH_HEAD
 
-      - name: Setup python3.12
+      - name: Setup python3.10
         if: steps.check-bypass.outputs.can-skip != 'true'
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: '3.10'
           cache: 'pip'
 
       - name: Install dependencies
         if: steps.check-bypass.outputs.can-skip != 'true'
         run: |
-          pip install pre-commit==2.17.0 cpplint==1.6.0  clang-format==13.0.0
+          pip install pre-commit==2.17.0
 
       - name: Check pre-commit
         if: steps.check-bypass.outputs.can-skip != 'true'
-        env:
-          SKIP_CLANG_TIDY_CHECK: "ON"
         run: |
           set +e
           bash -x tools/codestyle/pre_commit.sh;EXCODE=$?

--- a/.github/workflows/Codestyle-Check.yml
+++ b/.github/workflows/Codestyle-Check.yml
@@ -18,7 +18,7 @@ jobs:
         run: |
           rm -rf * .[^.]*
 
-      - name: Checkout base repo
+      - name: Clone GraphNet
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.base.ref }}

--- a/.github/workflows/Validate-GPU.yml
+++ b/.github/workflows/Validate-GPU.yml
@@ -1,0 +1,76 @@
+name: Validate-GPU
+
+on:
+  pull_request:
+    branches:
+      - develop
+
+env:
+  PR_ID: ${{ github.event.pull_request.number }}
+  COMMIT_ID: ${{ github.event.pull_request.head.sha }}
+  TASK: GraphNet-CI-${{ github.event.pull_request.number }}-Validate
+  BRANCH: ${{ github.event.pull_request.base.ref }}
+  CI_name: ci-graphnet-validate
+  CFS_DIR: /home/data/cfs
+  no_proxy: "bcebos.com,apiin.im.baidu.com,gitee.com,aliyun.com,.baidu.com,.tuna.tsinghua.edu.cn"
+  docker_image: "ccr-2vdh3abv-pub.cnc.bj.baidubce.com/ci/paddle:4251d0b615371e0d0ed9040d7455e2b4" # cuda11.7
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  validate:
+    name: Validate
+    if: ${{ inputs.can-skip != 'true' }}
+    runs-on:
+      group: BD_BJ-V100
+    steps:
+      - name: Check docker image and run container
+        env:
+          work_dir: ${{ github.workspace }}
+          CACHE_DIR: /home/data/cfs/.cache
+        run: |
+          container_name=${TASK}-${core_index}-$(date +%Y%m%d-%H%M%S)
+          echo "container_name=${container_name}" >> ${{ github.env }}
+          ls ${{ github.workspace }}
+          docker container ls -a --filter "name=GraphNet-CI-*-Validate-${core_index}*" --format "{{.ID}}" | xargs -r docker rm -f
+          docker run -d -t --gpus all --name ${container_name} --shm-size=128g \
+            -v "/home/data/cfs:/home/data/cfs" \
+            -v "/home/data/cfs/.cache:/root/.cache" \
+            -v "/home/data/cfs/.ccache:/root/.ccache" \
+            -v "/dev/shm:/dev/shm" \
+            -v ${{ github.workspace }}/../../..:${{ github.workspace }}/../../.. \
+            -v ${{ github.workspace }}:/graphnet \
+            -e python \
+            -e core_index \
+            -e BRANCH \
+            -e PR_ID \
+            -e COMMIT_ID \
+            -e work_dir \
+            -e no_proxy \
+            -e CI_name \
+            -e CACHE_DIR \
+            -e GITHUB_API_TOKEN \
+            -e CFS_DIR \
+            -w /graphnet --network host ${docker_image}
+
+      - name: Run check
+        env:
+          work_dir: ${{ github.workspace }}
+        run: |
+          docker exec -t ${{ env.container_name }} /bin/bash -c '
+          source ${{ github.workspace }}/../../../proxy
+          git config --global --add safe.directory ${work_dir}
+          pwd
+          ls /graphnet
+          ls ${work_dir}
+          bash ${work_dir}/tools/ci/check_validate.sh
+          '
+
+      - name: Terminate and delete the container
+        if: always()
+        run: |
+          set +e
+          docker exec -t ${{ env.container_name }} /bin/bash -c 'rm -rf * .[^.]*'
+          docker rm -f ${{ env.container_name }}

--- a/.github/workflows/Validate-GPU.yml
+++ b/.github/workflows/Validate-GPU.yml
@@ -26,14 +26,34 @@ jobs:
     runs-on:
       group: BD_BJ-V100
     steps:
+      - name: Clone GraphNet
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.ref }}
+          submodules: 'recursive'
+          fetch-depth: 1000
+
+      - name: Check bypass
+        id: check-bypass
+        uses: ./.github/actions/check-bypass
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          workflow-name: validate
+
+      - name: Merge PR to test branch
+        if: steps.check-bypass.outputs.can-skip != 'true'
+        run: |
+          git fetch origin pull/${PR_ID}/merge
+          git checkout -b test FETCH_HEAD
+
       - name: Check docker image and run container
         env:
           work_dir: ${{ github.workspace }}
           CACHE_DIR: /home/data/cfs/.cache
+        if: steps.check-bypass.outputs.can-skip != 'true'
         run: |
           container_name=${TASK}-${core_index}-$(date +%Y%m%d-%H%M%S)
           echo "container_name=${container_name}" >> ${{ github.env }}
-          ls ${{ github.workspace }}
           docker container ls -a --filter "name=GraphNet-CI-*-Validate-${core_index}*" --format "{{.ID}}" | xargs -r docker rm -f
           docker run -d -t --gpus all --name ${container_name} --shm-size=128g \
             -v "/home/data/cfs:/home/data/cfs" \
@@ -62,9 +82,6 @@ jobs:
           docker exec -t ${{ env.container_name }} /bin/bash -c '
           source ${{ github.workspace }}/../../../proxy
           git config --global --add safe.directory ${work_dir}
-          pwd
-          ls /graphnet
-          ls ${work_dir}
           bash ${work_dir}/tools/ci/check_validate.sh
           '
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/psf/black
-  rev: 23.1.0      # 指定你想用的 Black 版本
+  rev: 23.1.0
   hooks:
   - id: black
     language_version: python3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+pre-commit

--- a/samples/transformers-auto-model/distilbert-base-uncased/model.py
+++ b/samples/transformers-auto-model/distilbert-base-uncased/model.py
@@ -1,17 +1,132 @@
 import torch
 
+
 class GraphModule(torch.nn.Module):
-    
-    
-    
-    def forward(self, s0 : torch.SymInt, L_input_ids_ : torch.Tensor, L_self_config_num_hidden_layers : torch.SymInt, L_self_modules_embeddings_modules_word_embeddings_parameters_weight_ : torch.nn.parameter.Parameter, L_self_modules_embeddings_buffers_position_ids_ : torch.Tensor, L_self_modules_embeddings_modules_position_embeddings_parameters_weight_ : torch.nn.parameter.Parameter, L_self_modules_embeddings_modules_LayerNorm_parameters_weight_ : torch.nn.parameter.Parameter, L_self_modules_embeddings_modules_LayerNorm_parameters_bias_ : torch.nn.parameter.Parameter, L_attention_mask_ : torch.Tensor, L_self_modules_transformer_modules_layer_modules_0_modules_attention_modules_q_lin_parameters_weight_ : torch.nn.parameter.Parameter, L_self_modules_transformer_modules_layer_modules_0_modules_attention_modules_q_lin_parameters_bias_ : torch.nn.parameter.Parameter, L_self_modules_transformer_modules_layer_modules_0_modules_attention_modules_k_lin_parameters_weight_ : torch.nn.parameter.Parameter, L_self_modules_transformer_modules_layer_modules_0_modules_attention_modules_k_lin_parameters_bias_ : torch.nn.parameter.Parameter, L_self_modules_transformer_modules_layer_modules_0_modules_attention_modules_v_lin_parameters_weight_ : torch.nn.parameter.Parameter, L_self_modules_transformer_modules_layer_modules_0_modules_attention_modules_v_lin_parameters_bias_ : torch.nn.parameter.Parameter, L_self_modules_transformer_modules_layer_modules_0_modules_attention_modules_out_lin_parameters_weight_ : torch.nn.parameter.Parameter, L_self_modules_transformer_modules_layer_modules_0_modules_attention_modules_out_lin_parameters_bias_ : torch.nn.parameter.Parameter, L_self_modules_transformer_modules_layer_modules_0_modules_sa_layer_norm_parameters_weight_ : torch.nn.parameter.Parameter, L_self_modules_transformer_modules_layer_modules_0_modules_sa_layer_norm_parameters_bias_ : torch.nn.parameter.Parameter, L_self_modules_transformer_modules_layer_modules_0_modules_ffn_modules_lin1_parameters_weight_ : torch.nn.parameter.Parameter, L_self_modules_transformer_modules_layer_modules_0_modules_ffn_modules_lin1_parameters_bias_ : torch.nn.parameter.Parameter, L_self_modules_transformer_modules_layer_modules_0_modules_ffn_modules_lin2_parameters_weight_ : torch.nn.parameter.Parameter, L_self_modules_transformer_modules_layer_modules_0_modules_ffn_modules_lin2_parameters_bias_ : torch.nn.parameter.Parameter, L_self_modules_transformer_modules_layer_modules_0_modules_output_layer_norm_parameters_weight_ : torch.nn.parameter.Parameter, L_self_modules_transformer_modules_layer_modules_0_modules_output_layer_norm_parameters_bias_ : torch.nn.parameter.Parameter, L_self_modules_transformer_modules_layer_modules_1_modules_attention_modules_q_lin_parameters_weight_ : torch.nn.parameter.Parameter, L_self_modules_transformer_modules_layer_modules_1_modules_attention_modules_q_lin_parameters_bias_ : torch.nn.parameter.Parameter, L_self_modules_transformer_modules_layer_modules_1_modules_attention_modules_k_lin_parameters_weight_ : torch.nn.parameter.Parameter, L_self_modules_transformer_modules_layer_modules_1_modules_attention_modules_k_lin_parameters_bias_ : torch.nn.parameter.Parameter, L_self_modules_transformer_modules_layer_modules_1_modules_attention_modules_v_lin_parameters_weight_ : torch.nn.parameter.Parameter, L_self_modules_transformer_modules_layer_modules_1_modules_attention_modules_v_lin_parameters_bias_ : torch.nn.parameter.Parameter, L_self_modules_transformer_modules_layer_modules_1_modules_attention_modules_out_lin_parameters_weight_ : torch.nn.parameter.Parameter, L_self_modules_transformer_modules_layer_modules_1_modules_attention_modules_out_lin_parameters_bias_ : torch.nn.parameter.Parameter, L_self_modules_transformer_modules_layer_modules_1_modules_sa_layer_norm_parameters_weight_ : torch.nn.parameter.Parameter, L_self_modules_transformer_modules_layer_modules_1_modules_sa_layer_norm_parameters_bias_ : torch.nn.parameter.Parameter, L_self_modules_transformer_modules_layer_modules_1_modules_ffn_modules_lin1_parameters_weight_ : torch.nn.parameter.Parameter, L_self_modules_transformer_modules_layer_modules_1_modules_ffn_modules_lin1_parameters_bias_ : torch.nn.parameter.Parameter, L_self_modules_transformer_modules_layer_modules_1_modules_ffn_modules_lin2_parameters_weight_ : torch.nn.parameter.Parameter, L_self_modules_transformer_modules_layer_modules_1_modules_ffn_modules_lin2_parameters_bias_ : torch.nn.parameter.Parameter, L_self_modules_transformer_modules_layer_modules_1_modules_output_layer_norm_parameters_weight_ : torch.nn.parameter.Parameter, L_self_modules_transformer_modules_layer_modules_1_modules_output_layer_norm_parameters_bias_ : torch.nn.parameter.Parameter, L_self_modules_transformer_modules_layer_modules_2_modules_attention_modules_q_lin_parameters_weight_ : torch.nn.parameter.Parameter, L_self_modules_transformer_modules_layer_modules_2_modules_attention_modules_q_lin_parameters_bias_ : torch.nn.parameter.Parameter, L_self_modules_transformer_modules_layer_modules_2_modules_attention_modules_k_lin_parameters_weight_ : torch.nn.parameter.Parameter, L_self_modules_transformer_modules_layer_modules_2_modules_attention_modules_k_lin_parameters_bias_ : torch.nn.parameter.Parameter, L_self_modules_transformer_modules_layer_modules_2_modules_attention_modules_v_lin_parameters_weight_ : torch.nn.parameter.Parameter, L_self_modules_transformer_modules_layer_modules_2_modules_attention_modules_v_lin_parameters_bias_ : torch.nn.parameter.Parameter, L_self_modules_transformer_modules_layer_modules_2_modules_attention_modules_out_lin_parameters_weight_ : torch.nn.parameter.Parameter, L_self_modules_transformer_modules_layer_modules_2_modules_attention_modules_out_lin_parameters_bias_ : torch.nn.parameter.Parameter, L_self_modules_transformer_modules_layer_modules_2_modules_sa_layer_norm_parameters_weight_ : torch.nn.parameter.Parameter, L_self_modules_transformer_modules_layer_modules_2_modules_sa_layer_norm_parameters_bias_ : torch.nn.parameter.Parameter, L_self_modules_transformer_modules_layer_modules_2_modules_ffn_modules_lin1_parameters_weight_ : torch.nn.parameter.Parameter, L_self_modules_transformer_modules_layer_modules_2_modules_ffn_modules_lin1_parameters_bias_ : torch.nn.parameter.Parameter, L_self_modules_transformer_modules_layer_modules_2_modules_ffn_modules_lin2_parameters_weight_ : torch.nn.parameter.Parameter, L_self_modules_transformer_modules_layer_modules_2_modules_ffn_modules_lin2_parameters_bias_ : torch.nn.parameter.Parameter, L_self_modules_transformer_modules_layer_modules_2_modules_output_layer_norm_parameters_weight_ : torch.nn.parameter.Parameter, L_self_modules_transformer_modules_layer_modules_2_modules_output_layer_norm_parameters_bias_ : torch.nn.parameter.Parameter, L_self_modules_transformer_modules_layer_modules_3_modules_attention_modules_q_lin_parameters_weight_ : torch.nn.parameter.Parameter, L_self_modules_transformer_modules_layer_modules_3_modules_attention_modules_q_lin_parameters_bias_ : torch.nn.parameter.Parameter, L_self_modules_transformer_modules_layer_modules_3_modules_attention_modules_k_lin_parameters_weight_ : torch.nn.parameter.Parameter, L_self_modules_transformer_modules_layer_modules_3_modules_attention_modules_k_lin_parameters_bias_ : torch.nn.parameter.Parameter, L_self_modules_transformer_modules_layer_modules_3_modules_attention_modules_v_lin_parameters_weight_ : torch.nn.parameter.Parameter, L_self_modules_transformer_modules_layer_modules_3_modules_attention_modules_v_lin_parameters_bias_ : torch.nn.parameter.Parameter, L_self_modules_transformer_modules_layer_modules_3_modules_attention_modules_out_lin_parameters_weight_ : torch.nn.parameter.Parameter, L_self_modules_transformer_modules_layer_modules_3_modules_attention_modules_out_lin_parameters_bias_ : torch.nn.parameter.Parameter, L_self_modules_transformer_modules_layer_modules_3_modules_sa_layer_norm_parameters_weight_ : torch.nn.parameter.Parameter, L_self_modules_transformer_modules_layer_modules_3_modules_sa_layer_norm_parameters_bias_ : torch.nn.parameter.Parameter, L_self_modules_transformer_modules_layer_modules_3_modules_ffn_modules_lin1_parameters_weight_ : torch.nn.parameter.Parameter, L_self_modules_transformer_modules_layer_modules_3_modules_ffn_modules_lin1_parameters_bias_ : torch.nn.parameter.Parameter, L_self_modules_transformer_modules_layer_modules_3_modules_ffn_modules_lin2_parameters_weight_ : torch.nn.parameter.Parameter, L_self_modules_transformer_modules_layer_modules_3_modules_ffn_modules_lin2_parameters_bias_ : torch.nn.parameter.Parameter, L_self_modules_transformer_modules_layer_modules_3_modules_output_layer_norm_parameters_weight_ : torch.nn.parameter.Parameter, L_self_modules_transformer_modules_layer_modules_3_modules_output_layer_norm_parameters_bias_ : torch.nn.parameter.Parameter, L_self_modules_transformer_modules_layer_modules_4_modules_attention_modules_q_lin_parameters_weight_ : torch.nn.parameter.Parameter, L_self_modules_transformer_modules_layer_modules_4_modules_attention_modules_q_lin_parameters_bias_ : torch.nn.parameter.Parameter, L_self_modules_transformer_modules_layer_modules_4_modules_attention_modules_k_lin_parameters_weight_ : torch.nn.parameter.Parameter, L_self_modules_transformer_modules_layer_modules_4_modules_attention_modules_k_lin_parameters_bias_ : torch.nn.parameter.Parameter, L_self_modules_transformer_modules_layer_modules_4_modules_attention_modules_v_lin_parameters_weight_ : torch.nn.parameter.Parameter, L_self_modules_transformer_modules_layer_modules_4_modules_attention_modules_v_lin_parameters_bias_ : torch.nn.parameter.Parameter, L_self_modules_transformer_modules_layer_modules_4_modules_attention_modules_out_lin_parameters_weight_ : torch.nn.parameter.Parameter, L_self_modules_transformer_modules_layer_modules_4_modules_attention_modules_out_lin_parameters_bias_ : torch.nn.parameter.Parameter, L_self_modules_transformer_modules_layer_modules_4_modules_sa_layer_norm_parameters_weight_ : torch.nn.parameter.Parameter, L_self_modules_transformer_modules_layer_modules_4_modules_sa_layer_norm_parameters_bias_ : torch.nn.parameter.Parameter, L_self_modules_transformer_modules_layer_modules_4_modules_ffn_modules_lin1_parameters_weight_ : torch.nn.parameter.Parameter, L_self_modules_transformer_modules_layer_modules_4_modules_ffn_modules_lin1_parameters_bias_ : torch.nn.parameter.Parameter, L_self_modules_transformer_modules_layer_modules_4_modules_ffn_modules_lin2_parameters_weight_ : torch.nn.parameter.Parameter, L_self_modules_transformer_modules_layer_modules_4_modules_ffn_modules_lin2_parameters_bias_ : torch.nn.parameter.Parameter, L_self_modules_transformer_modules_layer_modules_4_modules_output_layer_norm_parameters_weight_ : torch.nn.parameter.Parameter, L_self_modules_transformer_modules_layer_modules_4_modules_output_layer_norm_parameters_bias_ : torch.nn.parameter.Parameter, L_self_modules_transformer_modules_layer_modules_5_modules_attention_modules_q_lin_parameters_weight_ : torch.nn.parameter.Parameter, L_self_modules_transformer_modules_layer_modules_5_modules_attention_modules_q_lin_parameters_bias_ : torch.nn.parameter.Parameter, L_self_modules_transformer_modules_layer_modules_5_modules_attention_modules_k_lin_parameters_weight_ : torch.nn.parameter.Parameter, L_self_modules_transformer_modules_layer_modules_5_modules_attention_modules_k_lin_parameters_bias_ : torch.nn.parameter.Parameter, L_self_modules_transformer_modules_layer_modules_5_modules_attention_modules_v_lin_parameters_weight_ : torch.nn.parameter.Parameter, L_self_modules_transformer_modules_layer_modules_5_modules_attention_modules_v_lin_parameters_bias_ : torch.nn.parameter.Parameter, L_self_modules_transformer_modules_layer_modules_5_modules_attention_modules_out_lin_parameters_weight_ : torch.nn.parameter.Parameter, L_self_modules_transformer_modules_layer_modules_5_modules_attention_modules_out_lin_parameters_bias_ : torch.nn.parameter.Parameter, L_self_modules_transformer_modules_layer_modules_5_modules_sa_layer_norm_parameters_weight_ : torch.nn.parameter.Parameter, L_self_modules_transformer_modules_layer_modules_5_modules_sa_layer_norm_parameters_bias_ : torch.nn.parameter.Parameter, L_self_modules_transformer_modules_layer_modules_5_modules_ffn_modules_lin1_parameters_weight_ : torch.nn.parameter.Parameter, L_self_modules_transformer_modules_layer_modules_5_modules_ffn_modules_lin1_parameters_bias_ : torch.nn.parameter.Parameter, L_self_modules_transformer_modules_layer_modules_5_modules_ffn_modules_lin2_parameters_weight_ : torch.nn.parameter.Parameter, L_self_modules_transformer_modules_layer_modules_5_modules_ffn_modules_lin2_parameters_bias_ : torch.nn.parameter.Parameter, L_self_modules_transformer_modules_layer_modules_5_modules_output_layer_norm_parameters_weight_ : torch.nn.parameter.Parameter, L_self_modules_transformer_modules_layer_modules_5_modules_output_layer_norm_parameters_bias_ : torch.nn.parameter.Parameter):
+    def forward(
+        self,
+        s0: torch.SymInt,
+        L_input_ids_: torch.Tensor,
+        L_self_config_num_hidden_layers: torch.SymInt,
+        L_self_modules_embeddings_modules_word_embeddings_parameters_weight_: torch.nn.parameter.Parameter,
+        L_self_modules_embeddings_buffers_position_ids_: torch.Tensor,
+        L_self_modules_embeddings_modules_position_embeddings_parameters_weight_: torch.nn.parameter.Parameter,
+        L_self_modules_embeddings_modules_LayerNorm_parameters_weight_: torch.nn.parameter.Parameter,
+        L_self_modules_embeddings_modules_LayerNorm_parameters_bias_: torch.nn.parameter.Parameter,
+        L_attention_mask_: torch.Tensor,
+        L_self_modules_transformer_modules_layer_modules_0_modules_attention_modules_q_lin_parameters_weight_: torch.nn.parameter.Parameter,
+        L_self_modules_transformer_modules_layer_modules_0_modules_attention_modules_q_lin_parameters_bias_: torch.nn.parameter.Parameter,
+        L_self_modules_transformer_modules_layer_modules_0_modules_attention_modules_k_lin_parameters_weight_: torch.nn.parameter.Parameter,
+        L_self_modules_transformer_modules_layer_modules_0_modules_attention_modules_k_lin_parameters_bias_: torch.nn.parameter.Parameter,
+        L_self_modules_transformer_modules_layer_modules_0_modules_attention_modules_v_lin_parameters_weight_: torch.nn.parameter.Parameter,
+        L_self_modules_transformer_modules_layer_modules_0_modules_attention_modules_v_lin_parameters_bias_: torch.nn.parameter.Parameter,
+        L_self_modules_transformer_modules_layer_modules_0_modules_attention_modules_out_lin_parameters_weight_: torch.nn.parameter.Parameter,
+        L_self_modules_transformer_modules_layer_modules_0_modules_attention_modules_out_lin_parameters_bias_: torch.nn.parameter.Parameter,
+        L_self_modules_transformer_modules_layer_modules_0_modules_sa_layer_norm_parameters_weight_: torch.nn.parameter.Parameter,
+        L_self_modules_transformer_modules_layer_modules_0_modules_sa_layer_norm_parameters_bias_: torch.nn.parameter.Parameter,
+        L_self_modules_transformer_modules_layer_modules_0_modules_ffn_modules_lin1_parameters_weight_: torch.nn.parameter.Parameter,
+        L_self_modules_transformer_modules_layer_modules_0_modules_ffn_modules_lin1_parameters_bias_: torch.nn.parameter.Parameter,
+        L_self_modules_transformer_modules_layer_modules_0_modules_ffn_modules_lin2_parameters_weight_: torch.nn.parameter.Parameter,
+        L_self_modules_transformer_modules_layer_modules_0_modules_ffn_modules_lin2_parameters_bias_: torch.nn.parameter.Parameter,
+        L_self_modules_transformer_modules_layer_modules_0_modules_output_layer_norm_parameters_weight_: torch.nn.parameter.Parameter,
+        L_self_modules_transformer_modules_layer_modules_0_modules_output_layer_norm_parameters_bias_: torch.nn.parameter.Parameter,
+        L_self_modules_transformer_modules_layer_modules_1_modules_attention_modules_q_lin_parameters_weight_: torch.nn.parameter.Parameter,
+        L_self_modules_transformer_modules_layer_modules_1_modules_attention_modules_q_lin_parameters_bias_: torch.nn.parameter.Parameter,
+        L_self_modules_transformer_modules_layer_modules_1_modules_attention_modules_k_lin_parameters_weight_: torch.nn.parameter.Parameter,
+        L_self_modules_transformer_modules_layer_modules_1_modules_attention_modules_k_lin_parameters_bias_: torch.nn.parameter.Parameter,
+        L_self_modules_transformer_modules_layer_modules_1_modules_attention_modules_v_lin_parameters_weight_: torch.nn.parameter.Parameter,
+        L_self_modules_transformer_modules_layer_modules_1_modules_attention_modules_v_lin_parameters_bias_: torch.nn.parameter.Parameter,
+        L_self_modules_transformer_modules_layer_modules_1_modules_attention_modules_out_lin_parameters_weight_: torch.nn.parameter.Parameter,
+        L_self_modules_transformer_modules_layer_modules_1_modules_attention_modules_out_lin_parameters_bias_: torch.nn.parameter.Parameter,
+        L_self_modules_transformer_modules_layer_modules_1_modules_sa_layer_norm_parameters_weight_: torch.nn.parameter.Parameter,
+        L_self_modules_transformer_modules_layer_modules_1_modules_sa_layer_norm_parameters_bias_: torch.nn.parameter.Parameter,
+        L_self_modules_transformer_modules_layer_modules_1_modules_ffn_modules_lin1_parameters_weight_: torch.nn.parameter.Parameter,
+        L_self_modules_transformer_modules_layer_modules_1_modules_ffn_modules_lin1_parameters_bias_: torch.nn.parameter.Parameter,
+        L_self_modules_transformer_modules_layer_modules_1_modules_ffn_modules_lin2_parameters_weight_: torch.nn.parameter.Parameter,
+        L_self_modules_transformer_modules_layer_modules_1_modules_ffn_modules_lin2_parameters_bias_: torch.nn.parameter.Parameter,
+        L_self_modules_transformer_modules_layer_modules_1_modules_output_layer_norm_parameters_weight_: torch.nn.parameter.Parameter,
+        L_self_modules_transformer_modules_layer_modules_1_modules_output_layer_norm_parameters_bias_: torch.nn.parameter.Parameter,
+        L_self_modules_transformer_modules_layer_modules_2_modules_attention_modules_q_lin_parameters_weight_: torch.nn.parameter.Parameter,
+        L_self_modules_transformer_modules_layer_modules_2_modules_attention_modules_q_lin_parameters_bias_: torch.nn.parameter.Parameter,
+        L_self_modules_transformer_modules_layer_modules_2_modules_attention_modules_k_lin_parameters_weight_: torch.nn.parameter.Parameter,
+        L_self_modules_transformer_modules_layer_modules_2_modules_attention_modules_k_lin_parameters_bias_: torch.nn.parameter.Parameter,
+        L_self_modules_transformer_modules_layer_modules_2_modules_attention_modules_v_lin_parameters_weight_: torch.nn.parameter.Parameter,
+        L_self_modules_transformer_modules_layer_modules_2_modules_attention_modules_v_lin_parameters_bias_: torch.nn.parameter.Parameter,
+        L_self_modules_transformer_modules_layer_modules_2_modules_attention_modules_out_lin_parameters_weight_: torch.nn.parameter.Parameter,
+        L_self_modules_transformer_modules_layer_modules_2_modules_attention_modules_out_lin_parameters_bias_: torch.nn.parameter.Parameter,
+        L_self_modules_transformer_modules_layer_modules_2_modules_sa_layer_norm_parameters_weight_: torch.nn.parameter.Parameter,
+        L_self_modules_transformer_modules_layer_modules_2_modules_sa_layer_norm_parameters_bias_: torch.nn.parameter.Parameter,
+        L_self_modules_transformer_modules_layer_modules_2_modules_ffn_modules_lin1_parameters_weight_: torch.nn.parameter.Parameter,
+        L_self_modules_transformer_modules_layer_modules_2_modules_ffn_modules_lin1_parameters_bias_: torch.nn.parameter.Parameter,
+        L_self_modules_transformer_modules_layer_modules_2_modules_ffn_modules_lin2_parameters_weight_: torch.nn.parameter.Parameter,
+        L_self_modules_transformer_modules_layer_modules_2_modules_ffn_modules_lin2_parameters_bias_: torch.nn.parameter.Parameter,
+        L_self_modules_transformer_modules_layer_modules_2_modules_output_layer_norm_parameters_weight_: torch.nn.parameter.Parameter,
+        L_self_modules_transformer_modules_layer_modules_2_modules_output_layer_norm_parameters_bias_: torch.nn.parameter.Parameter,
+        L_self_modules_transformer_modules_layer_modules_3_modules_attention_modules_q_lin_parameters_weight_: torch.nn.parameter.Parameter,
+        L_self_modules_transformer_modules_layer_modules_3_modules_attention_modules_q_lin_parameters_bias_: torch.nn.parameter.Parameter,
+        L_self_modules_transformer_modules_layer_modules_3_modules_attention_modules_k_lin_parameters_weight_: torch.nn.parameter.Parameter,
+        L_self_modules_transformer_modules_layer_modules_3_modules_attention_modules_k_lin_parameters_bias_: torch.nn.parameter.Parameter,
+        L_self_modules_transformer_modules_layer_modules_3_modules_attention_modules_v_lin_parameters_weight_: torch.nn.parameter.Parameter,
+        L_self_modules_transformer_modules_layer_modules_3_modules_attention_modules_v_lin_parameters_bias_: torch.nn.parameter.Parameter,
+        L_self_modules_transformer_modules_layer_modules_3_modules_attention_modules_out_lin_parameters_weight_: torch.nn.parameter.Parameter,
+        L_self_modules_transformer_modules_layer_modules_3_modules_attention_modules_out_lin_parameters_bias_: torch.nn.parameter.Parameter,
+        L_self_modules_transformer_modules_layer_modules_3_modules_sa_layer_norm_parameters_weight_: torch.nn.parameter.Parameter,
+        L_self_modules_transformer_modules_layer_modules_3_modules_sa_layer_norm_parameters_bias_: torch.nn.parameter.Parameter,
+        L_self_modules_transformer_modules_layer_modules_3_modules_ffn_modules_lin1_parameters_weight_: torch.nn.parameter.Parameter,
+        L_self_modules_transformer_modules_layer_modules_3_modules_ffn_modules_lin1_parameters_bias_: torch.nn.parameter.Parameter,
+        L_self_modules_transformer_modules_layer_modules_3_modules_ffn_modules_lin2_parameters_weight_: torch.nn.parameter.Parameter,
+        L_self_modules_transformer_modules_layer_modules_3_modules_ffn_modules_lin2_parameters_bias_: torch.nn.parameter.Parameter,
+        L_self_modules_transformer_modules_layer_modules_3_modules_output_layer_norm_parameters_weight_: torch.nn.parameter.Parameter,
+        L_self_modules_transformer_modules_layer_modules_3_modules_output_layer_norm_parameters_bias_: torch.nn.parameter.Parameter,
+        L_self_modules_transformer_modules_layer_modules_4_modules_attention_modules_q_lin_parameters_weight_: torch.nn.parameter.Parameter,
+        L_self_modules_transformer_modules_layer_modules_4_modules_attention_modules_q_lin_parameters_bias_: torch.nn.parameter.Parameter,
+        L_self_modules_transformer_modules_layer_modules_4_modules_attention_modules_k_lin_parameters_weight_: torch.nn.parameter.Parameter,
+        L_self_modules_transformer_modules_layer_modules_4_modules_attention_modules_k_lin_parameters_bias_: torch.nn.parameter.Parameter,
+        L_self_modules_transformer_modules_layer_modules_4_modules_attention_modules_v_lin_parameters_weight_: torch.nn.parameter.Parameter,
+        L_self_modules_transformer_modules_layer_modules_4_modules_attention_modules_v_lin_parameters_bias_: torch.nn.parameter.Parameter,
+        L_self_modules_transformer_modules_layer_modules_4_modules_attention_modules_out_lin_parameters_weight_: torch.nn.parameter.Parameter,
+        L_self_modules_transformer_modules_layer_modules_4_modules_attention_modules_out_lin_parameters_bias_: torch.nn.parameter.Parameter,
+        L_self_modules_transformer_modules_layer_modules_4_modules_sa_layer_norm_parameters_weight_: torch.nn.parameter.Parameter,
+        L_self_modules_transformer_modules_layer_modules_4_modules_sa_layer_norm_parameters_bias_: torch.nn.parameter.Parameter,
+        L_self_modules_transformer_modules_layer_modules_4_modules_ffn_modules_lin1_parameters_weight_: torch.nn.parameter.Parameter,
+        L_self_modules_transformer_modules_layer_modules_4_modules_ffn_modules_lin1_parameters_bias_: torch.nn.parameter.Parameter,
+        L_self_modules_transformer_modules_layer_modules_4_modules_ffn_modules_lin2_parameters_weight_: torch.nn.parameter.Parameter,
+        L_self_modules_transformer_modules_layer_modules_4_modules_ffn_modules_lin2_parameters_bias_: torch.nn.parameter.Parameter,
+        L_self_modules_transformer_modules_layer_modules_4_modules_output_layer_norm_parameters_weight_: torch.nn.parameter.Parameter,
+        L_self_modules_transformer_modules_layer_modules_4_modules_output_layer_norm_parameters_bias_: torch.nn.parameter.Parameter,
+        L_self_modules_transformer_modules_layer_modules_5_modules_attention_modules_q_lin_parameters_weight_: torch.nn.parameter.Parameter,
+        L_self_modules_transformer_modules_layer_modules_5_modules_attention_modules_q_lin_parameters_bias_: torch.nn.parameter.Parameter,
+        L_self_modules_transformer_modules_layer_modules_5_modules_attention_modules_k_lin_parameters_weight_: torch.nn.parameter.Parameter,
+        L_self_modules_transformer_modules_layer_modules_5_modules_attention_modules_k_lin_parameters_bias_: torch.nn.parameter.Parameter,
+        L_self_modules_transformer_modules_layer_modules_5_modules_attention_modules_v_lin_parameters_weight_: torch.nn.parameter.Parameter,
+        L_self_modules_transformer_modules_layer_modules_5_modules_attention_modules_v_lin_parameters_bias_: torch.nn.parameter.Parameter,
+        L_self_modules_transformer_modules_layer_modules_5_modules_attention_modules_out_lin_parameters_weight_: torch.nn.parameter.Parameter,
+        L_self_modules_transformer_modules_layer_modules_5_modules_attention_modules_out_lin_parameters_bias_: torch.nn.parameter.Parameter,
+        L_self_modules_transformer_modules_layer_modules_5_modules_sa_layer_norm_parameters_weight_: torch.nn.parameter.Parameter,
+        L_self_modules_transformer_modules_layer_modules_5_modules_sa_layer_norm_parameters_bias_: torch.nn.parameter.Parameter,
+        L_self_modules_transformer_modules_layer_modules_5_modules_ffn_modules_lin1_parameters_weight_: torch.nn.parameter.Parameter,
+        L_self_modules_transformer_modules_layer_modules_5_modules_ffn_modules_lin1_parameters_bias_: torch.nn.parameter.Parameter,
+        L_self_modules_transformer_modules_layer_modules_5_modules_ffn_modules_lin2_parameters_weight_: torch.nn.parameter.Parameter,
+        L_self_modules_transformer_modules_layer_modules_5_modules_ffn_modules_lin2_parameters_bias_: torch.nn.parameter.Parameter,
+        L_self_modules_transformer_modules_layer_modules_5_modules_output_layer_norm_parameters_weight_: torch.nn.parameter.Parameter,
+        L_self_modules_transformer_modules_layer_modules_5_modules_output_layer_norm_parameters_bias_: torch.nn.parameter.Parameter,
+    ):
         l_input_ids_ = L_input_ids_
         l_self_config_num_hidden_layers = L_self_config_num_hidden_layers
-        l_self_modules_embeddings_modules_word_embeddings_parameters_weight_ = L_self_modules_embeddings_modules_word_embeddings_parameters_weight_
-        l_self_modules_embeddings_buffers_position_ids_ = L_self_modules_embeddings_buffers_position_ids_
-        l_self_modules_embeddings_modules_position_embeddings_parameters_weight_ = L_self_modules_embeddings_modules_position_embeddings_parameters_weight_
-        l_self_modules_embeddings_modules_layer_norm_parameters_weight_ = L_self_modules_embeddings_modules_LayerNorm_parameters_weight_
-        l_self_modules_embeddings_modules_layer_norm_parameters_bias_ = L_self_modules_embeddings_modules_LayerNorm_parameters_bias_
+        l_self_modules_embeddings_modules_word_embeddings_parameters_weight_ = (
+            L_self_modules_embeddings_modules_word_embeddings_parameters_weight_
+        )
+        l_self_modules_embeddings_buffers_position_ids_ = (
+            L_self_modules_embeddings_buffers_position_ids_
+        )
+        l_self_modules_embeddings_modules_position_embeddings_parameters_weight_ = (
+            L_self_modules_embeddings_modules_position_embeddings_parameters_weight_
+        )
+        l_self_modules_embeddings_modules_layer_norm_parameters_weight_ = (
+            L_self_modules_embeddings_modules_LayerNorm_parameters_weight_
+        )
+        l_self_modules_embeddings_modules_layer_norm_parameters_bias_ = (
+            L_self_modules_embeddings_modules_LayerNorm_parameters_bias_
+        )
         l_attention_mask_ = L_attention_mask_
         l_self_modules_transformer_modules_layer_modules_0_modules_attention_modules_q_lin_parameters_weight_ = L_self_modules_transformer_modules_layer_modules_0_modules_attention_modules_q_lin_parameters_weight_
         l_self_modules_transformer_modules_layer_modules_0_modules_attention_modules_q_lin_parameters_bias_ = L_self_modules_transformer_modules_layer_modules_0_modules_attention_modules_q_lin_parameters_bias_
@@ -109,151 +224,554 @@ class GraphModule(torch.nn.Module):
         l_self_modules_transformer_modules_layer_modules_5_modules_ffn_modules_lin2_parameters_bias_ = L_self_modules_transformer_modules_layer_modules_5_modules_ffn_modules_lin2_parameters_bias_
         l_self_modules_transformer_modules_layer_modules_5_modules_output_layer_norm_parameters_weight_ = L_self_modules_transformer_modules_layer_modules_5_modules_output_layer_norm_parameters_weight_
         l_self_modules_transformer_modules_layer_modules_5_modules_output_layer_norm_parameters_bias_ = L_self_modules_transformer_modules_layer_modules_5_modules_output_layer_norm_parameters_bias_
-        mul = [None] * l_self_config_num_hidden_layers;  l_self_config_num_hidden_layers = mul = None
-        input_embeds = torch.nn.functional.embedding(l_input_ids_, l_self_modules_embeddings_modules_word_embeddings_parameters_weight_, 0, None, 2.0, False, False);  l_input_ids_ = l_self_modules_embeddings_modules_word_embeddings_parameters_weight_ = None
-        position_ids = l_self_modules_embeddings_buffers_position_ids_[(slice(None, None, None), slice(None, s0, None))];  l_self_modules_embeddings_buffers_position_ids_ = None
-        position_embeddings = torch.nn.functional.embedding(position_ids, l_self_modules_embeddings_modules_position_embeddings_parameters_weight_, None, None, 2.0, False, False);  position_ids = l_self_modules_embeddings_modules_position_embeddings_parameters_weight_ = None
-        embeddings = input_embeds + position_embeddings;  input_embeds = position_embeddings = None
-        embeddings_1 = torch.nn.functional.layer_norm(embeddings, (768,), l_self_modules_embeddings_modules_layer_norm_parameters_weight_, l_self_modules_embeddings_modules_layer_norm_parameters_bias_, 1e-12);  embeddings = l_self_modules_embeddings_modules_layer_norm_parameters_weight_ = l_self_modules_embeddings_modules_layer_norm_parameters_bias_ = None
-        embeddings_2 = torch.nn.functional.dropout(embeddings_1, 0.1, False, False);  embeddings_1 = None
-        getitem_7 = l_attention_mask_[(slice(None, None, None), None, None, slice(None, None, None))];  l_attention_mask_ = None
-        expand = getitem_7.expand(1, 1, s0, s0);  getitem_7 = s0 = None
-        expanded_mask = expand.to(torch.float32);  expand = None
-        tensor = torch.tensor(1.0, dtype = torch.float32)
-        inverted_mask = tensor - expanded_mask;  tensor = expanded_mask = None
+        mul = [None] * l_self_config_num_hidden_layers
+        l_self_config_num_hidden_layers = mul = None
+        input_embeds = torch.nn.functional.embedding(
+            l_input_ids_,
+            l_self_modules_embeddings_modules_word_embeddings_parameters_weight_,
+            0,
+            None,
+            2.0,
+            False,
+            False,
+        )
+        l_input_ids_ = (
+            l_self_modules_embeddings_modules_word_embeddings_parameters_weight_
+        ) = None
+        position_ids = l_self_modules_embeddings_buffers_position_ids_[
+            (slice(None, None, None), slice(None, s0, None))
+        ]
+        l_self_modules_embeddings_buffers_position_ids_ = None
+        position_embeddings = torch.nn.functional.embedding(
+            position_ids,
+            l_self_modules_embeddings_modules_position_embeddings_parameters_weight_,
+            None,
+            None,
+            2.0,
+            False,
+            False,
+        )
+        position_ids = (
+            l_self_modules_embeddings_modules_position_embeddings_parameters_weight_
+        ) = None
+        embeddings = input_embeds + position_embeddings
+        input_embeds = position_embeddings = None
+        embeddings_1 = torch.nn.functional.layer_norm(
+            embeddings,
+            (768,),
+            l_self_modules_embeddings_modules_layer_norm_parameters_weight_,
+            l_self_modules_embeddings_modules_layer_norm_parameters_bias_,
+            1e-12,
+        )
+        embeddings = (
+            l_self_modules_embeddings_modules_layer_norm_parameters_weight_
+        ) = l_self_modules_embeddings_modules_layer_norm_parameters_bias_ = None
+        embeddings_2 = torch.nn.functional.dropout(embeddings_1, 0.1, False, False)
+        embeddings_1 = None
+        getitem_7 = l_attention_mask_[
+            (slice(None, None, None), None, None, slice(None, None, None))
+        ]
+        l_attention_mask_ = None
+        expand = getitem_7.expand(1, 1, s0, s0)
+        getitem_7 = s0 = None
+        expanded_mask = expand.to(torch.float32)
+        expand = None
+        tensor = torch.tensor(1.0, dtype=torch.float32)
+        inverted_mask = tensor - expanded_mask
+        tensor = expanded_mask = None
         to_1 = inverted_mask.to(torch.bool)
-        attention_mask = inverted_mask.masked_fill(to_1, -3.4028234663852886e+38);  inverted_mask = to_1 = None
-        linear = torch._C._nn.linear(embeddings_2, l_self_modules_transformer_modules_layer_modules_0_modules_attention_modules_q_lin_parameters_weight_, l_self_modules_transformer_modules_layer_modules_0_modules_attention_modules_q_lin_parameters_bias_);  l_self_modules_transformer_modules_layer_modules_0_modules_attention_modules_q_lin_parameters_weight_ = l_self_modules_transformer_modules_layer_modules_0_modules_attention_modules_q_lin_parameters_bias_ = None
-        view = linear.view(1, -1, 12, 64);  linear = None
-        q = view.transpose(1, 2);  view = None
-        linear_1 = torch._C._nn.linear(embeddings_2, l_self_modules_transformer_modules_layer_modules_0_modules_attention_modules_k_lin_parameters_weight_, l_self_modules_transformer_modules_layer_modules_0_modules_attention_modules_k_lin_parameters_bias_);  l_self_modules_transformer_modules_layer_modules_0_modules_attention_modules_k_lin_parameters_weight_ = l_self_modules_transformer_modules_layer_modules_0_modules_attention_modules_k_lin_parameters_bias_ = None
-        view_1 = linear_1.view(1, -1, 12, 64);  linear_1 = None
-        k = view_1.transpose(1, 2);  view_1 = None
-        linear_2 = torch._C._nn.linear(embeddings_2, l_self_modules_transformer_modules_layer_modules_0_modules_attention_modules_v_lin_parameters_weight_, l_self_modules_transformer_modules_layer_modules_0_modules_attention_modules_v_lin_parameters_bias_);  l_self_modules_transformer_modules_layer_modules_0_modules_attention_modules_v_lin_parameters_weight_ = l_self_modules_transformer_modules_layer_modules_0_modules_attention_modules_v_lin_parameters_bias_ = None
-        view_2 = linear_2.view(1, -1, 12, 64);  linear_2 = None
-        v = view_2.transpose(1, 2);  view_2 = None
-        attn_output = torch._C._nn.scaled_dot_product_attention(q, k, v, attn_mask = attention_mask, dropout_p = 0.0, is_causal = False);  q = k = v = None
-        transpose_3 = attn_output.transpose(1, 2);  attn_output = None
-        contiguous = transpose_3.contiguous();  transpose_3 = None
-        attn_output_1 = contiguous.view(1, -1, 768);  contiguous = None
-        attn_output_2 = torch._C._nn.linear(attn_output_1, l_self_modules_transformer_modules_layer_modules_0_modules_attention_modules_out_lin_parameters_weight_, l_self_modules_transformer_modules_layer_modules_0_modules_attention_modules_out_lin_parameters_bias_);  attn_output_1 = l_self_modules_transformer_modules_layer_modules_0_modules_attention_modules_out_lin_parameters_weight_ = l_self_modules_transformer_modules_layer_modules_0_modules_attention_modules_out_lin_parameters_bias_ = None
-        add_1 = attn_output_2 + embeddings_2;  attn_output_2 = embeddings_2 = None
-        sa_output = torch.nn.functional.layer_norm(add_1, (768,), l_self_modules_transformer_modules_layer_modules_0_modules_sa_layer_norm_parameters_weight_, l_self_modules_transformer_modules_layer_modules_0_modules_sa_layer_norm_parameters_bias_, 1e-12);  add_1 = l_self_modules_transformer_modules_layer_modules_0_modules_sa_layer_norm_parameters_weight_ = l_self_modules_transformer_modules_layer_modules_0_modules_sa_layer_norm_parameters_bias_ = None
-        x = torch._C._nn.linear(sa_output, l_self_modules_transformer_modules_layer_modules_0_modules_ffn_modules_lin1_parameters_weight_, l_self_modules_transformer_modules_layer_modules_0_modules_ffn_modules_lin1_parameters_bias_);  l_self_modules_transformer_modules_layer_modules_0_modules_ffn_modules_lin1_parameters_weight_ = l_self_modules_transformer_modules_layer_modules_0_modules_ffn_modules_lin1_parameters_bias_ = None
-        x_1 = torch._C._nn.gelu(x);  x = None
-        x_2 = torch._C._nn.linear(x_1, l_self_modules_transformer_modules_layer_modules_0_modules_ffn_modules_lin2_parameters_weight_, l_self_modules_transformer_modules_layer_modules_0_modules_ffn_modules_lin2_parameters_bias_);  x_1 = l_self_modules_transformer_modules_layer_modules_0_modules_ffn_modules_lin2_parameters_weight_ = l_self_modules_transformer_modules_layer_modules_0_modules_ffn_modules_lin2_parameters_bias_ = None
-        x_3 = torch.nn.functional.dropout(x_2, 0.1, False, False);  x_2 = None
-        add_2 = x_3 + sa_output;  x_3 = sa_output = None
-        ffn_output = torch.nn.functional.layer_norm(add_2, (768,), l_self_modules_transformer_modules_layer_modules_0_modules_output_layer_norm_parameters_weight_, l_self_modules_transformer_modules_layer_modules_0_modules_output_layer_norm_parameters_bias_, 1e-12);  add_2 = l_self_modules_transformer_modules_layer_modules_0_modules_output_layer_norm_parameters_weight_ = l_self_modules_transformer_modules_layer_modules_0_modules_output_layer_norm_parameters_bias_ = None
-        linear_6 = torch._C._nn.linear(ffn_output, l_self_modules_transformer_modules_layer_modules_1_modules_attention_modules_q_lin_parameters_weight_, l_self_modules_transformer_modules_layer_modules_1_modules_attention_modules_q_lin_parameters_bias_);  l_self_modules_transformer_modules_layer_modules_1_modules_attention_modules_q_lin_parameters_weight_ = l_self_modules_transformer_modules_layer_modules_1_modules_attention_modules_q_lin_parameters_bias_ = None
-        view_4 = linear_6.view(1, -1, 12, 64);  linear_6 = None
-        q_1 = view_4.transpose(1, 2);  view_4 = None
-        linear_7 = torch._C._nn.linear(ffn_output, l_self_modules_transformer_modules_layer_modules_1_modules_attention_modules_k_lin_parameters_weight_, l_self_modules_transformer_modules_layer_modules_1_modules_attention_modules_k_lin_parameters_bias_);  l_self_modules_transformer_modules_layer_modules_1_modules_attention_modules_k_lin_parameters_weight_ = l_self_modules_transformer_modules_layer_modules_1_modules_attention_modules_k_lin_parameters_bias_ = None
-        view_5 = linear_7.view(1, -1, 12, 64);  linear_7 = None
-        k_1 = view_5.transpose(1, 2);  view_5 = None
-        linear_8 = torch._C._nn.linear(ffn_output, l_self_modules_transformer_modules_layer_modules_1_modules_attention_modules_v_lin_parameters_weight_, l_self_modules_transformer_modules_layer_modules_1_modules_attention_modules_v_lin_parameters_bias_);  l_self_modules_transformer_modules_layer_modules_1_modules_attention_modules_v_lin_parameters_weight_ = l_self_modules_transformer_modules_layer_modules_1_modules_attention_modules_v_lin_parameters_bias_ = None
-        view_6 = linear_8.view(1, -1, 12, 64);  linear_8 = None
-        v_1 = view_6.transpose(1, 2);  view_6 = None
-        attn_output_3 = torch._C._nn.scaled_dot_product_attention(q_1, k_1, v_1, attn_mask = attention_mask, dropout_p = 0.0, is_causal = False);  q_1 = k_1 = v_1 = None
-        transpose_7 = attn_output_3.transpose(1, 2);  attn_output_3 = None
-        contiguous_1 = transpose_7.contiguous();  transpose_7 = None
-        attn_output_4 = contiguous_1.view(1, -1, 768);  contiguous_1 = None
-        attn_output_5 = torch._C._nn.linear(attn_output_4, l_self_modules_transformer_modules_layer_modules_1_modules_attention_modules_out_lin_parameters_weight_, l_self_modules_transformer_modules_layer_modules_1_modules_attention_modules_out_lin_parameters_bias_);  attn_output_4 = l_self_modules_transformer_modules_layer_modules_1_modules_attention_modules_out_lin_parameters_weight_ = l_self_modules_transformer_modules_layer_modules_1_modules_attention_modules_out_lin_parameters_bias_ = None
-        add_3 = attn_output_5 + ffn_output;  attn_output_5 = ffn_output = None
-        sa_output_1 = torch.nn.functional.layer_norm(add_3, (768,), l_self_modules_transformer_modules_layer_modules_1_modules_sa_layer_norm_parameters_weight_, l_self_modules_transformer_modules_layer_modules_1_modules_sa_layer_norm_parameters_bias_, 1e-12);  add_3 = l_self_modules_transformer_modules_layer_modules_1_modules_sa_layer_norm_parameters_weight_ = l_self_modules_transformer_modules_layer_modules_1_modules_sa_layer_norm_parameters_bias_ = None
-        x_4 = torch._C._nn.linear(sa_output_1, l_self_modules_transformer_modules_layer_modules_1_modules_ffn_modules_lin1_parameters_weight_, l_self_modules_transformer_modules_layer_modules_1_modules_ffn_modules_lin1_parameters_bias_);  l_self_modules_transformer_modules_layer_modules_1_modules_ffn_modules_lin1_parameters_weight_ = l_self_modules_transformer_modules_layer_modules_1_modules_ffn_modules_lin1_parameters_bias_ = None
-        x_5 = torch._C._nn.gelu(x_4);  x_4 = None
-        x_6 = torch._C._nn.linear(x_5, l_self_modules_transformer_modules_layer_modules_1_modules_ffn_modules_lin2_parameters_weight_, l_self_modules_transformer_modules_layer_modules_1_modules_ffn_modules_lin2_parameters_bias_);  x_5 = l_self_modules_transformer_modules_layer_modules_1_modules_ffn_modules_lin2_parameters_weight_ = l_self_modules_transformer_modules_layer_modules_1_modules_ffn_modules_lin2_parameters_bias_ = None
-        x_7 = torch.nn.functional.dropout(x_6, 0.1, False, False);  x_6 = None
-        add_4 = x_7 + sa_output_1;  x_7 = sa_output_1 = None
-        ffn_output_1 = torch.nn.functional.layer_norm(add_4, (768,), l_self_modules_transformer_modules_layer_modules_1_modules_output_layer_norm_parameters_weight_, l_self_modules_transformer_modules_layer_modules_1_modules_output_layer_norm_parameters_bias_, 1e-12);  add_4 = l_self_modules_transformer_modules_layer_modules_1_modules_output_layer_norm_parameters_weight_ = l_self_modules_transformer_modules_layer_modules_1_modules_output_layer_norm_parameters_bias_ = None
-        linear_12 = torch._C._nn.linear(ffn_output_1, l_self_modules_transformer_modules_layer_modules_2_modules_attention_modules_q_lin_parameters_weight_, l_self_modules_transformer_modules_layer_modules_2_modules_attention_modules_q_lin_parameters_bias_);  l_self_modules_transformer_modules_layer_modules_2_modules_attention_modules_q_lin_parameters_weight_ = l_self_modules_transformer_modules_layer_modules_2_modules_attention_modules_q_lin_parameters_bias_ = None
-        view_8 = linear_12.view(1, -1, 12, 64);  linear_12 = None
-        q_2 = view_8.transpose(1, 2);  view_8 = None
-        linear_13 = torch._C._nn.linear(ffn_output_1, l_self_modules_transformer_modules_layer_modules_2_modules_attention_modules_k_lin_parameters_weight_, l_self_modules_transformer_modules_layer_modules_2_modules_attention_modules_k_lin_parameters_bias_);  l_self_modules_transformer_modules_layer_modules_2_modules_attention_modules_k_lin_parameters_weight_ = l_self_modules_transformer_modules_layer_modules_2_modules_attention_modules_k_lin_parameters_bias_ = None
-        view_9 = linear_13.view(1, -1, 12, 64);  linear_13 = None
-        k_2 = view_9.transpose(1, 2);  view_9 = None
-        linear_14 = torch._C._nn.linear(ffn_output_1, l_self_modules_transformer_modules_layer_modules_2_modules_attention_modules_v_lin_parameters_weight_, l_self_modules_transformer_modules_layer_modules_2_modules_attention_modules_v_lin_parameters_bias_);  l_self_modules_transformer_modules_layer_modules_2_modules_attention_modules_v_lin_parameters_weight_ = l_self_modules_transformer_modules_layer_modules_2_modules_attention_modules_v_lin_parameters_bias_ = None
-        view_10 = linear_14.view(1, -1, 12, 64);  linear_14 = None
-        v_2 = view_10.transpose(1, 2);  view_10 = None
-        attn_output_6 = torch._C._nn.scaled_dot_product_attention(q_2, k_2, v_2, attn_mask = attention_mask, dropout_p = 0.0, is_causal = False);  q_2 = k_2 = v_2 = None
-        transpose_11 = attn_output_6.transpose(1, 2);  attn_output_6 = None
-        contiguous_2 = transpose_11.contiguous();  transpose_11 = None
-        attn_output_7 = contiguous_2.view(1, -1, 768);  contiguous_2 = None
-        attn_output_8 = torch._C._nn.linear(attn_output_7, l_self_modules_transformer_modules_layer_modules_2_modules_attention_modules_out_lin_parameters_weight_, l_self_modules_transformer_modules_layer_modules_2_modules_attention_modules_out_lin_parameters_bias_);  attn_output_7 = l_self_modules_transformer_modules_layer_modules_2_modules_attention_modules_out_lin_parameters_weight_ = l_self_modules_transformer_modules_layer_modules_2_modules_attention_modules_out_lin_parameters_bias_ = None
-        add_5 = attn_output_8 + ffn_output_1;  attn_output_8 = ffn_output_1 = None
-        sa_output_2 = torch.nn.functional.layer_norm(add_5, (768,), l_self_modules_transformer_modules_layer_modules_2_modules_sa_layer_norm_parameters_weight_, l_self_modules_transformer_modules_layer_modules_2_modules_sa_layer_norm_parameters_bias_, 1e-12);  add_5 = l_self_modules_transformer_modules_layer_modules_2_modules_sa_layer_norm_parameters_weight_ = l_self_modules_transformer_modules_layer_modules_2_modules_sa_layer_norm_parameters_bias_ = None
-        x_8 = torch._C._nn.linear(sa_output_2, l_self_modules_transformer_modules_layer_modules_2_modules_ffn_modules_lin1_parameters_weight_, l_self_modules_transformer_modules_layer_modules_2_modules_ffn_modules_lin1_parameters_bias_);  l_self_modules_transformer_modules_layer_modules_2_modules_ffn_modules_lin1_parameters_weight_ = l_self_modules_transformer_modules_layer_modules_2_modules_ffn_modules_lin1_parameters_bias_ = None
-        x_9 = torch._C._nn.gelu(x_8);  x_8 = None
-        x_10 = torch._C._nn.linear(x_9, l_self_modules_transformer_modules_layer_modules_2_modules_ffn_modules_lin2_parameters_weight_, l_self_modules_transformer_modules_layer_modules_2_modules_ffn_modules_lin2_parameters_bias_);  x_9 = l_self_modules_transformer_modules_layer_modules_2_modules_ffn_modules_lin2_parameters_weight_ = l_self_modules_transformer_modules_layer_modules_2_modules_ffn_modules_lin2_parameters_bias_ = None
-        x_11 = torch.nn.functional.dropout(x_10, 0.1, False, False);  x_10 = None
-        add_6 = x_11 + sa_output_2;  x_11 = sa_output_2 = None
-        ffn_output_2 = torch.nn.functional.layer_norm(add_6, (768,), l_self_modules_transformer_modules_layer_modules_2_modules_output_layer_norm_parameters_weight_, l_self_modules_transformer_modules_layer_modules_2_modules_output_layer_norm_parameters_bias_, 1e-12);  add_6 = l_self_modules_transformer_modules_layer_modules_2_modules_output_layer_norm_parameters_weight_ = l_self_modules_transformer_modules_layer_modules_2_modules_output_layer_norm_parameters_bias_ = None
-        linear_18 = torch._C._nn.linear(ffn_output_2, l_self_modules_transformer_modules_layer_modules_3_modules_attention_modules_q_lin_parameters_weight_, l_self_modules_transformer_modules_layer_modules_3_modules_attention_modules_q_lin_parameters_bias_);  l_self_modules_transformer_modules_layer_modules_3_modules_attention_modules_q_lin_parameters_weight_ = l_self_modules_transformer_modules_layer_modules_3_modules_attention_modules_q_lin_parameters_bias_ = None
-        view_12 = linear_18.view(1, -1, 12, 64);  linear_18 = None
-        q_3 = view_12.transpose(1, 2);  view_12 = None
-        linear_19 = torch._C._nn.linear(ffn_output_2, l_self_modules_transformer_modules_layer_modules_3_modules_attention_modules_k_lin_parameters_weight_, l_self_modules_transformer_modules_layer_modules_3_modules_attention_modules_k_lin_parameters_bias_);  l_self_modules_transformer_modules_layer_modules_3_modules_attention_modules_k_lin_parameters_weight_ = l_self_modules_transformer_modules_layer_modules_3_modules_attention_modules_k_lin_parameters_bias_ = None
-        view_13 = linear_19.view(1, -1, 12, 64);  linear_19 = None
-        k_3 = view_13.transpose(1, 2);  view_13 = None
-        linear_20 = torch._C._nn.linear(ffn_output_2, l_self_modules_transformer_modules_layer_modules_3_modules_attention_modules_v_lin_parameters_weight_, l_self_modules_transformer_modules_layer_modules_3_modules_attention_modules_v_lin_parameters_bias_);  l_self_modules_transformer_modules_layer_modules_3_modules_attention_modules_v_lin_parameters_weight_ = l_self_modules_transformer_modules_layer_modules_3_modules_attention_modules_v_lin_parameters_bias_ = None
-        view_14 = linear_20.view(1, -1, 12, 64);  linear_20 = None
-        v_3 = view_14.transpose(1, 2);  view_14 = None
-        attn_output_9 = torch._C._nn.scaled_dot_product_attention(q_3, k_3, v_3, attn_mask = attention_mask, dropout_p = 0.0, is_causal = False);  q_3 = k_3 = v_3 = None
-        transpose_15 = attn_output_9.transpose(1, 2);  attn_output_9 = None
-        contiguous_3 = transpose_15.contiguous();  transpose_15 = None
-        attn_output_10 = contiguous_3.view(1, -1, 768);  contiguous_3 = None
-        attn_output_11 = torch._C._nn.linear(attn_output_10, l_self_modules_transformer_modules_layer_modules_3_modules_attention_modules_out_lin_parameters_weight_, l_self_modules_transformer_modules_layer_modules_3_modules_attention_modules_out_lin_parameters_bias_);  attn_output_10 = l_self_modules_transformer_modules_layer_modules_3_modules_attention_modules_out_lin_parameters_weight_ = l_self_modules_transformer_modules_layer_modules_3_modules_attention_modules_out_lin_parameters_bias_ = None
-        add_7 = attn_output_11 + ffn_output_2;  attn_output_11 = ffn_output_2 = None
-        sa_output_3 = torch.nn.functional.layer_norm(add_7, (768,), l_self_modules_transformer_modules_layer_modules_3_modules_sa_layer_norm_parameters_weight_, l_self_modules_transformer_modules_layer_modules_3_modules_sa_layer_norm_parameters_bias_, 1e-12);  add_7 = l_self_modules_transformer_modules_layer_modules_3_modules_sa_layer_norm_parameters_weight_ = l_self_modules_transformer_modules_layer_modules_3_modules_sa_layer_norm_parameters_bias_ = None
-        x_12 = torch._C._nn.linear(sa_output_3, l_self_modules_transformer_modules_layer_modules_3_modules_ffn_modules_lin1_parameters_weight_, l_self_modules_transformer_modules_layer_modules_3_modules_ffn_modules_lin1_parameters_bias_);  l_self_modules_transformer_modules_layer_modules_3_modules_ffn_modules_lin1_parameters_weight_ = l_self_modules_transformer_modules_layer_modules_3_modules_ffn_modules_lin1_parameters_bias_ = None
-        x_13 = torch._C._nn.gelu(x_12);  x_12 = None
-        x_14 = torch._C._nn.linear(x_13, l_self_modules_transformer_modules_layer_modules_3_modules_ffn_modules_lin2_parameters_weight_, l_self_modules_transformer_modules_layer_modules_3_modules_ffn_modules_lin2_parameters_bias_);  x_13 = l_self_modules_transformer_modules_layer_modules_3_modules_ffn_modules_lin2_parameters_weight_ = l_self_modules_transformer_modules_layer_modules_3_modules_ffn_modules_lin2_parameters_bias_ = None
-        x_15 = torch.nn.functional.dropout(x_14, 0.1, False, False);  x_14 = None
-        add_8 = x_15 + sa_output_3;  x_15 = sa_output_3 = None
-        ffn_output_3 = torch.nn.functional.layer_norm(add_8, (768,), l_self_modules_transformer_modules_layer_modules_3_modules_output_layer_norm_parameters_weight_, l_self_modules_transformer_modules_layer_modules_3_modules_output_layer_norm_parameters_bias_, 1e-12);  add_8 = l_self_modules_transformer_modules_layer_modules_3_modules_output_layer_norm_parameters_weight_ = l_self_modules_transformer_modules_layer_modules_3_modules_output_layer_norm_parameters_bias_ = None
-        linear_24 = torch._C._nn.linear(ffn_output_3, l_self_modules_transformer_modules_layer_modules_4_modules_attention_modules_q_lin_parameters_weight_, l_self_modules_transformer_modules_layer_modules_4_modules_attention_modules_q_lin_parameters_bias_);  l_self_modules_transformer_modules_layer_modules_4_modules_attention_modules_q_lin_parameters_weight_ = l_self_modules_transformer_modules_layer_modules_4_modules_attention_modules_q_lin_parameters_bias_ = None
-        view_16 = linear_24.view(1, -1, 12, 64);  linear_24 = None
-        q_4 = view_16.transpose(1, 2);  view_16 = None
-        linear_25 = torch._C._nn.linear(ffn_output_3, l_self_modules_transformer_modules_layer_modules_4_modules_attention_modules_k_lin_parameters_weight_, l_self_modules_transformer_modules_layer_modules_4_modules_attention_modules_k_lin_parameters_bias_);  l_self_modules_transformer_modules_layer_modules_4_modules_attention_modules_k_lin_parameters_weight_ = l_self_modules_transformer_modules_layer_modules_4_modules_attention_modules_k_lin_parameters_bias_ = None
-        view_17 = linear_25.view(1, -1, 12, 64);  linear_25 = None
-        k_4 = view_17.transpose(1, 2);  view_17 = None
-        linear_26 = torch._C._nn.linear(ffn_output_3, l_self_modules_transformer_modules_layer_modules_4_modules_attention_modules_v_lin_parameters_weight_, l_self_modules_transformer_modules_layer_modules_4_modules_attention_modules_v_lin_parameters_bias_);  l_self_modules_transformer_modules_layer_modules_4_modules_attention_modules_v_lin_parameters_weight_ = l_self_modules_transformer_modules_layer_modules_4_modules_attention_modules_v_lin_parameters_bias_ = None
-        view_18 = linear_26.view(1, -1, 12, 64);  linear_26 = None
-        v_4 = view_18.transpose(1, 2);  view_18 = None
-        attn_output_12 = torch._C._nn.scaled_dot_product_attention(q_4, k_4, v_4, attn_mask = attention_mask, dropout_p = 0.0, is_causal = False);  q_4 = k_4 = v_4 = None
-        transpose_19 = attn_output_12.transpose(1, 2);  attn_output_12 = None
-        contiguous_4 = transpose_19.contiguous();  transpose_19 = None
-        attn_output_13 = contiguous_4.view(1, -1, 768);  contiguous_4 = None
-        attn_output_14 = torch._C._nn.linear(attn_output_13, l_self_modules_transformer_modules_layer_modules_4_modules_attention_modules_out_lin_parameters_weight_, l_self_modules_transformer_modules_layer_modules_4_modules_attention_modules_out_lin_parameters_bias_);  attn_output_13 = l_self_modules_transformer_modules_layer_modules_4_modules_attention_modules_out_lin_parameters_weight_ = l_self_modules_transformer_modules_layer_modules_4_modules_attention_modules_out_lin_parameters_bias_ = None
-        add_9 = attn_output_14 + ffn_output_3;  attn_output_14 = ffn_output_3 = None
-        sa_output_4 = torch.nn.functional.layer_norm(add_9, (768,), l_self_modules_transformer_modules_layer_modules_4_modules_sa_layer_norm_parameters_weight_, l_self_modules_transformer_modules_layer_modules_4_modules_sa_layer_norm_parameters_bias_, 1e-12);  add_9 = l_self_modules_transformer_modules_layer_modules_4_modules_sa_layer_norm_parameters_weight_ = l_self_modules_transformer_modules_layer_modules_4_modules_sa_layer_norm_parameters_bias_ = None
-        x_16 = torch._C._nn.linear(sa_output_4, l_self_modules_transformer_modules_layer_modules_4_modules_ffn_modules_lin1_parameters_weight_, l_self_modules_transformer_modules_layer_modules_4_modules_ffn_modules_lin1_parameters_bias_);  l_self_modules_transformer_modules_layer_modules_4_modules_ffn_modules_lin1_parameters_weight_ = l_self_modules_transformer_modules_layer_modules_4_modules_ffn_modules_lin1_parameters_bias_ = None
-        x_17 = torch._C._nn.gelu(x_16);  x_16 = None
-        x_18 = torch._C._nn.linear(x_17, l_self_modules_transformer_modules_layer_modules_4_modules_ffn_modules_lin2_parameters_weight_, l_self_modules_transformer_modules_layer_modules_4_modules_ffn_modules_lin2_parameters_bias_);  x_17 = l_self_modules_transformer_modules_layer_modules_4_modules_ffn_modules_lin2_parameters_weight_ = l_self_modules_transformer_modules_layer_modules_4_modules_ffn_modules_lin2_parameters_bias_ = None
-        x_19 = torch.nn.functional.dropout(x_18, 0.1, False, False);  x_18 = None
-        add_10 = x_19 + sa_output_4;  x_19 = sa_output_4 = None
-        ffn_output_4 = torch.nn.functional.layer_norm(add_10, (768,), l_self_modules_transformer_modules_layer_modules_4_modules_output_layer_norm_parameters_weight_, l_self_modules_transformer_modules_layer_modules_4_modules_output_layer_norm_parameters_bias_, 1e-12);  add_10 = l_self_modules_transformer_modules_layer_modules_4_modules_output_layer_norm_parameters_weight_ = l_self_modules_transformer_modules_layer_modules_4_modules_output_layer_norm_parameters_bias_ = None
-        linear_30 = torch._C._nn.linear(ffn_output_4, l_self_modules_transformer_modules_layer_modules_5_modules_attention_modules_q_lin_parameters_weight_, l_self_modules_transformer_modules_layer_modules_5_modules_attention_modules_q_lin_parameters_bias_);  l_self_modules_transformer_modules_layer_modules_5_modules_attention_modules_q_lin_parameters_weight_ = l_self_modules_transformer_modules_layer_modules_5_modules_attention_modules_q_lin_parameters_bias_ = None
-        view_20 = linear_30.view(1, -1, 12, 64);  linear_30 = None
-        q_5 = view_20.transpose(1, 2);  view_20 = None
-        linear_31 = torch._C._nn.linear(ffn_output_4, l_self_modules_transformer_modules_layer_modules_5_modules_attention_modules_k_lin_parameters_weight_, l_self_modules_transformer_modules_layer_modules_5_modules_attention_modules_k_lin_parameters_bias_);  l_self_modules_transformer_modules_layer_modules_5_modules_attention_modules_k_lin_parameters_weight_ = l_self_modules_transformer_modules_layer_modules_5_modules_attention_modules_k_lin_parameters_bias_ = None
-        view_21 = linear_31.view(1, -1, 12, 64);  linear_31 = None
-        k_5 = view_21.transpose(1, 2);  view_21 = None
-        linear_32 = torch._C._nn.linear(ffn_output_4, l_self_modules_transformer_modules_layer_modules_5_modules_attention_modules_v_lin_parameters_weight_, l_self_modules_transformer_modules_layer_modules_5_modules_attention_modules_v_lin_parameters_bias_);  l_self_modules_transformer_modules_layer_modules_5_modules_attention_modules_v_lin_parameters_weight_ = l_self_modules_transformer_modules_layer_modules_5_modules_attention_modules_v_lin_parameters_bias_ = None
-        view_22 = linear_32.view(1, -1, 12, 64);  linear_32 = None
-        v_5 = view_22.transpose(1, 2);  view_22 = None
-        attn_output_15 = torch._C._nn.scaled_dot_product_attention(q_5, k_5, v_5, attn_mask = attention_mask, dropout_p = 0.0, is_causal = False);  q_5 = k_5 = v_5 = attention_mask = None
-        transpose_23 = attn_output_15.transpose(1, 2);  attn_output_15 = None
-        contiguous_5 = transpose_23.contiguous();  transpose_23 = None
-        attn_output_16 = contiguous_5.view(1, -1, 768);  contiguous_5 = None
-        attn_output_17 = torch._C._nn.linear(attn_output_16, l_self_modules_transformer_modules_layer_modules_5_modules_attention_modules_out_lin_parameters_weight_, l_self_modules_transformer_modules_layer_modules_5_modules_attention_modules_out_lin_parameters_bias_);  attn_output_16 = l_self_modules_transformer_modules_layer_modules_5_modules_attention_modules_out_lin_parameters_weight_ = l_self_modules_transformer_modules_layer_modules_5_modules_attention_modules_out_lin_parameters_bias_ = None
-        add_11 = attn_output_17 + ffn_output_4;  attn_output_17 = ffn_output_4 = None
-        sa_output_5 = torch.nn.functional.layer_norm(add_11, (768,), l_self_modules_transformer_modules_layer_modules_5_modules_sa_layer_norm_parameters_weight_, l_self_modules_transformer_modules_layer_modules_5_modules_sa_layer_norm_parameters_bias_, 1e-12);  add_11 = l_self_modules_transformer_modules_layer_modules_5_modules_sa_layer_norm_parameters_weight_ = l_self_modules_transformer_modules_layer_modules_5_modules_sa_layer_norm_parameters_bias_ = None
-        x_20 = torch._C._nn.linear(sa_output_5, l_self_modules_transformer_modules_layer_modules_5_modules_ffn_modules_lin1_parameters_weight_, l_self_modules_transformer_modules_layer_modules_5_modules_ffn_modules_lin1_parameters_bias_);  l_self_modules_transformer_modules_layer_modules_5_modules_ffn_modules_lin1_parameters_weight_ = l_self_modules_transformer_modules_layer_modules_5_modules_ffn_modules_lin1_parameters_bias_ = None
-        x_21 = torch._C._nn.gelu(x_20);  x_20 = None
-        x_22 = torch._C._nn.linear(x_21, l_self_modules_transformer_modules_layer_modules_5_modules_ffn_modules_lin2_parameters_weight_, l_self_modules_transformer_modules_layer_modules_5_modules_ffn_modules_lin2_parameters_bias_);  x_21 = l_self_modules_transformer_modules_layer_modules_5_modules_ffn_modules_lin2_parameters_weight_ = l_self_modules_transformer_modules_layer_modules_5_modules_ffn_modules_lin2_parameters_bias_ = None
-        x_23 = torch.nn.functional.dropout(x_22, 0.1, False, False);  x_22 = None
-        add_12 = x_23 + sa_output_5;  x_23 = sa_output_5 = None
-        ffn_output_5 = torch.nn.functional.layer_norm(add_12, (768,), l_self_modules_transformer_modules_layer_modules_5_modules_output_layer_norm_parameters_weight_, l_self_modules_transformer_modules_layer_modules_5_modules_output_layer_norm_parameters_bias_, 1e-12);  add_12 = l_self_modules_transformer_modules_layer_modules_5_modules_output_layer_norm_parameters_weight_ = l_self_modules_transformer_modules_layer_modules_5_modules_output_layer_norm_parameters_bias_ = None
+        attention_mask = inverted_mask.masked_fill(to_1, -3.4028234663852886e38)
+        inverted_mask = to_1 = None
+        linear = torch._C._nn.linear(
+            embeddings_2,
+            l_self_modules_transformer_modules_layer_modules_0_modules_attention_modules_q_lin_parameters_weight_,
+            l_self_modules_transformer_modules_layer_modules_0_modules_attention_modules_q_lin_parameters_bias_,
+        )
+        l_self_modules_transformer_modules_layer_modules_0_modules_attention_modules_q_lin_parameters_weight_ = l_self_modules_transformer_modules_layer_modules_0_modules_attention_modules_q_lin_parameters_bias_ = (None)
+        view = linear.view(1, -1, 12, 64)
+        linear = None
+        q = view.transpose(1, 2)
+        view = None
+        linear_1 = torch._C._nn.linear(
+            embeddings_2,
+            l_self_modules_transformer_modules_layer_modules_0_modules_attention_modules_k_lin_parameters_weight_,
+            l_self_modules_transformer_modules_layer_modules_0_modules_attention_modules_k_lin_parameters_bias_,
+        )
+        l_self_modules_transformer_modules_layer_modules_0_modules_attention_modules_k_lin_parameters_weight_ = l_self_modules_transformer_modules_layer_modules_0_modules_attention_modules_k_lin_parameters_bias_ = (None)
+        view_1 = linear_1.view(1, -1, 12, 64)
+        linear_1 = None
+        k = view_1.transpose(1, 2)
+        view_1 = None
+        linear_2 = torch._C._nn.linear(
+            embeddings_2,
+            l_self_modules_transformer_modules_layer_modules_0_modules_attention_modules_v_lin_parameters_weight_,
+            l_self_modules_transformer_modules_layer_modules_0_modules_attention_modules_v_lin_parameters_bias_,
+        )
+        l_self_modules_transformer_modules_layer_modules_0_modules_attention_modules_v_lin_parameters_weight_ = l_self_modules_transformer_modules_layer_modules_0_modules_attention_modules_v_lin_parameters_bias_ = (None)
+        view_2 = linear_2.view(1, -1, 12, 64)
+        linear_2 = None
+        v = view_2.transpose(1, 2)
+        view_2 = None
+        attn_output = torch._C._nn.scaled_dot_product_attention(
+            q, k, v, attn_mask=attention_mask, dropout_p=0.0, is_causal=False
+        )
+        q = k = v = None
+        transpose_3 = attn_output.transpose(1, 2)
+        attn_output = None
+        contiguous = transpose_3.contiguous()
+        transpose_3 = None
+        attn_output_1 = contiguous.view(1, -1, 768)
+        contiguous = None
+        attn_output_2 = torch._C._nn.linear(
+            attn_output_1,
+            l_self_modules_transformer_modules_layer_modules_0_modules_attention_modules_out_lin_parameters_weight_,
+            l_self_modules_transformer_modules_layer_modules_0_modules_attention_modules_out_lin_parameters_bias_,
+        )
+        attn_output_1 = l_self_modules_transformer_modules_layer_modules_0_modules_attention_modules_out_lin_parameters_weight_ = l_self_modules_transformer_modules_layer_modules_0_modules_attention_modules_out_lin_parameters_bias_ = (None)
+        add_1 = attn_output_2 + embeddings_2
+        attn_output_2 = embeddings_2 = None
+        sa_output = torch.nn.functional.layer_norm(
+            add_1,
+            (768,),
+            l_self_modules_transformer_modules_layer_modules_0_modules_sa_layer_norm_parameters_weight_,
+            l_self_modules_transformer_modules_layer_modules_0_modules_sa_layer_norm_parameters_bias_,
+            1e-12,
+        )
+        add_1 = l_self_modules_transformer_modules_layer_modules_0_modules_sa_layer_norm_parameters_weight_ = l_self_modules_transformer_modules_layer_modules_0_modules_sa_layer_norm_parameters_bias_ = (None)
+        x = torch._C._nn.linear(
+            sa_output,
+            l_self_modules_transformer_modules_layer_modules_0_modules_ffn_modules_lin1_parameters_weight_,
+            l_self_modules_transformer_modules_layer_modules_0_modules_ffn_modules_lin1_parameters_bias_,
+        )
+        l_self_modules_transformer_modules_layer_modules_0_modules_ffn_modules_lin1_parameters_weight_ = l_self_modules_transformer_modules_layer_modules_0_modules_ffn_modules_lin1_parameters_bias_ = (None)
+        x_1 = torch._C._nn.gelu(x)
+        x = None
+        x_2 = torch._C._nn.linear(
+            x_1,
+            l_self_modules_transformer_modules_layer_modules_0_modules_ffn_modules_lin2_parameters_weight_,
+            l_self_modules_transformer_modules_layer_modules_0_modules_ffn_modules_lin2_parameters_bias_,
+        )
+        x_1 = l_self_modules_transformer_modules_layer_modules_0_modules_ffn_modules_lin2_parameters_weight_ = l_self_modules_transformer_modules_layer_modules_0_modules_ffn_modules_lin2_parameters_bias_ = (None)
+        x_3 = torch.nn.functional.dropout(x_2, 0.1, False, False)
+        x_2 = None
+        add_2 = x_3 + sa_output
+        x_3 = sa_output = None
+        ffn_output = torch.nn.functional.layer_norm(
+            add_2,
+            (768,),
+            l_self_modules_transformer_modules_layer_modules_0_modules_output_layer_norm_parameters_weight_,
+            l_self_modules_transformer_modules_layer_modules_0_modules_output_layer_norm_parameters_bias_,
+            1e-12,
+        )
+        add_2 = l_self_modules_transformer_modules_layer_modules_0_modules_output_layer_norm_parameters_weight_ = l_self_modules_transformer_modules_layer_modules_0_modules_output_layer_norm_parameters_bias_ = (None)
+        linear_6 = torch._C._nn.linear(
+            ffn_output,
+            l_self_modules_transformer_modules_layer_modules_1_modules_attention_modules_q_lin_parameters_weight_,
+            l_self_modules_transformer_modules_layer_modules_1_modules_attention_modules_q_lin_parameters_bias_,
+        )
+        l_self_modules_transformer_modules_layer_modules_1_modules_attention_modules_q_lin_parameters_weight_ = l_self_modules_transformer_modules_layer_modules_1_modules_attention_modules_q_lin_parameters_bias_ = (None)
+        view_4 = linear_6.view(1, -1, 12, 64)
+        linear_6 = None
+        q_1 = view_4.transpose(1, 2)
+        view_4 = None
+        linear_7 = torch._C._nn.linear(
+            ffn_output,
+            l_self_modules_transformer_modules_layer_modules_1_modules_attention_modules_k_lin_parameters_weight_,
+            l_self_modules_transformer_modules_layer_modules_1_modules_attention_modules_k_lin_parameters_bias_,
+        )
+        l_self_modules_transformer_modules_layer_modules_1_modules_attention_modules_k_lin_parameters_weight_ = l_self_modules_transformer_modules_layer_modules_1_modules_attention_modules_k_lin_parameters_bias_ = (None)
+        view_5 = linear_7.view(1, -1, 12, 64)
+        linear_7 = None
+        k_1 = view_5.transpose(1, 2)
+        view_5 = None
+        linear_8 = torch._C._nn.linear(
+            ffn_output,
+            l_self_modules_transformer_modules_layer_modules_1_modules_attention_modules_v_lin_parameters_weight_,
+            l_self_modules_transformer_modules_layer_modules_1_modules_attention_modules_v_lin_parameters_bias_,
+        )
+        l_self_modules_transformer_modules_layer_modules_1_modules_attention_modules_v_lin_parameters_weight_ = l_self_modules_transformer_modules_layer_modules_1_modules_attention_modules_v_lin_parameters_bias_ = (None)
+        view_6 = linear_8.view(1, -1, 12, 64)
+        linear_8 = None
+        v_1 = view_6.transpose(1, 2)
+        view_6 = None
+        attn_output_3 = torch._C._nn.scaled_dot_product_attention(
+            q_1, k_1, v_1, attn_mask=attention_mask, dropout_p=0.0, is_causal=False
+        )
+        q_1 = k_1 = v_1 = None
+        transpose_7 = attn_output_3.transpose(1, 2)
+        attn_output_3 = None
+        contiguous_1 = transpose_7.contiguous()
+        transpose_7 = None
+        attn_output_4 = contiguous_1.view(1, -1, 768)
+        contiguous_1 = None
+        attn_output_5 = torch._C._nn.linear(
+            attn_output_4,
+            l_self_modules_transformer_modules_layer_modules_1_modules_attention_modules_out_lin_parameters_weight_,
+            l_self_modules_transformer_modules_layer_modules_1_modules_attention_modules_out_lin_parameters_bias_,
+        )
+        attn_output_4 = l_self_modules_transformer_modules_layer_modules_1_modules_attention_modules_out_lin_parameters_weight_ = l_self_modules_transformer_modules_layer_modules_1_modules_attention_modules_out_lin_parameters_bias_ = (None)
+        add_3 = attn_output_5 + ffn_output
+        attn_output_5 = ffn_output = None
+        sa_output_1 = torch.nn.functional.layer_norm(
+            add_3,
+            (768,),
+            l_self_modules_transformer_modules_layer_modules_1_modules_sa_layer_norm_parameters_weight_,
+            l_self_modules_transformer_modules_layer_modules_1_modules_sa_layer_norm_parameters_bias_,
+            1e-12,
+        )
+        add_3 = l_self_modules_transformer_modules_layer_modules_1_modules_sa_layer_norm_parameters_weight_ = l_self_modules_transformer_modules_layer_modules_1_modules_sa_layer_norm_parameters_bias_ = (None)
+        x_4 = torch._C._nn.linear(
+            sa_output_1,
+            l_self_modules_transformer_modules_layer_modules_1_modules_ffn_modules_lin1_parameters_weight_,
+            l_self_modules_transformer_modules_layer_modules_1_modules_ffn_modules_lin1_parameters_bias_,
+        )
+        l_self_modules_transformer_modules_layer_modules_1_modules_ffn_modules_lin1_parameters_weight_ = l_self_modules_transformer_modules_layer_modules_1_modules_ffn_modules_lin1_parameters_bias_ = (None)
+        x_5 = torch._C._nn.gelu(x_4)
+        x_4 = None
+        x_6 = torch._C._nn.linear(
+            x_5,
+            l_self_modules_transformer_modules_layer_modules_1_modules_ffn_modules_lin2_parameters_weight_,
+            l_self_modules_transformer_modules_layer_modules_1_modules_ffn_modules_lin2_parameters_bias_,
+        )
+        x_5 = l_self_modules_transformer_modules_layer_modules_1_modules_ffn_modules_lin2_parameters_weight_ = l_self_modules_transformer_modules_layer_modules_1_modules_ffn_modules_lin2_parameters_bias_ = (None)
+        x_7 = torch.nn.functional.dropout(x_6, 0.1, False, False)
+        x_6 = None
+        add_4 = x_7 + sa_output_1
+        x_7 = sa_output_1 = None
+        ffn_output_1 = torch.nn.functional.layer_norm(
+            add_4,
+            (768,),
+            l_self_modules_transformer_modules_layer_modules_1_modules_output_layer_norm_parameters_weight_,
+            l_self_modules_transformer_modules_layer_modules_1_modules_output_layer_norm_parameters_bias_,
+            1e-12,
+        )
+        add_4 = l_self_modules_transformer_modules_layer_modules_1_modules_output_layer_norm_parameters_weight_ = l_self_modules_transformer_modules_layer_modules_1_modules_output_layer_norm_parameters_bias_ = (None)
+        linear_12 = torch._C._nn.linear(
+            ffn_output_1,
+            l_self_modules_transformer_modules_layer_modules_2_modules_attention_modules_q_lin_parameters_weight_,
+            l_self_modules_transformer_modules_layer_modules_2_modules_attention_modules_q_lin_parameters_bias_,
+        )
+        l_self_modules_transformer_modules_layer_modules_2_modules_attention_modules_q_lin_parameters_weight_ = l_self_modules_transformer_modules_layer_modules_2_modules_attention_modules_q_lin_parameters_bias_ = (None)
+        view_8 = linear_12.view(1, -1, 12, 64)
+        linear_12 = None
+        q_2 = view_8.transpose(1, 2)
+        view_8 = None
+        linear_13 = torch._C._nn.linear(
+            ffn_output_1,
+            l_self_modules_transformer_modules_layer_modules_2_modules_attention_modules_k_lin_parameters_weight_,
+            l_self_modules_transformer_modules_layer_modules_2_modules_attention_modules_k_lin_parameters_bias_,
+        )
+        l_self_modules_transformer_modules_layer_modules_2_modules_attention_modules_k_lin_parameters_weight_ = l_self_modules_transformer_modules_layer_modules_2_modules_attention_modules_k_lin_parameters_bias_ = (None)
+        view_9 = linear_13.view(1, -1, 12, 64)
+        linear_13 = None
+        k_2 = view_9.transpose(1, 2)
+        view_9 = None
+        linear_14 = torch._C._nn.linear(
+            ffn_output_1,
+            l_self_modules_transformer_modules_layer_modules_2_modules_attention_modules_v_lin_parameters_weight_,
+            l_self_modules_transformer_modules_layer_modules_2_modules_attention_modules_v_lin_parameters_bias_,
+        )
+        l_self_modules_transformer_modules_layer_modules_2_modules_attention_modules_v_lin_parameters_weight_ = l_self_modules_transformer_modules_layer_modules_2_modules_attention_modules_v_lin_parameters_bias_ = (None)
+        view_10 = linear_14.view(1, -1, 12, 64)
+        linear_14 = None
+        v_2 = view_10.transpose(1, 2)
+        view_10 = None
+        attn_output_6 = torch._C._nn.scaled_dot_product_attention(
+            q_2, k_2, v_2, attn_mask=attention_mask, dropout_p=0.0, is_causal=False
+        )
+        q_2 = k_2 = v_2 = None
+        transpose_11 = attn_output_6.transpose(1, 2)
+        attn_output_6 = None
+        contiguous_2 = transpose_11.contiguous()
+        transpose_11 = None
+        attn_output_7 = contiguous_2.view(1, -1, 768)
+        contiguous_2 = None
+        attn_output_8 = torch._C._nn.linear(
+            attn_output_7,
+            l_self_modules_transformer_modules_layer_modules_2_modules_attention_modules_out_lin_parameters_weight_,
+            l_self_modules_transformer_modules_layer_modules_2_modules_attention_modules_out_lin_parameters_bias_,
+        )
+        attn_output_7 = l_self_modules_transformer_modules_layer_modules_2_modules_attention_modules_out_lin_parameters_weight_ = l_self_modules_transformer_modules_layer_modules_2_modules_attention_modules_out_lin_parameters_bias_ = (None)
+        add_5 = attn_output_8 + ffn_output_1
+        attn_output_8 = ffn_output_1 = None
+        sa_output_2 = torch.nn.functional.layer_norm(
+            add_5,
+            (768,),
+            l_self_modules_transformer_modules_layer_modules_2_modules_sa_layer_norm_parameters_weight_,
+            l_self_modules_transformer_modules_layer_modules_2_modules_sa_layer_norm_parameters_bias_,
+            1e-12,
+        )
+        add_5 = l_self_modules_transformer_modules_layer_modules_2_modules_sa_layer_norm_parameters_weight_ = l_self_modules_transformer_modules_layer_modules_2_modules_sa_layer_norm_parameters_bias_ = (None)
+        x_8 = torch._C._nn.linear(
+            sa_output_2,
+            l_self_modules_transformer_modules_layer_modules_2_modules_ffn_modules_lin1_parameters_weight_,
+            l_self_modules_transformer_modules_layer_modules_2_modules_ffn_modules_lin1_parameters_bias_,
+        )
+        l_self_modules_transformer_modules_layer_modules_2_modules_ffn_modules_lin1_parameters_weight_ = l_self_modules_transformer_modules_layer_modules_2_modules_ffn_modules_lin1_parameters_bias_ = (None)
+        x_9 = torch._C._nn.gelu(x_8)
+        x_8 = None
+        x_10 = torch._C._nn.linear(
+            x_9,
+            l_self_modules_transformer_modules_layer_modules_2_modules_ffn_modules_lin2_parameters_weight_,
+            l_self_modules_transformer_modules_layer_modules_2_modules_ffn_modules_lin2_parameters_bias_,
+        )
+        x_9 = l_self_modules_transformer_modules_layer_modules_2_modules_ffn_modules_lin2_parameters_weight_ = l_self_modules_transformer_modules_layer_modules_2_modules_ffn_modules_lin2_parameters_bias_ = (None)
+        x_11 = torch.nn.functional.dropout(x_10, 0.1, False, False)
+        x_10 = None
+        add_6 = x_11 + sa_output_2
+        x_11 = sa_output_2 = None
+        ffn_output_2 = torch.nn.functional.layer_norm(
+            add_6,
+            (768,),
+            l_self_modules_transformer_modules_layer_modules_2_modules_output_layer_norm_parameters_weight_,
+            l_self_modules_transformer_modules_layer_modules_2_modules_output_layer_norm_parameters_bias_,
+            1e-12,
+        )
+        add_6 = l_self_modules_transformer_modules_layer_modules_2_modules_output_layer_norm_parameters_weight_ = l_self_modules_transformer_modules_layer_modules_2_modules_output_layer_norm_parameters_bias_ = (None)
+        linear_18 = torch._C._nn.linear(
+            ffn_output_2,
+            l_self_modules_transformer_modules_layer_modules_3_modules_attention_modules_q_lin_parameters_weight_,
+            l_self_modules_transformer_modules_layer_modules_3_modules_attention_modules_q_lin_parameters_bias_,
+        )
+        l_self_modules_transformer_modules_layer_modules_3_modules_attention_modules_q_lin_parameters_weight_ = l_self_modules_transformer_modules_layer_modules_3_modules_attention_modules_q_lin_parameters_bias_ = (None)
+        view_12 = linear_18.view(1, -1, 12, 64)
+        linear_18 = None
+        q_3 = view_12.transpose(1, 2)
+        view_12 = None
+        linear_19 = torch._C._nn.linear(
+            ffn_output_2,
+            l_self_modules_transformer_modules_layer_modules_3_modules_attention_modules_k_lin_parameters_weight_,
+            l_self_modules_transformer_modules_layer_modules_3_modules_attention_modules_k_lin_parameters_bias_,
+        )
+        l_self_modules_transformer_modules_layer_modules_3_modules_attention_modules_k_lin_parameters_weight_ = l_self_modules_transformer_modules_layer_modules_3_modules_attention_modules_k_lin_parameters_bias_ = (None)
+        view_13 = linear_19.view(1, -1, 12, 64)
+        linear_19 = None
+        k_3 = view_13.transpose(1, 2)
+        view_13 = None
+        linear_20 = torch._C._nn.linear(
+            ffn_output_2,
+            l_self_modules_transformer_modules_layer_modules_3_modules_attention_modules_v_lin_parameters_weight_,
+            l_self_modules_transformer_modules_layer_modules_3_modules_attention_modules_v_lin_parameters_bias_,
+        )
+        l_self_modules_transformer_modules_layer_modules_3_modules_attention_modules_v_lin_parameters_weight_ = l_self_modules_transformer_modules_layer_modules_3_modules_attention_modules_v_lin_parameters_bias_ = (None)
+        view_14 = linear_20.view(1, -1, 12, 64)
+        linear_20 = None
+        v_3 = view_14.transpose(1, 2)
+        view_14 = None
+        attn_output_9 = torch._C._nn.scaled_dot_product_attention(
+            q_3, k_3, v_3, attn_mask=attention_mask, dropout_p=0.0, is_causal=False
+        )
+        q_3 = k_3 = v_3 = None
+        transpose_15 = attn_output_9.transpose(1, 2)
+        attn_output_9 = None
+        contiguous_3 = transpose_15.contiguous()
+        transpose_15 = None
+        attn_output_10 = contiguous_3.view(1, -1, 768)
+        contiguous_3 = None
+        attn_output_11 = torch._C._nn.linear(
+            attn_output_10,
+            l_self_modules_transformer_modules_layer_modules_3_modules_attention_modules_out_lin_parameters_weight_,
+            l_self_modules_transformer_modules_layer_modules_3_modules_attention_modules_out_lin_parameters_bias_,
+        )
+        attn_output_10 = l_self_modules_transformer_modules_layer_modules_3_modules_attention_modules_out_lin_parameters_weight_ = l_self_modules_transformer_modules_layer_modules_3_modules_attention_modules_out_lin_parameters_bias_ = (None)
+        add_7 = attn_output_11 + ffn_output_2
+        attn_output_11 = ffn_output_2 = None
+        sa_output_3 = torch.nn.functional.layer_norm(
+            add_7,
+            (768,),
+            l_self_modules_transformer_modules_layer_modules_3_modules_sa_layer_norm_parameters_weight_,
+            l_self_modules_transformer_modules_layer_modules_3_modules_sa_layer_norm_parameters_bias_,
+            1e-12,
+        )
+        add_7 = l_self_modules_transformer_modules_layer_modules_3_modules_sa_layer_norm_parameters_weight_ = l_self_modules_transformer_modules_layer_modules_3_modules_sa_layer_norm_parameters_bias_ = (None)
+        x_12 = torch._C._nn.linear(
+            sa_output_3,
+            l_self_modules_transformer_modules_layer_modules_3_modules_ffn_modules_lin1_parameters_weight_,
+            l_self_modules_transformer_modules_layer_modules_3_modules_ffn_modules_lin1_parameters_bias_,
+        )
+        l_self_modules_transformer_modules_layer_modules_3_modules_ffn_modules_lin1_parameters_weight_ = l_self_modules_transformer_modules_layer_modules_3_modules_ffn_modules_lin1_parameters_bias_ = (None)
+        x_13 = torch._C._nn.gelu(x_12)
+        x_12 = None
+        x_14 = torch._C._nn.linear(
+            x_13,
+            l_self_modules_transformer_modules_layer_modules_3_modules_ffn_modules_lin2_parameters_weight_,
+            l_self_modules_transformer_modules_layer_modules_3_modules_ffn_modules_lin2_parameters_bias_,
+        )
+        x_13 = l_self_modules_transformer_modules_layer_modules_3_modules_ffn_modules_lin2_parameters_weight_ = l_self_modules_transformer_modules_layer_modules_3_modules_ffn_modules_lin2_parameters_bias_ = (None)
+        x_15 = torch.nn.functional.dropout(x_14, 0.1, False, False)
+        x_14 = None
+        add_8 = x_15 + sa_output_3
+        x_15 = sa_output_3 = None
+        ffn_output_3 = torch.nn.functional.layer_norm(
+            add_8,
+            (768,),
+            l_self_modules_transformer_modules_layer_modules_3_modules_output_layer_norm_parameters_weight_,
+            l_self_modules_transformer_modules_layer_modules_3_modules_output_layer_norm_parameters_bias_,
+            1e-12,
+        )
+        add_8 = l_self_modules_transformer_modules_layer_modules_3_modules_output_layer_norm_parameters_weight_ = l_self_modules_transformer_modules_layer_modules_3_modules_output_layer_norm_parameters_bias_ = (None)
+        linear_24 = torch._C._nn.linear(
+            ffn_output_3,
+            l_self_modules_transformer_modules_layer_modules_4_modules_attention_modules_q_lin_parameters_weight_,
+            l_self_modules_transformer_modules_layer_modules_4_modules_attention_modules_q_lin_parameters_bias_,
+        )
+        l_self_modules_transformer_modules_layer_modules_4_modules_attention_modules_q_lin_parameters_weight_ = l_self_modules_transformer_modules_layer_modules_4_modules_attention_modules_q_lin_parameters_bias_ = (None)
+        view_16 = linear_24.view(1, -1, 12, 64)
+        linear_24 = None
+        q_4 = view_16.transpose(1, 2)
+        view_16 = None
+        linear_25 = torch._C._nn.linear(
+            ffn_output_3,
+            l_self_modules_transformer_modules_layer_modules_4_modules_attention_modules_k_lin_parameters_weight_,
+            l_self_modules_transformer_modules_layer_modules_4_modules_attention_modules_k_lin_parameters_bias_,
+        )
+        l_self_modules_transformer_modules_layer_modules_4_modules_attention_modules_k_lin_parameters_weight_ = l_self_modules_transformer_modules_layer_modules_4_modules_attention_modules_k_lin_parameters_bias_ = (None)
+        view_17 = linear_25.view(1, -1, 12, 64)
+        linear_25 = None
+        k_4 = view_17.transpose(1, 2)
+        view_17 = None
+        linear_26 = torch._C._nn.linear(
+            ffn_output_3,
+            l_self_modules_transformer_modules_layer_modules_4_modules_attention_modules_v_lin_parameters_weight_,
+            l_self_modules_transformer_modules_layer_modules_4_modules_attention_modules_v_lin_parameters_bias_,
+        )
+        l_self_modules_transformer_modules_layer_modules_4_modules_attention_modules_v_lin_parameters_weight_ = l_self_modules_transformer_modules_layer_modules_4_modules_attention_modules_v_lin_parameters_bias_ = (None)
+        view_18 = linear_26.view(1, -1, 12, 64)
+        linear_26 = None
+        v_4 = view_18.transpose(1, 2)
+        view_18 = None
+        attn_output_12 = torch._C._nn.scaled_dot_product_attention(
+            q_4, k_4, v_4, attn_mask=attention_mask, dropout_p=0.0, is_causal=False
+        )
+        q_4 = k_4 = v_4 = None
+        transpose_19 = attn_output_12.transpose(1, 2)
+        attn_output_12 = None
+        contiguous_4 = transpose_19.contiguous()
+        transpose_19 = None
+        attn_output_13 = contiguous_4.view(1, -1, 768)
+        contiguous_4 = None
+        attn_output_14 = torch._C._nn.linear(
+            attn_output_13,
+            l_self_modules_transformer_modules_layer_modules_4_modules_attention_modules_out_lin_parameters_weight_,
+            l_self_modules_transformer_modules_layer_modules_4_modules_attention_modules_out_lin_parameters_bias_,
+        )
+        attn_output_13 = l_self_modules_transformer_modules_layer_modules_4_modules_attention_modules_out_lin_parameters_weight_ = l_self_modules_transformer_modules_layer_modules_4_modules_attention_modules_out_lin_parameters_bias_ = (None)
+        add_9 = attn_output_14 + ffn_output_3
+        attn_output_14 = ffn_output_3 = None
+        sa_output_4 = torch.nn.functional.layer_norm(
+            add_9,
+            (768,),
+            l_self_modules_transformer_modules_layer_modules_4_modules_sa_layer_norm_parameters_weight_,
+            l_self_modules_transformer_modules_layer_modules_4_modules_sa_layer_norm_parameters_bias_,
+            1e-12,
+        )
+        add_9 = l_self_modules_transformer_modules_layer_modules_4_modules_sa_layer_norm_parameters_weight_ = l_self_modules_transformer_modules_layer_modules_4_modules_sa_layer_norm_parameters_bias_ = (None)
+        x_16 = torch._C._nn.linear(
+            sa_output_4,
+            l_self_modules_transformer_modules_layer_modules_4_modules_ffn_modules_lin1_parameters_weight_,
+            l_self_modules_transformer_modules_layer_modules_4_modules_ffn_modules_lin1_parameters_bias_,
+        )
+        l_self_modules_transformer_modules_layer_modules_4_modules_ffn_modules_lin1_parameters_weight_ = l_self_modules_transformer_modules_layer_modules_4_modules_ffn_modules_lin1_parameters_bias_ = (None)
+        x_17 = torch._C._nn.gelu(x_16)
+        x_16 = None
+        x_18 = torch._C._nn.linear(
+            x_17,
+            l_self_modules_transformer_modules_layer_modules_4_modules_ffn_modules_lin2_parameters_weight_,
+            l_self_modules_transformer_modules_layer_modules_4_modules_ffn_modules_lin2_parameters_bias_,
+        )
+        x_17 = l_self_modules_transformer_modules_layer_modules_4_modules_ffn_modules_lin2_parameters_weight_ = l_self_modules_transformer_modules_layer_modules_4_modules_ffn_modules_lin2_parameters_bias_ = (None)
+        x_19 = torch.nn.functional.dropout(x_18, 0.1, False, False)
+        x_18 = None
+        add_10 = x_19 + sa_output_4
+        x_19 = sa_output_4 = None
+        ffn_output_4 = torch.nn.functional.layer_norm(
+            add_10,
+            (768,),
+            l_self_modules_transformer_modules_layer_modules_4_modules_output_layer_norm_parameters_weight_,
+            l_self_modules_transformer_modules_layer_modules_4_modules_output_layer_norm_parameters_bias_,
+            1e-12,
+        )
+        add_10 = l_self_modules_transformer_modules_layer_modules_4_modules_output_layer_norm_parameters_weight_ = l_self_modules_transformer_modules_layer_modules_4_modules_output_layer_norm_parameters_bias_ = (None)
+        linear_30 = torch._C._nn.linear(
+            ffn_output_4,
+            l_self_modules_transformer_modules_layer_modules_5_modules_attention_modules_q_lin_parameters_weight_,
+            l_self_modules_transformer_modules_layer_modules_5_modules_attention_modules_q_lin_parameters_bias_,
+        )
+        l_self_modules_transformer_modules_layer_modules_5_modules_attention_modules_q_lin_parameters_weight_ = l_self_modules_transformer_modules_layer_modules_5_modules_attention_modules_q_lin_parameters_bias_ = (None)
+        view_20 = linear_30.view(1, -1, 12, 64)
+        linear_30 = None
+        q_5 = view_20.transpose(1, 2)
+        view_20 = None
+        linear_31 = torch._C._nn.linear(
+            ffn_output_4,
+            l_self_modules_transformer_modules_layer_modules_5_modules_attention_modules_k_lin_parameters_weight_,
+            l_self_modules_transformer_modules_layer_modules_5_modules_attention_modules_k_lin_parameters_bias_,
+        )
+        l_self_modules_transformer_modules_layer_modules_5_modules_attention_modules_k_lin_parameters_weight_ = l_self_modules_transformer_modules_layer_modules_5_modules_attention_modules_k_lin_parameters_bias_ = (None)
+        view_21 = linear_31.view(1, -1, 12, 64)
+        linear_31 = None
+        k_5 = view_21.transpose(1, 2)
+        view_21 = None
+        linear_32 = torch._C._nn.linear(
+            ffn_output_4,
+            l_self_modules_transformer_modules_layer_modules_5_modules_attention_modules_v_lin_parameters_weight_,
+            l_self_modules_transformer_modules_layer_modules_5_modules_attention_modules_v_lin_parameters_bias_,
+        )
+        l_self_modules_transformer_modules_layer_modules_5_modules_attention_modules_v_lin_parameters_weight_ = l_self_modules_transformer_modules_layer_modules_5_modules_attention_modules_v_lin_parameters_bias_ = (None)
+        view_22 = linear_32.view(1, -1, 12, 64)
+        linear_32 = None
+        v_5 = view_22.transpose(1, 2)
+        view_22 = None
+        attn_output_15 = torch._C._nn.scaled_dot_product_attention(
+            q_5, k_5, v_5, attn_mask=attention_mask, dropout_p=0.0, is_causal=False
+        )
+        q_5 = k_5 = v_5 = attention_mask = None
+        transpose_23 = attn_output_15.transpose(1, 2)
+        attn_output_15 = None
+        contiguous_5 = transpose_23.contiguous()
+        transpose_23 = None
+        attn_output_16 = contiguous_5.view(1, -1, 768)
+        contiguous_5 = None
+        attn_output_17 = torch._C._nn.linear(
+            attn_output_16,
+            l_self_modules_transformer_modules_layer_modules_5_modules_attention_modules_out_lin_parameters_weight_,
+            l_self_modules_transformer_modules_layer_modules_5_modules_attention_modules_out_lin_parameters_bias_,
+        )
+        attn_output_16 = l_self_modules_transformer_modules_layer_modules_5_modules_attention_modules_out_lin_parameters_weight_ = l_self_modules_transformer_modules_layer_modules_5_modules_attention_modules_out_lin_parameters_bias_ = (None)
+        add_11 = attn_output_17 + ffn_output_4
+        attn_output_17 = ffn_output_4 = None
+        sa_output_5 = torch.nn.functional.layer_norm(
+            add_11,
+            (768,),
+            l_self_modules_transformer_modules_layer_modules_5_modules_sa_layer_norm_parameters_weight_,
+            l_self_modules_transformer_modules_layer_modules_5_modules_sa_layer_norm_parameters_bias_,
+            1e-12,
+        )
+        add_11 = l_self_modules_transformer_modules_layer_modules_5_modules_sa_layer_norm_parameters_weight_ = l_self_modules_transformer_modules_layer_modules_5_modules_sa_layer_norm_parameters_bias_ = (None)
+        x_20 = torch._C._nn.linear(
+            sa_output_5,
+            l_self_modules_transformer_modules_layer_modules_5_modules_ffn_modules_lin1_parameters_weight_,
+            l_self_modules_transformer_modules_layer_modules_5_modules_ffn_modules_lin1_parameters_bias_,
+        )
+        l_self_modules_transformer_modules_layer_modules_5_modules_ffn_modules_lin1_parameters_weight_ = l_self_modules_transformer_modules_layer_modules_5_modules_ffn_modules_lin1_parameters_bias_ = (None)
+        x_21 = torch._C._nn.gelu(x_20)
+        x_20 = None
+        x_22 = torch._C._nn.linear(
+            x_21,
+            l_self_modules_transformer_modules_layer_modules_5_modules_ffn_modules_lin2_parameters_weight_,
+            l_self_modules_transformer_modules_layer_modules_5_modules_ffn_modules_lin2_parameters_bias_,
+        )
+        x_21 = l_self_modules_transformer_modules_layer_modules_5_modules_ffn_modules_lin2_parameters_weight_ = l_self_modules_transformer_modules_layer_modules_5_modules_ffn_modules_lin2_parameters_bias_ = (None)
+        x_23 = torch.nn.functional.dropout(x_22, 0.1, False, False)
+        x_22 = None
+        add_12 = x_23 + sa_output_5
+        x_23 = sa_output_5 = None
+        ffn_output_5 = torch.nn.functional.layer_norm(
+            add_12,
+            (768,),
+            l_self_modules_transformer_modules_layer_modules_5_modules_output_layer_norm_parameters_weight_,
+            l_self_modules_transformer_modules_layer_modules_5_modules_output_layer_norm_parameters_bias_,
+            1e-12,
+        )
+        add_12 = l_self_modules_transformer_modules_layer_modules_5_modules_output_layer_norm_parameters_weight_ = l_self_modules_transformer_modules_layer_modules_5_modules_output_layer_norm_parameters_bias_ = (None)
         return (ffn_output_5,)
-        

--- a/samples/transformers-auto-model/distilbert-base-uncased/weight_meta.py
+++ b/samples/transformers-auto-model/distilbert-base-uncased/weight_meta.py
@@ -1,944 +1,1561 @@
 class Program_weight_tensor_meta_s0:
-	name = "s0"
-	shape = []
-	dtype = "torch.int64"
-	device = "cpu"
-	mean = None
-	std = None
-	data = [4]
+    name = "s0"
+    shape = []
+    dtype = "torch.int64"
+    device = "cpu"
+    mean = None
+    std = None
+    data = [4]
+
 
 class Program_weight_tensor_meta_L_input_ids_:
-	name = "L_input_ids_"
-	shape = [1, 4]
-	dtype = "torch.int64"
-	device = "cuda:0"
-	mean = None
-	std = None
-	data = [101, 7592, 2088, 102]
+    name = "L_input_ids_"
+    shape = [1, 4]
+    dtype = "torch.int64"
+    device = "cuda:0"
+    mean = None
+    std = None
+    data = [101, 7592, 2088, 102]
+
 
 class Program_weight_tensor_meta_L_self_config_num_hidden_layers:
-	name = "L_self_config_num_hidden_layers"
-	shape = []
-	dtype = "torch.int64"
-	device = "cpu"
-	mean = None
-	std = None
-	data = [4]
+    name = "L_self_config_num_hidden_layers"
+    shape = []
+    dtype = "torch.int64"
+    device = "cpu"
+    mean = None
+    std = None
+    data = [4]
+
 
 class Program_weight_tensor_meta_L_self_modules_embeddings_modules_word_embeddings_parameters_weight_:
-	name = "L_self_modules_embeddings_modules_word_embeddings_parameters_weight_"
-	shape = [30522, 768]
-	dtype = "torch.float32"
-	device = "cuda:0"
-	mean = -0.038
-	std = 0.047
-	data = None
+    name = "L_self_modules_embeddings_modules_word_embeddings_parameters_weight_"
+    shape = [30522, 768]
+    dtype = "torch.float32"
+    device = "cuda:0"
+    mean = -0.038
+    std = 0.047
+    data = None
+
 
 class Program_weight_tensor_meta_L_self_modules_embeddings_buffers_position_ids_:
-	name = "L_self_modules_embeddings_buffers_position_ids_"
-	shape = [1, 512]
-	dtype = "torch.int64"
-	device = "cuda:0"
-	mean = None
-	std = None
-	data = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148, 149, 150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160, 161, 162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175, 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191, 192, 193, 194, 195, 196, 197, 198, 199, 200, 201, 202, 203, 204, 205, 206, 207, 208, 209, 210, 211, 212, 213, 214, 215, 216, 217, 218, 219, 220, 221, 222, 223, 224, 225, 226, 227, 228, 229, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239, 240, 241, 242, 243, 244, 245, 246, 247, 248, 249, 250, 251, 252, 253, 254, 255, 256, 257, 258, 259, 260, 261, 262, 263, 264, 265, 266, 267, 268, 269, 270, 271, 272, 273, 274, 275, 276, 277, 278, 279, 280, 281, 282, 283, 284, 285, 286, 287, 288, 289, 290, 291, 292, 293, 294, 295, 296, 297, 298, 299, 300, 301, 302, 303, 304, 305, 306, 307, 308, 309, 310, 311, 312, 313, 314, 315, 316, 317, 318, 319, 320, 321, 322, 323, 324, 325, 326, 327, 328, 329, 330, 331, 332, 333, 334, 335, 336, 337, 338, 339, 340, 341, 342, 343, 344, 345, 346, 347, 348, 349, 350, 351, 352, 353, 354, 355, 356, 357, 358, 359, 360, 361, 362, 363, 364, 365, 366, 367, 368, 369, 370, 371, 372, 373, 374, 375, 376, 377, 378, 379, 380, 381, 382, 383, 384, 385, 386, 387, 388, 389, 390, 391, 392, 393, 394, 395, 396, 397, 398, 399, 400, 401, 402, 403, 404, 405, 406, 407, 408, 409, 410, 411, 412, 413, 414, 415, 416, 417, 418, 419, 420, 421, 422, 423, 424, 425, 426, 427, 428, 429, 430, 431, 432, 433, 434, 435, 436, 437, 438, 439, 440, 441, 442, 443, 444, 445, 446, 447, 448, 449, 450, 451, 452, 453, 454, 455, 456, 457, 458, 459, 460, 461, 462, 463, 464, 465, 466, 467, 468, 469, 470, 471, 472, 473, 474, 475, 476, 477, 478, 479, 480, 481, 482, 483, 484, 485, 486, 487, 488, 489, 490, 491, 492, 493, 494, 495, 496, 497, 498, 499, 500, 501, 502, 503, 504, 505, 506, 507, 508, 509, 510, 511]
+    name = "L_self_modules_embeddings_buffers_position_ids_"
+    shape = [1, 512]
+    dtype = "torch.int64"
+    device = "cuda:0"
+    mean = None
+    std = None
+    data = [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15,
+        16,
+        17,
+        18,
+        19,
+        20,
+        21,
+        22,
+        23,
+        24,
+        25,
+        26,
+        27,
+        28,
+        29,
+        30,
+        31,
+        32,
+        33,
+        34,
+        35,
+        36,
+        37,
+        38,
+        39,
+        40,
+        41,
+        42,
+        43,
+        44,
+        45,
+        46,
+        47,
+        48,
+        49,
+        50,
+        51,
+        52,
+        53,
+        54,
+        55,
+        56,
+        57,
+        58,
+        59,
+        60,
+        61,
+        62,
+        63,
+        64,
+        65,
+        66,
+        67,
+        68,
+        69,
+        70,
+        71,
+        72,
+        73,
+        74,
+        75,
+        76,
+        77,
+        78,
+        79,
+        80,
+        81,
+        82,
+        83,
+        84,
+        85,
+        86,
+        87,
+        88,
+        89,
+        90,
+        91,
+        92,
+        93,
+        94,
+        95,
+        96,
+        97,
+        98,
+        99,
+        100,
+        101,
+        102,
+        103,
+        104,
+        105,
+        106,
+        107,
+        108,
+        109,
+        110,
+        111,
+        112,
+        113,
+        114,
+        115,
+        116,
+        117,
+        118,
+        119,
+        120,
+        121,
+        122,
+        123,
+        124,
+        125,
+        126,
+        127,
+        128,
+        129,
+        130,
+        131,
+        132,
+        133,
+        134,
+        135,
+        136,
+        137,
+        138,
+        139,
+        140,
+        141,
+        142,
+        143,
+        144,
+        145,
+        146,
+        147,
+        148,
+        149,
+        150,
+        151,
+        152,
+        153,
+        154,
+        155,
+        156,
+        157,
+        158,
+        159,
+        160,
+        161,
+        162,
+        163,
+        164,
+        165,
+        166,
+        167,
+        168,
+        169,
+        170,
+        171,
+        172,
+        173,
+        174,
+        175,
+        176,
+        177,
+        178,
+        179,
+        180,
+        181,
+        182,
+        183,
+        184,
+        185,
+        186,
+        187,
+        188,
+        189,
+        190,
+        191,
+        192,
+        193,
+        194,
+        195,
+        196,
+        197,
+        198,
+        199,
+        200,
+        201,
+        202,
+        203,
+        204,
+        205,
+        206,
+        207,
+        208,
+        209,
+        210,
+        211,
+        212,
+        213,
+        214,
+        215,
+        216,
+        217,
+        218,
+        219,
+        220,
+        221,
+        222,
+        223,
+        224,
+        225,
+        226,
+        227,
+        228,
+        229,
+        230,
+        231,
+        232,
+        233,
+        234,
+        235,
+        236,
+        237,
+        238,
+        239,
+        240,
+        241,
+        242,
+        243,
+        244,
+        245,
+        246,
+        247,
+        248,
+        249,
+        250,
+        251,
+        252,
+        253,
+        254,
+        255,
+        256,
+        257,
+        258,
+        259,
+        260,
+        261,
+        262,
+        263,
+        264,
+        265,
+        266,
+        267,
+        268,
+        269,
+        270,
+        271,
+        272,
+        273,
+        274,
+        275,
+        276,
+        277,
+        278,
+        279,
+        280,
+        281,
+        282,
+        283,
+        284,
+        285,
+        286,
+        287,
+        288,
+        289,
+        290,
+        291,
+        292,
+        293,
+        294,
+        295,
+        296,
+        297,
+        298,
+        299,
+        300,
+        301,
+        302,
+        303,
+        304,
+        305,
+        306,
+        307,
+        308,
+        309,
+        310,
+        311,
+        312,
+        313,
+        314,
+        315,
+        316,
+        317,
+        318,
+        319,
+        320,
+        321,
+        322,
+        323,
+        324,
+        325,
+        326,
+        327,
+        328,
+        329,
+        330,
+        331,
+        332,
+        333,
+        334,
+        335,
+        336,
+        337,
+        338,
+        339,
+        340,
+        341,
+        342,
+        343,
+        344,
+        345,
+        346,
+        347,
+        348,
+        349,
+        350,
+        351,
+        352,
+        353,
+        354,
+        355,
+        356,
+        357,
+        358,
+        359,
+        360,
+        361,
+        362,
+        363,
+        364,
+        365,
+        366,
+        367,
+        368,
+        369,
+        370,
+        371,
+        372,
+        373,
+        374,
+        375,
+        376,
+        377,
+        378,
+        379,
+        380,
+        381,
+        382,
+        383,
+        384,
+        385,
+        386,
+        387,
+        388,
+        389,
+        390,
+        391,
+        392,
+        393,
+        394,
+        395,
+        396,
+        397,
+        398,
+        399,
+        400,
+        401,
+        402,
+        403,
+        404,
+        405,
+        406,
+        407,
+        408,
+        409,
+        410,
+        411,
+        412,
+        413,
+        414,
+        415,
+        416,
+        417,
+        418,
+        419,
+        420,
+        421,
+        422,
+        423,
+        424,
+        425,
+        426,
+        427,
+        428,
+        429,
+        430,
+        431,
+        432,
+        433,
+        434,
+        435,
+        436,
+        437,
+        438,
+        439,
+        440,
+        441,
+        442,
+        443,
+        444,
+        445,
+        446,
+        447,
+        448,
+        449,
+        450,
+        451,
+        452,
+        453,
+        454,
+        455,
+        456,
+        457,
+        458,
+        459,
+        460,
+        461,
+        462,
+        463,
+        464,
+        465,
+        466,
+        467,
+        468,
+        469,
+        470,
+        471,
+        472,
+        473,
+        474,
+        475,
+        476,
+        477,
+        478,
+        479,
+        480,
+        481,
+        482,
+        483,
+        484,
+        485,
+        486,
+        487,
+        488,
+        489,
+        490,
+        491,
+        492,
+        493,
+        494,
+        495,
+        496,
+        497,
+        498,
+        499,
+        500,
+        501,
+        502,
+        503,
+        504,
+        505,
+        506,
+        507,
+        508,
+        509,
+        510,
+        511,
+    ]
+
 
 class Program_weight_tensor_meta_L_self_modules_embeddings_modules_position_embeddings_parameters_weight_:
-	name = "L_self_modules_embeddings_modules_position_embeddings_parameters_weight_"
-	shape = [512, 768]
-	dtype = "torch.float32"
-	device = "cuda:0"
-	mean = -0.000
-	std = 0.016
-	data = None
+    name = "L_self_modules_embeddings_modules_position_embeddings_parameters_weight_"
+    shape = [512, 768]
+    dtype = "torch.float32"
+    device = "cuda:0"
+    mean = -0.000
+    std = 0.016
+    data = None
+
 
 class Program_weight_tensor_meta_L_self_modules_embeddings_modules_LayerNorm_parameters_weight_:
-	name = "L_self_modules_embeddings_modules_LayerNorm_parameters_weight_"
-	shape = [768]
-	dtype = "torch.float32"
-	device = "cuda:0"
-	mean = 0.744
-	std = 0.136
-	data = None
+    name = "L_self_modules_embeddings_modules_LayerNorm_parameters_weight_"
+    shape = [768]
+    dtype = "torch.float32"
+    device = "cuda:0"
+    mean = 0.744
+    std = 0.136
+    data = None
+
 
 class Program_weight_tensor_meta_L_self_modules_embeddings_modules_LayerNorm_parameters_bias_:
-	name = "L_self_modules_embeddings_modules_LayerNorm_parameters_bias_"
-	shape = [768]
-	dtype = "torch.float32"
-	device = "cuda:0"
-	mean = -0.010
-	std = 0.091
-	data = None
+    name = "L_self_modules_embeddings_modules_LayerNorm_parameters_bias_"
+    shape = [768]
+    dtype = "torch.float32"
+    device = "cuda:0"
+    mean = -0.010
+    std = 0.091
+    data = None
+
 
 class Program_weight_tensor_meta_L_attention_mask_:
-	name = "L_attention_mask_"
-	shape = [1, 4]
-	dtype = "torch.int64"
-	device = "cuda:0"
-	mean = None
-	std = None
-	data = [1, 1, 1, 1]
+    name = "L_attention_mask_"
+    shape = [1, 4]
+    dtype = "torch.int64"
+    device = "cuda:0"
+    mean = None
+    std = None
+    data = [1, 1, 1, 1]
+
 
 class Program_weight_tensor_meta_L_self_modules_transformer_modules_layer_modules_0_modules_attention_modules_q_lin_parameters_weight_:
-	name = "L_self_modules_transformer_modules_layer_modules_0_modules_attention_modules_q_lin_parameters_weight_"
-	shape = [768, 768]
-	dtype = "torch.float32"
-	device = "cuda:0"
-	mean = 0.000
-	std = 0.043
-	data = None
+    name = "L_self_modules_transformer_modules_layer_modules_0_modules_attention_modules_q_lin_parameters_weight_"
+    shape = [768, 768]
+    dtype = "torch.float32"
+    device = "cuda:0"
+    mean = 0.000
+    std = 0.043
+    data = None
+
 
 class Program_weight_tensor_meta_L_self_modules_transformer_modules_layer_modules_0_modules_attention_modules_q_lin_parameters_bias_:
-	name = "L_self_modules_transformer_modules_layer_modules_0_modules_attention_modules_q_lin_parameters_bias_"
-	shape = [768]
-	dtype = "torch.float32"
-	device = "cuda:0"
-	mean = 0.009
-	std = 0.324
-	data = None
+    name = "L_self_modules_transformer_modules_layer_modules_0_modules_attention_modules_q_lin_parameters_bias_"
+    shape = [768]
+    dtype = "torch.float32"
+    device = "cuda:0"
+    mean = 0.009
+    std = 0.324
+    data = None
+
 
 class Program_weight_tensor_meta_L_self_modules_transformer_modules_layer_modules_0_modules_attention_modules_k_lin_parameters_weight_:
-	name = "L_self_modules_transformer_modules_layer_modules_0_modules_attention_modules_k_lin_parameters_weight_"
-	shape = [768, 768]
-	dtype = "torch.float32"
-	device = "cuda:0"
-	mean = 0.000
-	std = 0.043
-	data = None
+    name = "L_self_modules_transformer_modules_layer_modules_0_modules_attention_modules_k_lin_parameters_weight_"
+    shape = [768, 768]
+    dtype = "torch.float32"
+    device = "cuda:0"
+    mean = 0.000
+    std = 0.043
+    data = None
+
 
 class Program_weight_tensor_meta_L_self_modules_transformer_modules_layer_modules_0_modules_attention_modules_k_lin_parameters_bias_:
-	name = "L_self_modules_transformer_modules_layer_modules_0_modules_attention_modules_k_lin_parameters_bias_"
-	shape = [768]
-	dtype = "torch.float32"
-	device = "cuda:0"
-	mean = -0.000
-	std = 0.003
-	data = None
+    name = "L_self_modules_transformer_modules_layer_modules_0_modules_attention_modules_k_lin_parameters_bias_"
+    shape = [768]
+    dtype = "torch.float32"
+    device = "cuda:0"
+    mean = -0.000
+    std = 0.003
+    data = None
+
 
 class Program_weight_tensor_meta_L_self_modules_transformer_modules_layer_modules_0_modules_attention_modules_v_lin_parameters_weight_:
-	name = "L_self_modules_transformer_modules_layer_modules_0_modules_attention_modules_v_lin_parameters_weight_"
-	shape = [768, 768]
-	dtype = "torch.float32"
-	device = "cuda:0"
-	mean = -0.000
-	std = 0.034
-	data = None
+    name = "L_self_modules_transformer_modules_layer_modules_0_modules_attention_modules_v_lin_parameters_weight_"
+    shape = [768, 768]
+    dtype = "torch.float32"
+    device = "cuda:0"
+    mean = -0.000
+    std = 0.034
+    data = None
+
 
 class Program_weight_tensor_meta_L_self_modules_transformer_modules_layer_modules_0_modules_attention_modules_v_lin_parameters_bias_:
-	name = "L_self_modules_transformer_modules_layer_modules_0_modules_attention_modules_v_lin_parameters_bias_"
-	shape = [768]
-	dtype = "torch.float32"
-	device = "cuda:0"
-	mean = 0.005
-	std = 0.081
-	data = None
+    name = "L_self_modules_transformer_modules_layer_modules_0_modules_attention_modules_v_lin_parameters_bias_"
+    shape = [768]
+    dtype = "torch.float32"
+    device = "cuda:0"
+    mean = 0.005
+    std = 0.081
+    data = None
+
 
 class Program_weight_tensor_meta_L_self_modules_transformer_modules_layer_modules_0_modules_attention_modules_out_lin_parameters_weight_:
-	name = "L_self_modules_transformer_modules_layer_modules_0_modules_attention_modules_out_lin_parameters_weight_"
-	shape = [768, 768]
-	dtype = "torch.float32"
-	device = "cuda:0"
-	mean = -0.000
-	std = 0.035
-	data = None
+    name = "L_self_modules_transformer_modules_layer_modules_0_modules_attention_modules_out_lin_parameters_weight_"
+    shape = [768, 768]
+    dtype = "torch.float32"
+    device = "cuda:0"
+    mean = -0.000
+    std = 0.035
+    data = None
+
 
 class Program_weight_tensor_meta_L_self_modules_transformer_modules_layer_modules_0_modules_attention_modules_out_lin_parameters_bias_:
-	name = "L_self_modules_transformer_modules_layer_modules_0_modules_attention_modules_out_lin_parameters_bias_"
-	shape = [768]
-	dtype = "torch.float32"
-	device = "cuda:0"
-	mean = -0.001
-	std = 0.047
-	data = None
+    name = "L_self_modules_transformer_modules_layer_modules_0_modules_attention_modules_out_lin_parameters_bias_"
+    shape = [768]
+    dtype = "torch.float32"
+    device = "cuda:0"
+    mean = -0.001
+    std = 0.047
+    data = None
+
 
 class Program_weight_tensor_meta_L_self_modules_transformer_modules_layer_modules_0_modules_sa_layer_norm_parameters_weight_:
-	name = "L_self_modules_transformer_modules_layer_modules_0_modules_sa_layer_norm_parameters_weight_"
-	shape = [768]
-	dtype = "torch.float32"
-	device = "cuda:0"
-	mean = 0.841
-	std = 0.094
-	data = None
+    name = "L_self_modules_transformer_modules_layer_modules_0_modules_sa_layer_norm_parameters_weight_"
+    shape = [768]
+    dtype = "torch.float32"
+    device = "cuda:0"
+    mean = 0.841
+    std = 0.094
+    data = None
+
 
 class Program_weight_tensor_meta_L_self_modules_transformer_modules_layer_modules_0_modules_sa_layer_norm_parameters_bias_:
-	name = "L_self_modules_transformer_modules_layer_modules_0_modules_sa_layer_norm_parameters_bias_"
-	shape = [768]
-	dtype = "torch.float32"
-	device = "cuda:0"
-	mean = -0.021
-	std = 0.336
-	data = None
+    name = "L_self_modules_transformer_modules_layer_modules_0_modules_sa_layer_norm_parameters_bias_"
+    shape = [768]
+    dtype = "torch.float32"
+    device = "cuda:0"
+    mean = -0.021
+    std = 0.336
+    data = None
+
 
 class Program_weight_tensor_meta_L_self_modules_transformer_modules_layer_modules_0_modules_ffn_modules_lin1_parameters_weight_:
-	name = "L_self_modules_transformer_modules_layer_modules_0_modules_ffn_modules_lin1_parameters_weight_"
-	shape = [3072, 768]
-	dtype = "torch.float32"
-	device = "cuda:0"
-	mean = -0.000
-	std = 0.042
-	data = None
+    name = "L_self_modules_transformer_modules_layer_modules_0_modules_ffn_modules_lin1_parameters_weight_"
+    shape = [3072, 768]
+    dtype = "torch.float32"
+    device = "cuda:0"
+    mean = -0.000
+    std = 0.042
+    data = None
+
 
 class Program_weight_tensor_meta_L_self_modules_transformer_modules_layer_modules_0_modules_ffn_modules_lin1_parameters_bias_:
-	name = "L_self_modules_transformer_modules_layer_modules_0_modules_ffn_modules_lin1_parameters_bias_"
-	shape = [3072]
-	dtype = "torch.float32"
-	device = "cuda:0"
-	mean = -0.112
-	std = 0.056
-	data = None
+    name = "L_self_modules_transformer_modules_layer_modules_0_modules_ffn_modules_lin1_parameters_bias_"
+    shape = [3072]
+    dtype = "torch.float32"
+    device = "cuda:0"
+    mean = -0.112
+    std = 0.056
+    data = None
+
 
 class Program_weight_tensor_meta_L_self_modules_transformer_modules_layer_modules_0_modules_ffn_modules_lin2_parameters_weight_:
-	name = "L_self_modules_transformer_modules_layer_modules_0_modules_ffn_modules_lin2_parameters_weight_"
-	shape = [768, 3072]
-	dtype = "torch.float32"
-	device = "cuda:0"
-	mean = -0.000
-	std = 0.043
-	data = None
+    name = "L_self_modules_transformer_modules_layer_modules_0_modules_ffn_modules_lin2_parameters_weight_"
+    shape = [768, 3072]
+    dtype = "torch.float32"
+    device = "cuda:0"
+    mean = -0.000
+    std = 0.043
+    data = None
+
 
 class Program_weight_tensor_meta_L_self_modules_transformer_modules_layer_modules_0_modules_ffn_modules_lin2_parameters_bias_:
-	name = "L_self_modules_transformer_modules_layer_modules_0_modules_ffn_modules_lin2_parameters_bias_"
-	shape = [768]
-	dtype = "torch.float32"
-	device = "cuda:0"
-	mean = -0.002
-	std = 0.084
-	data = None
+    name = "L_self_modules_transformer_modules_layer_modules_0_modules_ffn_modules_lin2_parameters_bias_"
+    shape = [768]
+    dtype = "torch.float32"
+    device = "cuda:0"
+    mean = -0.002
+    std = 0.084
+    data = None
+
 
 class Program_weight_tensor_meta_L_self_modules_transformer_modules_layer_modules_0_modules_output_layer_norm_parameters_weight_:
-	name = "L_self_modules_transformer_modules_layer_modules_0_modules_output_layer_norm_parameters_weight_"
-	shape = [768]
-	dtype = "torch.float32"
-	device = "cuda:0"
-	mean = 0.747
-	std = 0.071
-	data = None
+    name = "L_self_modules_transformer_modules_layer_modules_0_modules_output_layer_norm_parameters_weight_"
+    shape = [768]
+    dtype = "torch.float32"
+    device = "cuda:0"
+    mean = 0.747
+    std = 0.071
+    data = None
+
 
 class Program_weight_tensor_meta_L_self_modules_transformer_modules_layer_modules_0_modules_output_layer_norm_parameters_bias_:
-	name = "L_self_modules_transformer_modules_layer_modules_0_modules_output_layer_norm_parameters_bias_"
-	shape = [768]
-	dtype = "torch.float32"
-	device = "cuda:0"
-	mean = -0.042
-	std = 0.098
-	data = None
+    name = "L_self_modules_transformer_modules_layer_modules_0_modules_output_layer_norm_parameters_bias_"
+    shape = [768]
+    dtype = "torch.float32"
+    device = "cuda:0"
+    mean = -0.042
+    std = 0.098
+    data = None
+
 
 class Program_weight_tensor_meta_L_self_modules_transformer_modules_layer_modules_1_modules_attention_modules_q_lin_parameters_weight_:
-	name = "L_self_modules_transformer_modules_layer_modules_1_modules_attention_modules_q_lin_parameters_weight_"
-	shape = [768, 768]
-	dtype = "torch.float32"
-	device = "cuda:0"
-	mean = -0.000
-	std = 0.056
-	data = None
+    name = "L_self_modules_transformer_modules_layer_modules_1_modules_attention_modules_q_lin_parameters_weight_"
+    shape = [768, 768]
+    dtype = "torch.float32"
+    device = "cuda:0"
+    mean = -0.000
+    std = 0.056
+    data = None
+
 
 class Program_weight_tensor_meta_L_self_modules_transformer_modules_layer_modules_1_modules_attention_modules_q_lin_parameters_bias_:
-	name = "L_self_modules_transformer_modules_layer_modules_1_modules_attention_modules_q_lin_parameters_bias_"
-	shape = [768]
-	dtype = "torch.float32"
-	device = "cuda:0"
-	mean = 0.001
-	std = 0.146
-	data = None
+    name = "L_self_modules_transformer_modules_layer_modules_1_modules_attention_modules_q_lin_parameters_bias_"
+    shape = [768]
+    dtype = "torch.float32"
+    device = "cuda:0"
+    mean = 0.001
+    std = 0.146
+    data = None
+
 
 class Program_weight_tensor_meta_L_self_modules_transformer_modules_layer_modules_1_modules_attention_modules_k_lin_parameters_weight_:
-	name = "L_self_modules_transformer_modules_layer_modules_1_modules_attention_modules_k_lin_parameters_weight_"
-	shape = [768, 768]
-	dtype = "torch.float32"
-	device = "cuda:0"
-	mean = 0.000
-	std = 0.055
-	data = None
+    name = "L_self_modules_transformer_modules_layer_modules_1_modules_attention_modules_k_lin_parameters_weight_"
+    shape = [768, 768]
+    dtype = "torch.float32"
+    device = "cuda:0"
+    mean = 0.000
+    std = 0.055
+    data = None
+
 
 class Program_weight_tensor_meta_L_self_modules_transformer_modules_layer_modules_1_modules_attention_modules_k_lin_parameters_bias_:
-	name = "L_self_modules_transformer_modules_layer_modules_1_modules_attention_modules_k_lin_parameters_bias_"
-	shape = [768]
-	dtype = "torch.float32"
-	device = "cuda:0"
-	mean = -0.000
-	std = 0.004
-	data = None
+    name = "L_self_modules_transformer_modules_layer_modules_1_modules_attention_modules_k_lin_parameters_bias_"
+    shape = [768]
+    dtype = "torch.float32"
+    device = "cuda:0"
+    mean = -0.000
+    std = 0.004
+    data = None
+
 
 class Program_weight_tensor_meta_L_self_modules_transformer_modules_layer_modules_1_modules_attention_modules_v_lin_parameters_weight_:
-	name = "L_self_modules_transformer_modules_layer_modules_1_modules_attention_modules_v_lin_parameters_weight_"
-	shape = [768, 768]
-	dtype = "torch.float32"
-	device = "cuda:0"
-	mean = -0.000
-	std = 0.036
-	data = None
+    name = "L_self_modules_transformer_modules_layer_modules_1_modules_attention_modules_v_lin_parameters_weight_"
+    shape = [768, 768]
+    dtype = "torch.float32"
+    device = "cuda:0"
+    mean = -0.000
+    std = 0.036
+    data = None
+
 
 class Program_weight_tensor_meta_L_self_modules_transformer_modules_layer_modules_1_modules_attention_modules_v_lin_parameters_bias_:
-	name = "L_self_modules_transformer_modules_layer_modules_1_modules_attention_modules_v_lin_parameters_bias_"
-	shape = [768]
-	dtype = "torch.float32"
-	device = "cuda:0"
-	mean = 0.004
-	std = 0.064
-	data = None
+    name = "L_self_modules_transformer_modules_layer_modules_1_modules_attention_modules_v_lin_parameters_bias_"
+    shape = [768]
+    dtype = "torch.float32"
+    device = "cuda:0"
+    mean = 0.004
+    std = 0.064
+    data = None
+
 
 class Program_weight_tensor_meta_L_self_modules_transformer_modules_layer_modules_1_modules_attention_modules_out_lin_parameters_weight_:
-	name = "L_self_modules_transformer_modules_layer_modules_1_modules_attention_modules_out_lin_parameters_weight_"
-	shape = [768, 768]
-	dtype = "torch.float32"
-	device = "cuda:0"
-	mean = -0.000
-	std = 0.035
-	data = None
+    name = "L_self_modules_transformer_modules_layer_modules_1_modules_attention_modules_out_lin_parameters_weight_"
+    shape = [768, 768]
+    dtype = "torch.float32"
+    device = "cuda:0"
+    mean = -0.000
+    std = 0.035
+    data = None
+
 
 class Program_weight_tensor_meta_L_self_modules_transformer_modules_layer_modules_1_modules_attention_modules_out_lin_parameters_bias_:
-	name = "L_self_modules_transformer_modules_layer_modules_1_modules_attention_modules_out_lin_parameters_bias_"
-	shape = [768]
-	dtype = "torch.float32"
-	device = "cuda:0"
-	mean = -0.001
-	std = 0.096
-	data = None
+    name = "L_self_modules_transformer_modules_layer_modules_1_modules_attention_modules_out_lin_parameters_bias_"
+    shape = [768]
+    dtype = "torch.float32"
+    device = "cuda:0"
+    mean = -0.001
+    std = 0.096
+    data = None
+
 
 class Program_weight_tensor_meta_L_self_modules_transformer_modules_layer_modules_1_modules_sa_layer_norm_parameters_weight_:
-	name = "L_self_modules_transformer_modules_layer_modules_1_modules_sa_layer_norm_parameters_weight_"
-	shape = [768]
-	dtype = "torch.float32"
-	device = "cuda:0"
-	mean = 0.782
-	std = 0.091
-	data = None
+    name = "L_self_modules_transformer_modules_layer_modules_1_modules_sa_layer_norm_parameters_weight_"
+    shape = [768]
+    dtype = "torch.float32"
+    device = "cuda:0"
+    mean = 0.782
+    std = 0.091
+    data = None
+
 
 class Program_weight_tensor_meta_L_self_modules_transformer_modules_layer_modules_1_modules_sa_layer_norm_parameters_bias_:
-	name = "L_self_modules_transformer_modules_layer_modules_1_modules_sa_layer_norm_parameters_bias_"
-	shape = [768]
-	dtype = "torch.float32"
-	device = "cuda:0"
-	mean = -0.018
-	std = 0.184
-	data = None
+    name = "L_self_modules_transformer_modules_layer_modules_1_modules_sa_layer_norm_parameters_bias_"
+    shape = [768]
+    dtype = "torch.float32"
+    device = "cuda:0"
+    mean = -0.018
+    std = 0.184
+    data = None
+
 
 class Program_weight_tensor_meta_L_self_modules_transformer_modules_layer_modules_1_modules_ffn_modules_lin1_parameters_weight_:
-	name = "L_self_modules_transformer_modules_layer_modules_1_modules_ffn_modules_lin1_parameters_weight_"
-	shape = [3072, 768]
-	dtype = "torch.float32"
-	device = "cuda:0"
-	mean = 0.000
-	std = 0.045
-	data = None
+    name = "L_self_modules_transformer_modules_layer_modules_1_modules_ffn_modules_lin1_parameters_weight_"
+    shape = [3072, 768]
+    dtype = "torch.float32"
+    device = "cuda:0"
+    mean = 0.000
+    std = 0.045
+    data = None
+
 
 class Program_weight_tensor_meta_L_self_modules_transformer_modules_layer_modules_1_modules_ffn_modules_lin1_parameters_bias_:
-	name = "L_self_modules_transformer_modules_layer_modules_1_modules_ffn_modules_lin1_parameters_bias_"
-	shape = [3072]
-	dtype = "torch.float32"
-	device = "cuda:0"
-	mean = -0.102
-	std = 0.070
-	data = None
+    name = "L_self_modules_transformer_modules_layer_modules_1_modules_ffn_modules_lin1_parameters_bias_"
+    shape = [3072]
+    dtype = "torch.float32"
+    device = "cuda:0"
+    mean = -0.102
+    std = 0.070
+    data = None
+
 
 class Program_weight_tensor_meta_L_self_modules_transformer_modules_layer_modules_1_modules_ffn_modules_lin2_parameters_weight_:
-	name = "L_self_modules_transformer_modules_layer_modules_1_modules_ffn_modules_lin2_parameters_weight_"
-	shape = [768, 3072]
-	dtype = "torch.float32"
-	device = "cuda:0"
-	mean = -0.000
-	std = 0.043
-	data = None
+    name = "L_self_modules_transformer_modules_layer_modules_1_modules_ffn_modules_lin2_parameters_weight_"
+    shape = [768, 3072]
+    dtype = "torch.float32"
+    device = "cuda:0"
+    mean = -0.000
+    std = 0.043
+    data = None
+
 
 class Program_weight_tensor_meta_L_self_modules_transformer_modules_layer_modules_1_modules_ffn_modules_lin2_parameters_bias_:
-	name = "L_self_modules_transformer_modules_layer_modules_1_modules_ffn_modules_lin2_parameters_bias_"
-	shape = [768]
-	dtype = "torch.float32"
-	device = "cuda:0"
-	mean = -0.001
-	std = 0.080
-	data = None
+    name = "L_self_modules_transformer_modules_layer_modules_1_modules_ffn_modules_lin2_parameters_bias_"
+    shape = [768]
+    dtype = "torch.float32"
+    device = "cuda:0"
+    mean = -0.001
+    std = 0.080
+    data = None
+
 
 class Program_weight_tensor_meta_L_self_modules_transformer_modules_layer_modules_1_modules_output_layer_norm_parameters_weight_:
-	name = "L_self_modules_transformer_modules_layer_modules_1_modules_output_layer_norm_parameters_weight_"
-	shape = [768]
-	dtype = "torch.float32"
-	device = "cuda:0"
-	mean = 0.826
-	std = 0.072
-	data = None
+    name = "L_self_modules_transformer_modules_layer_modules_1_modules_output_layer_norm_parameters_weight_"
+    shape = [768]
+    dtype = "torch.float32"
+    device = "cuda:0"
+    mean = 0.826
+    std = 0.072
+    data = None
+
 
 class Program_weight_tensor_meta_L_self_modules_transformer_modules_layer_modules_1_modules_output_layer_norm_parameters_bias_:
-	name = "L_self_modules_transformer_modules_layer_modules_1_modules_output_layer_norm_parameters_bias_"
-	shape = [768]
-	dtype = "torch.float32"
-	device = "cuda:0"
-	mean = -0.039
-	std = 0.071
-	data = None
+    name = "L_self_modules_transformer_modules_layer_modules_1_modules_output_layer_norm_parameters_bias_"
+    shape = [768]
+    dtype = "torch.float32"
+    device = "cuda:0"
+    mean = -0.039
+    std = 0.071
+    data = None
+
 
 class Program_weight_tensor_meta_L_self_modules_transformer_modules_layer_modules_2_modules_attention_modules_q_lin_parameters_weight_:
-	name = "L_self_modules_transformer_modules_layer_modules_2_modules_attention_modules_q_lin_parameters_weight_"
-	shape = [768, 768]
-	dtype = "torch.float32"
-	device = "cuda:0"
-	mean = -0.000
-	std = 0.047
-	data = None
+    name = "L_self_modules_transformer_modules_layer_modules_2_modules_attention_modules_q_lin_parameters_weight_"
+    shape = [768, 768]
+    dtype = "torch.float32"
+    device = "cuda:0"
+    mean = -0.000
+    std = 0.047
+    data = None
+
 
 class Program_weight_tensor_meta_L_self_modules_transformer_modules_layer_modules_2_modules_attention_modules_q_lin_parameters_bias_:
-	name = "L_self_modules_transformer_modules_layer_modules_2_modules_attention_modules_q_lin_parameters_bias_"
-	shape = [768]
-	dtype = "torch.float32"
-	device = "cuda:0"
-	mean = 0.003
-	std = 0.160
-	data = None
+    name = "L_self_modules_transformer_modules_layer_modules_2_modules_attention_modules_q_lin_parameters_bias_"
+    shape = [768]
+    dtype = "torch.float32"
+    device = "cuda:0"
+    mean = 0.003
+    std = 0.160
+    data = None
+
 
 class Program_weight_tensor_meta_L_self_modules_transformer_modules_layer_modules_2_modules_attention_modules_k_lin_parameters_weight_:
-	name = "L_self_modules_transformer_modules_layer_modules_2_modules_attention_modules_k_lin_parameters_weight_"
-	shape = [768, 768]
-	dtype = "torch.float32"
-	device = "cuda:0"
-	mean = 0.000
-	std = 0.047
-	data = None
+    name = "L_self_modules_transformer_modules_layer_modules_2_modules_attention_modules_k_lin_parameters_weight_"
+    shape = [768, 768]
+    dtype = "torch.float32"
+    device = "cuda:0"
+    mean = 0.000
+    std = 0.047
+    data = None
+
 
 class Program_weight_tensor_meta_L_self_modules_transformer_modules_layer_modules_2_modules_attention_modules_k_lin_parameters_bias_:
-	name = "L_self_modules_transformer_modules_layer_modules_2_modules_attention_modules_k_lin_parameters_bias_"
-	shape = [768]
-	dtype = "torch.float32"
-	device = "cuda:0"
-	mean = 0.000
-	std = 0.005
-	data = None
+    name = "L_self_modules_transformer_modules_layer_modules_2_modules_attention_modules_k_lin_parameters_bias_"
+    shape = [768]
+    dtype = "torch.float32"
+    device = "cuda:0"
+    mean = 0.000
+    std = 0.005
+    data = None
+
 
 class Program_weight_tensor_meta_L_self_modules_transformer_modules_layer_modules_2_modules_attention_modules_v_lin_parameters_weight_:
-	name = "L_self_modules_transformer_modules_layer_modules_2_modules_attention_modules_v_lin_parameters_weight_"
-	shape = [768, 768]
-	dtype = "torch.float32"
-	device = "cuda:0"
-	mean = 0.000
-	std = 0.042
-	data = None
+    name = "L_self_modules_transformer_modules_layer_modules_2_modules_attention_modules_v_lin_parameters_weight_"
+    shape = [768, 768]
+    dtype = "torch.float32"
+    device = "cuda:0"
+    mean = 0.000
+    std = 0.042
+    data = None
+
 
 class Program_weight_tensor_meta_L_self_modules_transformer_modules_layer_modules_2_modules_attention_modules_v_lin_parameters_bias_:
-	name = "L_self_modules_transformer_modules_layer_modules_2_modules_attention_modules_v_lin_parameters_bias_"
-	shape = [768]
-	dtype = "torch.float32"
-	device = "cuda:0"
-	mean = -0.000
-	std = 0.033
-	data = None
+    name = "L_self_modules_transformer_modules_layer_modules_2_modules_attention_modules_v_lin_parameters_bias_"
+    shape = [768]
+    dtype = "torch.float32"
+    device = "cuda:0"
+    mean = -0.000
+    std = 0.033
+    data = None
+
 
 class Program_weight_tensor_meta_L_self_modules_transformer_modules_layer_modules_2_modules_attention_modules_out_lin_parameters_weight_:
-	name = "L_self_modules_transformer_modules_layer_modules_2_modules_attention_modules_out_lin_parameters_weight_"
-	shape = [768, 768]
-	dtype = "torch.float32"
-	device = "cuda:0"
-	mean = 0.000
-	std = 0.040
-	data = None
+    name = "L_self_modules_transformer_modules_layer_modules_2_modules_attention_modules_out_lin_parameters_weight_"
+    shape = [768, 768]
+    dtype = "torch.float32"
+    device = "cuda:0"
+    mean = 0.000
+    std = 0.040
+    data = None
+
 
 class Program_weight_tensor_meta_L_self_modules_transformer_modules_layer_modules_2_modules_attention_modules_out_lin_parameters_bias_:
-	name = "L_self_modules_transformer_modules_layer_modules_2_modules_attention_modules_out_lin_parameters_bias_"
-	shape = [768]
-	dtype = "torch.float32"
-	device = "cuda:0"
-	mean = 0.000
-	std = 0.052
-	data = None
+    name = "L_self_modules_transformer_modules_layer_modules_2_modules_attention_modules_out_lin_parameters_bias_"
+    shape = [768]
+    dtype = "torch.float32"
+    device = "cuda:0"
+    mean = 0.000
+    std = 0.052
+    data = None
+
 
 class Program_weight_tensor_meta_L_self_modules_transformer_modules_layer_modules_2_modules_sa_layer_norm_parameters_weight_:
-	name = "L_self_modules_transformer_modules_layer_modules_2_modules_sa_layer_norm_parameters_weight_"
-	shape = [768]
-	dtype = "torch.float32"
-	device = "cuda:0"
-	mean = 0.749
-	std = 0.148
-	data = None
+    name = "L_self_modules_transformer_modules_layer_modules_2_modules_sa_layer_norm_parameters_weight_"
+    shape = [768]
+    dtype = "torch.float32"
+    device = "cuda:0"
+    mean = 0.749
+    std = 0.148
+    data = None
+
 
 class Program_weight_tensor_meta_L_self_modules_transformer_modules_layer_modules_2_modules_sa_layer_norm_parameters_bias_:
-	name = "L_self_modules_transformer_modules_layer_modules_2_modules_sa_layer_norm_parameters_bias_"
-	shape = [768]
-	dtype = "torch.float32"
-	device = "cuda:0"
-	mean = -0.024
-	std = 0.158
-	data = None
+    name = "L_self_modules_transformer_modules_layer_modules_2_modules_sa_layer_norm_parameters_bias_"
+    shape = [768]
+    dtype = "torch.float32"
+    device = "cuda:0"
+    mean = -0.024
+    std = 0.158
+    data = None
+
 
 class Program_weight_tensor_meta_L_self_modules_transformer_modules_layer_modules_2_modules_ffn_modules_lin1_parameters_weight_:
-	name = "L_self_modules_transformer_modules_layer_modules_2_modules_ffn_modules_lin1_parameters_weight_"
-	shape = [3072, 768]
-	dtype = "torch.float32"
-	device = "cuda:0"
-	mean = 0.000
-	std = 0.046
-	data = None
+    name = "L_self_modules_transformer_modules_layer_modules_2_modules_ffn_modules_lin1_parameters_weight_"
+    shape = [3072, 768]
+    dtype = "torch.float32"
+    device = "cuda:0"
+    mean = 0.000
+    std = 0.046
+    data = None
+
 
 class Program_weight_tensor_meta_L_self_modules_transformer_modules_layer_modules_2_modules_ffn_modules_lin1_parameters_bias_:
-	name = "L_self_modules_transformer_modules_layer_modules_2_modules_ffn_modules_lin1_parameters_bias_"
-	shape = [3072]
-	dtype = "torch.float32"
-	device = "cuda:0"
-	mean = -0.104
-	std = 0.080
-	data = None
+    name = "L_self_modules_transformer_modules_layer_modules_2_modules_ffn_modules_lin1_parameters_bias_"
+    shape = [3072]
+    dtype = "torch.float32"
+    device = "cuda:0"
+    mean = -0.104
+    std = 0.080
+    data = None
+
 
 class Program_weight_tensor_meta_L_self_modules_transformer_modules_layer_modules_2_modules_ffn_modules_lin2_parameters_weight_:
-	name = "L_self_modules_transformer_modules_layer_modules_2_modules_ffn_modules_lin2_parameters_weight_"
-	shape = [768, 3072]
-	dtype = "torch.float32"
-	device = "cuda:0"
-	mean = -0.000
-	std = 0.045
-	data = None
+    name = "L_self_modules_transformer_modules_layer_modules_2_modules_ffn_modules_lin2_parameters_weight_"
+    shape = [768, 3072]
+    dtype = "torch.float32"
+    device = "cuda:0"
+    mean = -0.000
+    std = 0.045
+    data = None
+
 
 class Program_weight_tensor_meta_L_self_modules_transformer_modules_layer_modules_2_modules_ffn_modules_lin2_parameters_bias_:
-	name = "L_self_modules_transformer_modules_layer_modules_2_modules_ffn_modules_lin2_parameters_bias_"
-	shape = [768]
-	dtype = "torch.float32"
-	device = "cuda:0"
-	mean = -0.001
-	std = 0.058
-	data = None
+    name = "L_self_modules_transformer_modules_layer_modules_2_modules_ffn_modules_lin2_parameters_bias_"
+    shape = [768]
+    dtype = "torch.float32"
+    device = "cuda:0"
+    mean = -0.001
+    std = 0.058
+    data = None
+
 
 class Program_weight_tensor_meta_L_self_modules_transformer_modules_layer_modules_2_modules_output_layer_norm_parameters_weight_:
-	name = "L_self_modules_transformer_modules_layer_modules_2_modules_output_layer_norm_parameters_weight_"
-	shape = [768]
-	dtype = "torch.float32"
-	device = "cuda:0"
-	mean = 0.811
-	std = 0.076
-	data = None
+    name = "L_self_modules_transformer_modules_layer_modules_2_modules_output_layer_norm_parameters_weight_"
+    shape = [768]
+    dtype = "torch.float32"
+    device = "cuda:0"
+    mean = 0.811
+    std = 0.076
+    data = None
+
 
 class Program_weight_tensor_meta_L_self_modules_transformer_modules_layer_modules_2_modules_output_layer_norm_parameters_bias_:
-	name = "L_self_modules_transformer_modules_layer_modules_2_modules_output_layer_norm_parameters_bias_"
-	shape = [768]
-	dtype = "torch.float32"
-	device = "cuda:0"
-	mean = -0.036
-	std = 0.050
-	data = None
+    name = "L_self_modules_transformer_modules_layer_modules_2_modules_output_layer_norm_parameters_bias_"
+    shape = [768]
+    dtype = "torch.float32"
+    device = "cuda:0"
+    mean = -0.036
+    std = 0.050
+    data = None
+
 
 class Program_weight_tensor_meta_L_self_modules_transformer_modules_layer_modules_3_modules_attention_modules_q_lin_parameters_weight_:
-	name = "L_self_modules_transformer_modules_layer_modules_3_modules_attention_modules_q_lin_parameters_weight_"
-	shape = [768, 768]
-	dtype = "torch.float32"
-	device = "cuda:0"
-	mean = -0.000
-	std = 0.049
-	data = None
+    name = "L_self_modules_transformer_modules_layer_modules_3_modules_attention_modules_q_lin_parameters_weight_"
+    shape = [768, 768]
+    dtype = "torch.float32"
+    device = "cuda:0"
+    mean = -0.000
+    std = 0.049
+    data = None
+
 
 class Program_weight_tensor_meta_L_self_modules_transformer_modules_layer_modules_3_modules_attention_modules_q_lin_parameters_bias_:
-	name = "L_self_modules_transformer_modules_layer_modules_3_modules_attention_modules_q_lin_parameters_bias_"
-	shape = [768]
-	dtype = "torch.float32"
-	device = "cuda:0"
-	mean = -0.003
-	std = 0.159
-	data = None
+    name = "L_self_modules_transformer_modules_layer_modules_3_modules_attention_modules_q_lin_parameters_bias_"
+    shape = [768]
+    dtype = "torch.float32"
+    device = "cuda:0"
+    mean = -0.003
+    std = 0.159
+    data = None
+
 
 class Program_weight_tensor_meta_L_self_modules_transformer_modules_layer_modules_3_modules_attention_modules_k_lin_parameters_weight_:
-	name = "L_self_modules_transformer_modules_layer_modules_3_modules_attention_modules_k_lin_parameters_weight_"
-	shape = [768, 768]
-	dtype = "torch.float32"
-	device = "cuda:0"
-	mean = -0.000
-	std = 0.049
-	data = None
+    name = "L_self_modules_transformer_modules_layer_modules_3_modules_attention_modules_k_lin_parameters_weight_"
+    shape = [768, 768]
+    dtype = "torch.float32"
+    device = "cuda:0"
+    mean = -0.000
+    std = 0.049
+    data = None
+
 
 class Program_weight_tensor_meta_L_self_modules_transformer_modules_layer_modules_3_modules_attention_modules_k_lin_parameters_bias_:
-	name = "L_self_modules_transformer_modules_layer_modules_3_modules_attention_modules_k_lin_parameters_bias_"
-	shape = [768]
-	dtype = "torch.float32"
-	device = "cuda:0"
-	mean = 0.000
-	std = 0.005
-	data = None
+    name = "L_self_modules_transformer_modules_layer_modules_3_modules_attention_modules_k_lin_parameters_bias_"
+    shape = [768]
+    dtype = "torch.float32"
+    device = "cuda:0"
+    mean = 0.000
+    std = 0.005
+    data = None
+
 
 class Program_weight_tensor_meta_L_self_modules_transformer_modules_layer_modules_3_modules_attention_modules_v_lin_parameters_weight_:
-	name = "L_self_modules_transformer_modules_layer_modules_3_modules_attention_modules_v_lin_parameters_weight_"
-	shape = [768, 768]
-	dtype = "torch.float32"
-	device = "cuda:0"
-	mean = 0.000
-	std = 0.046
-	data = None
+    name = "L_self_modules_transformer_modules_layer_modules_3_modules_attention_modules_v_lin_parameters_weight_"
+    shape = [768, 768]
+    dtype = "torch.float32"
+    device = "cuda:0"
+    mean = 0.000
+    std = 0.046
+    data = None
+
 
 class Program_weight_tensor_meta_L_self_modules_transformer_modules_layer_modules_3_modules_attention_modules_v_lin_parameters_bias_:
-	name = "L_self_modules_transformer_modules_layer_modules_3_modules_attention_modules_v_lin_parameters_bias_"
-	shape = [768]
-	dtype = "torch.float32"
-	device = "cuda:0"
-	mean = -0.003
-	std = 0.047
-	data = None
+    name = "L_self_modules_transformer_modules_layer_modules_3_modules_attention_modules_v_lin_parameters_bias_"
+    shape = [768]
+    dtype = "torch.float32"
+    device = "cuda:0"
+    mean = -0.003
+    std = 0.047
+    data = None
+
 
 class Program_weight_tensor_meta_L_self_modules_transformer_modules_layer_modules_3_modules_attention_modules_out_lin_parameters_weight_:
-	name = "L_self_modules_transformer_modules_layer_modules_3_modules_attention_modules_out_lin_parameters_weight_"
-	shape = [768, 768]
-	dtype = "torch.float32"
-	device = "cuda:0"
-	mean = -0.000
-	std = 0.044
-	data = None
+    name = "L_self_modules_transformer_modules_layer_modules_3_modules_attention_modules_out_lin_parameters_weight_"
+    shape = [768, 768]
+    dtype = "torch.float32"
+    device = "cuda:0"
+    mean = -0.000
+    std = 0.044
+    data = None
+
 
 class Program_weight_tensor_meta_L_self_modules_transformer_modules_layer_modules_3_modules_attention_modules_out_lin_parameters_bias_:
-	name = "L_self_modules_transformer_modules_layer_modules_3_modules_attention_modules_out_lin_parameters_bias_"
-	shape = [768]
-	dtype = "torch.float32"
-	device = "cuda:0"
-	mean = 0.001
-	std = 0.071
-	data = None
+    name = "L_self_modules_transformer_modules_layer_modules_3_modules_attention_modules_out_lin_parameters_bias_"
+    shape = [768]
+    dtype = "torch.float32"
+    device = "cuda:0"
+    mean = 0.001
+    std = 0.071
+    data = None
+
 
 class Program_weight_tensor_meta_L_self_modules_transformer_modules_layer_modules_3_modules_sa_layer_norm_parameters_weight_:
-	name = "L_self_modules_transformer_modules_layer_modules_3_modules_sa_layer_norm_parameters_weight_"
-	shape = [768]
-	dtype = "torch.float32"
-	device = "cuda:0"
-	mean = 0.739
-	std = 0.129
-	data = None
+    name = "L_self_modules_transformer_modules_layer_modules_3_modules_sa_layer_norm_parameters_weight_"
+    shape = [768]
+    dtype = "torch.float32"
+    device = "cuda:0"
+    mean = 0.739
+    std = 0.129
+    data = None
+
 
 class Program_weight_tensor_meta_L_self_modules_transformer_modules_layer_modules_3_modules_sa_layer_norm_parameters_bias_:
-	name = "L_self_modules_transformer_modules_layer_modules_3_modules_sa_layer_norm_parameters_bias_"
-	shape = [768]
-	dtype = "torch.float32"
-	device = "cuda:0"
-	mean = -0.032
-	std = 0.155
-	data = None
+    name = "L_self_modules_transformer_modules_layer_modules_3_modules_sa_layer_norm_parameters_bias_"
+    shape = [768]
+    dtype = "torch.float32"
+    device = "cuda:0"
+    mean = -0.032
+    std = 0.155
+    data = None
+
 
 class Program_weight_tensor_meta_L_self_modules_transformer_modules_layer_modules_3_modules_ffn_modules_lin1_parameters_weight_:
-	name = "L_self_modules_transformer_modules_layer_modules_3_modules_ffn_modules_lin1_parameters_weight_"
-	shape = [3072, 768]
-	dtype = "torch.float32"
-	device = "cuda:0"
-	mean = 0.001
-	std = 0.043
-	data = None
+    name = "L_self_modules_transformer_modules_layer_modules_3_modules_ffn_modules_lin1_parameters_weight_"
+    shape = [3072, 768]
+    dtype = "torch.float32"
+    device = "cuda:0"
+    mean = 0.001
+    std = 0.043
+    data = None
+
 
 class Program_weight_tensor_meta_L_self_modules_transformer_modules_layer_modules_3_modules_ffn_modules_lin1_parameters_bias_:
-	name = "L_self_modules_transformer_modules_layer_modules_3_modules_ffn_modules_lin1_parameters_bias_"
-	shape = [3072]
-	dtype = "torch.float32"
-	device = "cuda:0"
-	mean = -0.110
-	std = 0.071
-	data = None
+    name = "L_self_modules_transformer_modules_layer_modules_3_modules_ffn_modules_lin1_parameters_bias_"
+    shape = [3072]
+    dtype = "torch.float32"
+    device = "cuda:0"
+    mean = -0.110
+    std = 0.071
+    data = None
+
 
 class Program_weight_tensor_meta_L_self_modules_transformer_modules_layer_modules_3_modules_ffn_modules_lin2_parameters_weight_:
-	name = "L_self_modules_transformer_modules_layer_modules_3_modules_ffn_modules_lin2_parameters_weight_"
-	shape = [768, 3072]
-	dtype = "torch.float32"
-	device = "cuda:0"
-	mean = 0.000
-	std = 0.041
-	data = None
+    name = "L_self_modules_transformer_modules_layer_modules_3_modules_ffn_modules_lin2_parameters_weight_"
+    shape = [768, 3072]
+    dtype = "torch.float32"
+    device = "cuda:0"
+    mean = 0.000
+    std = 0.041
+    data = None
+
 
 class Program_weight_tensor_meta_L_self_modules_transformer_modules_layer_modules_3_modules_ffn_modules_lin2_parameters_bias_:
-	name = "L_self_modules_transformer_modules_layer_modules_3_modules_ffn_modules_lin2_parameters_bias_"
-	shape = [768]
-	dtype = "torch.float32"
-	device = "cuda:0"
-	mean = -0.000
-	std = 0.085
-	data = None
+    name = "L_self_modules_transformer_modules_layer_modules_3_modules_ffn_modules_lin2_parameters_bias_"
+    shape = [768]
+    dtype = "torch.float32"
+    device = "cuda:0"
+    mean = -0.000
+    std = 0.085
+    data = None
+
 
 class Program_weight_tensor_meta_L_self_modules_transformer_modules_layer_modules_3_modules_output_layer_norm_parameters_weight_:
-	name = "L_self_modules_transformer_modules_layer_modules_3_modules_output_layer_norm_parameters_weight_"
-	shape = [768]
-	dtype = "torch.float32"
-	device = "cuda:0"
-	mean = 0.775
-	std = 0.050
-	data = None
+    name = "L_self_modules_transformer_modules_layer_modules_3_modules_output_layer_norm_parameters_weight_"
+    shape = [768]
+    dtype = "torch.float32"
+    device = "cuda:0"
+    mean = 0.775
+    std = 0.050
+    data = None
+
 
 class Program_weight_tensor_meta_L_self_modules_transformer_modules_layer_modules_3_modules_output_layer_norm_parameters_bias_:
-	name = "L_self_modules_transformer_modules_layer_modules_3_modules_output_layer_norm_parameters_bias_"
-	shape = [768]
-	dtype = "torch.float32"
-	device = "cuda:0"
-	mean = -0.037
-	std = 0.065
-	data = None
+    name = "L_self_modules_transformer_modules_layer_modules_3_modules_output_layer_norm_parameters_bias_"
+    shape = [768]
+    dtype = "torch.float32"
+    device = "cuda:0"
+    mean = -0.037
+    std = 0.065
+    data = None
+
 
 class Program_weight_tensor_meta_L_self_modules_transformer_modules_layer_modules_4_modules_attention_modules_q_lin_parameters_weight_:
-	name = "L_self_modules_transformer_modules_layer_modules_4_modules_attention_modules_q_lin_parameters_weight_"
-	shape = [768, 768]
-	dtype = "torch.float32"
-	device = "cuda:0"
-	mean = -0.000
-	std = 0.049
-	data = None
+    name = "L_self_modules_transformer_modules_layer_modules_4_modules_attention_modules_q_lin_parameters_weight_"
+    shape = [768, 768]
+    dtype = "torch.float32"
+    device = "cuda:0"
+    mean = -0.000
+    std = 0.049
+    data = None
+
 
 class Program_weight_tensor_meta_L_self_modules_transformer_modules_layer_modules_4_modules_attention_modules_q_lin_parameters_bias_:
-	name = "L_self_modules_transformer_modules_layer_modules_4_modules_attention_modules_q_lin_parameters_bias_"
-	shape = [768]
-	dtype = "torch.float32"
-	device = "cuda:0"
-	mean = 0.007
-	std = 0.208
-	data = None
+    name = "L_self_modules_transformer_modules_layer_modules_4_modules_attention_modules_q_lin_parameters_bias_"
+    shape = [768]
+    dtype = "torch.float32"
+    device = "cuda:0"
+    mean = 0.007
+    std = 0.208
+    data = None
+
 
 class Program_weight_tensor_meta_L_self_modules_transformer_modules_layer_modules_4_modules_attention_modules_k_lin_parameters_weight_:
-	name = "L_self_modules_transformer_modules_layer_modules_4_modules_attention_modules_k_lin_parameters_weight_"
-	shape = [768, 768]
-	dtype = "torch.float32"
-	device = "cuda:0"
-	mean = -0.000
-	std = 0.049
-	data = None
+    name = "L_self_modules_transformer_modules_layer_modules_4_modules_attention_modules_k_lin_parameters_weight_"
+    shape = [768, 768]
+    dtype = "torch.float32"
+    device = "cuda:0"
+    mean = -0.000
+    std = 0.049
+    data = None
+
 
 class Program_weight_tensor_meta_L_self_modules_transformer_modules_layer_modules_4_modules_attention_modules_k_lin_parameters_bias_:
-	name = "L_self_modules_transformer_modules_layer_modules_4_modules_attention_modules_k_lin_parameters_bias_"
-	shape = [768]
-	dtype = "torch.float32"
-	device = "cuda:0"
-	mean = 0.000
-	std = 0.007
-	data = None
+    name = "L_self_modules_transformer_modules_layer_modules_4_modules_attention_modules_k_lin_parameters_bias_"
+    shape = [768]
+    dtype = "torch.float32"
+    device = "cuda:0"
+    mean = 0.000
+    std = 0.007
+    data = None
+
 
 class Program_weight_tensor_meta_L_self_modules_transformer_modules_layer_modules_4_modules_attention_modules_v_lin_parameters_weight_:
-	name = "L_self_modules_transformer_modules_layer_modules_4_modules_attention_modules_v_lin_parameters_weight_"
-	shape = [768, 768]
-	dtype = "torch.float32"
-	device = "cuda:0"
-	mean = 0.000
-	std = 0.047
-	data = None
+    name = "L_self_modules_transformer_modules_layer_modules_4_modules_attention_modules_v_lin_parameters_weight_"
+    shape = [768, 768]
+    dtype = "torch.float32"
+    device = "cuda:0"
+    mean = 0.000
+    std = 0.047
+    data = None
+
 
 class Program_weight_tensor_meta_L_self_modules_transformer_modules_layer_modules_4_modules_attention_modules_v_lin_parameters_bias_:
-	name = "L_self_modules_transformer_modules_layer_modules_4_modules_attention_modules_v_lin_parameters_bias_"
-	shape = [768]
-	dtype = "torch.float32"
-	device = "cuda:0"
-	mean = -0.001
-	std = 0.040
-	data = None
+    name = "L_self_modules_transformer_modules_layer_modules_4_modules_attention_modules_v_lin_parameters_bias_"
+    shape = [768]
+    dtype = "torch.float32"
+    device = "cuda:0"
+    mean = -0.001
+    std = 0.040
+    data = None
+
 
 class Program_weight_tensor_meta_L_self_modules_transformer_modules_layer_modules_4_modules_attention_modules_out_lin_parameters_weight_:
-	name = "L_self_modules_transformer_modules_layer_modules_4_modules_attention_modules_out_lin_parameters_weight_"
-	shape = [768, 768]
-	dtype = "torch.float32"
-	device = "cuda:0"
-	mean = 0.000
-	std = 0.045
-	data = None
+    name = "L_self_modules_transformer_modules_layer_modules_4_modules_attention_modules_out_lin_parameters_weight_"
+    shape = [768, 768]
+    dtype = "torch.float32"
+    device = "cuda:0"
+    mean = 0.000
+    std = 0.045
+    data = None
+
 
 class Program_weight_tensor_meta_L_self_modules_transformer_modules_layer_modules_4_modules_attention_modules_out_lin_parameters_bias_:
-	name = "L_self_modules_transformer_modules_layer_modules_4_modules_attention_modules_out_lin_parameters_bias_"
-	shape = [768]
-	dtype = "torch.float32"
-	device = "cuda:0"
-	mean = 0.001
-	std = 0.070
-	data = None
+    name = "L_self_modules_transformer_modules_layer_modules_4_modules_attention_modules_out_lin_parameters_bias_"
+    shape = [768]
+    dtype = "torch.float32"
+    device = "cuda:0"
+    mean = 0.001
+    std = 0.070
+    data = None
+
 
 class Program_weight_tensor_meta_L_self_modules_transformer_modules_layer_modules_4_modules_sa_layer_norm_parameters_weight_:
-	name = "L_self_modules_transformer_modules_layer_modules_4_modules_sa_layer_norm_parameters_weight_"
-	shape = [768]
-	dtype = "torch.float32"
-	device = "cuda:0"
-	mean = 0.732
-	std = 0.094
-	data = None
+    name = "L_self_modules_transformer_modules_layer_modules_4_modules_sa_layer_norm_parameters_weight_"
+    shape = [768]
+    dtype = "torch.float32"
+    device = "cuda:0"
+    mean = 0.732
+    std = 0.094
+    data = None
+
 
 class Program_weight_tensor_meta_L_self_modules_transformer_modules_layer_modules_4_modules_sa_layer_norm_parameters_bias_:
-	name = "L_self_modules_transformer_modules_layer_modules_4_modules_sa_layer_norm_parameters_bias_"
-	shape = [768]
-	dtype = "torch.float32"
-	device = "cuda:0"
-	mean = -0.037
-	std = 0.138
-	data = None
+    name = "L_self_modules_transformer_modules_layer_modules_4_modules_sa_layer_norm_parameters_bias_"
+    shape = [768]
+    dtype = "torch.float32"
+    device = "cuda:0"
+    mean = -0.037
+    std = 0.138
+    data = None
+
 
 class Program_weight_tensor_meta_L_self_modules_transformer_modules_layer_modules_4_modules_ffn_modules_lin1_parameters_weight_:
-	name = "L_self_modules_transformer_modules_layer_modules_4_modules_ffn_modules_lin1_parameters_weight_"
-	shape = [3072, 768]
-	dtype = "torch.float32"
-	device = "cuda:0"
-	mean = 0.001
-	std = 0.043
-	data = None
+    name = "L_self_modules_transformer_modules_layer_modules_4_modules_ffn_modules_lin1_parameters_weight_"
+    shape = [3072, 768]
+    dtype = "torch.float32"
+    device = "cuda:0"
+    mean = 0.001
+    std = 0.043
+    data = None
+
 
 class Program_weight_tensor_meta_L_self_modules_transformer_modules_layer_modules_4_modules_ffn_modules_lin1_parameters_bias_:
-	name = "L_self_modules_transformer_modules_layer_modules_4_modules_ffn_modules_lin1_parameters_bias_"
-	shape = [3072]
-	dtype = "torch.float32"
-	device = "cuda:0"
-	mean = -0.110
-	std = 0.053
-	data = None
+    name = "L_self_modules_transformer_modules_layer_modules_4_modules_ffn_modules_lin1_parameters_bias_"
+    shape = [3072]
+    dtype = "torch.float32"
+    device = "cuda:0"
+    mean = -0.110
+    std = 0.053
+    data = None
+
 
 class Program_weight_tensor_meta_L_self_modules_transformer_modules_layer_modules_4_modules_ffn_modules_lin2_parameters_weight_:
-	name = "L_self_modules_transformer_modules_layer_modules_4_modules_ffn_modules_lin2_parameters_weight_"
-	shape = [768, 3072]
-	dtype = "torch.float32"
-	device = "cuda:0"
-	mean = -0.000
-	std = 0.042
-	data = None
+    name = "L_self_modules_transformer_modules_layer_modules_4_modules_ffn_modules_lin2_parameters_weight_"
+    shape = [768, 3072]
+    dtype = "torch.float32"
+    device = "cuda:0"
+    mean = -0.000
+    std = 0.042
+    data = None
+
 
 class Program_weight_tensor_meta_L_self_modules_transformer_modules_layer_modules_4_modules_ffn_modules_lin2_parameters_bias_:
-	name = "L_self_modules_transformer_modules_layer_modules_4_modules_ffn_modules_lin2_parameters_bias_"
-	shape = [768]
-	dtype = "torch.float32"
-	device = "cuda:0"
-	mean = -0.000
-	std = 0.084
-	data = None
+    name = "L_self_modules_transformer_modules_layer_modules_4_modules_ffn_modules_lin2_parameters_bias_"
+    shape = [768]
+    dtype = "torch.float32"
+    device = "cuda:0"
+    mean = -0.000
+    std = 0.084
+    data = None
+
 
 class Program_weight_tensor_meta_L_self_modules_transformer_modules_layer_modules_4_modules_output_layer_norm_parameters_weight_:
-	name = "L_self_modules_transformer_modules_layer_modules_4_modules_output_layer_norm_parameters_weight_"
-	shape = [768]
-	dtype = "torch.float32"
-	device = "cuda:0"
-	mean = 0.777
-	std = 0.067
-	data = None
+    name = "L_self_modules_transformer_modules_layer_modules_4_modules_output_layer_norm_parameters_weight_"
+    shape = [768]
+    dtype = "torch.float32"
+    device = "cuda:0"
+    mean = 0.777
+    std = 0.067
+    data = None
+
 
 class Program_weight_tensor_meta_L_self_modules_transformer_modules_layer_modules_4_modules_output_layer_norm_parameters_bias_:
-	name = "L_self_modules_transformer_modules_layer_modules_4_modules_output_layer_norm_parameters_bias_"
-	shape = [768]
-	dtype = "torch.float32"
-	device = "cuda:0"
-	mean = -0.039
-	std = 0.054
-	data = None
+    name = "L_self_modules_transformer_modules_layer_modules_4_modules_output_layer_norm_parameters_bias_"
+    shape = [768]
+    dtype = "torch.float32"
+    device = "cuda:0"
+    mean = -0.039
+    std = 0.054
+    data = None
+
 
 class Program_weight_tensor_meta_L_self_modules_transformer_modules_layer_modules_5_modules_attention_modules_q_lin_parameters_weight_:
-	name = "L_self_modules_transformer_modules_layer_modules_5_modules_attention_modules_q_lin_parameters_weight_"
-	shape = [768, 768]
-	dtype = "torch.float32"
-	device = "cuda:0"
-	mean = -0.000
-	std = 0.049
-	data = None
+    name = "L_self_modules_transformer_modules_layer_modules_5_modules_attention_modules_q_lin_parameters_weight_"
+    shape = [768, 768]
+    dtype = "torch.float32"
+    device = "cuda:0"
+    mean = -0.000
+    std = 0.049
+    data = None
+
 
 class Program_weight_tensor_meta_L_self_modules_transformer_modules_layer_modules_5_modules_attention_modules_q_lin_parameters_bias_:
-	name = "L_self_modules_transformer_modules_layer_modules_5_modules_attention_modules_q_lin_parameters_bias_"
-	shape = [768]
-	dtype = "torch.float32"
-	device = "cuda:0"
-	mean = 0.013
-	std = 0.239
-	data = None
+    name = "L_self_modules_transformer_modules_layer_modules_5_modules_attention_modules_q_lin_parameters_bias_"
+    shape = [768]
+    dtype = "torch.float32"
+    device = "cuda:0"
+    mean = 0.013
+    std = 0.239
+    data = None
+
 
 class Program_weight_tensor_meta_L_self_modules_transformer_modules_layer_modules_5_modules_attention_modules_k_lin_parameters_weight_:
-	name = "L_self_modules_transformer_modules_layer_modules_5_modules_attention_modules_k_lin_parameters_weight_"
-	shape = [768, 768]
-	dtype = "torch.float32"
-	device = "cuda:0"
-	mean = 0.000
-	std = 0.049
-	data = None
+    name = "L_self_modules_transformer_modules_layer_modules_5_modules_attention_modules_k_lin_parameters_weight_"
+    shape = [768, 768]
+    dtype = "torch.float32"
+    device = "cuda:0"
+    mean = 0.000
+    std = 0.049
+    data = None
+
 
 class Program_weight_tensor_meta_L_self_modules_transformer_modules_layer_modules_5_modules_attention_modules_k_lin_parameters_bias_:
-	name = "L_self_modules_transformer_modules_layer_modules_5_modules_attention_modules_k_lin_parameters_bias_"
-	shape = [768]
-	dtype = "torch.float32"
-	device = "cuda:0"
-	mean = -0.000
-	std = 0.005
-	data = None
+    name = "L_self_modules_transformer_modules_layer_modules_5_modules_attention_modules_k_lin_parameters_bias_"
+    shape = [768]
+    dtype = "torch.float32"
+    device = "cuda:0"
+    mean = -0.000
+    std = 0.005
+    data = None
+
 
 class Program_weight_tensor_meta_L_self_modules_transformer_modules_layer_modules_5_modules_attention_modules_v_lin_parameters_weight_:
-	name = "L_self_modules_transformer_modules_layer_modules_5_modules_attention_modules_v_lin_parameters_weight_"
-	shape = [768, 768]
-	dtype = "torch.float32"
-	device = "cuda:0"
-	mean = 0.000
-	std = 0.048
-	data = None
+    name = "L_self_modules_transformer_modules_layer_modules_5_modules_attention_modules_v_lin_parameters_weight_"
+    shape = [768, 768]
+    dtype = "torch.float32"
+    device = "cuda:0"
+    mean = 0.000
+    std = 0.048
+    data = None
+
 
 class Program_weight_tensor_meta_L_self_modules_transformer_modules_layer_modules_5_modules_attention_modules_v_lin_parameters_bias_:
-	name = "L_self_modules_transformer_modules_layer_modules_5_modules_attention_modules_v_lin_parameters_bias_"
-	shape = [768]
-	dtype = "torch.float32"
-	device = "cuda:0"
-	mean = 0.000
-	std = 0.022
-	data = None
+    name = "L_self_modules_transformer_modules_layer_modules_5_modules_attention_modules_v_lin_parameters_bias_"
+    shape = [768]
+    dtype = "torch.float32"
+    device = "cuda:0"
+    mean = 0.000
+    std = 0.022
+    data = None
+
 
 class Program_weight_tensor_meta_L_self_modules_transformer_modules_layer_modules_5_modules_attention_modules_out_lin_parameters_weight_:
-	name = "L_self_modules_transformer_modules_layer_modules_5_modules_attention_modules_out_lin_parameters_weight_"
-	shape = [768, 768]
-	dtype = "torch.float32"
-	device = "cuda:0"
-	mean = 0.000
-	std = 0.045
-	data = None
+    name = "L_self_modules_transformer_modules_layer_modules_5_modules_attention_modules_out_lin_parameters_weight_"
+    shape = [768, 768]
+    dtype = "torch.float32"
+    device = "cuda:0"
+    mean = 0.000
+    std = 0.045
+    data = None
+
 
 class Program_weight_tensor_meta_L_self_modules_transformer_modules_layer_modules_5_modules_attention_modules_out_lin_parameters_bias_:
-	name = "L_self_modules_transformer_modules_layer_modules_5_modules_attention_modules_out_lin_parameters_bias_"
-	shape = [768]
-	dtype = "torch.float32"
-	device = "cuda:0"
-	mean = -0.000
-	std = 0.051
-	data = None
+    name = "L_self_modules_transformer_modules_layer_modules_5_modules_attention_modules_out_lin_parameters_bias_"
+    shape = [768]
+    dtype = "torch.float32"
+    device = "cuda:0"
+    mean = -0.000
+    std = 0.051
+    data = None
+
 
 class Program_weight_tensor_meta_L_self_modules_transformer_modules_layer_modules_5_modules_sa_layer_norm_parameters_weight_:
-	name = "L_self_modules_transformer_modules_layer_modules_5_modules_sa_layer_norm_parameters_weight_"
-	shape = [768]
-	dtype = "torch.float32"
-	device = "cuda:0"
-	mean = 0.772
-	std = 0.059
-	data = None
+    name = "L_self_modules_transformer_modules_layer_modules_5_modules_sa_layer_norm_parameters_weight_"
+    shape = [768]
+    dtype = "torch.float32"
+    device = "cuda:0"
+    mean = 0.772
+    std = 0.059
+    data = None
+
 
 class Program_weight_tensor_meta_L_self_modules_transformer_modules_layer_modules_5_modules_sa_layer_norm_parameters_bias_:
-	name = "L_self_modules_transformer_modules_layer_modules_5_modules_sa_layer_norm_parameters_bias_"
-	shape = [768]
-	dtype = "torch.float32"
-	device = "cuda:0"
-	mean = -0.046
-	std = 0.109
-	data = None
+    name = "L_self_modules_transformer_modules_layer_modules_5_modules_sa_layer_norm_parameters_bias_"
+    shape = [768]
+    dtype = "torch.float32"
+    device = "cuda:0"
+    mean = -0.046
+    std = 0.109
+    data = None
+
 
 class Program_weight_tensor_meta_L_self_modules_transformer_modules_layer_modules_5_modules_ffn_modules_lin1_parameters_weight_:
-	name = "L_self_modules_transformer_modules_layer_modules_5_modules_ffn_modules_lin1_parameters_weight_"
-	shape = [3072, 768]
-	dtype = "torch.float32"
-	device = "cuda:0"
-	mean = 0.001
-	std = 0.039
-	data = None
+    name = "L_self_modules_transformer_modules_layer_modules_5_modules_ffn_modules_lin1_parameters_weight_"
+    shape = [3072, 768]
+    dtype = "torch.float32"
+    device = "cuda:0"
+    mean = 0.001
+    std = 0.039
+    data = None
+
 
 class Program_weight_tensor_meta_L_self_modules_transformer_modules_layer_modules_5_modules_ffn_modules_lin1_parameters_bias_:
-	name = "L_self_modules_transformer_modules_layer_modules_5_modules_ffn_modules_lin1_parameters_bias_"
-	shape = [3072]
-	dtype = "torch.float32"
-	device = "cuda:0"
-	mean = -0.077
-	std = 0.059
-	data = None
+    name = "L_self_modules_transformer_modules_layer_modules_5_modules_ffn_modules_lin1_parameters_bias_"
+    shape = [3072]
+    dtype = "torch.float32"
+    device = "cuda:0"
+    mean = -0.077
+    std = 0.059
+    data = None
+
 
 class Program_weight_tensor_meta_L_self_modules_transformer_modules_layer_modules_5_modules_ffn_modules_lin2_parameters_weight_:
-	name = "L_self_modules_transformer_modules_layer_modules_5_modules_ffn_modules_lin2_parameters_weight_"
-	shape = [768, 3072]
-	dtype = "torch.float32"
-	device = "cuda:0"
-	mean = -0.000
-	std = 0.037
-	data = None
+    name = "L_self_modules_transformer_modules_layer_modules_5_modules_ffn_modules_lin2_parameters_weight_"
+    shape = [768, 3072]
+    dtype = "torch.float32"
+    device = "cuda:0"
+    mean = -0.000
+    std = 0.037
+    data = None
+
 
 class Program_weight_tensor_meta_L_self_modules_transformer_modules_layer_modules_5_modules_ffn_modules_lin2_parameters_bias_:
-	name = "L_self_modules_transformer_modules_layer_modules_5_modules_ffn_modules_lin2_parameters_bias_"
-	shape = [768]
-	dtype = "torch.float32"
-	device = "cuda:0"
-	mean = -0.001
-	std = 0.058
-	data = None
+    name = "L_self_modules_transformer_modules_layer_modules_5_modules_ffn_modules_lin2_parameters_bias_"
+    shape = [768]
+    dtype = "torch.float32"
+    device = "cuda:0"
+    mean = -0.001
+    std = 0.058
+    data = None
+
 
 class Program_weight_tensor_meta_L_self_modules_transformer_modules_layer_modules_5_modules_output_layer_norm_parameters_weight_:
-	name = "L_self_modules_transformer_modules_layer_modules_5_modules_output_layer_norm_parameters_weight_"
-	shape = [768]
-	dtype = "torch.float32"
-	device = "cuda:0"
-	mean = 0.606
-	std = 0.029
-	data = None
+    name = "L_self_modules_transformer_modules_layer_modules_5_modules_output_layer_norm_parameters_weight_"
+    shape = [768]
+    dtype = "torch.float32"
+    device = "cuda:0"
+    mean = 0.606
+    std = 0.029
+    data = None
+
 
 class Program_weight_tensor_meta_L_self_modules_transformer_modules_layer_modules_5_modules_output_layer_norm_parameters_bias_:
-	name = "L_self_modules_transformer_modules_layer_modules_5_modules_output_layer_norm_parameters_bias_"
-	shape = [768]
-	dtype = "torch.float32"
-	device = "cuda:0"
-	mean = -0.021
-	std = 0.048
-	data = None
+    name = "L_self_modules_transformer_modules_layer_modules_5_modules_output_layer_norm_parameters_bias_"
+    shape = [768]
+    dtype = "torch.float32"
+    device = "cuda:0"
+    mean = -0.021
+    std = 0.048
+    data = None

--- a/tools/ci/check_validate.sh
+++ b/tools/ci/check_validate.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+set +ex
+
+function LOG {
+  echo [$0:${BASH_LINENO[0]}] $* >&2
+}
+
+LOG "[INFO] Start validate samples changed by pull request ..."
+
+export GRAPH_NET_EXTRACT_WORKSPACE=$(cd $(dirname $0)/../.. && pwd)
+export PYTHONPATH=${GRAPH_NET_EXTRACT_WORKSPACE}:$PYTHONPATH
+
+[ -z "$CUDA_VISIBLE_DEVICES" ] && CUDA_VISIBLE_DEVICES="0"
+
+function prepare_env() {
+  num_changed_files=$(git diff --name-only develop | grep -E "samples/(.*\.py|.*\.json)" | wc -l)
+  if [ ${num_changed_files} -eq 0 ]; then
+    LOG "[INFO] This pull request doesn't change any files of op benchmark, skip the CI."
+    exit 0
+  fi
+
+  LOG "[INFO] Device Id: ${CUDA_VISIBLE_DEVICES}"
+  # Update pip
+  LOG "[INFO] Update pip ..."
+  env http_proxy="" https_proxy="" pip install -U pip > /dev/null
+  [ $? -ne 0 ] && LOG "[FATAL] Update pip failed!" && exit -1
+  # install torch 
+}
+
+function check_validation() {
+  LOG "[INFO] Start run validate for changed samples ..."
+  MODIFIED_MODEL_PATHS=()
+  for file in $(git diff --name-only develop | grep -E "samples/(.*\.py|.*\.json)")
+  do
+    LOG "[INFO] Found ${file} modified."
+    model_path=$(dirname ${file})
+    MODIFIED_MODEL_PATHS[${#MODIFIED_MODEL_PATHS[@]}]=$model_path
+  done
+  MODIFIED_MODEL_PATHS=($(echo ${MODIFIED_MODEL_PATHS[@]} | tr ' ' '\n' | sort | uniq))
+  LOG "[INFO] Validation of these models will run: ${MODIFIED_MODEL_PATHS[@]}"
+  fail_name=()
+  for model_path in ${MODIFIED_MODEL_PATHS[@]}
+  do
+    python -m graph_net.torch.validate --model-path ${GRAPH_NET_EXTRACT_WORKSPACE}/${model_path} >&2
+    [ $? -ne 0 ] && fail_name[${#fail_name[@]}]="${model_path}(Run on ${device_type})"
+  done
+  if [ ${#fail_name[@]} -ne 0 ]
+  then
+    LOG "[FATAL] Failed tests: ${fail_name[@]}"
+    echo ${fail_name[@]}
+    exit -1
+  fi
+}
+
+function summary_problems() {
+  local check_validation_code=$1
+  local check_validation_info=$2
+  if [ $check_validation_code -ne 0 ]
+  then
+    LOG "[FATAL] ============================================"
+    LOG "[FATAL] Summary problems:"
+    LOG "[FATAL] === API test error - Please fix the failed API tests accroding to fatal log:"
+    LOG "[FATAL] $check_validation_info"
+    exit $check_validation_code
+  fi
+}
+
+function main() {
+  prepare_env
+  check_validation_info=$(check_validation)
+  check_validation_code=$?
+  summary_problems $check_validation_code "$check_validation_info"
+  LOG "[INFO] check_validation run success and no error!"
+}
+
+main

--- a/tools/ci/check_validate.sh
+++ b/tools/ci/check_validate.sh
@@ -26,6 +26,7 @@ function prepare_env() {
   env http_proxy="" https_proxy="" pip install -U pip > /dev/null
   [ $? -ne 0 ] && LOG "[FATAL] Update pip failed!" && exit -1
   # install torch 
+  pip install torch==2.7.0 --index-url https://download.pytorch.org/whl/cu118
 }
 
 function check_validation() {


### PR DESCRIPTION
本PR的修改：
1. 对samples目录应用了`pre-commit`，修改了`samples/transformers-auto-model/distilbert-base-uncased`目录下模型文件的格式。

2. 新增用于CI执行的`check_validate.sh`脚本，其中会：（1）安装torch（2）依据PR修改的模型文件，确定PR要测试的模型目录（3）对PR修改的模型目录执行validate验证。该脚本在本地的执行日志如下：
```bash
$ bash check_validate.sh 
[check_validate.sh:9] [INFO] Start validate samples changed by pull request ...
[check_validate.sh:23] [INFO] Device Id: 0
[check_validate.sh:25] [INFO] Update pip ...
[check_validate.sh:32] [INFO] Start run validate for changed samples ...
[check_validate.sh:36] [INFO] Found samples/transformers-auto-model/distilbert-base-uncased/model.py modified.
[check_validate.sh:36] [INFO] Found samples/transformers-auto-model/distilbert-base-uncased/weight_meta.py modified.
[check_validate.sh:41] [INFO] Validation of these models will run: samples/transformers-auto-model/distilbert-base-uncased
model_path='/work/GraphNet/samples/transformers-auto-model/distilbert-base-uncased'
Graph and tensors for 'temp' extracted successfully to: /tmp/tmpthr_pecl/temp
tensor(505, device='cuda:0') tensor(1468, device='cuda:0')
torch.Size([1, 4, 768])
model_path='/tmp/tmpthr_pecl/temp'
tensor(794, device='cuda:0') tensor(1670, device='cuda:0')
torch.Size([1, 4, 768])
Validation success, model_path='/work/GraphNet/samples/transformers-auto-model/distilbert-base-uncased'
[check_validate.sh:74] [INFO] check_validation run success and no error!
```

3. 实现检查模型是否validate的ci配置