### PR TITLE
【Hackathon 9th No.117】Convert torch._C._linalg.linalg_norm to torch.linalg.norm

### DIFF
--- a/graph_net/torch/backend/unstable_to_stable_backend.py
+++ b/graph_net/torch/backend/unstable_to_stable_backend.py
@@ -178,7 +178,26 @@ class UnstableToStableBackend(GraphCompilerBackend):
 
         return gm
 
-    # replace this line with modification code for task 117 (torch._C._linalg.linalg_norm)
+    def _impl_unstable_to_stable_linalg_norm(self, gm):
+        """
+        Convert torch._C._linalg.linalg_norm to torch.linalg.norm
+        """
+        # Update graph nodes: replace torch._C._linalg.linalg_norm with torch.linalg.norm
+        issue_nodes = (
+            node
+            for node in gm.graph.nodes
+            if node.op == "call_function"
+            if hasattr(node.target, "__module__")
+            if node.target.__module__ == "torch._C._linalg"
+            if hasattr(node.target, "__name__")
+            if node.target.__name__ == "linalg_norm"
+        )
+        for node in issue_nodes:
+            node.target = torch.linalg.norm
+
+        # Recompile the graph
+        gm.recompile()
+        return gm
 
     def _impl_unstable_to_stable_softplus(self, gm):
         """

--- a/graph_net/torch/fx_graph_serialize_util.py
+++ b/graph_net/torch/fx_graph_serialize_util.py
@@ -140,7 +140,7 @@ def serialize_graph_module_to_str(gm: torch.fx.GraphModule) -> str:
         (r"torch\._C\._fft\.fft_fftn\(", "torch.fft.fftn("),
         (r"torch\._C\._special\.special_logit\(", "torch.special.logit("),
         (r"torch\._C\._linalg\.linalg_vector_norm\(", "torch.linalg.vector_norm("),
-        # replace this line with modification code for task 117 (torch._C._linalg.linalg_norm)
+        (r"torch\._C\._linalg\.linalg_norm\(", "torch.linalg.norm("),
         (r"torch\._C\._nn\.softplus\(", "torch.nn.functional.softplus("),
         (r"torch\._C\._nn\.one_hot\(", "torch.nn.functional.one_hot("),
         (r"torch\._C\._set_grad_enabled\(", "torch.set_grad_enabled("),


### PR DESCRIPTION
### Description
函数用于将 FX 计算图中的不稳定 API torch._C._linalg.linalg_norm 替换为 PyTorch 官方稳定的 torch.linalg.norm。该方法会遍历所有相关节点并完成替换，随后重新编译计算图，确保模型在编译和运行时只调用稳定接口。
<img width="3529" height="2159" alt="ddf27a6b75b59393de23aadd54995eeb" src="https://github.com/user-attachments/assets/51b7d791-e151-4fa9-bdd2-b9c2f574d9d9" />
