### PR TITLE
【Hackathon 9th No.125】Convert torch._C._nn.gelu to torch.nn.functional.gelu

### DIFF
--- a/graph_net/torch/fx_graph_serialize_util.py
+++ b/graph_net/torch/fx_graph_serialize_util.py
@@ -147,7 +147,7 @@ def serialize_graph_module_to_str(gm: torch.fx.GraphModule) -> str:
         (r"torch\._C\.set_grad_enabled\(", "torch.set_grad_enabled("),
         # replace this line with modification code for task 122 (torch._C._log_api_usage_once)
         (r"torch\._C\._nn\.pad\(", "torch.nn.functional.pad("),
-        # replace this line with modification code for task 125 (torch._C._nn.gelu)
+        (r"torch\._C\._nn\.gelu\(", "torch.nn.functional.gelu("),
         # replace this line with modification code for task 126 (torch._C._nn.scaled_dot_product_attention)
         (r"torch\._C\._nn\.linear\(", "torch.nn.functional.linear("),
     ]


### PR DESCRIPTION
### Description
函数用于将 FX 计算图中的不稳定 API torch._C._nn.gelu 替换为 PyTorch 官方稳定的 torch.nn.functional.gelu。该方法会遍历所有相关节点并完成替换，随后重新编译计算图，确保模型在编译和运行时只调用稳定接口
<img width="3529" height="2159" alt="d15c0d5d3962f7d7c5a7317462098131" src="https://github.com/user-attachments/assets/eb7d61fd-a8be-469e-8ae1-a07618a159cb" />
