### PR TITLE
【Hackathon 9th No.116】 feat: implement torch._C._linalg.linalg_vector_norm to stable API conversion

### DIFF
--- a/graph_net/torch/backend/unstable_to_stable_backend.py
+++ b/graph_net/torch/backend/unstable_to_stable_backend.py
@@ -130,6 +130,7 @@ class UnstableToStableBackend(GraphCompilerBackend):
         """
         Convert torch._C._linalg.linalg_vector_norm to torch.linalg.vector_norm
         """
+
         def replace_in_graph(graph_mod):
             # Update graph nodes: replace torch._C._linalg.linalg_vector_norm with torch.linalg.vector_norm
             for node in graph_mod.graph.nodes:
@@ -141,7 +142,7 @@ class UnstableToStableBackend(GraphCompilerBackend):
                         and node.target.__name__ == "linalg_vector_norm"
                     ):
                         node.target = torch.linalg.vector_norm
-            
+
             # Validate and recompile the graph
             graph_mod.graph.lint()
             graph_mod.recompile()

--- a/graph_net/torch/backend/unstable_to_stable_backend.py
+++ b/graph_net/torch/backend/unstable_to_stable_backend.py
@@ -126,6 +126,38 @@ class UnstableToStableBackend(GraphCompilerBackend):
 
         return gm
 
+    def _impl_unstable_to_stable_linalg_vector_norm(self, gm):
+        """
+        Convert torch._C._linalg.linalg_vector_norm to torch.linalg.vector_norm
+        """
+        def replace_in_graph(graph_mod):
+            # Update graph nodes: replace torch._C._linalg.linalg_vector_norm with torch.linalg.vector_norm
+            for node in graph_mod.graph.nodes:
+                if node.op == "call_function":
+                    if (
+                        hasattr(node.target, "__module__")
+                        and hasattr(node.target, "__name__")
+                        and node.target.__module__ == "torch._C._linalg"
+                        and node.target.__name__ == "linalg_vector_norm"
+                    ):
+                        node.target = torch.linalg.vector_norm
+            
+            # Validate and recompile the graph
+            graph_mod.graph.lint()
+            graph_mod.recompile()
+
+        # Process main gm and all nested GraphModules
+        modules = [gm]
+        modules += [
+            m
+            for _, m in gm.named_modules()
+            if isinstance(m, torch.fx.GraphModule) and m is not gm
+        ]
+        for m in modules:
+            replace_in_graph(m)
+
+        return gm
+
     def unstable_to_stable(self, gm):
         methods = (
             name

--- a/graph_net/torch/fx_graph_serialize_util.py
+++ b/graph_net/torch/fx_graph_serialize_util.py
@@ -24,6 +24,7 @@ def serialize_graph_module_to_str(gm: torch.fx.GraphModule) -> str:
         (r"torch\._C\._fft\.fft_irfft\(", "torch.fft.irfft("),
         (r"torch\._C\._fft\.fft_rfft\(", "torch.fft.rfft("),
         (r"torch\._C\._fft\.fft_fftn\(", "torch.fft.fftn("),
+        (r"torch\._C\._linalg\.linalg_vector_norm\(", "torch.linalg.vector_norm("),
         # Add new rules to this list as needed
     ]
     for pattern, repl in replacements:


### PR DESCRIPTION
This pull request adds support for converting the internal `torch._C._linalg.linalg_vector_norm` function to the public `torch.linalg.vector_norm` API in both the graph transformation logic and the graph serialization utility. This ensures that models using the internal function are properly mapped to the stable, public API during processing and serialization.

API normalization and conversion:

* Added a new method `_impl_unstable_to_stable_linalg_vector_norm` in `unstable_to_stable_backend.py` to replace all uses of `torch._C._linalg.linalg_vector_norm` with `torch.linalg.vector_norm` in a given `GraphModule` and its nested modules.
* Updated the `serialize_graph_module_to_str` function in `fx_graph_serialize_util.py` to include a regex replacement rule that serializes `torch._C._linalg.linalg_vector_norm` as `torch.linalg.vector_norm`.

<img width="3528" height="2158" alt="image" src="https://github.com/user-attachments/assets/5dc99cf1-bfc5-40a4-857f-9790c6da6aed" />
