### PR TITLE
【Hackathon 9th No.114】torch._C._fft.fft_rfft API转换 torch.fft.rfft

### DIFF
--- a/graph_net/torch/backend/unstable_to_stable_backend.py
+++ b/graph_net/torch/backend/unstable_to_stable_backend.py
@@ -57,15 +57,17 @@ class UnstableToStableBackend(GraphCompilerBackend):
         Convert torch._C._fft.fft_rfft to torch.fft.rfft
         """
         # Update graph nodes: replace torch._C._fft.fft_rfft with torch.fft.rfft
-        for node in gm.graph.nodes:
-            if node.op == "call_function":
-                if (
-                    hasattr(node.target, "__module__")
-                    and hasattr(node.target, "__name__")
-                    and node.target.__module__ == "torch._C._fft"
-                    and node.target.__name__ == "fft_rfft"
-                ):
-                    node.target = torch.fft.rfft
+        issue_nodes = (
+            node
+            for node in gm.graph.nodes
+            if node.op == "call_function"
+            if hasattr(node.target, "__module__")
+            if node.target.__module__ == "torch._C._fft"
+            if hasattr(node.target, "__name__")
+            if node.target.__name__ == "fft_rfft"
+        )
+        for node in issue_nodes:
+            node.target = torch.fft.rfft
 
         # Recompile the graph
         gm.recompile()

--- a/graph_net/torch/backend/unstable_to_stable_backend.py
+++ b/graph_net/torch/backend/unstable_to_stable_backend.py
@@ -52,10 +52,32 @@ class UnstableToStableBackend(GraphCompilerBackend):
 
         return gm
 
+    def fft_rfft_to_rfft(self, gm):
+        """
+        Convert torch._C._fft.fft_rfft to torch.fft.rfft
+        """
+        # Update graph nodes: replace torch._C._fft.fft_rfft with torch.fft.rfft
+        for node in gm.graph.nodes:
+            if node.op == "call_function":
+                if (
+                    hasattr(node.target, "__module__")
+                    and hasattr(node.target, "__name__")
+                    and node.target.__module__ == "torch._C._fft"
+                    and node.target.__name__ == "fft_rfft"
+                ):
+                    node.target = torch.fft.rfft
+
+        # Recompile the graph
+        gm.recompile()
+
+        return gm
+
     def unstable_to_stable(self, gm):
         # Convert based on unstable_api environment variable
         if self.unstable_api == "torch._C._nn.avg_pool2d":
             gm = self.avg_pool2d_to_avg_pool2d(gm)
+        elif self.unstable_api == "torch._C._fft.fft_rfft":
+            gm = self.fft_rfft_to_rfft(gm)
         return gm
 
     def check_unstable_api(self, gm):

--- a/graph_net/torch/backend/unstable_to_stable_backend.py
+++ b/graph_net/torch/backend/unstable_to_stable_backend.py
@@ -30,7 +30,37 @@ class UnstableToStableBackend(GraphCompilerBackend):
     **Stable API reference link:**
     """
 
-    def avg_pool2d_to_avg_pool2d(self, gm):
+    def _impl_unstable_to_stable_irfft(self, gm):
+        def replace_in_graph(graph_mod):
+            # Register stable implementation on GraphModule, codegen can use self.irfft
+            try:
+                setattr(graph_mod, "irfft", torch.fft.irfft)
+            except Exception:
+                pass
+
+            for node in graph_mod.graph.nodes:
+                if node.op == "call_function":
+                    # Match for all forms of target names
+                    if "fft_irfft" in str(node.target):
+                        # Directly point target to Python layer function
+                        node.target = torch.fft.irfft
+            # Validate and recompile the graph
+            graph_mod.graph.lint()
+            graph_mod.recompile()
+
+        # Process main gm and all nested GraphModules
+        modules = [gm]
+        modules += [
+            m
+            for _, m in gm.named_modules()
+            if isinstance(m, torch.fx.GraphModule) and m is not gm
+        ]
+        for m in modules:
+            replace_in_graph(m)
+
+        return gm
+
+    def _impl_unstable_to_stable_avg_pool2d(self, gm):
         """
         Convert torch._C._nn.avg_pool2d to torch.nn.functional.avg_pool2d
         """
@@ -52,7 +82,7 @@ class UnstableToStableBackend(GraphCompilerBackend):
 
         return gm
 
-    def fft_rfft_to_rfft(self, gm):
+    def _impl_unstable_to_stable_rfft(self, gm):
         """
         Convert torch._C._fft.fft_rfft to torch.fft.rfft
         """
@@ -75,11 +105,13 @@ class UnstableToStableBackend(GraphCompilerBackend):
         return gm
 
     def unstable_to_stable(self, gm):
-        # Convert based on unstable_api environment variable
-        if self.unstable_api == "torch._C._nn.avg_pool2d":
-            gm = self.avg_pool2d_to_avg_pool2d(gm)
-        elif self.unstable_api == "torch._C._fft.fft_rfft":
-            gm = self.fft_rfft_to_rfft(gm)
+        methods = (
+            name
+            for name in vars(type(self)).keys()
+            if name.startswith("_impl_unstable_to_stable")
+        )
+        for method in methods:
+            gm = getattr(self, method)(gm)
         return gm
 
     def check_unstable_api(self, gm):

--- a/graph_net/torch/fx_graph_serialize_util.py
+++ b/graph_net/torch/fx_graph_serialize_util.py
@@ -24,4 +24,9 @@ def serialize_graph_module_to_str(gm: torch.fx.GraphModule) -> str:
         "torch.nn.functional.avg_pool2d(",
         code,
     )
+    code = re.sub(
+        r"torch\._C\._fft\.fft_rfft\(",
+        "torch.fft.rfft(",
+        code,
+    )
     return code

--- a/graph_net/torch/fx_graph_serialize_util.py
+++ b/graph_net/torch/fx_graph_serialize_util.py
@@ -19,14 +19,12 @@ def serialize_graph_module_to_str(gm: torch.fx.GraphModule) -> str:
     """
     code = gm.code
     # Replace torch._C._nn.avg_pool2d with torch.nn.functional.avg_pool2d
-    code = re.sub(
-        r"torch\._C\._nn\.avg_pool2d\(",
-        "torch.nn.functional.avg_pool2d(",
-        code,
-    )
-    code = re.sub(
-        r"torch\._C\._fft\.fft_rfft\(",
-        "torch.fft.rfft(",
-        code,
-    )
+    replacements = [
+        (r"torch\._C\._nn\.avg_pool2d\(", "torch.nn.functional.avg_pool2d("),
+        (r"torch\._C\._fft\.fft_irfft\(", "torch.fft.irfft("),
+        (r"torch\._C\._fft\.fft_rfft\(", "torch.fft.rfft("),
+        # Add new rules to this list as needed
+    ]
+    for pattern, repl in replacements:
+        code = re.sub(pattern, repl, code)
     return code


### PR DESCRIPTION
### Description
为了解决 GraphNet 计算图中使用不稳定 API torch._C._fft.fft_rfft 导致无法转换为 Paddle 计算图的问题，新增了 fft_rfft_to_rfft 方法。该方法会遍历 FX Graph 的所有节点，查找 target 为 torch._C._fft.fft_rfft 的节点，并将其替换为 PyTorch 官方稳定 API torch.fft.rfft。替换完成后，重新编译计算图，确保后续模型运行时只会调用稳定接口。