### PR TITLE
【Hackathon 9th No.118】Convert torch._C._nn.softplus to torch.nn.functional.softplus

### DIFF
--- a/graph_net/torch/backend/unstable_to_stable_backend.py
+++ b/graph_net/torch/backend/unstable_to_stable_backend.py
@@ -126,27 +126,6 @@ class UnstableToStableBackend(GraphCompilerBackend):
 
         return gm
 
-    def _impl_unstable_to_stable_softplus(self, gm):
-        """
-        Convert torch._C._nn.softplus to torch.nn.functional.softplus
-        """
-        import torch.nn.functional as F
-
-        issue_nodes = (
-            node
-            for node in gm.graph.nodes
-            if node.op == "call_function"
-            if hasattr(node.target, "__module__")
-            if node.target.__module__ == "torch._C._nn"
-            if hasattr(node.target, "__name__")
-            if node.target.__name__ == "softplus"
-        )
-        for node in issue_nodes:
-            node.target = F.softplus
-
-        gm.recompile()
-        return gm
-
     def _impl_unstable_to_stable_special_logit(self, gm):
         """
         Convert torch._C._special.special_logit to torch.special.logit
@@ -171,7 +150,26 @@ class UnstableToStableBackend(GraphCompilerBackend):
 
     # replace this line with modification code for task 117 (torch._C._linalg.linalg_norm)
 
-    # replace this line with modification code for task 118 (torch._C._nn.softplus)
+    def _impl_unstable_to_stable_softplus(self, gm):
+        """
+        Convert torch._C._nn.softplus to torch.nn.functional.softplus
+        """
+        import torch.nn.functional as F
+
+        issue_nodes = (
+            node
+            for node in gm.graph.nodes
+            if node.op == "call_function"
+            if hasattr(node.target, "__module__")
+            if node.target.__module__ == "torch._C._nn"
+            if hasattr(node.target, "__name__")
+            if node.target.__name__ == "softplus"
+        )
+        for node in issue_nodes:
+            node.target = F.softplus
+
+        gm.recompile()
+        return gm
 
     # replace this line with modification code for task 119 (torch._C._nn.one_hot)
 

--- a/graph_net/torch/backend/unstable_to_stable_backend.py
+++ b/graph_net/torch/backend/unstable_to_stable_backend.py
@@ -147,6 +147,26 @@ class UnstableToStableBackend(GraphCompilerBackend):
         gm.recompile()
         return gm
 
+    def _impl_unstable_to_stable_special_logit(self, gm):
+        """
+        Convert torch._C._special.special_logit to torch.special.logit
+        """
+        issue_nodes = (
+            node
+            for node in gm.graph.nodes
+            if node.op == "call_function"
+            if hasattr(node.target, "__module__")
+            if node.target.__module__ == "torch._C._special"
+            if hasattr(node.target, "__name__")
+            if node.target.__name__ == "special_logit"
+        )
+        for node in issue_nodes:
+            node.target = torch.special.logit
+
+        # Recompile the graph
+        gm.recompile()
+        return gm
+
     def unstable_to_stable(self, gm):
         methods = (
             name

--- a/graph_net/torch/backend/unstable_to_stable_backend.py
+++ b/graph_net/torch/backend/unstable_to_stable_backend.py
@@ -126,6 +126,27 @@ class UnstableToStableBackend(GraphCompilerBackend):
 
         return gm
 
+    def _impl_unstable_to_stable_softplus(self, gm):
+        """
+        Convert torch._C._nn.softplus to torch.nn.functional.softplus
+        """
+        import torch.nn.functional as F
+
+        issue_nodes = (
+            node
+            for node in gm.graph.nodes
+            if node.op == "call_function"
+            if hasattr(node.target, "__module__")
+            if node.target.__module__ == "torch._C._nn"
+            if hasattr(node.target, "__name__")
+            if node.target.__name__ == "softplus"
+        )
+        for node in issue_nodes:
+            node.target = F.softplus
+
+        gm.recompile()
+        return gm
+
     def unstable_to_stable(self, gm):
         methods = (
             name

--- a/graph_net/torch/fx_graph_serialize_util.py
+++ b/graph_net/torch/fx_graph_serialize_util.py
@@ -24,6 +24,7 @@ def serialize_graph_module_to_str(gm: torch.fx.GraphModule) -> str:
         (r"torch\._C\._fft\.fft_irfft\(", "torch.fft.irfft("),
         (r"torch\._C\._fft\.fft_rfft\(", "torch.fft.rfft("),
         (r"torch\._C\._fft\.fft_fftn\(", "torch.fft.fftn("),
+        (r"torch\._C\._nn\.softplus\(", "torch.nn.functional.softplus("),
         # Add new rules to this list as needed
     ]
     for pattern, repl in replacements:

--- a/graph_net/torch/fx_graph_serialize_util.py
+++ b/graph_net/torch/fx_graph_serialize_util.py
@@ -24,11 +24,10 @@ def serialize_graph_module_to_str(gm: torch.fx.GraphModule) -> str:
         (r"torch\._C\._fft\.fft_irfft\(", "torch.fft.irfft("),
         (r"torch\._C\._fft\.fft_rfft\(", "torch.fft.rfft("),
         (r"torch\._C\._fft\.fft_fftn\(", "torch.fft.fftn("),
-        (r"torch\._C\._nn\.softplus\(", "torch.nn.functional.softplus("),
         (r"torch\._C\._special\.special_logit\(", "torch.special.logit("),
         # replace this line with modification code for task 116 (torch._C._linalg.linalg_vector_norm)
         # replace this line with modification code for task 117 (torch._C._linalg.linalg_norm)
-        # replace this line with modification code for task 118 (torch._C._nn.softplus)
+        (r"torch\._C\._nn\.softplus\(", "torch.nn.functional.softplus("),
         # replace this line with modification code for task 119 (torch._C._nn.one_hot)
         # replace this line with modification code for task 121 (torch._C._set_grad_enabled)
         # replace this line with modification code for task 122 (torch._C._log_api_usage_once)

--- a/graph_net/torch/fx_graph_serialize_util.py
+++ b/graph_net/torch/fx_graph_serialize_util.py
@@ -25,6 +25,7 @@ def serialize_graph_module_to_str(gm: torch.fx.GraphModule) -> str:
         (r"torch\._C\._fft\.fft_rfft\(", "torch.fft.rfft("),
         (r"torch\._C\._fft\.fft_fftn\(", "torch.fft.fftn("),
         (r"torch\._C\._nn\.softplus\(", "torch.nn.functional.softplus("),
+        (r"torch\._C\._special\.special_logit\(", "torch.special.logit("),
         # Add new rules to this list as needed
     ]
     for pattern, repl in replacements:


### PR DESCRIPTION
### Description
函数用于将 FX 计算图中的不稳定 API torch._C._nn.softplus 替换为 PyTorch 官方稳定的 torch.nn.functional.softplus。该方法会遍历所有相关节点并完成替换，随后重新编译计算图，确保模型在编译和运行时只调用稳定接口
<img width="3529" height="2159" alt="ES_result" src="https://github.com/user-attachments/assets/cdca8188-3a96-43ed-8625-c82145beeb60" />

