### PR TITLE
[Bug Fix] Support bool dtype in replay_tensor

### DIFF
--- a/graph_net/torch/utils.py
+++ b/graph_net/torch/utils.py
@@ -265,4 +265,6 @@ def replay_tensor(info):
     std = info["info"]["std"]
     if "data" in info and info["data"] is not None:
         return info["data"].to(device)
+    if dtype is torch.bool:
+        return (torch.randn(size=shape) > 0.5).to(dtype).to(device)
     return torch.randn(size=shape).to(dtype).to(device) * std * 0.2 + mean


### PR DESCRIPTION
### PR Category
<!-- One of [ New Sample | Feature Enhancement | Bug Fix | Other ] -->
Bug Fix

### Description
<!-- Describe what you’ve done -->
Support bool dtype in replay_tensor
在提取 CosyVoice 的 encode 时，最后提取到的图的输入是 bool 类型数据，
```
class Program_weight_tensor_meta_L_stack0_:
    name = "L_stack0_"
    shape = [1, 1, 763]
    dtype = "torch.bool"
    device = "cuda:0"
    mean = None
    std = None
    data = None
```
如下报错：所以对 bool 加了一个判断。
<img width="788" height="346" alt="图片" src="https://github.com/user-attachments/assets/fa1f9829-4250-4f1a-9dd0-c13d4ea2e7b2" />

#### Other
跑了几次都能通过，感觉和 True 和 False 的数量关系不大
同理之后可能也会遇到 complex 等类型