### PR TITLE
【Hackathon 9th No.116】Convert torch._C._linalg.linalg_vector_norm to torch.linalg.vector_norm

### DIFF
--- a/graph_net/torch/backend/unstable_to_stable_backend.py
+++ b/graph_net/torch/backend/unstable_to_stable_backend.py
@@ -147,7 +147,27 @@ class UnstableToStableBackend(GraphCompilerBackend):
 
         return gm
 
-    # replace this line with modification code for task 116 (torch._C._linalg.linalg_vector_norm)
+    def _impl_unstable_to_stable_linalg_vector_norm(self, gm):
+        """
+        Convert torch._C._linalg.linalg_vector_norm to torch.linalg.vector_norm
+        """
+        # Update graph nodes: replace torch._C._linalg.linalg_vector_norm with torch.linalg.vector_norm
+        issue_nodes = (
+            node
+            for node in gm.graph.nodes
+            if node.op == "call_function"
+            if hasattr(node.target, "__module__")
+            if node.target.__module__ == "torch._C._linalg"
+            if hasattr(node.target, "__name__")
+            if node.target.__name__ == "linalg_vector_norm"
+        )
+        for node in issue_nodes:
+            node.target = torch.linalg.vector_norm
+
+        # Recompile the graph
+        gm.recompile()
+
+        return gm
 
     # replace this line with modification code for task 117 (torch._C._linalg.linalg_norm)
 

--- a/graph_net/torch/fx_graph_serialize_util.py
+++ b/graph_net/torch/fx_graph_serialize_util.py
@@ -25,7 +25,7 @@ def serialize_graph_module_to_str(gm: torch.fx.GraphModule) -> str:
         (r"torch\._C\._fft\.fft_rfft\(", "torch.fft.rfft("),
         (r"torch\._C\._fft\.fft_fftn\(", "torch.fft.fftn("),
         (r"torch\._C\._special\.special_logit\(", "torch.special.logit("),
-        # replace this line with modification code for task 116 (torch._C._linalg.linalg_vector_norm)
+        (r"torch\._C\._linalg\.linalg_vector_norm\(", "torch.linalg.vector_norm("),
         # replace this line with modification code for task 117 (torch._C._linalg.linalg_norm)
         # replace this line with modification code for task 118 (torch._C._nn.softplus)
         # replace this line with modification code for task 119 (torch._C._nn.one_hot)


### PR DESCRIPTION
### Description
函数用于将 FX 计算图中的不稳定 API  torch._C._linalg.linalg_vector_norm 替换为 PyTorch 官方稳定的 torch.linalg.vector_norm。该方法会遍历所有相关节点并完成替换，随后重新编译计算图，确保模型在编译和运行时只调用稳定接口。
<img width="3529" height="2159" alt="4519db596e703a6465195b62b5d4ecd1" src="https://github.com/user-attachments/assets/550998d7-1784-42e8-897e-a57cd92bb8cd" />
