### PR TITLE
[Bug Fix] Fix when tensor with shape [1] and when device in gm.code

### DIFF
--- a/graph_net/torch/utils.py
+++ b/graph_net/torch/utils.py
@@ -8,17 +8,23 @@ import os
 import argparse
 import importlib
 import inspect
+import math
 
 
 def apply_templates(forward_code: str) -> str:
     tab = "    "
     forward_code = f"\n{tab}".join(forward_code.split("\n"))
-    return f"import torch\n\nclass GraphModule(torch.nn.Module):\n{tab}{forward_code}"
+    imports = "import torch"
+    if "device" in forward_code:
+        imports += "\n\nfrom torch import device"
+    return f"{imports}\n\nclass GraphModule(torch.nn.Module):\n{tab}{forward_code}"
 
 
 def get_limited_precision_float_str(value):
     if not isinstance(value, float):
         return value
+    if not math.isfinite(value):
+        return f'float("{value}")'
     return f"{value:.3f}"
 
 


### PR DESCRIPTION
### PR Category
<!-- One of [ New Sample | Feature Enhancement | Bug Fix | Other ] -->
Bug Fix

### Description
<!-- Describe what you’ve done -->
1. torch.complie 提取出来的 gm.code 有时会出现 device = device(type='cuda', index=0)，需要先 from torch import device
2. 获取张量的 std info 的时候，存在张量 shape = [1] ，出现 std=nan，直接保存到 weight_meta.py 会导致 nan 未定义，所以改成了 float("nan")
3. 问题模型在 https://github.com/PaddlePaddle/GraphNet/pull/83, 这里面是没修改之前的提取