### PR TITLE
[Bug Fix]  Set random seed for torch and fix invalid torch cv samples.

### DIFF
--- a/samples/mmseg/SegNeXt-b/weight_meta.py
+++ b/samples/mmseg/SegNeXt-b/weight_meta.py
@@ -2455,7 +2455,7 @@ class Program_weight_tensor_meta_L_self_modules_backbone_modules_block2_modules_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.477
-    std = 1.551
+    std = 0.551
     data = None
 
 
@@ -4341,7 +4341,7 @@ class Program_weight_tensor_meta_L_self_modules_backbone_modules_block3_modules_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.335
-    std = 1.516
+    std = 0.516
     data = None
 
 
@@ -4451,7 +4451,7 @@ class Program_weight_tensor_meta_L_self_modules_backbone_modules_block3_modules_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.365
-    std = 1.702
+    std = 0.702
     data = None
 
 
@@ -4701,7 +4701,7 @@ class Program_weight_tensor_meta_L_self_modules_backbone_modules_block3_modules_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.504
-    std = 3.092
+    std = 1.092
     data = None
 
 
@@ -4811,7 +4811,7 @@ class Program_weight_tensor_meta_L_self_modules_backbone_modules_block3_modules_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.585
-    std = 3.823
+    std = 1.823
     data = None
 
 
@@ -5061,7 +5061,7 @@ class Program_weight_tensor_meta_L_self_modules_backbone_modules_block3_modules_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.845
-    std = 6.773
+    std = 0.773
     data = None
 
 
@@ -5171,7 +5171,7 @@ class Program_weight_tensor_meta_L_self_modules_backbone_modules_block3_modules_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.955
-    std = 7.576
+    std = 0.576
     data = None
 
 
@@ -5421,7 +5421,7 @@ class Program_weight_tensor_meta_L_self_modules_backbone_modules_block3_modules_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.469
-    std = 14.217
+    std = 1.217
     data = None
 
 
@@ -5531,7 +5531,7 @@ class Program_weight_tensor_meta_L_self_modules_backbone_modules_block3_modules_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.598
-    std = 14.929
+    std = 0.929
     data = None
 
 
@@ -5781,7 +5781,7 @@ class Program_weight_tensor_meta_L_self_modules_backbone_modules_block3_modules_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 2.097
-    std = 20.441
+    std = 1.441
     data = None
 
 
@@ -5891,7 +5891,7 @@ class Program_weight_tensor_meta_L_self_modules_backbone_modules_block3_modules_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 2.233
-    std = 20.387
+    std = 1.387
     data = None
 
 
@@ -6141,7 +6141,7 @@ class Program_weight_tensor_meta_L_self_modules_backbone_modules_block3_modules_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 3.568
-    std = 38.412
+    std = 1.412
     data = None
 
 
@@ -6251,7 +6251,7 @@ class Program_weight_tensor_meta_L_self_modules_backbone_modules_block3_modules_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 3.865
-    std = 39.828
+    std = 1.828
     data = None
 
 
@@ -6500,8 +6500,8 @@ class Program_weight_tensor_meta_L_self_modules_backbone_modules_block3_modules_
     shape = [320]
     dtype = "torch.float32"
     device = "cuda:0"
-    mean = 6.457
-    std = 76.325
+    mean = 1.457
+    std = 1.325
     data = None
 
 
@@ -6510,7 +6510,7 @@ class Program_weight_tensor_meta_L_self_modules_backbone_modules_block3_modules_
     shape = [320]
     dtype = "torch.float32"
     device = "cuda:0"
-    mean = 1.964
+    mean = 0.564
     std = 0.359
     data = None
 
@@ -6611,7 +6611,7 @@ class Program_weight_tensor_meta_L_self_modules_backbone_modules_block3_modules_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 6.959
-    std = 79.050
+    std = 1.050
     data = None
 
 
@@ -6861,7 +6861,7 @@ class Program_weight_tensor_meta_L_self_modules_backbone_modules_block3_modules_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 14.760
-    std = 197.511
+    std = 1.511
     data = None
 
 
@@ -7667,7 +7667,7 @@ class Program_weight_tensor_meta_L_self_modules_backbone_modules_block4_modules_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 2.187
-    std = 41.543
+    std = 1.543
     data = None
 
 
@@ -7777,7 +7777,7 @@ class Program_weight_tensor_meta_L_self_modules_backbone_modules_block4_modules_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 2.757
-    std = 49.021
+    std = 1.021
     data = None
 
 
@@ -8027,7 +8027,7 @@ class Program_weight_tensor_meta_L_self_modules_backbone_modules_block4_modules_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 7.591
-    std = 111.366
+    std = 1.366
     data = None
 
 

--- a/samples/mmseg/SegNeXt-l/weight_meta.py
+++ b/samples/mmseg/SegNeXt-l/weight_meta.py
@@ -109,41 +109,39 @@ class Program_weight_tensor_meta_L_self_modules_backbone_modules_patch_embed1_mo
     shape = [32]
     dtype = "torch.float32"
     device = "cuda:0"
-    mean = 0.057
-    std = 0.097
     data = [
-        0.008679,
-        0.068203,
-        0.278992,
-        0.242473,
-        0.063812,
-        0.000295,
-        0.009019,
-        0.082137,
-        0.009187,
-        0.337933,
-        0.001437,
-        0.000630,
-        0.058658,
-        0.025440,
-        0.001868,
-        0.122884,
-        0.315453,
-        0.014938,
-        0.002086,
-        0.006910,
-        0.001044,
-        0.068529,
-        0.030413,
-        0.002386,
-        0.001662,
-        0.022674,
-        0.001405,
-        0.001309,
-        0.001083,
-        0.037178,
-        0.000210,
-        0.008762,
+        1.008679,
+        1.068203,
+        1.278992,
+        1.242473,
+        1.063812,
+        1.000295,
+        1.009019,
+        1.082137,
+        1.009187,
+        1.337933,
+        1.001437,
+        1.000630,
+        1.058658,
+        1.025440,
+        1.001868,
+        1.122884,
+        1.315453,
+        1.014938,
+        1.002086,
+        1.006910,
+        1.001044,
+        1.068529,
+        1.030413,
+        1.002386,
+        1.001662,
+        1.022674,
+        1.001405,
+        1.001309,
+        1.001083,
+        1.037178,
+        1.000210,
+        1.008762,
     ]
 
 
@@ -318,7 +316,7 @@ class Program_weight_tensor_meta_L_self_modules_backbone_modules_block1_modules_
     shape = [64]
     dtype = "torch.float32"
     device = "cuda:0"
-    mean = 0.102
+    mean = 1.102
     std = 0.533
     data = None
 
@@ -568,7 +566,7 @@ class Program_weight_tensor_meta_L_self_modules_backbone_modules_block1_modules_
     shape = [64]
     dtype = "torch.float32"
     device = "cuda:0"
-    mean = 0.160
+    mean = 1.160
     std = 0.369
     data = None
 
@@ -678,7 +676,7 @@ class Program_weight_tensor_meta_L_self_modules_backbone_modules_block1_modules_
     shape = [64]
     dtype = "torch.float32"
     device = "cuda:0"
-    mean = 0.184
+    mean = 1.184
     std = 0.390
     data = None
 
@@ -928,7 +926,7 @@ class Program_weight_tensor_meta_L_self_modules_backbone_modules_block1_modules_
     shape = [64]
     dtype = "torch.float32"
     device = "cuda:0"
-    mean = 0.240
+    mean = 1.240
     std = 0.615
     data = None
 
@@ -1038,7 +1036,7 @@ class Program_weight_tensor_meta_L_self_modules_backbone_modules_block1_modules_
     shape = [64]
     dtype = "torch.float32"
     device = "cuda:0"
-    mean = 0.306
+    mean = 1.306
     std = 0.678
     data = None
 
@@ -1288,7 +1286,7 @@ class Program_weight_tensor_meta_L_self_modules_backbone_modules_block1_modules_
     shape = [64]
     dtype = "torch.float32"
     device = "cuda:0"
-    mean = 0.789
+    mean = 1.789
     std = 1.994
     data = None
 
@@ -1432,7 +1430,7 @@ class Program_weight_tensor_meta_L_self_modules_backbone_modules_patch_embed2_mo
     shape = [128]
     dtype = "torch.float32"
     device = "cuda:0"
-    mean = 0.316
+    mean = 1.316
     std = 0.333
     data = None
 
@@ -1484,7 +1482,7 @@ class Program_weight_tensor_meta_L_self_modules_backbone_modules_block2_modules_
     shape = [128]
     dtype = "torch.float32"
     device = "cuda:0"
-    mean = 0.274
+    mean = 1.274
     std = 0.589
     data = None
 
@@ -1734,7 +1732,7 @@ class Program_weight_tensor_meta_L_self_modules_backbone_modules_block2_modules_
     shape = [128]
     dtype = "torch.float32"
     device = "cuda:0"
-    mean = 0.337
+    mean = 1.337
     std = 0.705
     data = None
 
@@ -1844,7 +1842,7 @@ class Program_weight_tensor_meta_L_self_modules_backbone_modules_block2_modules_
     shape = [128]
     dtype = "torch.float32"
     device = "cuda:0"
-    mean = 0.335
+    mean = 1.335
     std = 0.698
     data = None
 
@@ -2094,7 +2092,7 @@ class Program_weight_tensor_meta_L_self_modules_backbone_modules_block2_modules_
     shape = [128]
     dtype = "torch.float32"
     device = "cuda:0"
-    mean = 0.435
+    mean = 1.435
     std = 0.874
     data = None
 
@@ -2204,7 +2202,7 @@ class Program_weight_tensor_meta_L_self_modules_backbone_modules_block2_modules_
     shape = [128]
     dtype = "torch.float32"
     device = "cuda:0"
-    mean = 0.478
+    mean = 1.478
     std = 0.885
     data = None
 
@@ -2454,7 +2452,7 @@ class Program_weight_tensor_meta_L_self_modules_backbone_modules_block2_modules_
     shape = [128]
     dtype = "torch.float32"
     device = "cuda:0"
-    mean = 0.623
+    mean = 1.623
     std = 1.154
     data = None
 
@@ -2564,7 +2562,7 @@ class Program_weight_tensor_meta_L_self_modules_backbone_modules_block2_modules_
     shape = [128]
     dtype = "torch.float32"
     device = "cuda:0"
-    mean = 0.677
+    mean = 1.677
     std = 1.146
     data = None
 
@@ -3370,7 +3368,7 @@ class Program_weight_tensor_meta_L_self_modules_backbone_modules_block3_modules_
     shape = [320]
     dtype = "torch.float32"
     device = "cuda:0"
-    mean = 0.478
+    mean = 1.478
     std = 1.318
     data = None
 
@@ -3620,7 +3618,7 @@ class Program_weight_tensor_meta_L_self_modules_backbone_modules_block3_modules_
     shape = [320]
     dtype = "torch.float32"
     device = "cuda:0"
-    mean = 0.509
+    mean = 1.509
     std = 1.382
     data = None
 
@@ -3730,7 +3728,7 @@ class Program_weight_tensor_meta_L_self_modules_backbone_modules_block3_modules_
     shape = [320]
     dtype = "torch.float32"
     device = "cuda:0"
-    mean = 0.509
+    mean = 1.509
     std = 1.378
     data = None
 
@@ -3980,7 +3978,7 @@ class Program_weight_tensor_meta_L_self_modules_backbone_modules_block3_modules_
     shape = [320]
     dtype = "torch.float32"
     device = "cuda:0"
-    mean = 0.530
+    mean = 1.530
     std = 1.389
     data = None
 
@@ -4090,7 +4088,7 @@ class Program_weight_tensor_meta_L_self_modules_backbone_modules_block3_modules_
     shape = [320]
     dtype = "torch.float32"
     device = "cuda:0"
-    mean = 0.526
+    mean = 1.526
     std = 1.367
     data = None
 
@@ -4340,7 +4338,7 @@ class Program_weight_tensor_meta_L_self_modules_backbone_modules_block3_modules_
     shape = [320]
     dtype = "torch.float32"
     device = "cuda:0"
-    mean = 0.553
+    mean = 1.553
     std = 1.400
     data = None
 
@@ -4450,7 +4448,7 @@ class Program_weight_tensor_meta_L_self_modules_backbone_modules_block3_modules_
     shape = [320]
     dtype = "torch.float32"
     device = "cuda:0"
-    mean = 0.556
+    mean = 1.556
     std = 1.396
     data = None
 
@@ -4700,7 +4698,7 @@ class Program_weight_tensor_meta_L_self_modules_backbone_modules_block3_modules_
     shape = [320]
     dtype = "torch.float32"
     device = "cuda:0"
-    mean = 0.598
+    mean = 1.598
     std = 1.458
     data = None
 
@@ -4810,7 +4808,7 @@ class Program_weight_tensor_meta_L_self_modules_backbone_modules_block3_modules_
     shape = [320]
     dtype = "torch.float32"
     device = "cuda:0"
-    mean = 0.608
+    mean = 1.608
     std = 1.468
     data = None
 
@@ -5060,7 +5058,7 @@ class Program_weight_tensor_meta_L_self_modules_backbone_modules_block3_modules_
     shape = [320]
     dtype = "torch.float32"
     device = "cuda:0"
-    mean = 0.672
+    mean = 1.672
     std = 1.600
     data = None
 
@@ -5170,7 +5168,7 @@ class Program_weight_tensor_meta_L_self_modules_backbone_modules_block3_modules_
     shape = [320]
     dtype = "torch.float32"
     device = "cuda:0"
-    mean = 0.693
+    mean = 1.693
     std = 1.624
     data = None
 
@@ -5420,7 +5418,7 @@ class Program_weight_tensor_meta_L_self_modules_backbone_modules_block3_modules_
     shape = [320]
     dtype = "torch.float32"
     device = "cuda:0"
-    mean = 0.827
+    mean = 1.827
     std = 1.965
     data = None
 
@@ -5530,7 +5528,7 @@ class Program_weight_tensor_meta_L_self_modules_backbone_modules_block3_modules_
     shape = [320]
     dtype = "torch.float32"
     device = "cuda:0"
-    mean = 0.881
+    mean = 1.881
     std = 2.155
     data = None
 
@@ -6861,7 +6859,7 @@ class Program_weight_tensor_meta_L_self_modules_backbone_modules_block3_modules_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 2.574
-    std = 16.078
+    std = 1.078
     data = None
 
 
@@ -6971,7 +6969,7 @@ class Program_weight_tensor_meta_L_self_modules_backbone_modules_block3_modules_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 2.648
-    std = 16.451
+    std = 1.451
     data = None
 
 
@@ -7221,7 +7219,7 @@ class Program_weight_tensor_meta_L_self_modules_backbone_modules_block3_modules_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 2.653
-    std = 14.917
+    std = 1.917
     data = None
 
 
@@ -7331,7 +7329,7 @@ class Program_weight_tensor_meta_L_self_modules_backbone_modules_block3_modules_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 2.767
-    std = 15.624
+    std = 1.624
     data = None
 
 
@@ -7581,7 +7579,7 @@ class Program_weight_tensor_meta_L_self_modules_backbone_modules_block3_modules_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 3.754
-    std = 28.198
+    std = 1.198
     data = None
 
 
@@ -7691,7 +7689,7 @@ class Program_weight_tensor_meta_L_self_modules_backbone_modules_block3_modules_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 3.870
-    std = 28.582
+    std = 1.582
     data = None
 
 
@@ -7941,7 +7939,7 @@ class Program_weight_tensor_meta_L_self_modules_backbone_modules_block3_modules_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 4.828
-    std = 42.190
+    std = 1.190
     data = None
 
 
@@ -8051,7 +8049,7 @@ class Program_weight_tensor_meta_L_self_modules_backbone_modules_block3_modules_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 4.977
-    std = 42.625
+    std = 1.625
     data = None
 
 
@@ -8301,7 +8299,7 @@ class Program_weight_tensor_meta_L_self_modules_backbone_modules_block3_modules_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 5.812
-    std = 53.249
+    std = 1.249
     data = None
 
 
@@ -8411,7 +8409,7 @@ class Program_weight_tensor_meta_L_self_modules_backbone_modules_block3_modules_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 5.933
-    std = 52.848
+    std = 1.848
     data = None
 
 
@@ -8661,7 +8659,7 @@ class Program_weight_tensor_meta_L_self_modules_backbone_modules_block3_modules_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 6.765
-    std = 62.515
+    std = 1.515
     data = None
 
 
@@ -8771,7 +8769,7 @@ class Program_weight_tensor_meta_L_self_modules_backbone_modules_block3_modules_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 6.907
-    std = 62.191
+    std = 1.191
     data = None
 
 
@@ -9021,7 +9019,7 @@ class Program_weight_tensor_meta_L_self_modules_backbone_modules_block3_modules_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 8.145
-    std = 77.740
+    std = 1.740
     data = None
 
 
@@ -9131,7 +9129,7 @@ class Program_weight_tensor_meta_L_self_modules_backbone_modules_block3_modules_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 8.331
-    std = 77.721
+    std = 1.721
     data = None
 
 
@@ -9381,7 +9379,7 @@ class Program_weight_tensor_meta_L_self_modules_backbone_modules_block3_modules_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 9.434
-    std = 90.438
+    std = 1.438
     data = None
 
 
@@ -9491,7 +9489,7 @@ class Program_weight_tensor_meta_L_self_modules_backbone_modules_block3_modules_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 9.652
-    std = 89.882
+    std = 1.882
     data = None
 
 
@@ -9741,7 +9739,7 @@ class Program_weight_tensor_meta_L_self_modules_backbone_modules_block3_modules_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 11.188
-    std = 108.454
+    std = 1.454
     data = None
 
 
@@ -9851,7 +9849,7 @@ class Program_weight_tensor_meta_L_self_modules_backbone_modules_block3_modules_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 11.426
-    std = 107.622
+    std = 1.622
     data = None
 
 
@@ -10101,7 +10099,7 @@ class Program_weight_tensor_meta_L_self_modules_backbone_modules_block3_modules_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 13.079
-    std = 126.864
+    std = 1.864
     data = None
 
 
@@ -10211,7 +10209,7 @@ class Program_weight_tensor_meta_L_self_modules_backbone_modules_block3_modules_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 13.309
-    std = 125.796
+    std = 1.796
     data = None
 
 
@@ -10461,7 +10459,7 @@ class Program_weight_tensor_meta_L_self_modules_backbone_modules_block3_modules_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 14.911
-    std = 141.205
+    std = 1.205
     data = None
 
 
@@ -10571,7 +10569,7 @@ class Program_weight_tensor_meta_L_self_modules_backbone_modules_block3_modules_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 15.227
-    std = 140.671
+    std = 1.671
     data = None
 
 
@@ -10821,7 +10819,7 @@ class Program_weight_tensor_meta_L_self_modules_backbone_modules_block3_modules_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 16.685
-    std = 152.359
+    std = 1.359
     data = None
 
 
@@ -10931,7 +10929,7 @@ class Program_weight_tensor_meta_L_self_modules_backbone_modules_block3_modules_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 16.960
-    std = 150.580
+    std = 1.580
     data = None
 
 
@@ -11181,7 +11179,7 @@ class Program_weight_tensor_meta_L_self_modules_backbone_modules_block3_modules_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 20.252
-    std = 188.848
+    std = 1.848
     data = None
 
 
@@ -11291,7 +11289,7 @@ class Program_weight_tensor_meta_L_self_modules_backbone_modules_block3_modules_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 20.352
-    std = 182.794
+    std = 1.794
     data = None
 
 
@@ -11541,7 +11539,7 @@ class Program_weight_tensor_meta_L_self_modules_backbone_modules_block3_modules_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 26.550
-    std = 264.224
+    std = 2.224
     data = None
 
 
@@ -11651,7 +11649,7 @@ class Program_weight_tensor_meta_L_self_modules_backbone_modules_block3_modules_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 26.334
-    std = 252.677
+    std = 2.677
     data = None
 
 
@@ -11901,7 +11899,7 @@ class Program_weight_tensor_meta_L_self_modules_backbone_modules_block3_modules_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 32.828
-    std = 326.406
+    std = 3.406
     data = None
 
 
@@ -12011,7 +12009,7 @@ class Program_weight_tensor_meta_L_self_modules_backbone_modules_block3_modules_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 32.379
-    std = 307.781
+    std = 3.781
     data = None
 
 
@@ -12261,7 +12259,7 @@ class Program_weight_tensor_meta_L_self_modules_backbone_modules_block3_modules_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 42.073
-    std = 429.485
+    std = 4.485
     data = None
 
 
@@ -12371,7 +12369,7 @@ class Program_weight_tensor_meta_L_self_modules_backbone_modules_block3_modules_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 44.674
-    std = 461.903
+    std = 4.903
     data = None
 
 
@@ -12621,7 +12619,7 @@ class Program_weight_tensor_meta_L_self_modules_backbone_modules_block3_modules_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 70.722
-    std = 845.178
+    std = 8.178
     data = None
 
 
@@ -12731,7 +12729,7 @@ class Program_weight_tensor_meta_L_self_modules_backbone_modules_block3_modules_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 98.946
-    std = 1335.225
+    std = 13.225
     data = None
 
 
@@ -12981,7 +12979,7 @@ class Program_weight_tensor_meta_L_self_modules_backbone_modules_block3_modules_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 356.153
-    std = 5729.401
+    std = 5.401
     data = None
 
 
@@ -13427,7 +13425,7 @@ class Program_weight_tensor_meta_L_self_modules_backbone_modules_block4_modules_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 5.474
-    std = 103.566
+    std = 1.566
     data = None
 
 
@@ -13537,7 +13535,7 @@ class Program_weight_tensor_meta_L_self_modules_backbone_modules_block4_modules_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 6.726
-    std = 124.595
+    std = 1.595
     data = None
 
 
@@ -13787,7 +13785,7 @@ class Program_weight_tensor_meta_L_self_modules_backbone_modules_block4_modules_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 12.737
-    std = 241.009
+    std = 2.009
     data = None
 
 
@@ -13897,7 +13895,7 @@ class Program_weight_tensor_meta_L_self_modules_backbone_modules_block4_modules_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 19.245
-    std = 337.131
+    std = 3.131
     data = None
 
 
@@ -14147,7 +14145,7 @@ class Program_weight_tensor_meta_L_self_modules_backbone_modules_block4_modules_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 32.098
-    std = 588.391
+    std = 5.391
     data = None
 
 

--- a/samples/timm/hgnetv2_b0.ssld_stage1_in22k_in1k/weight_meta.py
+++ b/samples/timm/hgnetv2_b0.ssld_stage1_in22k_in1k/weight_meta.py
@@ -74,7 +74,7 @@ class Program_weight_tensor_meta_L_self_modules_stem_modules_stem1_modules_lab_p
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -84,7 +84,7 @@ class Program_weight_tensor_meta_L_self_modules_stem_modules_stem1_modules_lab_p
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -144,7 +144,7 @@ class Program_weight_tensor_meta_L_self_modules_stem_modules_stem2a_modules_lab_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -154,7 +154,7 @@ class Program_weight_tensor_meta_L_self_modules_stem_modules_stem2a_modules_lab_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -214,7 +214,7 @@ class Program_weight_tensor_meta_L_self_modules_stem_modules_stem2b_modules_lab_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -224,7 +224,7 @@ class Program_weight_tensor_meta_L_self_modules_stem_modules_stem2b_modules_lab_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -284,7 +284,7 @@ class Program_weight_tensor_meta_L_self_modules_stem_modules_stem3_modules_lab_p
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -294,7 +294,7 @@ class Program_weight_tensor_meta_L_self_modules_stem_modules_stem3_modules_lab_p
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -354,7 +354,7 @@ class Program_weight_tensor_meta_L_self_modules_stem_modules_stem4_modules_lab_p
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -364,7 +364,7 @@ class Program_weight_tensor_meta_L_self_modules_stem_modules_stem4_modules_lab_p
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -424,7 +424,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_0_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -434,7 +434,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_0_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -494,7 +494,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_0_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -504,7 +504,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_0_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -564,7 +564,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_0_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -574,7 +574,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_0_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -634,7 +634,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_0_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -644,7 +644,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_0_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -704,7 +704,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_0_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -714,7 +714,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_0_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -826,7 +826,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_1_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -836,7 +836,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_1_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -896,7 +896,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_1_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -906,7 +906,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_1_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -966,7 +966,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_1_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -976,7 +976,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_1_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1036,7 +1036,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_1_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1046,7 +1046,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_1_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1106,7 +1106,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_1_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1116,7 +1116,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_1_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1278,7 +1278,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1288,7 +1288,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1398,7 +1398,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1408,7 +1408,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1518,7 +1518,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1528,7 +1528,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1588,7 +1588,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1598,7 +1598,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1658,7 +1658,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1668,7 +1668,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1778,7 +1778,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1788,7 +1788,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1898,7 +1898,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1908,7 +1908,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2018,7 +2018,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2028,7 +2028,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2088,7 +2088,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2098,7 +2098,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2158,7 +2158,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2168,7 +2168,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2330,7 +2330,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_3_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2340,7 +2340,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_3_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2450,7 +2450,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_3_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2460,7 +2460,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_3_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2570,7 +2570,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_3_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2580,7 +2580,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_3_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2640,7 +2640,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_3_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2650,7 +2650,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_3_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2710,7 +2710,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_3_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2720,7 +2720,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_3_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2740,7 +2740,7 @@ class Program_weight_tensor_meta_L_self_modules_head_modules_last_conv_modules_2
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2750,7 +2750,7 @@ class Program_weight_tensor_meta_L_self_modules_head_modules_last_conv_modules_2
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 

--- a/samples/timm/hgnetv2_b1.ssld_stage1_in22k_in1k/weight_meta.py
+++ b/samples/timm/hgnetv2_b1.ssld_stage1_in22k_in1k/weight_meta.py
@@ -74,7 +74,7 @@ class Program_weight_tensor_meta_L_self_modules_stem_modules_stem1_modules_lab_p
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -84,7 +84,7 @@ class Program_weight_tensor_meta_L_self_modules_stem_modules_stem1_modules_lab_p
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -144,7 +144,7 @@ class Program_weight_tensor_meta_L_self_modules_stem_modules_stem2a_modules_lab_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -154,7 +154,7 @@ class Program_weight_tensor_meta_L_self_modules_stem_modules_stem2a_modules_lab_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -214,7 +214,7 @@ class Program_weight_tensor_meta_L_self_modules_stem_modules_stem2b_modules_lab_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -224,7 +224,7 @@ class Program_weight_tensor_meta_L_self_modules_stem_modules_stem2b_modules_lab_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -284,7 +284,7 @@ class Program_weight_tensor_meta_L_self_modules_stem_modules_stem3_modules_lab_p
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -294,7 +294,7 @@ class Program_weight_tensor_meta_L_self_modules_stem_modules_stem3_modules_lab_p
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -354,7 +354,7 @@ class Program_weight_tensor_meta_L_self_modules_stem_modules_stem4_modules_lab_p
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -364,7 +364,7 @@ class Program_weight_tensor_meta_L_self_modules_stem_modules_stem4_modules_lab_p
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -424,7 +424,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_0_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -434,7 +434,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_0_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -494,7 +494,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_0_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -504,7 +504,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_0_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -564,7 +564,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_0_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -574,7 +574,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_0_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -634,7 +634,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_0_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -644,7 +644,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_0_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -704,7 +704,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_0_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -714,7 +714,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_0_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -826,7 +826,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_1_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -836,7 +836,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_1_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -896,7 +896,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_1_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -906,7 +906,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_1_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -966,7 +966,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_1_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -976,7 +976,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_1_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1036,7 +1036,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_1_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1046,7 +1046,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_1_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1106,7 +1106,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_1_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1116,7 +1116,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_1_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1278,7 +1278,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1288,7 +1288,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1398,7 +1398,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1408,7 +1408,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1518,7 +1518,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1528,7 +1528,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1588,7 +1588,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1598,7 +1598,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1658,7 +1658,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1668,7 +1668,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1778,7 +1778,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1788,7 +1788,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1898,7 +1898,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1908,7 +1908,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2018,7 +2018,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2028,7 +2028,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2088,7 +2088,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2098,7 +2098,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2158,7 +2158,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2168,7 +2168,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2330,7 +2330,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_3_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2340,7 +2340,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_3_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2450,7 +2450,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_3_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2460,7 +2460,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_3_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2570,7 +2570,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_3_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2580,7 +2580,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_3_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2640,7 +2640,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_3_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2650,7 +2650,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_3_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2710,7 +2710,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_3_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2720,7 +2720,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_3_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2740,7 +2740,7 @@ class Program_weight_tensor_meta_L_self_modules_head_modules_last_conv_modules_2
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2750,7 +2750,7 @@ class Program_weight_tensor_meta_L_self_modules_head_modules_last_conv_modules_2
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 

--- a/samples/timm/hgnetv2_b2.ssld_stage1_in22k_in1k/weight_meta.py
+++ b/samples/timm/hgnetv2_b2.ssld_stage1_in22k_in1k/weight_meta.py
@@ -74,7 +74,7 @@ class Program_weight_tensor_meta_L_self_modules_stem_modules_stem1_modules_lab_p
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -84,7 +84,7 @@ class Program_weight_tensor_meta_L_self_modules_stem_modules_stem1_modules_lab_p
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -144,7 +144,7 @@ class Program_weight_tensor_meta_L_self_modules_stem_modules_stem2a_modules_lab_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -154,7 +154,7 @@ class Program_weight_tensor_meta_L_self_modules_stem_modules_stem2a_modules_lab_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -214,7 +214,7 @@ class Program_weight_tensor_meta_L_self_modules_stem_modules_stem2b_modules_lab_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -224,7 +224,7 @@ class Program_weight_tensor_meta_L_self_modules_stem_modules_stem2b_modules_lab_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -284,7 +284,7 @@ class Program_weight_tensor_meta_L_self_modules_stem_modules_stem3_modules_lab_p
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -294,7 +294,7 @@ class Program_weight_tensor_meta_L_self_modules_stem_modules_stem3_modules_lab_p
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -354,7 +354,7 @@ class Program_weight_tensor_meta_L_self_modules_stem_modules_stem4_modules_lab_p
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -364,7 +364,7 @@ class Program_weight_tensor_meta_L_self_modules_stem_modules_stem4_modules_lab_p
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -424,7 +424,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_0_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -434,7 +434,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_0_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -494,7 +494,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_0_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -504,7 +504,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_0_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -564,7 +564,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_0_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -574,7 +574,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_0_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -634,7 +634,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_0_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -644,7 +644,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_0_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -704,7 +704,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_0_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -714,7 +714,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_0_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -774,7 +774,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_0_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -784,7 +784,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_0_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -896,7 +896,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_1_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -906,7 +906,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_1_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -966,7 +966,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_1_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -976,7 +976,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_1_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1036,7 +1036,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_1_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1046,7 +1046,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_1_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1106,7 +1106,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_1_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1116,7 +1116,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_1_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1176,7 +1176,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_1_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1186,7 +1186,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_1_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1246,7 +1246,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_1_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1256,7 +1256,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_1_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1418,7 +1418,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1428,7 +1428,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1538,7 +1538,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1548,7 +1548,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1658,7 +1658,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1668,7 +1668,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1778,7 +1778,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1788,7 +1788,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1848,7 +1848,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1858,7 +1858,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1918,7 +1918,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1928,7 +1928,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2038,7 +2038,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2048,7 +2048,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2158,7 +2158,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2168,7 +2168,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2278,7 +2278,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2288,7 +2288,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2398,7 +2398,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2408,7 +2408,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2468,7 +2468,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2478,7 +2478,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2538,7 +2538,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2548,7 +2548,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2658,7 +2658,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2668,7 +2668,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2778,7 +2778,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2788,7 +2788,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2898,7 +2898,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2908,7 +2908,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -3018,7 +3018,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -3028,7 +3028,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -3088,7 +3088,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -3098,7 +3098,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -3158,7 +3158,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -3168,7 +3168,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -3330,7 +3330,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_3_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -3340,7 +3340,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_3_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -3450,7 +3450,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_3_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -3460,7 +3460,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_3_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -3570,7 +3570,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_3_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -3580,7 +3580,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_3_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -3690,7 +3690,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_3_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -3700,7 +3700,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_3_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -3760,7 +3760,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_3_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -3770,7 +3770,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_3_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -3830,7 +3830,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_3_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -3840,7 +3840,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_3_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -3860,7 +3860,7 @@ class Program_weight_tensor_meta_L_self_modules_head_modules_last_conv_modules_2
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -3870,7 +3870,7 @@ class Program_weight_tensor_meta_L_self_modules_head_modules_last_conv_modules_2
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 

--- a/samples/timm/hgnetv2_b3.ssld_stage1_in22k_in1k/weight_meta.py
+++ b/samples/timm/hgnetv2_b3.ssld_stage1_in22k_in1k/weight_meta.py
@@ -74,7 +74,7 @@ class Program_weight_tensor_meta_L_self_modules_stem_modules_stem1_modules_lab_p
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -84,7 +84,7 @@ class Program_weight_tensor_meta_L_self_modules_stem_modules_stem1_modules_lab_p
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -144,7 +144,7 @@ class Program_weight_tensor_meta_L_self_modules_stem_modules_stem2a_modules_lab_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -154,7 +154,7 @@ class Program_weight_tensor_meta_L_self_modules_stem_modules_stem2a_modules_lab_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -214,7 +214,7 @@ class Program_weight_tensor_meta_L_self_modules_stem_modules_stem2b_modules_lab_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -224,7 +224,7 @@ class Program_weight_tensor_meta_L_self_modules_stem_modules_stem2b_modules_lab_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -284,7 +284,7 @@ class Program_weight_tensor_meta_L_self_modules_stem_modules_stem3_modules_lab_p
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -294,7 +294,7 @@ class Program_weight_tensor_meta_L_self_modules_stem_modules_stem3_modules_lab_p
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -354,7 +354,7 @@ class Program_weight_tensor_meta_L_self_modules_stem_modules_stem4_modules_lab_p
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -364,7 +364,7 @@ class Program_weight_tensor_meta_L_self_modules_stem_modules_stem4_modules_lab_p
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -424,7 +424,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_0_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -434,7 +434,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_0_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -494,7 +494,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_0_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -504,7 +504,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_0_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -564,7 +564,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_0_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -574,7 +574,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_0_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -634,7 +634,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_0_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -644,7 +644,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_0_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -704,7 +704,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_0_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -714,7 +714,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_0_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -774,7 +774,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_0_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -784,7 +784,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_0_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -844,7 +844,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_0_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -854,7 +854,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_0_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -966,7 +966,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_1_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -976,7 +976,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_1_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1036,7 +1036,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_1_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1046,7 +1046,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_1_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1106,7 +1106,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_1_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1116,7 +1116,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_1_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1176,7 +1176,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_1_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1186,7 +1186,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_1_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1246,7 +1246,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_1_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1256,7 +1256,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_1_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1316,7 +1316,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_1_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1326,7 +1326,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_1_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1386,7 +1386,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_1_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1396,7 +1396,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_1_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1558,7 +1558,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1568,7 +1568,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1678,7 +1678,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1688,7 +1688,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1798,7 +1798,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1808,7 +1808,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1918,7 +1918,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1928,7 +1928,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2038,7 +2038,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2048,7 +2048,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2108,7 +2108,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2118,7 +2118,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2178,7 +2178,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2188,7 +2188,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2298,7 +2298,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2308,7 +2308,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2418,7 +2418,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2428,7 +2428,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2538,7 +2538,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2548,7 +2548,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2658,7 +2658,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2668,7 +2668,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2778,7 +2778,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2788,7 +2788,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2848,7 +2848,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2858,7 +2858,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2918,7 +2918,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2928,7 +2928,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -3038,7 +3038,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -3048,7 +3048,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -3158,7 +3158,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -3168,7 +3168,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -3278,7 +3278,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -3288,7 +3288,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -3398,7 +3398,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -3408,7 +3408,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -3518,7 +3518,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -3528,7 +3528,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -3588,7 +3588,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -3598,7 +3598,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -3658,7 +3658,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -3668,7 +3668,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -3830,7 +3830,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_3_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -3840,7 +3840,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_3_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -3950,7 +3950,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_3_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -3960,7 +3960,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_3_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -4070,7 +4070,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_3_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -4080,7 +4080,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_3_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -4190,7 +4190,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_3_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -4200,7 +4200,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_3_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -4310,7 +4310,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_3_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -4320,7 +4320,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_3_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -4380,7 +4380,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_3_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -4390,7 +4390,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_3_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -4450,7 +4450,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_3_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -4460,7 +4460,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_3_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -4480,7 +4480,7 @@ class Program_weight_tensor_meta_L_self_modules_head_modules_last_conv_modules_2
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -4490,7 +4490,7 @@ class Program_weight_tensor_meta_L_self_modules_head_modules_last_conv_modules_2
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 

--- a/samples/timm/poolformerv2_m36.sail_in1k/weight_meta.py
+++ b/samples/timm/poolformerv2_m36.sail_in1k/weight_meta.py
@@ -84,7 +84,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_0_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -94,7 +94,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_0_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -144,7 +144,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_0_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -154,7 +154,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_0_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -204,7 +204,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_0_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -214,7 +214,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_0_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -264,7 +264,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_0_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -274,7 +274,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_0_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -324,7 +324,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_0_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -334,7 +334,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_0_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -384,7 +384,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_0_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -394,7 +394,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_0_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -474,7 +474,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_1_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -484,7 +484,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_1_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -534,7 +534,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_1_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -544,7 +544,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_1_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -594,7 +594,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_1_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -604,7 +604,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_1_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -654,7 +654,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_1_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -664,7 +664,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_1_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -714,7 +714,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_1_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -724,7 +724,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_1_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -774,7 +774,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_1_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -784,7 +784,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_1_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -884,7 +884,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -894,7 +894,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -964,7 +964,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -974,7 +974,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1044,7 +1044,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1054,7 +1054,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1124,7 +1124,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1134,7 +1134,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1204,7 +1204,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1214,7 +1214,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1284,7 +1284,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1294,7 +1294,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1364,7 +1364,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1374,7 +1374,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1444,7 +1444,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1454,7 +1454,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1524,7 +1524,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1534,7 +1534,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1604,7 +1604,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1614,7 +1614,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1684,7 +1684,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1694,7 +1694,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1764,7 +1764,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1774,7 +1774,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1844,7 +1844,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1854,7 +1854,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1924,7 +1924,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1934,7 +1934,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2004,7 +2004,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2014,7 +2014,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2084,7 +2084,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2094,7 +2094,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2164,7 +2164,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2174,7 +2174,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2244,7 +2244,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2254,7 +2254,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2354,7 +2354,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_3_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2364,7 +2364,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_3_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2434,7 +2434,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_3_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2444,7 +2444,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_3_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2514,7 +2514,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_3_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2524,7 +2524,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_3_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2594,7 +2594,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_3_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2604,7 +2604,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_3_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2674,7 +2674,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_3_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2684,7 +2684,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_3_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2754,7 +2754,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_3_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2764,7 +2764,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_3_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 

--- a/samples/timm/poolformerv2_m48.sail_in1k/weight_meta.py
+++ b/samples/timm/poolformerv2_m48.sail_in1k/weight_meta.py
@@ -84,7 +84,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_0_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -94,7 +94,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_0_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -144,7 +144,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_0_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -154,7 +154,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_0_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -204,7 +204,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_0_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -214,7 +214,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_0_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -264,7 +264,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_0_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -274,7 +274,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_0_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -324,7 +324,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_0_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -334,7 +334,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_0_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -384,7 +384,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_0_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -394,7 +394,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_0_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -444,7 +444,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_0_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -454,7 +454,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_0_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -504,7 +504,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_0_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -514,7 +514,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_0_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -594,7 +594,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_1_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -604,7 +604,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_1_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -654,7 +654,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_1_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -664,7 +664,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_1_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -714,7 +714,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_1_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -724,7 +724,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_1_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -774,7 +774,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_1_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -784,7 +784,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_1_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -834,7 +834,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_1_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -844,7 +844,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_1_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -894,7 +894,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_1_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -904,7 +904,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_1_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -954,7 +954,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_1_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -964,7 +964,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_1_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1014,7 +1014,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_1_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1024,7 +1024,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_1_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1124,7 +1124,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1134,7 +1134,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1204,7 +1204,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1214,7 +1214,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1284,7 +1284,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1294,7 +1294,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1364,7 +1364,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1374,7 +1374,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1444,7 +1444,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1454,7 +1454,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1524,7 +1524,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1534,7 +1534,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1604,7 +1604,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1614,7 +1614,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1684,7 +1684,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1694,7 +1694,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1764,7 +1764,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1774,7 +1774,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1844,7 +1844,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1854,7 +1854,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1924,7 +1924,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1934,7 +1934,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2004,7 +2004,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2014,7 +2014,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2084,7 +2084,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2094,7 +2094,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2164,7 +2164,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2174,7 +2174,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2244,7 +2244,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2254,7 +2254,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2324,7 +2324,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2334,7 +2334,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2404,7 +2404,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2414,7 +2414,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2484,7 +2484,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2494,7 +2494,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2564,7 +2564,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2574,7 +2574,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2644,7 +2644,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2654,7 +2654,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2724,7 +2724,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2734,7 +2734,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2804,7 +2804,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2814,7 +2814,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2884,7 +2884,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2894,7 +2894,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2964,7 +2964,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2974,7 +2974,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -3074,7 +3074,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_3_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -3084,7 +3084,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_3_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -3154,7 +3154,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_3_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -3164,7 +3164,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_3_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -3234,7 +3234,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_3_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -3244,7 +3244,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_3_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -3314,7 +3314,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_3_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -3324,7 +3324,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_3_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -3394,7 +3394,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_3_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -3404,7 +3404,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_3_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -3474,7 +3474,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_3_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -3484,7 +3484,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_3_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -3554,7 +3554,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_3_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -3564,7 +3564,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_3_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -3634,7 +3634,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_3_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -3644,7 +3644,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_3_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 

--- a/samples/timm/poolformerv2_s12.sail_in1k/weight_meta.py
+++ b/samples/timm/poolformerv2_s12.sail_in1k/weight_meta.py
@@ -84,7 +84,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_0_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -94,7 +94,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_0_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -144,7 +144,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_0_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -154,7 +154,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_0_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -234,7 +234,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_1_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -244,7 +244,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_1_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -294,7 +294,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_1_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -304,7 +304,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_1_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -404,7 +404,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -414,7 +414,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -484,7 +484,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -494,7 +494,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -564,7 +564,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -574,7 +574,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -644,7 +644,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -654,7 +654,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -724,7 +724,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -734,7 +734,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -804,7 +804,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -814,7 +814,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -914,7 +914,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_3_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -924,7 +924,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_3_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -994,7 +994,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_3_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1004,7 +1004,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_3_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 

--- a/samples/timm/poolformerv2_s24.sail_in1k/weight_meta.py
+++ b/samples/timm/poolformerv2_s24.sail_in1k/weight_meta.py
@@ -84,7 +84,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_0_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -94,7 +94,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_0_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -144,7 +144,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_0_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -154,7 +154,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_0_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -204,7 +204,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_0_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -214,7 +214,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_0_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -264,7 +264,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_0_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -274,7 +274,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_0_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -354,7 +354,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_1_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -364,7 +364,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_1_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -414,7 +414,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_1_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -424,7 +424,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_1_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -474,7 +474,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_1_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -484,7 +484,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_1_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -534,7 +534,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_1_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -544,7 +544,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_1_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -644,7 +644,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -654,7 +654,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -724,7 +724,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -734,7 +734,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -804,7 +804,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -814,7 +814,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -884,7 +884,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -894,7 +894,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -964,7 +964,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -974,7 +974,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1044,7 +1044,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1054,7 +1054,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1124,7 +1124,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1134,7 +1134,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1204,7 +1204,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1214,7 +1214,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1284,7 +1284,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1294,7 +1294,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1364,7 +1364,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1374,7 +1374,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1444,7 +1444,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1454,7 +1454,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1524,7 +1524,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1534,7 +1534,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1634,7 +1634,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_3_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1644,7 +1644,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_3_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1714,7 +1714,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_3_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1724,7 +1724,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_3_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1794,7 +1794,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_3_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1804,7 +1804,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_3_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1874,7 +1874,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_3_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1884,7 +1884,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_3_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 

--- a/samples/timm/poolformerv2_s36.sail_in1k/weight_meta.py
+++ b/samples/timm/poolformerv2_s36.sail_in1k/weight_meta.py
@@ -84,7 +84,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_0_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -94,7 +94,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_0_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -144,7 +144,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_0_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -154,7 +154,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_0_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -204,7 +204,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_0_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -214,7 +214,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_0_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -264,7 +264,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_0_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -274,7 +274,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_0_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -324,7 +324,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_0_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -334,7 +334,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_0_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -384,7 +384,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_0_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -394,7 +394,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_0_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -474,7 +474,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_1_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -484,7 +484,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_1_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -534,7 +534,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_1_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -544,7 +544,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_1_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -594,7 +594,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_1_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -604,7 +604,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_1_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -654,7 +654,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_1_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -664,7 +664,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_1_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -714,7 +714,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_1_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -724,7 +724,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_1_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -774,7 +774,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_1_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -784,7 +784,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_1_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -884,7 +884,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -894,7 +894,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -964,7 +964,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -974,7 +974,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1044,7 +1044,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1054,7 +1054,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1124,7 +1124,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1134,7 +1134,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1204,7 +1204,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1214,7 +1214,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1284,7 +1284,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1294,7 +1294,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1364,7 +1364,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1374,7 +1374,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1444,7 +1444,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1454,7 +1454,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1524,7 +1524,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1534,7 +1534,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1604,7 +1604,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1614,7 +1614,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1684,7 +1684,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1694,7 +1694,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1764,7 +1764,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1774,7 +1774,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1844,7 +1844,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1854,7 +1854,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1924,7 +1924,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -1934,7 +1934,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2004,7 +2004,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2014,7 +2014,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2084,7 +2084,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2094,7 +2094,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2164,7 +2164,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2174,7 +2174,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2244,7 +2244,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2254,7 +2254,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_2_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2354,7 +2354,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_3_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2364,7 +2364,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_3_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2434,7 +2434,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_3_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2444,7 +2444,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_3_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2514,7 +2514,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_3_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2524,7 +2524,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_3_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2594,7 +2594,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_3_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2604,7 +2604,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_3_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2674,7 +2674,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_3_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2684,7 +2684,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_3_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2754,7 +2754,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_3_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 1.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 
@@ -2764,7 +2764,7 @@ class Program_weight_tensor_meta_L_self_modules_stages_modules_3_modules_blocks_
     dtype = "torch.float32"
     device = "cuda:0"
     mean = 0.000
-    std = float("nan")
+    std = 5.000
     data = None
 
 


### PR DESCRIPTION
### PR Category
<!-- One of [ New Sample | Feature Enhancement | Bug Fix | Other ] -->
Bug Fix

### Description
<!-- Describe what you’ve done -->
1. 为torch的test_compiler设置固定的随机种子，保证多次运行结果一样。
2. 修复非法cv样本，主要包括2类：
  - batch_norm的running_var值太小，一般是由于std太大造成，导致Tensor数值经过batch_norm后逐渐膨胀直至溢出。
  - meta中存在`std = float("nan")`，改成`std = 5.0`。