### PR TITLE
【Hackathon 9th No.121】Convert torch._C._set_grad_enabled and torch._C.set_grad_enabled to torch.set_grad_enabled

### DIFF
--- a/graph_net/torch/backend/unstable_to_stable_backend.py
+++ b/graph_net/torch/backend/unstable_to_stable_backend.py
@@ -155,7 +155,28 @@ class UnstableToStableBackend(GraphCompilerBackend):
 
     # replace this line with modification code for task 119 (torch._C._nn.one_hot)
 
-    # replace this line with modification code for task 121 (torch._C._set_grad_enabled)
+    def _impl_unstable_to_stable_set_grad_enabled(self, gm):
+        """
+        Convert torch._C._set_grad_enabled and torch._C.set_grad_enabled to torch.set_grad_enabled
+        """
+
+        def replace_in_graph(graph_mod):
+            for node in graph_mod.graph.nodes:
+                if node.op == "call_function":
+                    if "set_grad_enabled" in str(node.target):
+                        node.target = torch.set_grad_enabled
+            graph_mod.recompile()
+
+        modules = [gm]
+        modules += [
+            m
+            for _, m in gm.named_modules()
+            if isinstance(m, torch.fx.GraphModule) and m is not gm
+        ]
+        for m in modules:
+            replace_in_graph(m)
+
+        return gm
 
     # replace this line with modification code for task 122 (torch._C._log_api_usage_once)
 

--- a/graph_net/torch/fx_graph_serialize_util.py
+++ b/graph_net/torch/fx_graph_serialize_util.py
@@ -29,7 +29,8 @@ def serialize_graph_module_to_str(gm: torch.fx.GraphModule) -> str:
         # replace this line with modification code for task 117 (torch._C._linalg.linalg_norm)
         # replace this line with modification code for task 118 (torch._C._nn.softplus)
         # replace this line with modification code for task 119 (torch._C._nn.one_hot)
-        # replace this line with modification code for task 121 (torch._C._set_grad_enabled)
+        (r"torch\._C\._set_grad_enabled\(", "torch.set_grad_enabled("),
+        (r"torch\._C\.set_grad_enabled\(", "torch.set_grad_enabled("),
         # replace this line with modification code for task 122 (torch._C._log_api_usage_once)
         # replace this line with modification code for task 123 (torch._C._nn.pad)
         # replace this line with modification code for task 125 (torch._C._nn.gelu)


### PR DESCRIPTION
### Description
函数用于将 FX 计算图中的不稳定 API  torch._C._set_grad_enabled 和 torch._C.set_grad_enabled 替换为 PyTorch 官方稳定的 torch.set_grad_enabled。该方法会遍历所有相关节点并完成替换，随后重新编译计算图，确保模型在编译和运行时只调用稳定接口。
<img width="3528" height="2158" alt="89186b46954a2e5c66acb475d8b3be9f" src="https://github.com/user-attachments/assets/a61e2761-5498-4f47-9ef8-6a2e57219620" />
