### PR TITLE
[Bug Fix] Fix std when numel eq to 1

### DIFF
--- a/graph_net/torch/utils.py
+++ b/graph_net/torch/utils.py
@@ -23,8 +23,6 @@ def apply_templates(forward_code: str) -> str:
 def get_limited_precision_float_str(value):
     if not isinstance(value, float):
         return value
-    if not math.isfinite(value):
-        return f'float("{value}")'
     return f"{value:.3f}"
 
 
@@ -32,7 +30,12 @@ def convert_state_and_inputs_impl(state_dict, example_inputs):
     def tensor_info(tensor):
         is_float = tensor.dtype.is_floating_point
         mean = float(tensor.mean().item()) if is_float else None
-        std = float(tensor.std().item()) if is_float else None
+        std = None
+        if is_float:
+            if tensor.numel() <= 1:
+                std = 0.0
+            else:
+                std = float(tensor.std().item())
         return {
             "shape": list(tensor.shape),
             "dtype": str(tensor.dtype),


### PR DESCRIPTION
### PR Category
<!-- One of [ New Sample | Feature Enhancement | Bug Fix | Other ] -->
Bug Fix

### Description
<!-- Describe what you’ve done -->
`return torch.randn(size=shape).to(dtype).to(device) * std * 0.2 + mean` 中之前 https://github.com/PaddlePaddle/GraphNet/pull/82 是默认使用了 nan，会产生 nan 的数据，虽然能让模型成功运行得到计算图。现在遇到开启 dynamic=True 的时候 **microsoft/mpnet-base** ，dropout 中的 p 参数会从 weight_meta 的 Tensor 形式 .item 中得到，这个时候 nan 的值就会报错，p 不期望是 nan. 所以现在改成了 std = 0