### PR TITLE
[Feature Enhancement] Optimize validate and test_compiler of paddle.

### DIFF
--- a/graph_net/benchmark_result.py
+++ b/graph_net/benchmark_result.py
@@ -5,11 +5,13 @@ import re
 
 
 class BenchmarkResult:
-    def __init__(self, args, hardware, compile_framework_version):
+    def __init__(self, args, framework, hardware, compile_framework_version):
         self.configuration = {
             "model_name": self.get_model_name(args),
+            "model_path": args.model_path,
             "device": args.device,
             "hardware": hardware,
+            "framework": framework,
             "compiler": args.compiler,
             "compile_framework_version": compile_framework_version,
             "warmup": args.warmup,

--- a/graph_net/benchmark_result.py
+++ b/graph_net/benchmark_result.py
@@ -1,0 +1,73 @@
+import os
+import sys
+import json
+import re
+
+
+class BenchmarkResult:
+    def __init__(self, args, hardware, compile_framework_version):
+        self.configuration = {
+            "model_name": self.get_model_name(args),
+            "device": args.device,
+            "hardware": hardware,
+            "compiler": args.compiler,
+            "compile_framework_version": compile_framework_version,
+            "warmup": args.warmup,
+            "trials": args.trials,
+        }
+        self.model_info = {
+            "num_ops": -1,
+            "input_dtypes": None,
+            "param_dtypes": None,
+        }
+        self.correctness = {}
+        self.performance = {
+            "eager": None,
+            "compiled": None,
+            "speedup": None,
+        }
+
+    def get_model_name(self, args):
+        fields = args.model_path.split(os.sep)
+
+        pattern = rf"^subgraph(_\d+)?$"
+        if re.match(pattern, fields[-1]):
+            model_name = f"{fields[-2]}_{fields[-1]}"
+        else:
+            model_name = fields[-1]
+        return model_name
+
+    def update_model_info(self, num_ops, input_dtypes, param_dtypes):
+        self.model_info["num_ops"] = num_ops
+        self.model_info["input_dtypes"] = input_dtypes
+        self.model_info["param_dtypes"] = param_dtypes
+
+    def update_corrrectness(self, key, cmp_ret):
+        self.correctness[key] = cmp_ret
+
+    def update_performance(self, eager_time_ms, compiled_time_ms):
+        self.performance["eager"] = eager_time_ms
+        self.performance["compiled"] = compiled_time_ms
+        if eager_time_ms > 0 and compiled_time_ms > 0:
+            self.performance["speedup"] = eager_time_ms / compiled_time_ms
+        return self.performance["speedup"]
+
+    def write_to_json(self, output_dir):
+        assert output_dir is not None
+        os.makedirs(output_dir, exist_ok=True)
+        result_data = {
+            "configuration": self.configuration,
+            "model_info": self.model_info,
+            "correctness": self.correctness,
+            "performance": {
+                k: float(f"{v:.6f}") if isinstance(v, float) else v
+                for k, v in self.performance.items()
+            },
+        }
+        model_name = self.configuration["model_name"]
+        compiler_name = self.configuration["compiler"]
+        file_path = os.path.join(output_dir, f"{model_name}_{compiler_name}.json")
+        with open(file_path, "w") as f:
+            json.dump(result_data, f, indent=4)
+        print(f"Result saved to {file_path}", file=sys.stderr)
+        print(result_data)

--- a/graph_net/benchmark_result.py
+++ b/graph_net/benchmark_result.py
@@ -8,6 +8,7 @@ class BenchmarkResult:
     def __init__(self, args, framework, hardware, compile_framework_version):
         self.configuration = {
             "model_name": self.get_model_name(args),
+            "subgraph_tag": self.get_subgraph_tag(args),
             "model_path": args.model_path,
             "device": args.device,
             "hardware": hardware,
@@ -26,18 +27,35 @@ class BenchmarkResult:
         self.performance = {
             "eager": None,
             "compiled": None,
-            "speedup": None,
+            "speedup": {},
         }
 
-    def get_model_name(self, args):
-        fields = args.model_path.split(os.sep)
+        self.device = args.device
 
-        pattern = rf"^subgraph(_\d+)?$"
-        if re.match(pattern, fields[-1]):
-            model_name = f"{fields[-2]}_{fields[-1]}"
-        else:
-            model_name = fields[-1]
+        self.eager_e2e_time_ms = -1
+        self.compiled_e2e_time_ms = -1
+        self.e2e_speedup = -1
+
+        self.eager_gpu_time_ms = -1
+        self.compiled_gpu_time_ms = -1
+        self.gpu_speedup = -1
+
+    def get_model_name(self, args):
+        model_name = None
+        with open(os.path.join(args.model_path, "graph_net.json"), "r") as f:
+            data = json.load(f)
+            model_name = data.get("model_name", None)
+
+        if model_name is not None:
+            fields = args.model_path.split(os.sep)
+            pattern = rf"^subgraph(_\d+)?$"
+            model_name = fields[-2] if re.match(pattern, fields[-1]) else fields[-1]
         return model_name
+
+    def get_subgraph_tag(self, args):
+        fields = args.model_path.split(os.sep)
+        pattern = rf"^subgraph(_\d+)?$"
+        return fields[-1] if re.match(pattern, fields[-1]) else ""
 
     def update_model_info(self, num_ops, input_dtypes, param_dtypes):
         self.model_info["num_ops"] = num_ops
@@ -47,12 +65,22 @@ class BenchmarkResult:
     def update_corrrectness(self, key, cmp_ret):
         self.correctness[key] = cmp_ret
 
-    def update_performance(self, eager_time_ms, compiled_time_ms):
-        self.performance["eager"] = eager_time_ms
-        self.performance["compiled"] = compiled_time_ms
-        if eager_time_ms > 0 and compiled_time_ms > 0:
-            self.performance["speedup"] = eager_time_ms / compiled_time_ms
-        return self.performance["speedup"]
+    def update_performance(self, eager_stats, compiled_stats):
+        self.performance["eager"] = eager_stats
+        self.performance["compiled"] = compiled_stats
+
+        self.eager_e2e_time_ms = eager_stats.get("e2e", {}).get("mean", -1)
+        self.compiled_e2e_time_ms = compiled_stats.get("e2e", {}).get("mean", -1)
+        if self.eager_e2e_time_ms > 0 and self.compiled_e2e_time_ms > 0:
+            self.e2e_speedup = self.eager_e2e_time_ms / self.compiled_e2e_time_ms
+            self.performance["speedup"]["e2e"] = float(f"{self.e2e_speedup:.6g}")
+
+        if "cuda" in self.device:
+            self.eager_gpu_time_ms = eager_stats.get("gpu", {}).get("mean", -1)
+            self.compiled_gpu_time_ms = compiled_stats.get("gpu", {}).get("mean", -1)
+            if self.eager_gpu_time_ms > 0 and self.compiled_gpu_time_ms > 0:
+                self.gpu_speedup = self.eager_gpu_time_ms / self.compiled_gpu_time_ms
+            self.performance["speedup"]["gpu"] = float(f"{self.gpu_speedup:.6g}")
 
     def write_to_json(self, output_dir):
         assert output_dir is not None
@@ -61,14 +89,14 @@ class BenchmarkResult:
             "configuration": self.configuration,
             "model_info": self.model_info,
             "correctness": self.correctness,
-            "performance": {
-                k: float(f"{v:.6f}") if isinstance(v, float) else v
-                for k, v in self.performance.items()
-            },
+            "performance": self.performance,
         }
         model_name = self.configuration["model_name"]
+        subgraph_tag = self.configuration["subgraph_tag"]
         compiler_name = self.configuration["compiler"]
-        file_path = os.path.join(output_dir, f"{model_name}_{compiler_name}.json")
+        file_path = os.path.join(
+            output_dir, f"{model_name}_{subgraph_tag}_{compiler_name}.json"
+        )
         with open(file_path, "w") as f:
             json.dump(result_data, f, indent=4)
         print(f"Result saved to {file_path}", file=sys.stderr)

--- a/graph_net/paddle/test_compiler.py
+++ b/graph_net/paddle/test_compiler.py
@@ -215,6 +215,7 @@ def init_benchmark_result(args):
 
     result_data = BenchmarkResult(
         args=args,
+        framework="PaddlePaddle",
         hardware=hardware,
         compile_framework_version=compile_framework_version,
     )
@@ -249,9 +250,21 @@ def test_single_model(args):
         expected_out = [expected_out]
         compiled_out = [compiled_out]
     if isinstance(expected_out, list) or isinstance(expected_out, tuple):
+        output_dtypes = []
         for a, b in zip(expected_out, compiled_out):
             if (a is None and b is not None) or (a is not None and b is None):
                 raise ValueError("Both expected_out and compiled_out must be not None.")
+            if a is not None and b is not None:
+                assert (
+                    a.dtype == b.dtype
+                ), f"expected_out's dtype ({a.dtype}) is not the same as compiled_out's dtype {b.dtype}."
+                output_dtypes.append(str(a.dtype))
+        result_data.update_corrrectness("num_outpus", len(output_dtypes))
+        result_data.update_corrrectness("output_dtyps", output_dtypes)
+
+        # Remove all None in outputs
+        expected_out = [x for x in expected_out if x is not None]
+        compiled_out = [x for x in compiled_out if x is not None]
         expected_out = [
             regular_item(item)
             for item in expected_out

--- a/graph_net/paddle/test_compiler.py
+++ b/graph_net/paddle/test_compiler.py
@@ -1,17 +1,16 @@
-from . import utils
 import argparse
 import importlib.util
-import inspect
 import paddle
 from pathlib import Path
-from typing import Type, Any
 import sys
 import os
-import os.path
 from dataclasses import dataclass
 from contextlib import contextmanager
 import time
 import numpy as np
+import random
+
+from . import utils
 
 
 def load_class_from_file(file_path: str, class_name: str):
@@ -33,7 +32,6 @@ def load_class_from_file(file_path: str, class_name: str):
 
 
 def get_synchronizer_func(args):
-    assert args.compiler == "default"
     return paddle.device.synchronize
 
 
@@ -49,35 +47,44 @@ def get_input_dict(args):
     params = inputs_params["weight_info"]
     inputs = inputs_params["input_info"]
 
+    param_dtypes = set()
+    for name, info in params.items():
+        dtype = str(info["info"]["dtype"])
+        if dtype not in param_dtypes:
+            param_dtypes.add(dtype)
+
+    input_dtypes = set()
+    for name, info in inputs.items():
+        dtype = str(info["info"]["dtype"])
+        if dtype not in input_dtypes:
+            input_dtypes.add(dtype)
+
     params.update(inputs)
     state_dict = {k: utils.replay_tensor(v) for k, v in params.items()}
-    return state_dict
-
-
-@dataclass
-class DurationBox:
-    value: int
-
-
-@contextmanager
-def naive_timer(duration_box, get_synchronizer_func):
-    get_synchronizer_func()
-    start = time.time()
-    yield
-    get_synchronizer_func()
-    end = time.time()
-    duration_box.value = end - start
+    return state_dict, list(input_dtypes), list(param_dtypes)
 
 
 def get_input_spec(args):
     inputs_params_list = utils.load_converted_list_from_text(f"{args.model_path}")
     input_spec = [None] * len(inputs_params_list)
     for i, v in enumerate(inputs_params_list):
-        name = v["name"]
         dtype = v["info"]["dtype"]
         shape = v["info"]["shape"]
         input_spec[i] = paddle.static.InputSpec(shape, dtype)
     return input_spec
+
+
+def get_compiled_model(args, model):
+    input_spec = get_input_spec(args)
+    build_strategy = paddle.static.BuildStrategy()
+    compiled_model = paddle.jit.to_static(
+        model,
+        input_spec=input_spec,
+        build_strategy=build_strategy,
+        full_graph=True,
+    )
+    compiled_model.eval()
+    return compiled_model
 
 
 def regular_item(item):
@@ -90,37 +97,129 @@ def regular_item(item):
     return item
 
 
+def count_number_of_ops(args, model):
+    static_model = paddle.jit.to_static(
+        model,
+        input_spec=get_input_spec(args),
+        full_graph=True,
+        backend=None,
+    )
+    static_model.eval()
+    program = model.forward.concrete_program.main_program
+    # print(program)
+
+    num_ops = 0
+    for block in program.blocks:
+        for op in block.ops:
+            if op.name() != "pd_op.data" and not op.name().startswith("builtin."):
+                num_ops += 1
+    print(f"Totally {num_ops} ops.")
+    print("")
+    return num_ops
+
+
+@dataclass
+class DurationBox:
+    value: int
+
+
+@contextmanager
+def naive_timer(duration_box, synchronizer_func):
+    synchronizer_func()
+    start = time.time()
+    yield
+    synchronizer_func()
+    end = time.time()
+    duration_box.value = end - start
+
+
+def time_execution_with_cuda_event(
+    model_call, synchronizer_func, num_warmup=3, num_trials=10, profile=False
+):
+    outs = None
+
+    # warmups
+    for _ in range(num_warmup):
+        outs = model_call()
+    synchronizer_func()
+
+    elapsed_times = []
+    if profile:
+        paddle.base.core.nvprof_start()
+
+    # actual trials
+    for trial in range(num_trials):
+        # create event marker default is not interprocess
+        start_event = paddle.device.Event(enable_timing=True)
+        end_event = paddle.device.Event(enable_timing=True)
+
+        start_event.record()
+        outs = model_call()
+        end_event.record()
+        synchronizer_func()
+
+        # Calculate the elapsed time in milliseconds
+        elapsed_time_ms = start_event.elapsed_time(end_event)
+        elapsed_times.append(elapsed_time_ms)
+    if profile:
+        paddle.base.core.nvprof_stop()
+    elapsed_times = elapsed_times[num_trials // 2 :]
+    return outs, np.mean(elapsed_times)
+
+
+def time_execution_naive(model_call, synchronizer_func, num_warmup=3, num_trials=10):
+    outs = None
+
+    # warmups
+    for _ in range(num_warmup):
+        outs = model_call()
+
+    # actual trials
+    duration_box = DurationBox(-1)
+    with naive_timer(duration_box, synchronizer_func):
+        for i in range(num_trials):
+            outs = model_call()
+    return outs, duration_box.value * 1000 / float(num_trials)
+
+
+def measure_performance(model_call, synchronizer_func, args, profile=False):
+    if not args.use_naive_timer:
+        outs, times = time_execution_with_cuda_event(
+            model_call,
+            synchronizer_func=synchronizer_func,
+            num_warmup=args.warmup,
+            num_trials=args.trials,
+            profile=profile,
+        )
+    else:
+        outs, times = time_execution_naive(
+            model_call,
+            synchronizer_func=synchronizer_func,
+            num_warmup=args.warmup,
+            num_trials=args.trials,
+        )
+    return outs, times
+
+
 def test_single_model(args):
     synchronizer_func = get_synchronizer_func(args)
-    input_dict = get_input_dict(args)
-    model_dy = get_model(args)
+    input_dict, input_dtypes, param_dtypes = get_input_dict(args)
+    model = get_model(args)
+    model.eval()
 
-    # eager
-    print("-- Run with eager mode")
-    model_dy.eval()
-    for _ in range(args.warmup if args.warmup > 0 else 0):
-        model_dy(**input_dict)
-    eager_duration_box = DurationBox(-1)
-    with naive_timer(eager_duration_box, synchronizer_func):
-        expected_out = model_dy(**input_dict)
+    # Collect model information
+    num_ops = count_number_of_ops(args, model)
 
-    # compiled
-    print("-- Run with compiled mode")
-    input_spec = get_input_spec(args)
-    build_strategy = paddle.static.BuildStrategy()
-    # build_strategy.build_cinn_pass = True
-    compiled_model = paddle.jit.to_static(
-        model_dy,
-        input_spec=input_spec,
-        build_strategy=build_strategy,
-        full_graph=True,
+    print("Run on eager mode")
+    expected_out, eager_time_ms = measure_performance(
+        lambda: model(**input_dict), synchronizer_func, args, profile=False
     )
-    compiled_model.eval()
-    for _ in range(args.warmup if args.warmup > 0 else 0):
-        compiled_model(**input_dict)
-    compiled_duration_box = DurationBox(-1)
-    with naive_timer(compiled_duration_box, synchronizer_func):
-        compiled_out = compiled_model(**input_dict)
+
+    print("Run on compiling mode")
+    compiled_model = get_compiled_model(args, model)
+    compiled_out, compiled_time_ms = measure_performance(
+        lambda: compiled_model(**input_dict), synchronizer_func, args, profile=False
+    )
 
     if isinstance(expected_out, paddle.Tensor):
         expected_out = [expected_out]
@@ -164,7 +263,11 @@ def test_single_model(args):
     print_cmp("cmp.diff_count_atol2_rtol1", get_cmp_diff_count, atol=1e-2, rtol=1e-1)
 
     print(
-        f"{args.log_prompt} duration model_path:{args.model_path} eager:{eager_duration_box.value} compiled:{compiled_duration_box.value}",
+        f"{args.log_prompt} information model_path:{args.model_path} {num_ops} ops, param_dtypes:{param_dtypes}, input_dtypes:{input_dtypes}",
+        file=sys.stderr,
+    )
+    print(
+        f"{args.log_prompt} duration model_path:{args.model_path} eager:{eager_time_ms:.5f} ms, compiled:{compiled_time_ms:.5f} ms, speedup:{eager_time_ms / compiled_time_ms:.3f}",
         file=sys.stderr,
     )
 
@@ -210,6 +313,7 @@ def test_multi_models(args):
                 f"--model-path {model_path}",
                 f"--compiler {args.compiler}",
                 f"--warmup {args.warmup}",
+                f"--trials {args.trials}",
                 f"--log-prompt {args.log_prompt}",
             ]
         )
@@ -240,6 +344,13 @@ def is_single_model_dir(model_dir):
 
 def main(args):
     assert os.path.isdir(args.model_path)
+    assert args.compiler == "CINN"
+
+    random_seed = 123
+    paddle.seed(random_seed)
+    random.seed(random_seed)
+    np.random.seed(random_seed)
+
     if is_single_model_dir(args.model_path):
         test_single_model(args)
     else:
@@ -258,11 +369,20 @@ if __name__ == "__main__":
         "--compiler",
         type=str,
         required=False,
-        default="default",
+        default="CINN",
         help="Path to customized compiler python file",
     )
     parser.add_argument(
         "--warmup", type=int, required=False, default=5, help="Number of warmup steps"
+    )
+    parser.add_argument(
+        "--trials", type=int, required=False, default=10, help="Number of timing trials"
+    )
+    parser.add_argument(
+        "--use-naive-timer",
+        action="store_true",
+        default=False,
+        help="Use naive timer for permance measuring.",
     )
     parser.add_argument(
         "--log-prompt",

--- a/graph_net/paddle/test_compiler.py
+++ b/graph_net/paddle/test_compiler.py
@@ -90,11 +90,8 @@ def get_compiled_model(args, model):
 
 
 def regular_item(item):
-    if isinstance(item, paddle.Tensor) and (item.dtype == paddle.bfloat16):
-        item = np.array(item.astype("float32"))
-    else:
-        item = np.array(item)
-    if item.dtype == np.bool_:
+    assert isinstance(item, paddle.Tensor)
+    if item.dtype not in [paddle.float32, paddle.float64]:
         item = item.astype("float32")
     return item
 
@@ -306,32 +303,34 @@ def test_single_model(args):
 
 def get_cmp_equal(expected_out, compiled_out):
     return " ".join(
-        str(int(np.sum(np.equal(a, b)))) for a, b in zip(expected_out, compiled_out)
+        str(int(paddle.equal_all(a, b))) for a, b in zip(expected_out, compiled_out)
     )
 
 
 def get_cmp_all_close(expected_out, compiled_out, atol, rtol):
     return " ".join(
-        str(int(np.allclose(a, b, atol=atol, rtol=rtol)))
+        str(int(paddle.allclose(a, b, atol=atol, rtol=rtol)))
         for a, b in zip(expected_out, compiled_out)
     )
 
 
 def get_cmp_max_diff(expected_out, compiled_out):
     return " ".join(
-        str(np.max(np.abs(a - b)).item()) for a, b in zip(expected_out, compiled_out)
+        str(paddle.max(paddle.abs(a - b)).item())
+        for a, b in zip(expected_out, compiled_out)
     )
 
 
 def get_cmp_mean_diff(expected_out, compiled_out):
     return " ".join(
-        str(np.mean(np.abs(a - b)).item()) for a, b in zip(expected_out, compiled_out)
+        str(paddle.mean(paddle.abs(a - b)).item())
+        for a, b in zip(expected_out, compiled_out)
     )
 
 
 def get_cmp_diff_count(expected_out, compiled_out, atol, rtol):
     return " ".join(
-        str(np.sum(~np.isclose(a, b, atol=atol, rtol=rtol)).item())
+        str(paddle.sum(~paddle.isclose(a, b, atol=atol, rtol=rtol)).item())
         for a, b in zip(expected_out, compiled_out)
     )
 
@@ -344,9 +343,11 @@ def test_multi_models(args):
                 "-m graph_net.paddle.test_compiler",
                 f"--model-path {model_path}",
                 f"--compiler {args.compiler}",
+                f"--device {args.device}",
                 f"--warmup {args.warmup}",
                 f"--trials {args.trials}",
                 f"--log-prompt {args.log_prompt}",
+                f"--output-dir {args.output_dir}",
             ]
         )
         cmd_ret = os.system(cmd)

--- a/graph_net/paddle/test_compiler.py
+++ b/graph_net/paddle/test_compiler.py
@@ -9,8 +9,10 @@ from contextlib import contextmanager
 import time
 import numpy as np
 import random
+import platform
 
-from . import utils
+from graph_net.paddle import utils
+from graph_net.benchmark_result import BenchmarkResult
 
 
 def load_class_from_file(file_path: str, class_name: str):
@@ -201,6 +203,27 @@ def measure_performance(model_call, synchronizer_func, args, profile=False):
     return outs, times
 
 
+def init_benchmark_result(args):
+    if args.device == "cuda":
+        hardware = paddle.device.cuda.get_device_name(0)
+    elif args.device == "cpu":
+        hardware = platform.processor()
+    else:
+        hardware = "unknown"
+
+    if args.compiler == "CINN":
+        compile_framework_version = paddle.__version__
+    else:
+        compile_framework_version = "unknown"
+
+    result_data = BenchmarkResult(
+        args=args,
+        hardware=hardware,
+        compile_framework_version=compile_framework_version,
+    )
+    return result_data
+
+
 def test_single_model(args):
     synchronizer_func = get_synchronizer_func(args)
     input_dict, input_dtypes, param_dtypes = get_input_dict(args)
@@ -210,12 +233,16 @@ def test_single_model(args):
     # Collect model information
     num_ops = count_number_of_ops(args, model)
 
-    print("Run on eager mode")
+    # Initialize benchmark result
+    result_data = init_benchmark_result(args)
+    result_data.update_model_info(num_ops, input_dtypes, param_dtypes)
+
+    # Run on eager mode
     expected_out, eager_time_ms = measure_performance(
         lambda: model(**input_dict), synchronizer_func, args, profile=False
     )
 
-    print("Run on compiling mode")
+    # Run on compiling mode
     compiled_model = get_compiled_model(args, model)
     compiled_out, compiled_time_ms = measure_performance(
         lambda: compiled_model(**input_dict), synchronizer_func, args, profile=False
@@ -243,6 +270,7 @@ def test_single_model(args):
 
     def print_cmp(key, func, **kwargs):
         cmp_ret = func(expected_out, compiled_out, **kwargs)
+        result_data.update_corrrectness(key, cmp_ret)
         print(
             f"{args.log_prompt} {key} model_path:{args.model_path} {cmp_ret}",
             file=sys.stderr,
@@ -270,6 +298,10 @@ def test_single_model(args):
         f"{args.log_prompt} duration model_path:{args.model_path} eager:{eager_time_ms:.5f} ms, compiled:{compiled_time_ms:.5f} ms, speedup:{eager_time_ms / compiled_time_ms:.3f}",
         file=sys.stderr,
     )
+
+    result_data.update_performance(eager_time_ms, compiled_time_ms)
+    if args.output_dir:
+        result_data.write_to_json(args.output_dir)
 
 
 def get_cmp_equal(expected_out, compiled_out):
@@ -373,6 +405,13 @@ if __name__ == "__main__":
         help="Path to customized compiler python file",
     )
     parser.add_argument(
+        "--device",
+        type=str,
+        required=False,
+        default="cuda",
+        help="Device for testing the compiler (e.g., 'cpu' or 'cuda')",
+    )
+    parser.add_argument(
         "--warmup", type=int, required=False, default=5, help="Number of warmup steps"
     )
     parser.add_argument(
@@ -390,6 +429,13 @@ if __name__ == "__main__":
         required=False,
         default="graph-net-test-compiler-log",
         help="Log prompt for performance log filtering.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=str,
+        required=False,
+        default=None,
+        help="Directory to save the structured JSON result file.",
     )
     args = parser.parse_args()
     main(args=args)

--- a/graph_net/paddle/test_compiler.py
+++ b/graph_net/paddle/test_compiler.py
@@ -76,7 +76,6 @@ def get_input_spec(args):
         name = v["name"]
         dtype = v["info"]["dtype"]
         shape = v["info"]["shape"]
-        # print(f"-- i: {i}, v: name={name}, shape={shape}, dtype={dtype}")
         input_spec[i] = paddle.static.InputSpec(shape, dtype)
     return input_spec
 
@@ -95,9 +94,6 @@ def test_single_model(args):
     synchronizer_func = get_synchronizer_func(args)
     input_dict = get_input_dict(args)
     model_dy = get_model(args)
-    input_spec = get_input_spec(args)
-    build_strategy = paddle.static.BuildStrategy()
-    build_strategy.build_cinn_pass = False
 
     # eager
     print("-- Run with eager mode")
@@ -110,6 +106,7 @@ def test_single_model(args):
 
     # compiled
     print("-- Run with compiled mode")
+    input_spec = get_input_spec(args)
     build_strategy = paddle.static.BuildStrategy()
     # build_strategy.build_cinn_pass = True
     compiled_model = paddle.jit.to_static(

--- a/graph_net/paddle/test_compiler.py
+++ b/graph_net/paddle/test_compiler.py
@@ -96,16 +96,19 @@ def regular_item(item):
     return item
 
 
-def count_number_of_ops(args, model):
-    static_model = paddle.jit.to_static(
-        model,
-        input_spec=get_input_spec(args),
-        full_graph=True,
-        backend=None,
-    )
-    static_model.eval()
-    program = model.forward.concrete_program.main_program
-    # print(program)
+def count_number_of_ops(args, model, eager_mode):
+    if eager_mode:
+        static_model = paddle.jit.to_static(
+            model,
+            input_spec=get_input_spec(args),
+            full_graph=True,
+            backend=None,
+        )
+        static_model.eval()
+        program = static_model.forward.concrete_program.main_program
+    else:
+        program = model.forward.concrete_program.main_program
+        print(program)
 
     num_ops = 0
     for block in program.blocks:
@@ -129,75 +132,77 @@ def naive_timer(duration_box, synchronizer_func):
     yield
     synchronizer_func()
     end = time.time()
-    duration_box.value = end - start
+    duration_box.value = (end - start) * 1000  # Store in milliseconds
 
 
-def time_execution_with_cuda_event(
-    model_call, synchronizer_func, num_warmup=3, num_trials=10, profile=False
-):
-    outs = None
+def get_timing_stats(elapsed_times):
+    stats = {
+        "mean": float(f"{np.mean(elapsed_times):.6g}"),
+        "std": float(f"{np.std(elapsed_times):.6g}"),
+        "min": float(f"{np.min(elapsed_times):.6g}"),
+        "max": float(f"{np.max(elapsed_times):.6g}"),
+    }
+    return stats
 
-    # warmups
-    for _ in range(num_warmup):
+
+def measure_performance(model_call, args, synchronizer_func):
+    stats = {}
+
+    # Warmup runs
+    for _ in range(args.warmup):
         outs = model_call()
     synchronizer_func()
 
-    elapsed_times = []
-    if profile:
-        paddle.base.core.nvprof_start()
-
-    # actual trials
-    for trial in range(num_trials):
-        # create event marker default is not interprocess
-        start_event = paddle.device.Event(enable_timing=True)
-        end_event = paddle.device.Event(enable_timing=True)
-
-        start_event.record()
-        outs = model_call()
-        end_event.record()
-        synchronizer_func()
-
-        # Calculate the elapsed time in milliseconds
-        elapsed_time_ms = start_event.elapsed_time(end_event)
-        elapsed_times.append(elapsed_time_ms)
-    if profile:
-        paddle.base.core.nvprof_stop()
-    elapsed_times = elapsed_times[num_trials // 2 :]
-    return outs, np.mean(elapsed_times)
-
-
-def time_execution_naive(model_call, synchronizer_func, num_warmup=3, num_trials=10):
-    outs = None
-
-    # warmups
-    for _ in range(num_warmup):
-        outs = model_call()
-
-    # actual trials
-    duration_box = DurationBox(-1)
-    with naive_timer(duration_box, synchronizer_func):
-        for i in range(num_trials):
-            outs = model_call()
-    return outs, duration_box.value * 1000 / float(num_trials)
-
-
-def measure_performance(model_call, synchronizer_func, args, profile=False):
-    if not args.use_naive_timer:
-        outs, times = time_execution_with_cuda_event(
-            model_call,
-            synchronizer_func=synchronizer_func,
-            num_warmup=args.warmup,
-            num_trials=args.trials,
-            profile=profile,
+    if "cuda" in args.device:
+        """
+        Acknowledgement: We evaluate the performance on both end-to-end and GPU-only timings,
+        With reference to methods only based on CUDA events from KernelBench in https://github.com/ScalingIntelligence/KernelBench
+        """
+        hardware_name = paddle.device.cuda.get_device_name(0)
+        print(
+            f"{args.log_prompt} [Profiling] Using device: {args.device} {hardware_name}, warm up {args.warmup}, trials {args.trials}"
         )
-    else:
-        outs, times = time_execution_naive(
-            model_call,
-            synchronizer_func=synchronizer_func,
-            num_warmup=args.warmup,
-            num_trials=args.trials,
+
+        e2e_times = []
+        gpu_times = []
+
+        for i in range(args.trials):
+            # End-to-end timing (naive_timer)
+            duration_box = DurationBox(-1)
+            with naive_timer(duration_box, synchronizer_func):
+                # GPU-only timing (CUDA Events)
+                start_event = paddle.device.Event(enable_timing=True)
+                end_event = paddle.device.Event(enable_timing=True)
+
+                start_event.record()
+                outs = model_call()
+                end_event.record()
+
+            gpu_time_ms = start_event.elapsed_time(end_event)
+            e2e_times.append(duration_box.value)
+            gpu_times.append(gpu_time_ms)
+            print(
+                f"Trial {i + 1}: e2e={duration_box.value:.4f} ms, gpu={gpu_time_ms:.5g} ms"
+            )
+
+        stats["e2e"] = get_timing_stats(e2e_times)
+        stats["gpu"] = get_timing_stats(gpu_times)
+    else:  # CPU or other devices
+        hardware_name = platform.processor()
+        print(
+            f"[Profiling] Using device: {args.device} {hardware_name}, warm up {args.warmup}, trials {args.trials}"
         )
-    return outs, times
+
+        e2e_times = []
+        for i in range(args.trials):
+            duration_box = DurationBox(-1)
+            with naive_timer(duration_box, compiler.synchronize):
+                outs = model_call()
+            print(f"Trial {i + 1}: e2e={duration_box.value:.4f} ms")
+            e2e_times.append(duration_box.value)
+        stats["e2e"] = get_timing_stats(e2e_times)
+
+    return outs, stats
 
 
 def init_benchmark_result(args):
@@ -208,7 +213,7 @@ def init_benchmark_result(args):
     else:
         hardware = "unknown"
 
-    if args.compiler == "CINN":
+    if args.compiler == "cinn":
         compile_framework_version = paddle.__version__
     else:
         compile_framework_version = "unknown"
@@ -229,21 +234,21 @@ def test_single_model(args):
     model.eval()
 
     # Collect model information
-    num_ops = count_number_of_ops(args, model)
+    num_eager_ops = count_number_of_ops(args, model, eager_mode=True)
 
     # Initialize benchmark result
     result_data = init_benchmark_result(args)
-    result_data.update_model_info(num_ops, input_dtypes, param_dtypes)
+    result_data.update_model_info(num_eager_ops, input_dtypes, param_dtypes)
 
     # Run on eager mode
-    expected_out, eager_time_ms = measure_performance(
-        lambda: model(**input_dict), synchronizer_func, args, profile=False
+    expected_out, eager_time_stats = measure_performance(
+        lambda: model(**input_dict), args, synchronizer_func
     )
 
     # Run on compiling mode
     compiled_model = get_compiled_model(args, model)
-    compiled_out, compiled_time_ms = measure_performance(
-        lambda: compiled_model(**input_dict), synchronizer_func, args, profile=False
+    compiled_out, compiled_time_stats = measure_performance(
+        lambda: compiled_model(**input_dict), args, synchronizer_func
     )
 
     if isinstance(expected_out, paddle.Tensor):
@@ -301,15 +306,26 @@ def test_single_model(args):
     print_cmp("cmp.diff_count_atol2_rtol1", get_cmp_diff_count, atol=1e-2, rtol=1e-1)
 
     print(
-        f"{args.log_prompt} information model_path:{args.model_path} {num_ops} ops, param_dtypes:{param_dtypes}, input_dtypes:{input_dtypes}",
-        file=sys.stderr,
-    )
-    print(
-        f"{args.log_prompt} duration model_path:{args.model_path} eager:{eager_time_ms:.5f} ms, compiled:{compiled_time_ms:.5f} ms, speedup:{eager_time_ms / compiled_time_ms:.3f}",
+        f"{args.log_prompt} information model_path:{args.model_path} {num_eager_ops} ops, param_dtypes:{param_dtypes}, input_dtypes:{input_dtypes}",
         file=sys.stderr,
     )
 
-    result_data.update_performance(eager_time_ms, compiled_time_ms)
+    result_data.update_performance(eager_time_stats, compiled_time_stats)
+    duration_log = (
+        f"{args.log_prompt} [Duration] "
+        f"eager_e2e:{result_data.eager_e2e_time_ms:.4f} ms compiled_e2e:{result_data.compiled_e2e_time_ms:.4f} ms"
+    )
+    speedup_log = (
+        f"{args.log_prompt} [Speedup] " f"e2e_speedup:{result_data.e2e_speedup:.4f}"
+    )
+
+    if "cuda" in args.device:
+        duration_log += f" eager_gpu:{result_data.eager_gpu_time_ms:.4f} ms compiled_gpu:{result_data.compiled_gpu_time_ms:.4f} ms"
+        speedup_log += f" gpu_speedup:{result_data.gpu_speedup:.4f}"
+
+    print(duration_log, file=sys.stderr)
+    print(speedup_log, file=sys.stderr)
+
     if args.output_dir:
         result_data.write_to_json(args.output_dir)
 
@@ -390,7 +406,7 @@ def is_single_model_dir(model_dir):
 
 def main(args):
     assert os.path.isdir(args.model_path)
-    assert args.compiler == "CINN"
+    assert args.compiler == "cinn"
 
     random_seed = 123
     paddle.seed(random_seed)
@@ -415,7 +431,7 @@ if __name__ == "__main__":
         "--compiler",
         type=str,
         required=False,
-        default="CINN",
+        default="cinn",
         help="Path to customized compiler python file",
     )
     parser.add_argument(
@@ -430,12 +446,6 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--trials", type=int, required=False, default=10, help="Number of timing trials"
-    )
-    parser.add_argument(
-        "--use-naive-timer",
-        action="store_true",
-        default=False,
-        help="Use naive timer for permance measuring.",
     )
     parser.add_argument(
         "--log-prompt",

--- a/graph_net/paddle/utils.py
+++ b/graph_net/paddle/utils.py
@@ -9,6 +9,8 @@ import inspect
 import ast
 import paddle
 
+kLiteralTensorSize = 64
+
 
 def get_limited_precision_float_str(value):
     if not isinstance(value, float):
@@ -35,7 +37,7 @@ def convert_state_and_inputs_impl(state_dict, example_inputs):
 
         info = tensor_info(tensor)
         if tensor.dtype in [paddle.int8, paddle.int16, paddle.int32, paddle.int64]:
-            if tensor.numel() < 1024:
+            if tensor.numel() < kLiteralTensorSize:
                 return {
                     "type": "small_int_tensor",
                     "data": tensor.clone(),
@@ -43,7 +45,7 @@ def convert_state_and_inputs_impl(state_dict, example_inputs):
                 }
             else:
                 return {"type": "big_int_tensor", "data": tensor.clone(), "info": info}
-        elif tensor.numel() < 1024:
+        elif tensor.numel() < kLiteralTensorSize:
             return {"type": "small_tensor", "data": tensor.clone(), "info": info}
         else:
             return {"type": "random_tensor", "info": info}
@@ -141,10 +143,10 @@ def convert_meta_classes_to_tensors(file_path):
                 "shape": attrs.get("shape", []),
                 "dtype": data_type,
                 "device": attrs.get("device", "gpu"),
-                "mean": attrs.get("mean", 0.0),
-                "std": attrs.get("std", 1.0),
-                "low": attrs.get("low", 0),
-                "high": attrs.get("high", 2),
+                "mean": 0.0 if attrs.get("mean", None) is None else attrs.get("mean"),
+                "std": 1.0 if attrs.get("std", None) is None else attrs.get("std"),
+                "min_val": attrs.get("min_val", 0),
+                "max_val": attrs.get("max_val", 2),
             },
             "data": data_value,
             "name": attrs.get("name"),
@@ -173,17 +175,18 @@ def replay_tensor(info):
     device = info["info"]["device"]
     dtype = info["info"]["dtype"]
     shape = info["info"]["shape"]
-    min_value = info["info"]["low"] if "low" in info["info"] else 0
-    max_value = info["info"]["high"] if "high" in info["info"] else 0.5
+
+    mean = info["info"]["mean"]
+    std = info["info"]["std"]
+    min_val = info["info"]["min_val"]
+    max_val = info["info"]["max_val"]
     if None in shape:
         shape = list(map(lambda i: i if i is not None else 1, shape))
     if "data" in info and info["data"] is not None:
         return paddle.reshape(info["data"], shape).to(dtype).to(device)
     elif dtype == paddle.int32 or dtype == paddle.int64:
         return paddle.cast(
-            paddle.randint(
-                low=min_value, high=max_value + 1, shape=shape, dtype="int64"
-            ),
+            paddle.randint(low=min_val, high=max_val + 1, shape=shape, dtype="int64"),
             dtype,
         ).to(device)
     elif dtype == paddle.bool:
@@ -194,7 +197,9 @@ def replay_tensor(info):
     else:
         std = info["info"]["std"]
         return (
-            paddle.uniform(shape, dtype="float32", min=min_value, max=max_value)
+            paddle.clip(
+                paddle.normal(shape=shape, mean=mean, std=std), min=min_val, max=max_val
+            )
             .to(dtype)
             .to(device)
         )

--- a/graph_net/paddle/utils.py
+++ b/graph_net/paddle/utils.py
@@ -7,6 +7,7 @@ import argparse
 import importlib
 import inspect
 import ast
+import math
 import paddle
 
 kLiteralTensorSize = 64
@@ -121,6 +122,22 @@ def load_converted_list_from_text(file_path):
     return [*weight_info, *input_info]
 
 
+def ConvertToValidNumber(data_type, value):
+    if value is not None and data_type in [
+        paddle.float32,
+        paddle.float16,
+        paddle.bfloat16,
+    ]:
+        if math.isnan(value):
+            return None
+        if math.isinf(value) and value > 0:
+            return paddle.finfo(data_type).max
+        if math.isinf(value) and value < 0:
+            return paddle.finfo(data_type).min
+
+    return value
+
+
 def convert_meta_classes_to_tensors(file_path):
     for name, cls in _get_classes(file_path):
         attrs = {
@@ -143,10 +160,10 @@ def convert_meta_classes_to_tensors(file_path):
                 "shape": attrs.get("shape", []),
                 "dtype": data_type,
                 "device": attrs.get("device", "gpu"),
-                "mean": 0.0 if attrs.get("mean", None) is None else attrs.get("mean"),
-                "std": 1.0 if attrs.get("std", None) is None else attrs.get("std"),
-                "min_val": attrs.get("min_val", 0),
-                "max_val": attrs.get("max_val", 2),
+                "mean": ConvertToValidNumber(data_type, attrs.get("mean", None)),
+                "std": ConvertToValidNumber(data_type, attrs.get("std", None)),
+                "min_val": ConvertToValidNumber(data_type, attrs.get("min_val", 0)),
+                "max_val": ConvertToValidNumber(data_type, attrs.get("max_val", 2)),
             },
             "data": data_value,
             "name": attrs.get("name"),
@@ -195,11 +212,19 @@ def replay_tensor(info):
             paddle.bool,
         ).to(device)
     else:
-        std = info["info"]["std"]
-        return (
-            paddle.clip(
-                paddle.normal(shape=shape, mean=mean, std=std), min=min_val, max=max_val
+        if mean is not None and std is not None:
+            return (
+                paddle.clip(
+                    paddle.normal(shape=shape, mean=mean, std=std),
+                    min=min_val,
+                    max=max_val,
+                )
+                .to(dtype)
+                .to(device)
             )
-            .to(dtype)
-            .to(device)
-        )
+        else:
+            return (
+                paddle.uniform(shape=shape, dtype="float32", min=min_val, max=max_val)
+                .to(dtype)
+                .to(device)
+            )

--- a/graph_net/paddle/validate.py
+++ b/graph_net/paddle/validate.py
@@ -68,7 +68,6 @@ def main(args):
 
     y = model(**state_dict)
 
-    # print(np.argmin(y), np.argmax(y))
     if isinstance(y, paddle.Tensor):
         print(y.shape)
     elif isinstance(y, list) or isinstance(y, tuple):


### PR DESCRIPTION
### PR Category
<!-- One of [ New Sample | Feature Enhancement | Bug Fix | Other ] -->
Feature Enhancement

### Description
<!-- Describe what you’ve done -->
1. 完善数据初始化方式，根据数据元信息中存储的`max_val`、`min_val`、`mean`、`std`来初始化，并且支持`nan`、`inf`非数的处理。
2. 完善计时统计逻辑，改成与torch版一致。
3. 定义`BenchmarkResult`，记录评测结果，并且将结果支持导出到json文件。相比当前的torch版本，有额外多采集和记录一些模型信息。示例如下：
```
{                                                                                                                                                                                   
    "configuration": {
        "model_name": "DETR-R50",
        "subgraph_tag": "subgraph_0",
        "model_path": "/work/GraphNet/tests/paddle_samples_v5/DETR-R50/subgraph_0",
        "device": "cuda",
        "hardware": "NVIDIA H20-3e",
        "framework": "PaddlePaddle",
        "compiler": "cinn",
        "compile_framework_version": "3.0.0",
        "warmup": 5,
        "trials": 10
    },  
    "model_info": {
        "num_ops": 191,
        "input_dtypes": [
            "paddle.int32",
            "paddle.int64",
            "paddle.float32"
        ],
        "param_dtypes": []
    },
    "correctness": {
        "num_outpus": 1,
        "output_dtyps": [
            "paddle.float32"
        ],
        "cmp.equal": "1",
        "cmp.all_close_atol8_rtol8": "1",
        "cmp.all_close_atol8_rtol5": "1",
        "cmp.all_close_atol5_rtol5": "1",
        "cmp.all_close_atol3_rtol2": "1",
        "cmp.all_close_atol2_rtol1": "1",
        "cmp.max_diff": "0.0",
        "cmp.mean_diff": "0.0",
        "cmp.diff_count_atol8_rtol8": "0",
        "cmp.diff_count_atol8_rtol5": "0",
        "cmp.diff_count_atol5_rtol5": "0",
        "cmp.diff_count_atol3_rtol2": "0",
        "cmp.diff_count_atol2_rtol1": "0"
    },
    "performance": {
        "eager": {
            "e2e": {
                "mean": 1.43864,
                "std": 0.0473063,
                "min": 1.38211,
                "max": 1.56307
            },
            "gpu": {
                "mean": 1.41516,
                "std": 0.0350482,
                "min": 1.36419,
                "max": 1.49731
            }
        },
        "compiled": {
            "e2e": {
                "mean": 0.858569,
                "std": 0.0490112,
                "min": 0.798702,
                "max": 0.962019
            },
            "gpu": {
                "mean": 0.831565,
                "std": 0.0353753,
                "min": 0.781184,
                "max": 0.907424
            }
        },
        "speedup": {
            "e2e": 1.67563,
            "gpu": 1.7018
        }
    }
}
```