### PR TITLE
【Hackathon 9th No.120】Convert torch._C._special.special_logit to torch.special.logit

### DIFF
--- a/graph_net/torch/backend/unstable_to_stable_backend.py
+++ b/graph_net/torch/backend/unstable_to_stable_backend.py
@@ -126,16 +126,6 @@ class UnstableToStableBackend(GraphCompilerBackend):
 
         return gm
 
-    def unstable_to_stable(self, gm):
-        methods = (
-            name
-            for name in vars(type(self)).keys()
-            if name.startswith("_impl_unstable_to_stable")
-        )
-        for method in methods:
-            gm = getattr(self, method)(gm)
-        return gm
-
     def _impl_unstable_to_stable_special_logit(self, gm):
         """
         Convert torch._C._special.special_logit to torch.special.logit
@@ -155,6 +145,16 @@ class UnstableToStableBackend(GraphCompilerBackend):
         # Recompile the graph
         gm.recompile()
 
+        return gm
+
+    def unstable_to_stable(self, gm):
+        methods = (
+            name
+            for name in vars(type(self)).keys()
+            if name.startswith("_impl_unstable_to_stable")
+        )
+        for method in methods:
+            gm = getattr(self, method)(gm)
         return gm
 
     def check_unstable_api(self, gm):

--- a/graph_net/torch/backend/unstable_to_stable_backend.py
+++ b/graph_net/torch/backend/unstable_to_stable_backend.py
@@ -136,6 +136,27 @@ class UnstableToStableBackend(GraphCompilerBackend):
             gm = getattr(self, method)(gm)
         return gm
 
+    def _impl_unstable_to_stable_special_logit(self, gm):
+        """
+        Convert torch._C._special.special_logit to torch.special.logit
+        """
+        issue_nodes = (
+            node
+            for node in gm.graph.nodes
+            if node.op == "call_function"
+            if hasattr(node.target, "__module__")
+            if node.target.__module__ == "torch._C._special"
+            if hasattr(node.target, "__name__")
+            if node.target.__name__ == "special_logit"
+        )
+        for node in issue_nodes:
+            node.target = torch.special.logit
+
+        # Recompile the graph
+        gm.recompile()
+
+        return gm
+
     def check_unstable_api(self, gm):
         """
         Check whether gm contains the API specified in the environment

--- a/graph_net/torch/fx_graph_serialize_util.py
+++ b/graph_net/torch/fx_graph_serialize_util.py
@@ -24,6 +24,7 @@ def serialize_graph_module_to_str(gm: torch.fx.GraphModule) -> str:
         (r"torch\._C\._fft\.fft_irfft\(", "torch.fft.irfft("),
         (r"torch\._C\._fft\.fft_rfft\(", "torch.fft.rfft("),
         (r"torch\._C\._fft\.fft_fftn\(", "torch.fft.fftn("),
+        (r"torch\._C\._special\.special_logit\(", "torch.special.logit("),
         # Add new rules to this list as needed
     ]
     for pattern, repl in replacements:


### PR DESCRIPTION
### Description
函数用于将 FX 计算图中的不稳定 API torch._C._special.special_logit 替换为 PyTorch 官方稳定的 torch.special.logit。该方法会遍历所有相关节点并完成替换，随后重新编译计算图，确保模型在编译和运行时只调用稳定接口。
