### PR TITLE
[Bug Fix] Use astor instead of ast to unparse source code of paddle model, to avoid unstable result between different python versions.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 pre-commit
+astor

--- a/tools/ci/check_validate.sh
+++ b/tools/ci/check_validate.sh
@@ -37,6 +37,7 @@ function prepare_torch_env() {
     LOG "[INFO] Update pip ..."
     env http_proxy="" https_proxy="" pip install -U pip > /dev/null
     [ $? -ne 0 ] && LOG "[FATAL] Update pip failed!" && exit -1
+    pip install astor
     # install torch
     pip install torch==2.6.0 --index-url https://download.pytorch.org/whl/cu118 > /dev/null
     [ $? -ne 0 ] && LOG "[FATAL] Install torch2.6.0 failed!" && exit -1
@@ -56,7 +57,7 @@ function prepare_paddle_env() {
     env http_proxy="" https_proxy="" pip install -U pip > /dev/null
     [ $? -ne 0 ] && LOG "[FATAL] Update pip failed!" && exit -1
     # install paddle
-    pip uninstall torch==2.7.0 --yes
+    pip install astor
     LOG "[INFO] Install paddlepaddle-develop ..."
     python -m pip install --pre paddlepaddle-gpu -i https://www.paddlepaddle.org.cn/packages/nightly/cu118/ > /dev/null
     [ $? -ne 0 ] && LOG "[FATAL] Install paddlepaddle-develop failed!" && exit -1

--- a/tools/ci/check_validate.sh
+++ b/tools/ci/check_validate.sh
@@ -37,7 +37,6 @@ function prepare_torch_env() {
     LOG "[INFO] Update pip ..."
     env http_proxy="" https_proxy="" pip install -U pip > /dev/null
     [ $? -ne 0 ] && LOG "[FATAL] Update pip failed!" && exit -1
-    pip install astor
     # install torch
     pip install torch==2.6.0 --index-url https://download.pytorch.org/whl/cu118 > /dev/null
     [ $? -ne 0 ] && LOG "[FATAL] Install torch2.6.0 failed!" && exit -1


### PR DESCRIPTION
### PR Category
<!-- One of [ New Sample | Feature Enhancement | Bug Fix | Other ] -->
Bug Fix

### Description
<!-- Describe what you’ve done -->
Paddle样本在执行validate时，通过从`model.py`的`forward`函数中移除注释、解析模型结构，并依据模型结构的源码字符串生成样本的sha哈希值，写入`graph_hash.txt`。

https://github.com/PaddlePaddle/GraphNet/pull/266 改成用ast从model.py中解析python类型，并使用`ast.unparse`将AST转成源码。`ast.unparse`在不同Python版本下，针对多输出场景的源码格式化风格不一样，比如：
<img width="1786" height="339" alt="81ebdb28336d12e75ff2c98b57cdf252" src="https://github.com/user-attachments/assets/fe00b8fe-0da5-497b-8664-5874e43d72b3" />

这是Python内置AST打印器的“非稳定行为”，会导致在不同Python版本下得到的模型字符串不一样，从而会得到不同的哈希值。

本PR改成使用第三方库`astor`代替`ast.unparse`来生成源码，并修复CI上的依赖。
`astor.to_source`和`ast.unparse`转换得到的源码的对比：
| | `astor.to_source` | `ast.unparse` |
|---|---|---|
| 稳定性 | 第三方库（跨版本行为稳定，Python 3.6~3.12 基本一致）。适合做“跨版本、可预测”的源码还原。 | Python 3.9+ 标准库自带。行为可能随 Python 版本更新而变化（例如 tuple 结尾逗号、换行位置等）。 |
| 注释 | 不会保留注释（因为 ast 树里本身没有注释） | 不会保留注释（因为 ast 树里本身没有注释） |
| 格式化风格 | 始终使用 4 空格缩进；二元运算符两边强制加空格；一行多个语句会被拆分成多行；括号规则相对保守（只在需要时加）。| 格式更接近 Python 官方代码风格（PEP 8-ish），但在不同版本里会变动；有时会多加括号，或把表达式拆得更细；输出可能比 astor 更“冗余”。|

总结：
- `astor.to_source`，更稳定、更简洁、跨版本统一
- `ast.unparse`，官方实现、格式更严格，但跨版本差异大