### PR TITLE
【Hackathon 9th No.100】[Feature Enhancement] add BladeDISC for compiler backend

### DIFF
--- a/docs/BladeDISC_batch_test.txt
+++ b/docs/BladeDISC_batch_test.txt
@@ -1,0 +1,98 @@
+Expected bias to be of same shape as normalized_shape, but got bias of shape [2048] and normalized_shape = [512]
+Failed! Try to export it through torch.jit.script:
+
+
+Arguments for call are not valid.
+The following variants are available:
+  
+  aten::device(str a) -> (Device):
+  Argument a not provided.
+  
+  device(str type) -> (Device):
+  Keyword argument index unknown.
+
+The original call is:
+  File "/daiwenhao/GraphNet/samples/cosyvoice/CosyVoice-300M/model.py", line 409
+        q_with_bias_v = transpose_8 = None
+        zero_pad = torch.zeros(
+            (1, 8, 763, 1), device=device(type="cuda", index=0), dtype=torch.float32
+                                   ~~~~~~ <--- HERE
+        )
+        x_padded = torch.cat([zero_pad, matrix_bd], dim=-1)
+
+Fail to export torchscript on the top level of the model, We will iterate over the submodules and replace those that can be successfully exported by the torch.jit.script
+graph-net-test-compiler-log equal model_path:/daiwenhao/GraphNet/samples/cosyvoice/CosyVoice-300M 1
+graph-net-test-compiler-log all_close_atol8_rtol8 model_path:/daiwenhao/GraphNet/samples/cosyvoice/CosyVoice-300M 1
+graph-net-test-compiler-log all_close_atol8_rtol5 model_path:/daiwenhao/GraphNet/samples/cosyvoice/CosyVoice-300M 1
+graph-net-test-compiler-log all_close_atol5_rtol5 model_path:/daiwenhao/GraphNet/samples/cosyvoice/CosyVoice-300M 1
+graph-net-test-compiler-log all_close_atol3_rtol2 model_path:/daiwenhao/GraphNet/samples/cosyvoice/CosyVoice-300M 1
+graph-net-test-compiler-log all_close_atol2_rtol1 model_path:/daiwenhao/GraphNet/samples/cosyvoice/CosyVoice-300M 1
+graph-net-test-compiler-log max_diff model_path:/daiwenhao/GraphNet/samples/cosyvoice/CosyVoice-300M 0.0
+graph-net-test-compiler-log mean_diff model_path:/daiwenhao/GraphNet/samples/cosyvoice/CosyVoice-300M 0.0
+graph-net-test-compiler-log diff_count_atol8_rtol8 model_path:/daiwenhao/GraphNet/samples/cosyvoice/CosyVoice-300M 0
+graph-net-test-compiler-log diff_count_atol8_rtol5 model_path:/daiwenhao/GraphNet/samples/cosyvoice/CosyVoice-300M 0
+graph-net-test-compiler-log diff_count_atol5_rtol5 model_path:/daiwenhao/GraphNet/samples/cosyvoice/CosyVoice-300M 0
+graph-net-test-compiler-log diff_count_atol3_rtol2 model_path:/daiwenhao/GraphNet/samples/cosyvoice/CosyVoice-300M 0
+graph-net-test-compiler-log diff_count_atol2_rtol1 model_path:/daiwenhao/GraphNet/samples/cosyvoice/CosyVoice-300M 0
+graph-net-test-compiler-log duration model_path:/daiwenhao/GraphNet/samples/cosyvoice/CosyVoice-300M eager:8.6400 compiled:8.4100
+[Profiling] Using device: cuda:0 NVIDIA A100-SXM4-40GB, warm up 3, trials 5
+Trial 1: 9.36 ms
+Trial 2: 8.55 ms
+Trial 3: 8.48 ms
+Trial 4: 8.41 ms
+Trial 5: 8.41 ms
+[Profiling] Using device: cuda:0 NVIDIA A100-SXM4-40GB, warm up 3, trials 5
+Trial 1: 8.42 ms
+Trial 2: 8.41 ms
+Trial 3: 8.4 ms
+Trial 4: 8.4 ms
+Trial 5: 8.41 ms
+Expected bias to be of same shape as normalized_shape, but got bias of shape [2048] and normalized_shape = [512]
+Failed! Try to export it through torch.jit.script:
+
+
+Arguments for call are not valid.
+The following variants are available:
+  
+  aten::device(str a) -> (Device):
+  Argument a not provided.
+  
+  device(str type) -> (Device):
+  Keyword argument index unknown.
+
+The original call is:
+  File "/daiwenhao/GraphNet/samples/cosyvoice/CosyVoice2-0.5B/model.py", line 291
+        q_with_bias_v = transpose_8 = None
+        zero_pad = torch.zeros(
+            (1, 8, 796, 1), device=device(type="cuda", index=0), dtype=torch.float32
+                                   ~~~~~~ <--- HERE
+        )
+        x_padded = torch.cat([zero_pad, matrix_bd], dim=-1)
+
+Fail to export torchscript on the top level of the model, We will iterate over the submodules and replace those that can be successfully exported by the torch.jit.script
+graph-net-test-compiler-log equal model_path:/daiwenhao/GraphNet/samples/cosyvoice/CosyVoice2-0.5B 1
+graph-net-test-compiler-log all_close_atol8_rtol8 model_path:/daiwenhao/GraphNet/samples/cosyvoice/CosyVoice2-0.5B 1
+graph-net-test-compiler-log all_close_atol8_rtol5 model_path:/daiwenhao/GraphNet/samples/cosyvoice/CosyVoice2-0.5B 1
+graph-net-test-compiler-log all_close_atol5_rtol5 model_path:/daiwenhao/GraphNet/samples/cosyvoice/CosyVoice2-0.5B 1
+graph-net-test-compiler-log all_close_atol3_rtol2 model_path:/daiwenhao/GraphNet/samples/cosyvoice/CosyVoice2-0.5B 1
+graph-net-test-compiler-log all_close_atol2_rtol1 model_path:/daiwenhao/GraphNet/samples/cosyvoice/CosyVoice2-0.5B 1
+graph-net-test-compiler-log max_diff model_path:/daiwenhao/GraphNet/samples/cosyvoice/CosyVoice2-0.5B 0.0
+graph-net-test-compiler-log mean_diff model_path:/daiwenhao/GraphNet/samples/cosyvoice/CosyVoice2-0.5B 0.0
+graph-net-test-compiler-log diff_count_atol8_rtol8 model_path:/daiwenhao/GraphNet/samples/cosyvoice/CosyVoice2-0.5B 0
+graph-net-test-compiler-log diff_count_atol8_rtol5 model_path:/daiwenhao/GraphNet/samples/cosyvoice/CosyVoice2-0.5B 0
+graph-net-test-compiler-log diff_count_atol5_rtol5 model_path:/daiwenhao/GraphNet/samples/cosyvoice/CosyVoice2-0.5B 0
+graph-net-test-compiler-log diff_count_atol3_rtol2 model_path:/daiwenhao/GraphNet/samples/cosyvoice/CosyVoice2-0.5B 0
+graph-net-test-compiler-log diff_count_atol2_rtol1 model_path:/daiwenhao/GraphNet/samples/cosyvoice/CosyVoice2-0.5B 0
+graph-net-test-compiler-log duration model_path:/daiwenhao/GraphNet/samples/cosyvoice/CosyVoice2-0.5B eager:6.0600 compiled:6.0400
+[Profiling] Using device: cuda:0 NVIDIA A100-SXM4-40GB, warm up 3, trials 5
+Trial 1: 6.11 ms
+Trial 2: 6.05 ms
+Trial 3: 6.04 ms
+Trial 4: 6.04 ms
+Trial 5: 6.05 ms
+[Profiling] Using device: cuda:0 NVIDIA A100-SXM4-40GB, warm up 3, trials 5
+Trial 1: 6.03 ms
+Trial 2: 6.03 ms
+Trial 3: 6.04 ms
+Trial 4: 6.04 ms
+Trial 5: 6.06 ms

--- a/docs/BladeDISC_tech_report.md
+++ b/docs/BladeDISC_tech_report.md
@@ -1,0 +1,207 @@
+# 1 - Introduction
+
+BladeDISC is an end-to-end **Dynamic Shape Compiler** project for machine learning workloads, which is one of the key components of Alibaba's [PAI-Blade](https://www.aliyun.com/activity/bigdata/blade). For more information, please refer to  [Github BladeDISC | TorchBlade Overview](https://github.com/alibaba/BladeDISC/blob/main/docs/developers/bladedisc_torch_overview.md).
+
+This technical report demonstrates that `graph_net.torch.test_compiler` supports using the BladeDISC compiler as a backend, i.e., it supports configuring `--compiler "bladedisc"`, reads subgraphs from the `GraphNet/samples` directory, and successfully executes and obtains correct evaluation results.
+
+Taking BERT as an example  [Optimize and Inference BERT with TorchBlade](https://github.com/alibaba/BladeDISC/blob/main/docs/tutorials/torch_bert_inference.md), the main execution process is as follows:
+
+1. Convert the PyTorch model to TorchScript using `torch.jit.trace` or `torch.jit.script`.
+2. Compile and optimize the model using BladeDISC's `torch_blade.optimize` to generate the compiled model `compiled_model`.
+3. Combine the compiled model with input parameters `compiled_model(input)` to execute the forward pass.
+
+The process of compiling and optimizing with `torch.jit.trace` or `torch.jit.script` can be abstracted as follows:
+
+```shell
+# allow_tracing=True   using torch.jit.trace(model, inputs)
+compiled_model = torch_blade.optimize(model, allow_tracing=True, model_inputs=tuple(inputs))
+# allow_tracing=False  using torch.jit.script(model)  在本例中的尝试
+compiled_model = torch_blade.optimize(model, allow_tracing=False)
+```
+
+In the test of this report, `torch.jit.trace` was used.
+
+
+# 2 - Installation Instructions
+
+> The installation environment in this section is also the test environment used in Chapter 3.
+
+Official quick deployment options include [Install BladeDISC With Docker](https://github.com/alibaba/BladeDISC/blob/main/docs/install_with_docker.md) or  [Build BladeDISC from Source](https://github.com/alibaba/BladeDISC/blob/main/docs/build_from_source.md).
+
+However, BladeDISC's last official support ended in 2022, when it was adapted for PyTorch 1.X series. Compiling from source requires specific modifications to adapt to PyTorch 2.X. Therefore, it is recommended to use the official image `bladedisc/bladedisc:latest-runtime-torch1.12.0-cu113` to quickly obtain compiler performance evaluation data.
+
+```shell
+docker run -itd --gpus all --name torch_bladedisc_test -v /your_path:/your_path registry.cn-shanghai.aliyuncs.com/bladedisc/bladedisc:latest-runtime-torch1.12.0-cu113 /bin/bash
+```
+
+**Note**: Since BladeDISC is not adapted for PyTorch 2.X, certain parts of GraphNet that depend on higher versions of PyTorch should be commented out before execution. For example, `GraphNet/graph_net/torch/__init__.py` should be modified as follows:
+
+```shell
+"""
+GraphNet PyTorch Implementation
+"""
+# from .extractor import extract
+# from .samples_util import get_default_samples_directory
+# __all__ = ["extract", "get_default_samples_directory"]
+```
+
+
+
+### 3 - Test Report
+
+- BladeDISC for torch (import torch_blade) does not exhibit any entire category of models failing to run in the existing `/samples` (as of 2025.08.30).
+
+- For all models under `/samples/cosyvoice`, batch performance testing on GPU A100-SXM-40GB is documented in `BladeDISC_batch_test.txt`.
+
+- For each category in `/samples`, one model was tested. The validation report can be found in `BladeDISC_validation_report.txt`, with a performance overview as follows:
+
+  | Model                                                        | Eager (ms) | Compiled (ms) |
+  | ------------------------------------------------------------ | ---------- | ------------- |
+  | cosyvoice/CosyVoice-300M                                     | 8.4000     | 8.3600        |
+  | mmpose/2xmspn_50                                             | 17.1000    | 14.1000       |
+  | mmseg/ANN_R50                                                | 21.7000    | 21.8000       |
+  | nemo/parakeet-ctc-0.6b                                       | 55.3000    | 54.4000       |
+  | torchaudio/convtasnet_base_libri2mix                         | 99.4000    | 99.6000       |
+  | torchgeometric/LINKX                                         | 1.0300     | 0.7280        |
+  | timm/darknet17                                               | 2.1500     | 2.1300        |
+  | torchvision/deeplabv3_resnet50                               | 8.4300     | 7.6200        |
+  | transformers-auto-model/hf-tiny-model-private_tiny-random-AltCLIPModel | 6.0000     | 4.4200        |
+  | ultralytics/yolo11l-cls                                      | 17.6000    | 14.8000       |
+
+
+
+# 4 - Execution Issue Analysis
+
+### Issue 1: Unsupported Operators
+
+The PyTorch version is too old (1.X), and some operators are only available in newer versions. For example:
+
+```shell
+Traceback (most recent call last):
+  File "/usr/lib/python3.8/runpy.py", line 194, in _run_module_as_main
+    return _run_code(code, main_globals, None,
+  File "/usr/lib/python3.8/runpy.py", line 87, in _run_code
+    exec(code, run_globals)
+  File "/daiwenhao/GraphNet/graph_net/torch/test_compiler.py", line 490, in <module>
+    main(args=args)
+  File "/daiwenhao/GraphNet/graph_net/torch/test_compiler.py", line 442, in main
+    test_single_model(args)
+  File "/daiwenhao/GraphNet/graph_net/torch/test_compiler.py", line 243, in test_single_model
+    model = get_model(args)
+  File "/daiwenhao/GraphNet/graph_net/torch/test_compiler.py", line 102, in get_model
+    model_class = load_class_from_file(args, class_name="GraphModule")
+  File "/daiwenhao/GraphNet/graph_net/torch/test_compiler.py", line 90, in load_class_from_file
+    exec(compiled_code, module.__dict__)
+  File "/daiwenhao/GraphNet/samples/torchvision/alexnet/model.py", line 4, in <module>
+    class GraphModule(torch.nn.Module):
+  File "/daiwenhao/GraphNet/samples/torchvision/alexnet/model.py", line 9, in GraphModule
+    s1: torch.SymInt,
+AttributeError: module 'torch' has no attribute 'SymInt'
+```
+
+Another example:
+
+```shell
+weight should have at least three dimensions
+Failed! Try to export it through torch.jit.script:
+object has no attribute scaled_dot_product_attention:
+  File "/daiwenhao/GraphNet/samples/torchaudio/hubert_base/model.py", line 609
+        v = view_2.transpose(2, 1)
+        view_2 = None
+        attn_output = torch._C._nn.scaled_dot_product_attention(
+                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ <--- HERE
+            q, k, v, attn_mask=None, dropout_p=0.0, is_causal=False
+        )
+Fail to export torchscript on the top level of the model, We will iterate over the submodules and replace those that can be successfully exported by the torch.jit.script
+Traceback (most recent call last):
+  File "/usr/lib/python3.8/runpy.py", line 194, in _run_module_as_main
+    return _run_code(code, main_globals, None,
+  File "/usr/lib/python3.8/runpy.py", line 87, in _run_code
+    exec(code, run_globals)
+  File "/daiwenhao/GraphNet/graph_net/torch/test_compiler.py", line 494, in <module>
+    main(args=args)
+  File "/daiwenhao/GraphNet/graph_net/torch/test_compiler.py", line 446, in main
+    test_single_model(args)
+  File "/daiwenhao/GraphNet/graph_net/torch/test_compiler.py", line 290, in test_single_model
+    eager_stats = measure_performance(eager_model_call, args, compiler)
+  File "/daiwenhao/GraphNet/graph_net/torch/test_compiler.py", line 228, in measure_performance
+    times = time_execution_with_cuda_event(
+  File "/daiwenhao/GraphNet/graph_net/torch/test_compiler.py", line 167, in time_execution_with_cuda_event
+    kernel_fn(*args)
+  File "/daiwenhao/GraphNet/graph_net/torch/test_compiler.py", line 287, in <lambda>
+    eager_model_call = lambda: model(**input_dict)
+  File "/usr/local/lib/python3.8/dist-packages/torch/nn/modules/module.py", line 1130, in _call_impl
+    return forward_call(*input, **kwargs)
+  File "/daiwenhao/GraphNet/samples/torchaudio/hubert_base/model.py", line 609, in forward
+    attn_output = torch._C._nn.scaled_dot_product_attention(
+AttributeError: module 'torch._C._nn' has no attribute 'scaled_dot_product_attention'
+```
+
+### Issue 2: Unsupported Dynamic Types
+
+Still due to the outdated PyTorch version (1.X), dynamic types in models are not supported.
+
+```shell
+object has no attribute sym_size:
+  File "/daiwenhao/GraphNet/samples/torchgeometric/GAT/model.py", line 114
+        edge_index = l_edge_index_[(slice(None, None, None), mask)]
+        mask = None
+        sym_size_int = torch.ops.aten.sym_size.int(edge_index, 1)
+                       ~~~~~~~~~~~~~~~~~~~~~~~ <--- HERE
+        _check_is_size = torch._check_is_size(sym_size_int)
+        _check_is_size = None
+Fail to export torchscript on the top level of the model, We will iterate over the submodules and replace those that can be successfully exported by the torch.jit.script
+Traceback (most recent call last):
+  File "/usr/local/lib/python3.8/dist-packages/torch/_ops.py", line 198, in __getattr__
+    op, overload_names = torch._C._jit_get_operation(qualified_op_name)
+RuntimeError: No such operator aten::sym_size
+The above exception was the direct cause of the following exception:
+Traceback (most recent call last):
+  File "/usr/lib/python3.8/runpy.py", line 194, in _run_module_as_main
+    return _run_code(code, main_globals, None,
+  File "/usr/lib/python3.8/runpy.py", line 87, in _run_code
+    exec(code, run_globals)
+  File "/daiwenhao/GraphNet/graph_net/torch/test_compiler.py", line 492, in <module>
+    main(args=args)
+  File "/daiwenhao/GraphNet/graph_net/torch/test_compiler.py", line 444, in main
+    test_single_model(args)
+  File "/daiwenhao/GraphNet/graph_net/torch/test_compiler.py", line 288, in test_single_model
+    eager_stats = measure_performance(eager_model_call, args, compiler)
+  File "/daiwenhao/GraphNet/graph_net/torch/test_compiler.py", line 226, in measure_performance
+    times = time_execution_with_cuda_event(
+  File "/daiwenhao/GraphNet/graph_net/torch/test_compiler.py", line 165, in time_execution_with_cuda_event
+    kernel_fn(*args)
+  File "/daiwenhao/GraphNet/graph_net/torch/test_compiler.py", line 285, in <lambda>
+    eager_model_call = lambda: model(**input_dict)
+  File "/usr/local/lib/python3.8/dist-packages/torch/nn/modules/module.py", line 1130, in _call_impl
+    return forward_call(*input, **kwargs)
+  File "/daiwenhao/GraphNet/samples/torchgeometric/GAT/model.py", line 114, in forward
+    sym_size_int = torch.ops.aten.sym_size.int(edge_index, 1)
+  File "/usr/local/lib/python3.8/dist-packages/torch/_ops.py", line 202, in __getattr__
+    raise AttributeError(f"'_OpNamespace' object has no attribute '{op_name}'") from e
+AttributeError: '_OpNamespace' object has no attribute 'sym_size'
+```
+
+### Issue 3: Unsupported `device(type="cuda", index=0)`
+
+In torch.jit.script execution mode, the BladeDISCBackend does not require input specifications, but `device(type="cuda", index=0)` is not supported by TorchScript; only `torch.device("cuda")` is supported.
+
+```shell
+The following variants are available:
+  aten::device(str a) -> (Device):
+  Argument a not provided.
+  
+  device(str type) -> (Device):
+  Keyword argument index unknown.
+
+The original call is:
+  File "/daiwenhao/GraphNet/samples/ultralytics/yolo11l/model.py", line 6511
+        l_self_modules_model_modules_23_stride = None
+        arange = torch.arange(
+            end=80, device=device(type="cuda", index=0), dtype=torch.float32
+                           ~~~~~~ <--- HERE
+        )
+        sx = arange + 0.5
+
+Fail to export torchscript on the top level of the model, We will iterate over the submodules and replace those that can be successfully exported by the torch.jit.script
+```

--- a/docs/BladeDISC_tech_report.md
+++ b/docs/BladeDISC_tech_report.md
@@ -15,7 +15,7 @@ The process of compiling and optimizing with `torch.jit.trace` or `torch.jit.scr
 ```shell
 # allow_tracing=True   using torch.jit.trace(model, inputs)
 compiled_model = torch_blade.optimize(model, allow_tracing=True, model_inputs=tuple(inputs))
-# allow_tracing=False  using torch.jit.script(model)  在本例中的尝试
+# allow_tracing=False  using torch.jit.script(model)
 compiled_model = torch_blade.optimize(model, allow_tracing=False)
 ```
 

--- a/docs/BlaseDISC_validation_report.txt
+++ b/docs/BlaseDISC_validation_report.txt
@@ -1,0 +1,862 @@
+Expected bias to be of same shape as normalized_shape, but got bias of shape [2048] and normalized_shape = [512]
+Failed! Try to export it through torch.jit.script:
+
+
+Arguments for call are not valid.
+The following variants are available:
+  
+  aten::device(str a) -> (Device):
+  Argument a not provided.
+  
+  device(str type) -> (Device):
+  Keyword argument index unknown.
+
+The original call is:
+  File "/daiwenhao/GraphNet/samples/cosyvoice/CosyVoice-300M/model.py", line 409
+        q_with_bias_v = transpose_8 = None
+        zero_pad = torch.zeros(
+            (1, 8, 763, 1), device=device(type="cuda", index=0), dtype=torch.float32
+                                   ~~~~~~ <--- HERE
+        )
+        x_padded = torch.cat([zero_pad, matrix_bd], dim=-1)
+
+Fail to export torchscript on the top level of the model, We will iterate over the submodules and replace those that can be successfully exported by the torch.jit.script
+graph-net-test-compiler-log equal model_path:/daiwenhao/GraphNet/samples/cosyvoice/CosyVoice-300M 1
+graph-net-test-compiler-log all_close_atol8_rtol8 model_path:/daiwenhao/GraphNet/samples/cosyvoice/CosyVoice-300M 1
+graph-net-test-compiler-log all_close_atol8_rtol5 model_path:/daiwenhao/GraphNet/samples/cosyvoice/CosyVoice-300M 1
+graph-net-test-compiler-log all_close_atol5_rtol5 model_path:/daiwenhao/GraphNet/samples/cosyvoice/CosyVoice-300M 1
+graph-net-test-compiler-log all_close_atol3_rtol2 model_path:/daiwenhao/GraphNet/samples/cosyvoice/CosyVoice-300M 1
+graph-net-test-compiler-log all_close_atol2_rtol1 model_path:/daiwenhao/GraphNet/samples/cosyvoice/CosyVoice-300M 1
+graph-net-test-compiler-log max_diff model_path:/daiwenhao/GraphNet/samples/cosyvoice/CosyVoice-300M 0.0
+graph-net-test-compiler-log mean_diff model_path:/daiwenhao/GraphNet/samples/cosyvoice/CosyVoice-300M 0.0
+graph-net-test-compiler-log diff_count_atol8_rtol8 model_path:/daiwenhao/GraphNet/samples/cosyvoice/CosyVoice-300M 0
+graph-net-test-compiler-log diff_count_atol8_rtol5 model_path:/daiwenhao/GraphNet/samples/cosyvoice/CosyVoice-300M 0
+graph-net-test-compiler-log diff_count_atol5_rtol5 model_path:/daiwenhao/GraphNet/samples/cosyvoice/CosyVoice-300M 0
+graph-net-test-compiler-log diff_count_atol3_rtol2 model_path:/daiwenhao/GraphNet/samples/cosyvoice/CosyVoice-300M 0
+graph-net-test-compiler-log diff_count_atol2_rtol1 model_path:/daiwenhao/GraphNet/samples/cosyvoice/CosyVoice-300M 0
+graph-net-test-compiler-log duration model_path:/daiwenhao/GraphNet/samples/cosyvoice/CosyVoice-300M eager:8.4000 compiled:8.3600
+[Profiling] Using device: cuda:0 NVIDIA A100-SXM4-40GB, warm up 3, trials 5
+Trial 1: 8.45 ms
+Trial 2: 8.39 ms
+Trial 3: 8.4 ms
+Trial 4: 8.36 ms
+Trial 5: 8.37 ms
+[Profiling] Using device: cuda:0 NVIDIA A100-SXM4-40GB, warm up 3, trials 5
+Trial 1: 8.37 ms
+Trial 2: 8.37 ms
+Trial 3: 8.34 ms
+Trial 4: 8.38 ms
+Trial 5: 8.36 ms
+weight should have at least three dimensions
+Failed! Try to export it through torch.jit.script:
+
+The following operation failed in the TorchScript interpreter.
+Traceback of TorchScript (most recent call last):
+  File "/daiwenhao/GraphNet/samples/mmpose/2xmspn_50/model.py", line 1450, in _torch_blade_record_tensor
+        l_self_modules_head_modules_predict_layers_modules_7_modules_conv_layers_modules_1_modules_bn_parameters_weight_ = L_self_modules_head_modules_predict_layers_modules_7_modules_conv_layers_modules_1_modules_bn_parameters_weight_
+        l_self_modules_head_modules_predict_layers_modules_7_modules_conv_layers_modules_1_modules_bn_parameters_bias_ = L_self_modules_head_modules_predict_layers_modules_7_modules_conv_layers_modules_1_modules_bn_parameters_bias_
+        x = torch.conv2d(
+            ~~~~~~~~~~~~ <--- HERE
+            l_inputs_,
+            l_self_modules_backbone_modules_top_modules_top_modules_0_modules_conv_parameters_weight_,
+RuntimeError: weight should have at least three dimensions
+
+Some Tensors' shapes are not recorded.
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+graph-net-test-compiler-log equal model_path:/daiwenhao/GraphNet/samples/mmpose/2xmspn_50 0 0 0 0 0 0 0 0
+graph-net-test-compiler-log all_close_atol8_rtol8 model_path:/daiwenhao/GraphNet/samples/mmpose/2xmspn_50 0 0 0 0 0 0 0 0
+graph-net-test-compiler-log all_close_atol8_rtol5 model_path:/daiwenhao/GraphNet/samples/mmpose/2xmspn_50 0 0 0 0 0 0 0 0
+graph-net-test-compiler-log all_close_atol5_rtol5 model_path:/daiwenhao/GraphNet/samples/mmpose/2xmspn_50 0 0 0 0 0 0 0 0
+graph-net-test-compiler-log all_close_atol3_rtol2 model_path:/daiwenhao/GraphNet/samples/mmpose/2xmspn_50 0 0 0 0 0 0 0 0
+graph-net-test-compiler-log all_close_atol2_rtol1 model_path:/daiwenhao/GraphNet/samples/mmpose/2xmspn_50 0 0 0 0 0 0 0 0
+graph-net-test-compiler-log max_diff model_path:/daiwenhao/GraphNet/samples/mmpose/2xmspn_50 nan nan nan nan nan nan nan nan
+graph-net-test-compiler-log mean_diff model_path:/daiwenhao/GraphNet/samples/mmpose/2xmspn_50 nan nan nan nan nan nan nan nan
+graph-net-test-compiler-log diff_count_atol8_rtol8 model_path:/daiwenhao/GraphNet/samples/mmpose/2xmspn_50 52224 52224 52224 52224 52224 52224 52224 52224
+graph-net-test-compiler-log diff_count_atol8_rtol5 model_path:/daiwenhao/GraphNet/samples/mmpose/2xmspn_50 52224 52224 52224 52224 52224 52224 52224 52224
+graph-net-test-compiler-log diff_count_atol5_rtol5 model_path:/daiwenhao/GraphNet/samples/mmpose/2xmspn_50 52224 52224 52224 52224 52224 52224 52224 52224
+graph-net-test-compiler-log diff_count_atol3_rtol2 model_path:/daiwenhao/GraphNet/samples/mmpose/2xmspn_50 52224 52224 52224 52224 52224 52224 52224 52224
+graph-net-test-compiler-log diff_count_atol2_rtol1 model_path:/daiwenhao/GraphNet/samples/mmpose/2xmspn_50 52224 52224 52224 52224 52224 52224 52224 52224
+graph-net-test-compiler-log duration model_path:/daiwenhao/GraphNet/samples/mmpose/2xmspn_50 eager:17.1000 compiled:14.1000
+[Profiling] Using device: cuda:0 NVIDIA A100-SXM4-40GB, warm up 3, trials 5
+Trial 1: 17.4 ms
+Trial 2: 17.1 ms
+Trial 3: 17.1 ms
+Trial 4: 17.1 ms
+Trial 5: 17.1 ms
+[Profiling] Using device: cuda:0 NVIDIA A100-SXM4-40GB, warm up 3, trials 5
+Trial 1: 14.3 ms
+Trial 2: 14.1 ms
+Trial 3: 14 ms
+Trial 4: 14 ms
+Trial 5: 14 ms
+Expected 3D (unbatched) or 4D (batched) input to conv2d, but got input of size: [64]
+Failed! Try to export it through torch.jit.script:
+
+The following operation failed in the TorchScript interpreter.
+Traceback of TorchScript (most recent call last):
+  File "/daiwenhao/GraphNet/samples/mmseg/ANN_R50/model.py", line 678, in _torch_blade_record_tensor
+            L_self_modules_decode_head_modules_conv_seg_parameters_bias_
+        )
+        input_1 = torch.conv2d(
+                  ~~~~~~~~~~~~ <--- HERE
+            l_inputs_,
+            l_self_modules_backbone_modules_stem_modules_0_parameters_weight_,
+RuntimeError: Expected 3D (unbatched) or 4D (batched) input to conv2d, but got input of size: [64]
+
+Some Tensors' shapes are not recorded.
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+graph-net-test-compiler-log equal model_path:/daiwenhao/GraphNet/samples/mmseg/ANN_R50 0
+graph-net-test-compiler-log all_close_atol8_rtol8 model_path:/daiwenhao/GraphNet/samples/mmseg/ANN_R50 0
+graph-net-test-compiler-log all_close_atol8_rtol5 model_path:/daiwenhao/GraphNet/samples/mmseg/ANN_R50 0
+graph-net-test-compiler-log all_close_atol5_rtol5 model_path:/daiwenhao/GraphNet/samples/mmseg/ANN_R50 1
+graph-net-test-compiler-log all_close_atol3_rtol2 model_path:/daiwenhao/GraphNet/samples/mmseg/ANN_R50 1
+graph-net-test-compiler-log all_close_atol2_rtol1 model_path:/daiwenhao/GraphNet/samples/mmseg/ANN_R50 1
+graph-net-test-compiler-log max_diff model_path:/daiwenhao/GraphNet/samples/mmseg/ANN_R50 3.382563591003418e-06
+graph-net-test-compiler-log mean_diff model_path:/daiwenhao/GraphNet/samples/mmseg/ANN_R50 5.515127798894071e-10
+graph-net-test-compiler-log diff_count_atol8_rtol8 model_path:/daiwenhao/GraphNet/samples/mmseg/ANN_R50 75
+graph-net-test-compiler-log diff_count_atol8_rtol5 model_path:/daiwenhao/GraphNet/samples/mmseg/ANN_R50 54
+graph-net-test-compiler-log diff_count_atol5_rtol5 model_path:/daiwenhao/GraphNet/samples/mmseg/ANN_R50 0
+graph-net-test-compiler-log diff_count_atol3_rtol2 model_path:/daiwenhao/GraphNet/samples/mmseg/ANN_R50 0
+graph-net-test-compiler-log diff_count_atol2_rtol1 model_path:/daiwenhao/GraphNet/samples/mmseg/ANN_R50 0
+graph-net-test-compiler-log duration model_path:/daiwenhao/GraphNet/samples/mmseg/ANN_R50 eager:21.7000 compiled:21.8000
+[Profiling] Using device: cuda:0 NVIDIA A100-SXM4-40GB, warm up 3, trials 5
+Trial 1: 21.8 ms
+Trial 2: 21.7 ms
+Trial 3: 21.7 ms
+Trial 4: 21.7 ms
+Trial 5: 21.7 ms
+[Profiling] Using device: cuda:0 NVIDIA A100-SXM4-40GB, warm up 3, trials 5
+Trial 1: 24.7 ms
+Trial 2: 21.9 ms
+Trial 3: 20.8 ms
+Trial 4: 21.2 ms
+Trial 5: 20.7 ms
+Dimension out of range (expected to be in range of [-1, 0], but got 1)
+Failed! Try to export it through torch.jit.script:
+
+
+Arguments for call are not valid.
+The following variants are available:
+  
+  aten::device(str a) -> (Device):
+  Argument a not provided.
+  
+  device(str type) -> (Device):
+  Keyword argument index unknown.
+
+The original call is:
+  File "/daiwenhao/GraphNet/samples/nemo/parakeet-ctc-0.6b/model.py", line 2361
+        x_2 = None
+        att_mask = torch.ones(
+            1, 66, 66, dtype=torch.bool, device=device(type="cuda", index=0)
+                                                ~~~~~~ <--- HERE
+        )
+        arange = torch.arange(0, 66, device=device(type="cuda", index=0))
+
+Fail to export torchscript on the top level of the model, We will iterate over the submodules and replace those that can be successfully exported by the torch.jit.script
+graph-net-test-compiler-log equal model_path:/daiwenhao/GraphNet/samples/nemo/parakeet-ctc-0.6b 0 1
+graph-net-test-compiler-log all_close_atol8_rtol8 model_path:/daiwenhao/GraphNet/samples/nemo/parakeet-ctc-0.6b 0 1
+graph-net-test-compiler-log all_close_atol8_rtol5 model_path:/daiwenhao/GraphNet/samples/nemo/parakeet-ctc-0.6b 0 1
+graph-net-test-compiler-log all_close_atol5_rtol5 model_path:/daiwenhao/GraphNet/samples/nemo/parakeet-ctc-0.6b 0 1
+graph-net-test-compiler-log all_close_atol3_rtol2 model_path:/daiwenhao/GraphNet/samples/nemo/parakeet-ctc-0.6b 0 1
+graph-net-test-compiler-log all_close_atol2_rtol1 model_path:/daiwenhao/GraphNet/samples/nemo/parakeet-ctc-0.6b 0 1
+graph-net-test-compiler-log max_diff model_path:/daiwenhao/GraphNet/samples/nemo/parakeet-ctc-0.6b nan 0
+Traceback (most recent call last):
+  File "/usr/lib/python3.8/runpy.py", line 194, in _run_module_as_main
+    return _run_code(code, main_globals, None,
+  File "/usr/lib/python3.8/runpy.py", line 87, in _run_code
+    exec(code, run_globals)
+  File "/daiwenhao/GraphNet/graph_net/torch/test_compiler.py", line 494, in <module>
+    main(args=args)
+  File "/daiwenhao/GraphNet/graph_net/torch/test_compiler.py", line 446, in main
+    test_single_model(args)
+  File "/daiwenhao/GraphNet/graph_net/torch/test_compiler.py", line 321, in test_single_model
+    print_and_store_cmp("mean_diff", get_cmp_mean_diff)
+  File "/daiwenhao/GraphNet/graph_net/torch/test_compiler.py", line 297, in print_and_store_cmp
+    cmp_ret = func(expected_out, compiled_out, **kwargs)
+  File "/daiwenhao/GraphNet/graph_net/torch/test_compiler.py", line 382, in get_cmp_mean_diff
+    return " ".join(
+  File "/daiwenhao/GraphNet/graph_net/torch/test_compiler.py", line 383, in <genexpr>
+    str(torch.mean(torch.abs(a - b)).item())
+RuntimeError: mean(): could not infer output dtype. Input dtype must be either a floating point or complex dtype. Got: Long
+[Profiling] Using device: cuda:0 NVIDIA A100-SXM4-40GB, warm up 3, trials 5
+Trial 1: 55.3 ms
+Trial 2: 54.5 ms
+Trial 3: 54.6 ms
+Trial 4: 54.4 ms
+Trial 5: 57.1 ms
+[Profiling] Using device: cuda:0 NVIDIA A100-SXM4-40GB, warm up 3, trials 5
+Trial 1: 54.4 ms
+Trial 2: 54.3 ms
+Trial 3: 56.7 ms
+Trial 4: 54.3 ms
+Trial 5: 54.3 ms
+
+Expected weight to be a vector of size equal to the number of channels in input, but got weight of shape [512, 1, 16] and input of shape [1, 512, 4001]
+Failed! Try to export it through torch.jit.script:
+
+The following operation failed in the TorchScript interpreter.
+Traceback of TorchScript (most recent call last):
+  File "/daiwenhao/GraphNet/samples/torchaudio/convtasnet_base_libri2mix/model.py", line 724, in _torch_blade_record_tensor
+        )
+        l_input_ = l_self_modules_encoder_parameters_weight_ = None
+        feats_1 = torch.nn.functional.group_norm(
+                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ <--- HERE
+            feats,
+            1,
+  File "/usr/local/lib/python3.8/dist-packages/torch/nn/functional.py", line 2516, in group_norm
+        return handle_torch_function(group_norm, (input, weight, bias,), input, num_groups, weight=weight, bias=bias, eps=eps)
+    _verify_batch_size([input.size(0) * input.size(1) // num_groups, num_groups] + list(input.size()[2:]))
+    return torch.group_norm(input, num_groups, weight, bias, eps, torch.backends.cudnn.enabled)
+           ~~~~~~~~~~~~~~~~ <--- HERE
+RuntimeError: Expected weight to be a vector of size equal to the number of channels in input, but got weight of shape [512, 1, 16] and input of shape [1, 512, 4001]
+
+Some Tensors' shapes are not recorded.
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+2025-08-30 09:13:39.936834: I external/org_tensorflow/tensorflow/compiler/xla/stream_executor/cuda/cuda_dnn.cc:424] Loaded cuDNN version 8204
+graph-net-test-compiler-log equal model_path:/daiwenhao/GraphNet/samples/torchaudio/convtasnet_base_libri2mix 1
+graph-net-test-compiler-log all_close_atol8_rtol8 model_path:/daiwenhao/GraphNet/samples/torchaudio/convtasnet_base_libri2mix 1
+graph-net-test-compiler-log all_close_atol8_rtol5 model_path:/daiwenhao/GraphNet/samples/torchaudio/convtasnet_base_libri2mix 1
+graph-net-test-compiler-log all_close_atol5_rtol5 model_path:/daiwenhao/GraphNet/samples/torchaudio/convtasnet_base_libri2mix 1
+graph-net-test-compiler-log all_close_atol3_rtol2 model_path:/daiwenhao/GraphNet/samples/torchaudio/convtasnet_base_libri2mix 1
+graph-net-test-compiler-log all_close_atol2_rtol1 model_path:/daiwenhao/GraphNet/samples/torchaudio/convtasnet_base_libri2mix 1
+graph-net-test-compiler-log max_diff model_path:/daiwenhao/GraphNet/samples/torchaudio/convtasnet_base_libri2mix nan
+graph-net-test-compiler-log mean_diff model_path:/daiwenhao/GraphNet/samples/torchaudio/convtasnet_base_libri2mix nan
+graph-net-test-compiler-log diff_count_atol8_rtol8 model_path:/daiwenhao/GraphNet/samples/torchaudio/convtasnet_base_libri2mix 0
+graph-net-test-compiler-log diff_count_atol8_rtol5 model_path:/daiwenhao/GraphNet/samples/torchaudio/convtasnet_base_libri2mix 0
+graph-net-test-compiler-log diff_count_atol5_rtol5 model_path:/daiwenhao/GraphNet/samples/torchaudio/convtasnet_base_libri2mix 0
+graph-net-test-compiler-log diff_count_atol3_rtol2 model_path:/daiwenhao/GraphNet/samples/torchaudio/convtasnet_base_libri2mix 0
+graph-net-test-compiler-log diff_count_atol2_rtol1 model_path:/daiwenhao/GraphNet/samples/torchaudio/convtasnet_base_libri2mix 0
+graph-net-test-compiler-log duration model_path:/daiwenhao/GraphNet/samples/torchaudio/convtasnet_base_libri2mix eager:99.4000 compiled:99.6000
+[Profiling] Using device: cuda:0 NVIDIA A100-SXM4-40GB, warm up 3, trials 5
+Trial 1: 99.4 ms
+Trial 2: 99.5 ms
+Trial 3: 99.4 ms
+Trial 4: 99.5 ms
+Trial 5: 99.5 ms
+[Profiling] Using device: cuda:0 NVIDIA A100-SXM4-40GB, warm up 3, trials 5
+Trial 1: 99.6 ms
+Trial 2: 99.5 ms
+Trial 3: 99.7 ms
+Trial 4: 99.8 ms
+Trial 5: 99.7 ms
+"index_select_out_cuda_impl" not implemented for 'Float'
+Failed! Try to export it through torch.jit.script:
+
+The following operation failed in the TorchScript interpreter.
+Traceback of TorchScript (most recent call last):
+  File "/daiwenhao/GraphNet/samples/torchgeometric/LINKX/model.py", line 119, in _torch_blade_record_tensor
+        edge_index_j = l_edge_index_[0]
+        l_edge_index_ = None
+        weight_j = l_self_modules_edge_lin_parameters_weight_.index_select(
+                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ <--- HERE
+            -2, edge_index_j
+        )
+RuntimeError: "index_select_out_cuda_impl" not implemented for 'Float'
+
+Some Tensors' shapes are not recorded.
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+graph-net-test-compiler-log equal model_path:/daiwenhao/GraphNet/samples/torchgeometric/LINKX 1
+graph-net-test-compiler-log all_close_atol8_rtol8 model_path:/daiwenhao/GraphNet/samples/torchgeometric/LINKX 1
+graph-net-test-compiler-log all_close_atol8_rtol5 model_path:/daiwenhao/GraphNet/samples/torchgeometric/LINKX 1
+graph-net-test-compiler-log all_close_atol5_rtol5 model_path:/daiwenhao/GraphNet/samples/torchgeometric/LINKX 1
+graph-net-test-compiler-log all_close_atol3_rtol2 model_path:/daiwenhao/GraphNet/samples/torchgeometric/LINKX 1
+graph-net-test-compiler-log all_close_atol2_rtol1 model_path:/daiwenhao/GraphNet/samples/torchgeometric/LINKX 1
+graph-net-test-compiler-log max_diff model_path:/daiwenhao/GraphNet/samples/torchgeometric/LINKX 0.0
+graph-net-test-compiler-log mean_diff model_path:/daiwenhao/GraphNet/samples/torchgeometric/LINKX 0.0
+graph-net-test-compiler-log diff_count_atol8_rtol8 model_path:/daiwenhao/GraphNet/samples/torchgeometric/LINKX 0
+graph-net-test-compiler-log diff_count_atol8_rtol5 model_path:/daiwenhao/GraphNet/samples/torchgeometric/LINKX 0
+graph-net-test-compiler-log diff_count_atol5_rtol5 model_path:/daiwenhao/GraphNet/samples/torchgeometric/LINKX 0
+graph-net-test-compiler-log diff_count_atol3_rtol2 model_path:/daiwenhao/GraphNet/samples/torchgeometric/LINKX 0
+graph-net-test-compiler-log diff_count_atol2_rtol1 model_path:/daiwenhao/GraphNet/samples/torchgeometric/LINKX 0
+graph-net-test-compiler-log duration model_path:/daiwenhao/GraphNet/samples/torchgeometric/LINKX eager:1.0300 compiled:0.7280
+[Profiling] Using device: cuda:0 NVIDIA A100-SXM4-40GB, warm up 3, trials 5
+Trial 1: 1.06 ms
+Trial 2: 1.04 ms
+Trial 3: 1.02 ms
+Trial 4: 1 ms
+Trial 5: 1.02 ms
+[Profiling] Using device: cuda:0 NVIDIA A100-SXM4-40GB, warm up 3, trials 5
+Trial 1: 0.788 ms
+Trial 2: 0.736 ms
+Trial 3: 0.71 ms
+Trial 4: 0.718 ms
+Trial 5: 0.689 msExpected 3D (unbatched) or 4D (batched) input to conv2d, but got input of size: [1000, 1024]
+Failed! Try to export it through torch.jit.script:
+
+The following operation failed in the TorchScript interpreter.
+Traceback of TorchScript (most recent call last):
+  File "/daiwenhao/GraphNet/samples/timm/darknet17/model.py", line 188, in _torch_blade_record_tensor
+            L_self_modules_head_modules_fc_parameters_bias_
+        )
+        x = torch.conv2d(
+            ~~~~~~~~~~~~ <--- HERE
+            l_x_,
+            l_self_modules_stem_modules_conv1_modules_conv_parameters_weight_,
+RuntimeError: Expected 3D (unbatched) or 4D (batched) input to conv2d, but got input of size: [1000, 1024]
+
+Some Tensors' shapes are not recorded.
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+graph-net-test-compiler-log equal model_path:/daiwenhao/GraphNet/samples/timm/darknet17 1
+graph-net-test-compiler-log all_close_atol8_rtol8 model_path:/daiwenhao/GraphNet/samples/timm/darknet17 1
+graph-net-test-compiler-log all_close_atol8_rtol5 model_path:/daiwenhao/GraphNet/samples/timm/darknet17 1
+graph-net-test-compiler-log all_close_atol5_rtol5 model_path:/daiwenhao/GraphNet/samples/timm/darknet17 1
+graph-net-test-compiler-log all_close_atol3_rtol2 model_path:/daiwenhao/GraphNet/samples/timm/darknet17 1
+graph-net-test-compiler-log all_close_atol2_rtol1 model_path:/daiwenhao/GraphNet/samples/timm/darknet17 1
+graph-net-test-compiler-log max_diff model_path:/daiwenhao/GraphNet/samples/timm/darknet17 0.0
+graph-net-test-compiler-log mean_diff model_path:/daiwenhao/GraphNet/samples/timm/darknet17 0.0
+graph-net-test-compiler-log diff_count_atol8_rtol8 model_path:/daiwenhao/GraphNet/samples/timm/darknet17 0
+graph-net-test-compiler-log diff_count_atol8_rtol5 model_path:/daiwenhao/GraphNet/samples/timm/darknet17 0
+graph-net-test-compiler-log diff_count_atol5_rtol5 model_path:/daiwenhao/GraphNet/samples/timm/darknet17 0
+graph-net-test-compiler-log diff_count_atol3_rtol2 model_path:/daiwenhao/GraphNet/samples/timm/darknet17 0
+graph-net-test-compiler-log diff_count_atol2_rtol1 model_path:/daiwenhao/GraphNet/samples/timm/darknet17 0
+graph-net-test-compiler-log duration model_path:/daiwenhao/GraphNet/samples/timm/darknet17 eager:2.1500 compiled:2.1300
+[Profiling] Using device: cuda:0 NVIDIA A100-SXM4-40GB, warm up 3, trials 5
+Trial 1: 2.24 ms
+Trial 2: 2.13 ms
+Trial 3: 2.13 ms
+Trial 4: 2.13 ms
+Trial 5: 2.13 ms
+[Profiling] Using device: cuda:0 NVIDIA A100-SXM4-40GB, warm up 3, trials 5
+Trial 1: 2.13 ms
+Trial 2: 2.13 ms
+Trial 3: 2.14 ms
+Trial 4: 2.11 ms
+Trial 5: 2.13 ms
+weight should have at least three dimensions
+Failed! Try to export it through torch.jit.script:
+
+The following operation failed in the TorchScript interpreter.
+Traceback of TorchScript (most recent call last):
+  File "/daiwenhao/GraphNet/samples/torchvision/deeplabv3_resnet50/model.py", line 666, in _torch_blade_record_tensor
+            L_self_modules_aux_classifier_modules_4_parameters_bias_
+        )
+        x = torch.conv2d(
+            ~~~~~~~~~~~~ <--- HERE
+            l_x_,
+            l_self_modules_backbone_modules_conv1_parameters_weight_,
+RuntimeError: weight should have at least three dimensions
+
+Some Tensors' shapes are not recorded.
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+graph-net-test-compiler-log equal model_path:/daiwenhao/GraphNet/samples/torchvision/deeplabv3_resnet50 1 0
+graph-net-test-compiler-log all_close_atol8_rtol8 model_path:/daiwenhao/GraphNet/samples/torchvision/deeplabv3_resnet50 1 0
+graph-net-test-compiler-log all_close_atol8_rtol5 model_path:/daiwenhao/GraphNet/samples/torchvision/deeplabv3_resnet50 1 0
+graph-net-test-compiler-log all_close_atol5_rtol5 model_path:/daiwenhao/GraphNet/samples/torchvision/deeplabv3_resnet50 1 0
+graph-net-test-compiler-log all_close_atol3_rtol2 model_path:/daiwenhao/GraphNet/samples/torchvision/deeplabv3_resnet50 1 1
+graph-net-test-compiler-log all_close_atol2_rtol1 model_path:/daiwenhao/GraphNet/samples/torchvision/deeplabv3_resnet50 1 1
+graph-net-test-compiler-log max_diff model_path:/daiwenhao/GraphNet/samples/torchvision/deeplabv3_resnet50 0.0 1.7121434211730957e-05
+graph-net-test-compiler-log mean_diff model_path:/daiwenhao/GraphNet/samples/torchvision/deeplabv3_resnet50 0.0 1.762935575300162e-08
+graph-net-test-compiler-log diff_count_atol8_rtol8 model_path:/daiwenhao/GraphNet/samples/torchvision/deeplabv3_resnet50 0 15966
+graph-net-test-compiler-log diff_count_atol8_rtol5 model_path:/daiwenhao/GraphNet/samples/torchvision/deeplabv3_resnet50 0 5908
+graph-net-test-compiler-log diff_count_atol5_rtol5 model_path:/daiwenhao/GraphNet/samples/torchvision/deeplabv3_resnet50 0 40
+graph-net-test-compiler-log diff_count_atol3_rtol2 model_path:/daiwenhao/GraphNet/samples/torchvision/deeplabv3_resnet50 0 0
+graph-net-test-compiler-log diff_count_atol2_rtol1 model_path:/daiwenhao/GraphNet/samples/torchvision/deeplabv3_resnet50 0 0
+graph-net-test-compiler-log duration model_path:/daiwenhao/GraphNet/samples/torchvision/deeplabv3_resnet50 eager:8.4300 compiled:7.6200
+[Profiling] Using device: cuda:0 NVIDIA A100-SXM4-40GB, warm up 3, trials 5
+Trial 1: 8.5 ms
+Trial 2: 8.43 ms
+Trial 3: 8.41 ms
+Trial 4: 8.39 ms
+Trial 5: 8.42 ms
+[Profiling] Using device: cuda:0 NVIDIA A100-SXM4-40GB, warm up 3, trials 5
+Trial 1: 7.7 ms
+Trial 2: 7.62 ms
+Trial 3: 7.59 ms
+Trial 4: 7.59 ms
+Trial 5: 7.6 ms
+
+expand(torch.cuda.FloatTensor{[1, 3, 30, 30]}, size=[2, 17]): the number of sizes provided (2) must be greater or equal to the number of dimensions in the tensor (4)
+Failed! Try to export it through torch.jit.script:
+
+The following operation failed in the TorchScript interpreter.
+Traceback of TorchScript (most recent call last):
+  File "/daiwenhao/GraphNet/samples/transformers-auto-model/hf-tiny-model-private_tiny-random-AltCLIPModel/model.py", line 406, in _torch_blade_record_tensor
+            None
+        )
+        buffered_token_type_ids_expanded = buffered_token_type_ids.expand(2, 17)
+                                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ <--- HERE
+        buffered_token_type_ids = None
+        extended_attention_mask = l_attention_mask_[
+RuntimeError: expand(torch.cuda.FloatTensor{[1, 3, 30, 30]}, size=[2, 17]): the number of sizes provided (2) must be greater or equal to the number of dimensions in the tensor (4)
+
+Some Tensors' shapes are not recorded.
+graph-net-test-compiler-log equal model_path:/daiwenhao/GraphNet/samples/transformers-auto-model/hf-tiny-model-private_tiny-random-AltCLIPModel 0 0 0 0 0 0 0 0
+graph-net-test-compiler-log all_close_atol8_rtol8 model_path:/daiwenhao/GraphNet/samples/transformers-auto-model/hf-tiny-model-private_tiny-random-AltCLIPModel 0 1 0 0 0 0 0 0
+graph-net-test-compiler-log all_close_atol8_rtol5 model_path:/daiwenhao/GraphNet/samples/transformers-auto-model/hf-tiny-model-private_tiny-random-AltCLIPModel 1 1 0 1 1 1 1 1
+graph-net-test-compiler-log all_close_atol5_rtol5 model_path:/daiwenhao/GraphNet/samples/transformers-auto-model/hf-tiny-model-private_tiny-random-AltCLIPModel 1 1 1 1 1 1 1 1
+graph-net-test-compiler-log all_close_atol3_rtol2 model_path:/daiwenhao/GraphNet/samples/transformers-auto-model/hf-tiny-model-private_tiny-random-AltCLIPModel 1 1 1 1 1 1 1 1
+graph-net-test-compiler-log all_close_atol2_rtol1 model_path:/daiwenhao/GraphNet/samples/transformers-auto-model/hf-tiny-model-private_tiny-random-AltCLIPModel 1 1 1 1 1 1 1 1
+graph-net-test-compiler-log max_diff model_path:/daiwenhao/GraphNet/samples/transformers-auto-model/hf-tiny-model-private_tiny-random-AltCLIPModel 1.4901161193847656e-08 8.381903171539307e-09 4.76837158203125e-07 1.1920928955078125e-07 7.152557373046875e-07 7.152557373046875e-07 1.341104507446289e-07 5.960464477539063e-08
+graph-net-test-compiler-log mean_diff model_path:/daiwenhao/GraphNet/samples/transformers-auto-model/hf-tiny-model-private_tiny-random-AltCLIPModel 2.7375388622630226e-09 2.523847797419876e-09 4.827760591297192e-08 4.057073965668678e-08 4.76837158203125e-07 4.76837158203125e-07 1.966327545233071e-08 9.284121915698051e-09
+graph-net-test-compiler-log diff_count_atol8_rtol8 model_path:/daiwenhao/GraphNet/samples/transformers-auto-model/hf-tiny-model-private_tiny-random-AltCLIPModel 18 0 3233 20 2 2 90 22
+graph-net-test-compiler-log diff_count_atol8_rtol5 model_path:/daiwenhao/GraphNet/samples/transformers-auto-model/hf-tiny-model-private_tiny-random-AltCLIPModel 0 0 11 0 0 0 0 0
+graph-net-test-compiler-log diff_count_atol5_rtol5 model_path:/daiwenhao/GraphNet/samples/transformers-auto-model/hf-tiny-model-private_tiny-random-AltCLIPModel 0 0 0 0 0 0 0 0
+graph-net-test-compiler-log diff_count_atol3_rtol2 model_path:/daiwenhao/GraphNet/samples/transformers-auto-model/hf-tiny-model-private_tiny-random-AltCLIPModel 0 0 0 0 0 0 0 0
+graph-net-test-compiler-log diff_count_atol2_rtol1 model_path:/daiwenhao/GraphNet/samples/transformers-auto-model/hf-tiny-model-private_tiny-random-AltCLIPModel 0 0 0 0 0 0 0 0
+graph-net-test-compiler-log duration model_path:/daiwenhao/GraphNet/samples/transformers-auto-model/hf-tiny-model-private_tiny-random-AltCLIPModel eager:6.0000 compiled:4.4200
+[Profiling] Using device: cuda:0 NVIDIA A100-SXM4-40GB, warm up 3, trials 5
+Trial 1: 6.05 ms
+Trial 2: 6.02 ms
+Trial 3: 6 ms
+Trial 4: 5.96 ms
+Trial 5: 5.98 ms
+[Profiling] Using device: cuda:0 NVIDIA A100-SXM4-40GB, warm up 3, trials 5
+Trial 1: 4.85 ms
+Trial 2: 4.35 ms
+Trial 3: 4.31 ms
+Trial 4: 4.3 ms
+Trial 5: 4.3 ms
+Expected 3D (unbatched) or 4D (batched) input to conv2d, but got input of size: [64]
+Failed! Try to export it through torch.jit.script:
+
+The following operation failed in the TorchScript interpreter.
+Traceback of TorchScript (most recent call last):
+  File "/daiwenhao/GraphNet/samples/ultralytics/yolo11l-cls/model.py", line 1340, in _torch_blade_record_tensor
+            L_self_modules_model_modules_10_modules_linear_parameters_bias_
+        )
+        conv2d = torch.conv2d(
+                 ~~~~~~~~~~~~ <--- HERE
+            l_x_,
+            l_self_modules_model_modules_0_modules_conv_parameters_weight_,
+RuntimeError: Expected 3D (unbatched) or 4D (batched) input to conv2d, but got input of size: [64]
+
+Some Tensors' shapes are not recorded.
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+Expected tensor_type != nullptr to be true, but got false.  (Could this error message be improved?  If so, please report an enhancement request to PyTorch.)
+graph-net-test-compiler-log equal model_path:/daiwenhao/GraphNet/samples/ultralytics/yolo11l-cls 0 0
+graph-net-test-compiler-log all_close_atol8_rtol8 model_path:/daiwenhao/GraphNet/samples/ultralytics/yolo11l-cls 0 0
+graph-net-test-compiler-log all_close_atol8_rtol5 model_path:/daiwenhao/GraphNet/samples/ultralytics/yolo11l-cls 0 0
+graph-net-test-compiler-log all_close_atol5_rtol5 model_path:/daiwenhao/GraphNet/samples/ultralytics/yolo11l-cls 0 0
+graph-net-test-compiler-log all_close_atol3_rtol2 model_path:/daiwenhao/GraphNet/samples/ultralytics/yolo11l-cls 0 0
+graph-net-test-compiler-log all_close_atol2_rtol1 model_path:/daiwenhao/GraphNet/samples/ultralytics/yolo11l-cls 0 0
+graph-net-test-compiler-log max_diff model_path:/daiwenhao/GraphNet/samples/ultralytics/yolo11l-cls nan nan
+graph-net-test-compiler-log mean_diff model_path:/daiwenhao/GraphNet/samples/ultralytics/yolo11l-cls nan nan
+graph-net-test-compiler-log diff_count_atol8_rtol8 model_path:/daiwenhao/GraphNet/samples/ultralytics/yolo11l-cls 1000 1000
+graph-net-test-compiler-log diff_count_atol8_rtol5 model_path:/daiwenhao/GraphNet/samples/ultralytics/yolo11l-cls 1000 1000
+graph-net-test-compiler-log diff_count_atol5_rtol5 model_path:/daiwenhao/GraphNet/samples/ultralytics/yolo11l-cls 1000 1000
+graph-net-test-compiler-log diff_count_atol3_rtol2 model_path:/daiwenhao/GraphNet/samples/ultralytics/yolo11l-cls 1000 1000
+graph-net-test-compiler-log diff_count_atol2_rtol1 model_path:/daiwenhao/GraphNet/samples/ultralytics/yolo11l-cls 1000 1000
+graph-net-test-compiler-log duration model_path:/daiwenhao/GraphNet/samples/ultralytics/yolo11l-cls eager:17.6000 compiled:14.8000
+[Profiling] Using device: cuda:0 NVIDIA A100-SXM4-40GB, warm up 3, trials 5
+Trial 1: 17.7 ms
+Trial 2: 17.6 ms
+Trial 3: 17.6 ms
+Trial 4: 17.6 ms
+Trial 5: 17.5 ms
+[Profiling] Using device: cuda:0 NVIDIA A100-SXM4-40GB, warm up 3, trials 5
+Trial 1: 15.3 ms
+Trial 2: 14.8 ms
+Trial 3: 14.7 ms
+Trial 4: 14.7 ms
+Trial 5: 14.7 ms

--- a/graph_net/torch/blade_disc_backend.py
+++ b/graph_net/torch/blade_disc_backend.py
@@ -7,19 +7,29 @@ except ImportError:
     torch_blade = None
 
 
-class BladeDISCBackend(GraphCompilerBackend):
-    def __init__(self, input_dict):
-        self.input_dict = input_dict
+class BladeDISCCompiledModule(torch.nn.Module):
+    def __init__(self, module):
+        super().__init__()
+        self.module = module
+        self.counter = 0
 
+    def forward(self, *args, **kwargs):
+        if self.counter == 0:
+            self.module = self.compile(self.module, *args, **kwargs)
+        ret = self.module(*args, **kwargs)
+        self.counter += 1
+        return ret
+
+    def compile(self, module, *args, **kwargs):
+        dummy_input = tuple([*args, *kwargs.values()])
+        return torch_blade.optimize(
+            module, allow_tracing=True, model_inputs=dummy_input
+        )
+
+
+class BladeDISCBackend(GraphCompilerBackend):
     def __call__(self, model):
-        torch_config = torch_blade.config.Config()
-        torch_config.enable_mlir_amp = False
-        with torch.no_grad(), torch_config:
-            dummy_input = tuple(self.input_dict.values())
-            compiled_model = torch_blade.optimize(
-                model, allow_tracing=True, model_inputs=dummy_input
-            )
-        return compiled_model
+        return BladeDISCCompiledModule(model)
 
     def synchronize(self):
         if torch.cuda.is_available():

--- a/graph_net/torch/blade_disc_backend.py
+++ b/graph_net/torch/blade_disc_backend.py
@@ -1,0 +1,26 @@
+import torch
+from .graph_compiler_backend import GraphCompilerBackend
+
+try:
+    import torch_blade
+except ImportError:
+    torch_blade = None
+
+
+class BladeDISCBackend(GraphCompilerBackend):
+    def __init__(self, input_dict):
+        self.input_dict = input_dict
+
+    def __call__(self, model):
+        torch_config = torch_blade.config.Config()
+        torch_config.enable_mlir_amp = False
+        with torch.no_grad(), torch_config:
+            dummy_input = tuple(self.input_dict.values())
+            compiled_model = torch_blade.optimize(
+                model, allow_tracing=True, model_inputs=dummy_input
+            )
+        return compiled_model
+
+    def synchronize(self):
+        if torch.cuda.is_available():
+            torch.cuda.synchronize()

--- a/graph_net/torch/graph_compiler_backend.py
+++ b/graph_net/torch/graph_compiler_backend.py
@@ -1,0 +1,31 @@
+import torch
+
+try:
+    import torch_tensorrt
+except ImportError:
+    torch_tensorrt = None
+
+
+class GraphCompilerBackend:
+    def __call__(self, model):
+        raise NotImplementedError()
+
+    def synchronize(self):
+        raise NotImplementedError()
+
+
+class InductorBackend(GraphCompilerBackend):
+    def __call__(self, model):
+        return torch.compile(model, backend="inductor")
+
+    def synchronize(self):
+        if torch.cuda.is_available():
+            torch.cuda.synchronize()
+
+
+class TensorRTBackend(GraphCompilerBackend):
+    def __call__(self, model):
+        return torch.compile(model, backend="tensorrt")
+
+    def synchronize(self):
+        torch.cuda.synchronize()

--- a/graph_net/torch/graph_compiler_backend.py
+++ b/graph_net/torch/graph_compiler_backend.py
@@ -1,31 +1,6 @@
-import torch
-
-try:
-    import torch_tensorrt
-except ImportError:
-    torch_tensorrt = None
-
-
 class GraphCompilerBackend:
     def __call__(self, model):
         raise NotImplementedError()
 
     def synchronize(self):
         raise NotImplementedError()
-
-
-class InductorBackend(GraphCompilerBackend):
-    def __call__(self, model):
-        return torch.compile(model, backend="inductor")
-
-    def synchronize(self):
-        if torch.cuda.is_available():
-            torch.cuda.synchronize()
-
-
-class TensorRTBackend(GraphCompilerBackend):
-    def __call__(self, model):
-        return torch.compile(model, backend="tensorrt")
-
-    def synchronize(self):
-        torch.cuda.synchronize()

--- a/graph_net/torch/inductor_backend.py
+++ b/graph_net/torch/inductor_backend.py
@@ -1,0 +1,11 @@
+import torch
+from .graph_compiler_backend import GraphCompilerBackend
+
+
+class InductorBackend(GraphCompilerBackend):
+    def __call__(self, model):
+        return torch.compile(model, backend="inductor")
+
+    def synchronize(self):
+        if torch.cuda.is_available():
+            torch.cuda.synchronize()

--- a/graph_net/torch/tensorrt_backend.py
+++ b/graph_net/torch/tensorrt_backend.py
@@ -1,0 +1,18 @@
+import torch
+
+try:
+    import torch_tensorrt
+except ImportError:
+    torch_tensorrt = None
+
+from .graph_compiler_backend import GraphCompilerBackend
+
+
+class TensorRTBackend(GraphCompilerBackend):
+    def __call__(self, model):
+        if torch_tensorrt is None:
+            raise ImportError("torch_tensorrt not installed")
+        return torch.compile(model, backend="tensorrt")
+
+    def synchronize(self):
+        torch.cuda.synchronize()

--- a/graph_net/torch/test_compiler.py
+++ b/graph_net/torch/test_compiler.py
@@ -14,11 +14,9 @@ import time
 import json
 import numpy as np
 import platform
-from .graph_compiler_backend import (
-    GraphCompilerBackend,
-    InductorBackend,
-    TensorRTBackend,
-)
+from .graph_compiler_backend import GraphCompilerBackend
+from .inductor_backend import InductorBackend
+from .tensorrt_backend import TensorRTBackend
 from .blade_disc_backend import BladeDISCBackend
 
 

--- a/graph_net/torch/test_compiler.py
+++ b/graph_net/torch/test_compiler.py
@@ -4,9 +4,8 @@ import importlib.util
 import inspect
 import torch
 from pathlib import Path
-from typing import Type, Any
+from typing import Type, Any, List, Dict, Callable
 import sys
-from graph_net.torch.extractor import extract
 import os
 import os.path
 from dataclasses import dataclass
@@ -20,6 +19,11 @@ try:
     import torch_tensorrt
 except ImportError:
     torch_tensorrt = None
+
+try:
+    import torch_blade
+except ImportError:
+    torch_blade = None
 
 
 class GraphCompilerBackend:
@@ -45,12 +49,6 @@ class TensorRTBackend(GraphCompilerBackend):
 
     def synchronize(self):
         torch.cuda.synchronize()
-
-
-registry_backend = {
-    "inductor": InductorBackend(),
-    "tensorrt": TensorRTBackend(),
-}
 
 
 def load_class_from_file(
@@ -94,6 +92,33 @@ def get_input_dict(args):
     }
 
 
+class BladeDISCBackend(GraphCompilerBackend):
+    def __init__(self, input_dict=None):
+        self.input_dict = input_dict
+
+    def __call__(self, model):
+        torch_config = torch_blade.config.Config()
+        torch_config.enable_mlir_amp = False
+        with torch.no_grad(), torch_config:
+            input_dict = get_input_dict(args)
+            dummy_input = tuple(input_dict.values())
+            compiled_model = torch_blade.optimize(
+                model, allow_tracing=True, model_inputs=dummy_input
+            )
+        return compiled_model
+
+    def synchronize(self):
+        if torch.cuda.is_available():
+            torch.cuda.synchronize()
+
+
+registry_backend = {
+    "inductor": InductorBackend(),
+    "tensorrt": TensorRTBackend(),
+    "bladedisc": BladeDISCBackend(),
+}
+
+
 @dataclass
 class DurationBox:
     value: float
@@ -110,13 +135,13 @@ def naive_timer(duration_box, synchronizer_func):
 
 
 def time_execution_with_cuda_event(
-    kernel_fn: callable,
+    kernel_fn: Callable,
     *args,
     num_warmup: int = 3,
     num_trials: int = 10,
     verbose: bool = True,
     device: torch.device = None,
-) -> list[float]:
+) -> List[float]:
     """
     Acknowledgement: We introduce evaluation method in https://github.com/ScalingIntelligence/KernelBench to enhance function.
 
@@ -188,7 +213,7 @@ def time_execution_naive(
     return times
 
 
-def get_timing_stats(elapsed_times: list[float]):
+def get_timing_stats(elapsed_times: List[float]):
     stats = {
         "mean": float(f"{np.mean(elapsed_times):.3g}"),
         "std": float(f"{np.std(elapsed_times):.3g}"),

--- a/graph_net/torch/test_compiler.py
+++ b/graph_net/torch/test_compiler.py
@@ -14,10 +14,16 @@ import time
 import json
 import numpy as np
 import platform
-from .graph_compiler_backend import GraphCompilerBackend
-from .inductor_backend import InductorBackend
-from .tensorrt_backend import TensorRTBackend
-from .blade_disc_backend import BladeDISCBackend
+from graph_net.torch.graph_compiler_backend import GraphCompilerBackend
+from graph_net.torch.inductor_backend import InductorBackend
+from graph_net.torch.tensorrt_backend import TensorRTBackend
+from graph_net.torch.blade_disc_backend import BladeDISCBackend
+
+registry_backend = {
+    "inductor": InductorBackend(),
+    "tensorrt": TensorRTBackend(),
+    "bladedisc": BladeDISCBackend(),
+}
 
 
 def load_class_from_file(
@@ -39,25 +45,9 @@ def load_class_from_file(
     return model_class
 
 
-registry_backend_classes = {
-    "inductor": InductorBackend,
-    "tensorrt": TensorRTBackend,
-    "bladedisc": BladeDISCBackend,
-}
-
-
 def get_compiler_backend(args) -> GraphCompilerBackend:
-    assert (
-        args.compiler in registry_backend_classes
-    ), f"Unknown compiler: {args.compiler}"
-    cls = registry_backend_classes[args.compiler]
-    if cls == InductorBackend:
-        return InductorBackend()
-    elif cls == TensorRTBackend:
-        return TensorRTBackend()
-    elif cls == BladeDISCBackend:
-        input_dict = get_input_dict(args)
-        return BladeDISCBackend(input_dict)
+    assert args.compiler in registry_backend, f"Unknown compiler: {args.compiler}"
+    return registry_backend[args.compiler]
 
 
 def get_model(args):

--- a/graph_net/torch/test_compiler.py
+++ b/graph_net/torch/test_compiler.py
@@ -14,41 +14,12 @@ import time
 import json
 import numpy as np
 import platform
-
-try:
-    import torch_tensorrt
-except ImportError:
-    torch_tensorrt = None
-
-try:
-    import torch_blade
-except ImportError:
-    torch_blade = None
-
-
-class GraphCompilerBackend:
-    def __call__(self, model):
-        raise NotImplementedError()
-
-    def synchronize(self):
-        raise NotImplementedError()
-
-
-class InductorBackend(GraphCompilerBackend):
-    def __call__(self, model):
-        return torch.compile(model, backend="inductor")
-
-    def synchronize(self):
-        if torch.cuda.is_available():
-            torch.cuda.synchronize()
-
-
-class TensorRTBackend(GraphCompilerBackend):
-    def __call__(self, model):
-        return torch.compile(model, backend="tensorrt")
-
-    def synchronize(self):
-        torch.cuda.synchronize()
+from .graph_compiler_backend import (
+    GraphCompilerBackend,
+    InductorBackend,
+    TensorRTBackend,
+)
+from .blade_disc_backend import BladeDISCBackend
 
 
 def load_class_from_file(
@@ -70,9 +41,25 @@ def load_class_from_file(
     return model_class
 
 
+registry_backend_classes = {
+    "inductor": InductorBackend,
+    "tensorrt": TensorRTBackend,
+    "bladedisc": BladeDISCBackend,
+}
+
+
 def get_compiler_backend(args) -> GraphCompilerBackend:
-    assert args.compiler in registry_backend, f"Unknown compiler: {args.compiler}"
-    return registry_backend[args.compiler]
+    assert (
+        args.compiler in registry_backend_classes
+    ), f"Unknown compiler: {args.compiler}"
+    cls = registry_backend_classes[args.compiler]
+    if cls == InductorBackend:
+        return InductorBackend()
+    elif cls == TensorRTBackend:
+        return TensorRTBackend()
+    elif cls == BladeDISCBackend:
+        input_dict = get_input_dict(args)
+        return BladeDISCBackend(input_dict)
 
 
 def get_model(args):
@@ -90,33 +77,6 @@ def get_input_dict(args):
         k: utils.replay_tensor(v).to(torch.device(args.device))
         for k, v in params.items()
     }
-
-
-class BladeDISCBackend(GraphCompilerBackend):
-    def __init__(self, input_dict=None):
-        self.input_dict = input_dict
-
-    def __call__(self, model):
-        torch_config = torch_blade.config.Config()
-        torch_config.enable_mlir_amp = False
-        with torch.no_grad(), torch_config:
-            input_dict = get_input_dict(args)
-            dummy_input = tuple(input_dict.values())
-            compiled_model = torch_blade.optimize(
-                model, allow_tracing=True, model_inputs=dummy_input
-            )
-        return compiled_model
-
-    def synchronize(self):
-        if torch.cuda.is_available():
-            torch.cuda.synchronize()
-
-
-registry_backend = {
-    "inductor": InductorBackend(),
-    "tensorrt": TensorRTBackend(),
-    "bladedisc": BladeDISCBackend(),
-}
 
 
 @dataclass

--- a/graph_net/torch/test_compiler.py
+++ b/graph_net/torch/test_compiler.py
@@ -229,6 +229,10 @@ def test_single_model(args):
         result_data["configuration"][
             "compile_framework_version"
         ] = f"TensorRT {torch_tensorrt.version}"
+    elif args.compiler == "bladedisc":
+        result_data["configuration"][
+            "compile_framework_version"
+        ] = f"BladeDISC {torch_blade.version}"
     else:
         result_data["configuration"]["compiler_version"] = "unknown"
 


### PR DESCRIPTION
### PR Category
Feature Enhancement

### Description
为 `graph_net.torch.test_compiler`支持后端使用 BladeDISC 编译器，即支持配置` --compiler "bladedisc"`，读取`GraphNet/samples`目录下的子图，可成功执行并获得正确的评测结果。

以 Bert 为例 [Optimize and Inference BERT with TorchBlade](https://github.com/alibaba/BladeDISC/blob/main/docs/tutorials/torch_bert_inference.md)，主要执行流程为：
1. 用 `torch.jit.trace` 或 `torch.jit.script` 把 PyTorch 模型转成 TorchScript
2. 用 BladeDISC 的 `torch_blade.optimize` 进行编译优化，生成编译后的 compiled_model
3. 组合起来编译后的模型和输入参数  `compiled_model (input)` 以执行前向
其中，结合 `torch.jit.trace` 或 `torch.jit.script` 进行编译优化的过程可以简单抽象为：
```shell
# allow_tracing=True   using torch.jit.trace(model, inputs)
compiled_model = torch_blade.optimize(model, allow_tracing=True, model_inputs=tuple(inputs))
# allow_tracing=False  using torch.jit.script(model)  在本例中的尝试
compiled_model = torch_blade.optimize(model, allow_tracing=False)
```
在本次集成中使用的是`torch.jit.trace`; 使用官方镜像 `bladedisc/bladedisc:latest-runtime-torch1.12.0-cu113` 以快速获取编译器性能测评数据。详细技术报告请参考 `BladeDISC_tech_report.md`

测试报告：
+ BladeDISC for torch (`import torch_blade`）在（2025.08.30）现有 `/samples` 中没有出现一整类都无法运行的情况。
+ 对于 `/samples/cosyvoice` 下全部的模型，在GPU A100-SXM-40GB 上批量性能测试可见 `BladeDISC_batch_test.txt`。
+ 对于 `/samples` 每个类别测试一种模型，测试报告可见 `BladeDISC_validation_report.txt`，性能速览如下：

| Model                        | Eager (ms) | Compiled (ms) |
|------------------------------|-----------|--------------|
| cosyvoice/CosyVoice-300M      | 8.4000    | 8.3600       |
| mmpose/2xmspn_50             | 17.1000   | 14.1000      |
| mmseg/ANN_R50                | 21.7000   | 21.8000      |
| nemo/parakeet-ctc-0.6b       | 55.3000   | 54.4000      |
| torchaudio/convtasnet_base_libri2mix | 99.4000 | 99.6000      |
| torchgeometric/LINKX         | 1.0300    | 0.7280       |
| timm/darknet17               | 2.1500    | 2.1300       |
| torchvision/deeplabv3_resnet50 | 8.4300   | 7.6200       |
| transformers-auto-model/hf-tiny-model-private_tiny-random-AltCLIPModel | 6.0000 | 4.4200 |
| ultralytics/yolo11l-cls      | 17.6000   | 14.8000      |