### PR TITLE
【Hackathon 9th No.98】[Feature Enhancement] Add Xla Backend for test_compile

### DIFF
--- a/graph_net/torch/backend/xla_backend.py
+++ b/graph_net/torch/backend/xla_backend.py
@@ -7,11 +7,28 @@ except ImportError:
     torch_xla = None
 
 
+class XlaCompiledModule(torch.nn.Module):
+    def __init__(self, module):
+        super().__init__()
+        self.module = module
+        self.counter = 0
+        self.xla_input = {}
+
+    def forward(self, **kwargs):
+        if self.counter == 0:
+            self.xla_input = {k: v.to("xla") for k, v in kwargs.items()}
+            self.module = torch.compile(self.module, backend="openxla")
+
+        ret = self.module(**self.xla_input)
+        self.counter += 1
+        return ret
+
+
 class XlaBackend(GraphCompilerBackend):
     def __call__(self, model):
         if torch_xla is None:
             raise ImportError("torch_xla not installed")
-        return torch.compile(model, backend="openxla")
+        return XlaCompiledModule(model)
 
     def synchronize(self):
         torch_xla.sync()

--- a/graph_net/torch/backend/xla_backend.py
+++ b/graph_net/torch/backend/xla_backend.py
@@ -1,0 +1,20 @@
+import torch
+from .graph_compiler_backend import GraphCompilerBackend
+
+try:
+    import torch_xla
+except ImportError:
+    torch_xla = None
+
+
+class XlaBackend(GraphCompilerBackend):
+    def __call__(self, model):
+        if torch_xla is None:
+            raise ImportError("torch_xla not installed")
+        return torch.compile(model, backend="openxla")
+
+    def synchronize(self):
+        torch_xla.sync()
+
+    def version(self):
+        return torch_xla.version

--- a/graph_net/torch/test_compiler.py
+++ b/graph_net/torch/test_compiler.py
@@ -16,12 +16,14 @@ import numpy as np
 import platform
 from graph_net.torch.backend.graph_compiler_backend import GraphCompilerBackend
 from graph_net.torch.backend.tvm_backend import TvmBackend
+from graph_net.torch.backend.xla_backend import XlaBackend
 from graph_net.torch.backend.inductor_backend import InductorBackend
 from graph_net.torch.backend.tensorrt_backend import TensorRTBackend
 from graph_net.torch.backend.blade_disc_backend import BladeDISCBackend
 
 registry_backend = {
     "tvm": TvmBackend(),
+    "xla": XlaBackend(),
     "inductor": InductorBackend(),
     "tensorrt": TensorRTBackend(),
     "bladedisc": BladeDISCBackend(),
@@ -106,13 +108,13 @@ def measure_performance(model_call, args, compiler):
         model_call()
     compiler.synchronize()
 
-    if "cuda" in args.device:
+    if "cuda" in args.device or os.environ.get("PJRT_DEVICE") == "CUDA":
         """
         Acknowledgement: We evaluate the performance on both end-to-end and GPU-only timings,
         With reference to methods only based on CUDA events from KernelBench in https://github.com/ScalingIntelligence/KernelBench
         """
 
-        device = torch.device(args.device)
+        device = torch.device("cuda")
         hardware_name = torch.cuda.get_device_name(device)
         print(
             f"{args.log_prompt} [Profiling] Using device: {args.device} {hardware_name}, warm up {args.warmup}, trials {args.trials}"
@@ -187,11 +189,9 @@ def test_single_model(args):
         },
     }
 
-    if "cuda" in args.device:
-        result_data["configuration"]["hardware"] = torch.cuda.get_device_name(
-            args.device
-        )
-    elif args.device == "cpu":
+    if "cuda" in args.device or os.environ.get("PJRT_DEVICE") == "CUDA":
+        result_data["configuration"]["hardware"] = torch.cuda.get_device_name("cuda")
+    elif args.device == "cpu" or os.environ.get("PJRT_DEVICE") == "CPU":
         result_data["configuration"]["hardware"] = platform.processor()
     else:
         result_data["configuration"]["hardware"] = "unknown"
@@ -202,6 +202,10 @@ def test_single_model(args):
         result_data["configuration"][
             "compile_framework_version"
         ] = f"Tvm {compiler.version}"
+    elif args.compiler == "xla":
+        result_data["configuration"][
+            "compile_framework_version"
+        ] = f"Xla {compiler.version}"
     elif args.compiler == "tensorrt":
         result_data["configuration"][
             "compile_framework_version"
@@ -286,7 +290,7 @@ def test_single_model(args):
     )
     speedup_log = f"{args.log_prompt} [Speedup] " f"e2e_speedup:{e2e_speedup:.4f}"
 
-    if "cuda" in args.device:
+    if "cuda" in args.device or os.environ.get("PJRT_DEVICE") == "CUDA":
         eager_gpu_time_ms = eager_stats.get("gpu", {}).get("mean", 0)
         compiled_gpu_time_ms = compiled_stats.get("gpu", {}).get("mean", 0)
 

--- a/graph_net/torch/test_compiler.py
+++ b/graph_net/torch/test_compiler.py
@@ -31,7 +31,7 @@ registry_backend = {
 
 
 def load_class_from_file(
-    args: argparse.Namespace, class_name: str
+    args: argparse.Namespace, class_name: str, device: str
 ) -> Type[torch.nn.Module]:
     file_path = f"{args.model_path}/model.py"
     file = Path(file_path).resolve()
@@ -39,7 +39,7 @@ def load_class_from_file(
 
     with open(file_path, "r", encoding="utf-8") as f:
         model_code = f.read()
-    model_code = utils.modify_code_by_device(model_code, args.device)
+    model_code = utils.modify_code_by_device(model_code, device)
     spec = importlib.util.spec_from_loader(module_name, loader=None)
     module = importlib.util.module_from_spec(spec)
     sys.modules[module_name] = module
@@ -55,11 +55,10 @@ def get_compiler_backend(args) -> GraphCompilerBackend:
     return registry_backend[args.compiler]
 
 
-def get_model(args):
-    model_class = load_class_from_file(args, class_name="GraphModule")
+def get_model(args, device):
+    # device: Torch device object specifying the target device for model loading (e.g., 'cuda', 'cpu', 'xla')
+    model_class = load_class_from_file(args, class_name="GraphModule", device=device)
     model = model_class().to(torch.device(args.device))
-    # for param in model.parameters():
-    #     param.requires_grad_(False)
     return model
 
 
@@ -108,13 +107,13 @@ def measure_performance(model_call, args, compiler):
         model_call()
     compiler.synchronize()
 
-    if "cuda" in args.device or os.environ.get("PJRT_DEVICE") == "CUDA":
+    if "cuda" in args.device:
         """
         Acknowledgement: We evaluate the performance on both end-to-end and GPU-only timings,
         With reference to methods only based on CUDA events from KernelBench in https://github.com/ScalingIntelligence/KernelBench
         """
 
-        device = torch.device("cuda")
+        device = torch.device(args.device)
         hardware_name = torch.cuda.get_device_name(device)
         print(
             f"{args.log_prompt} [Profiling] Using device: {args.device} {hardware_name}, warm up {args.warmup}, trials {args.trials}"
@@ -168,8 +167,12 @@ def measure_performance(model_call, args, compiler):
 def test_single_model(args):
     compiler = get_compiler_backend(args)
     input_dict = get_input_dict(args)
-    model = get_model(args)
-    compiled_model = compiler(model)
+    model = get_model(args, args.device)
+    if args.compiler == "xla":
+        xla_model = get_model(args, "xla")
+        compiled_model = compiler(xla_model)
+    else:
+        compiled_model = compiler(model)
 
     result_data = {
         "configuration": {
@@ -189,9 +192,11 @@ def test_single_model(args):
         },
     }
 
-    if "cuda" in args.device or os.environ.get("PJRT_DEVICE") == "CUDA":
-        result_data["configuration"]["hardware"] = torch.cuda.get_device_name("cuda")
-    elif args.device == "cpu" or os.environ.get("PJRT_DEVICE") == "CPU":
+    if "cuda" in args.device:
+        result_data["configuration"]["hardware"] = torch.cuda.get_device_name(
+            args.device
+        )
+    elif args.device == "cpu":
         result_data["configuration"]["hardware"] = platform.processor()
     else:
         result_data["configuration"]["hardware"] = "unknown"
@@ -233,6 +238,8 @@ def test_single_model(args):
         expected_out = (expected_out,)
     if not isinstance(compiled_out, tuple):
         compiled_out = (compiled_out,)
+    if args.compiler == "xla":
+        compiled_out = tuple(item.to("cpu").to("cuda") for item in compiled_out)
 
     def print_and_store_cmp(key, func, **kwargs):
         cmp_ret = func(expected_out, compiled_out, **kwargs)
@@ -290,7 +297,7 @@ def test_single_model(args):
     )
     speedup_log = f"{args.log_prompt} [Speedup] " f"e2e_speedup:{e2e_speedup:.4f}"
 
-    if "cuda" in args.device or os.environ.get("PJRT_DEVICE") == "CUDA":
+    if "cuda" in args.device:
         eager_gpu_time_ms = eager_stats.get("gpu", {}).get("mean", 0)
         compiled_gpu_time_ms = compiled_stats.get("gpu", {}).get("mean", 0)
 

--- a/graph_net/torch/utils.py
+++ b/graph_net/torch/utils.py
@@ -5,10 +5,11 @@ from collections import OrderedDict
 import uuid
 import json
 import os
+import ast
+import math
+import inspect
 import argparse
 import importlib
-import inspect
-import math
 
 kLiteralTensorSize = 64
 
@@ -272,18 +273,73 @@ def replay_tensor(info):
     return torch.randn(size=shape).to(dtype).to(device) * std * 0.2 + mean
 
 
-def modify_code_by_device(code, device):
-    if device == "cuda":
-        pattern = r'device\(type="cpu"\)'
-        replacement = f'device(type="cuda", index={torch.cuda.current_device()})'
-        modify_code = re.sub(pattern, replacement, code)
-        return modify_code
-    elif device == "xla":
-        pattern = r'device\(type="(?:cpu|cuda)"(?:, index=\d+)?\)'
-        replacement = 'device(type="xla")'
-        modify_code = re.sub(pattern, replacement, code)
-        return modify_code
-    else:
-        pattern = r'device\(type="(?:cuda)"(?:, index=\d+)?\)'
-        replacement = 'device(type="cpu")'
-        modify_code = re
+def modify_code_by_device(code, new_device_str):
+    tree = ast.parse(code)
+
+    class DeviceReplacer(ast.NodeTransformer):
+        def __init__(self, new_device):
+            super().__init__()
+            self.new_device = new_device
+
+        def visit_Call(self, node):
+            # device.type("device")
+            if (
+                isinstance(node.func, ast.Attribute)
+                and isinstance(node.func.value, ast.Name)
+                and node.func.value.id == "device"
+                and node.func.attr == "type"
+            ):
+                if (
+                    node.args
+                    and isinstance(node.args[0], ast.Constant)
+                    and isinstance(node.args[0].value, str)
+                ):
+                    node.args[0].value = self.new_device
+                return node
+
+            # .to(device(type="device"))
+            if (
+                isinstance(node.func, ast.Attribute)
+                and node.func.attr == "to"
+                and len(node.args) == 1
+                and isinstance(node.args[0], ast.Call)
+                and isinstance(node.args[0].func, ast.Name)
+                and node.args[0].func.id == "device"
+            ):
+                device_call = node.args[0]
+                for keyword in device_call.keywords:
+                    if (
+                        keyword.arg == "type"
+                        and isinstance(keyword.value, ast.Constant)
+                        and isinstance(keyword.value.value, str)
+                    ):
+                        keyword.value.value = self.new_device
+                return node
+
+            # device=device(type="device")
+            new_keywords = []
+            for keyword in node.keywords:
+                if (
+                    keyword.arg == "device"
+                    and isinstance(keyword.value, ast.Call)
+                    and isinstance(keyword.value.func, ast.Name)
+                    and keyword.value.func.id == "device"
+                ):
+                    device_call = keyword.value
+                    for kw in device_call.keywords:
+                        if (
+                            kw.arg == "type"
+                            and isinstance(kw.value, ast.Constant)
+                            and isinstance(kw.value.value, str)
+                        ):
+                            kw.value.value = self.new_device
+                    new_keywords.append(keyword)
+                else:
+                    new_keywords.append(keyword)
+            node.keywords = new_keywords
+            return self.generic_visit(node)
+
+    transformer = DeviceReplacer(new_device_str)
+    modified_tree = transformer.visit(tree)
+    ast.fix_missing_locations(modified_tree)
+    return ast.unparse(modified_tree)

--- a/graph_net/torch/utils.py
+++ b/graph_net/torch/utils.py
@@ -278,8 +278,12 @@ def modify_code_by_device(code, device):
         replacement = f'device(type="cuda", index={torch.cuda.current_device()})'
         modify_code = re.sub(pattern, replacement, code)
         return modify_code
-    else:
-        pattern = r'device\(type="cuda"(?:, index=\d+)?\)'
-        replacement = 'device(type="cpu")'
+    elif device == "xla":
+        pattern = r'device\(type="(?:cpu|cuda)"(?:, index=\d+)?\)'
+        replacement = 'device(type="xla")'
         modify_code = re.sub(pattern, replacement, code)
         return modify_code
+    else:
+        pattern = r'device\(type="(?:cuda)"(?:, index=\d+)?\)'
+        replacement = 'device(type="cpu")'
+        modify_code = re


### PR DESCRIPTION
### PR Category
<!-- One of [ New Sample | Feature Enhancement | Bug Fix | Other ] -->
Feature Enhancement

### Description
<!-- Describe what you’ve done -->
为 **graph_net.torch.test_compiler**支持后端使用**Xla**编译器
需要配置 **--compiler "xla"**，同时需要设置环境变量**PJRT_DEVICE来指定cuda或者cpu**（不设置的话自动检测，优先使用cuda)

测试版本  torch_xla - 2.7 (CUDA 12.6 + Python 3.11)[whl包](https://storage.googleapis.com/pytorch-xla-releases/wheels/cuda/12.6/torch_xla-2.7.0-cp311-cp311-manylinux_2_28_x86_64.whl)，torch_xla 的版本和torch的版本是一一对应的(CUDA版本也是需要对应的，官方编译的现在大部分都是CPU的)，在最新版本的xla中，已经移除了对CUDA的支持，只支持TPU，CPU后端

对模型中创建张量时硬编码的设备处理上，使用抽象语法树来替代字符串提取替换，同时新增device参数
对于xla编译器，需要把所有张量都创建在xla设备上，xla仅支持转化到cpu上
对比速度的时候，前向运行在cuda上，编译过的模型运行在xla(实际设备为cuda)上