### PR TITLE
【Hackathon 9th No.119】 feat: implement torch._C._nn.one_hot to stable API conversion

### DIFF
--- a/graph_net/torch/backend/unstable_to_stable_backend.py
+++ b/graph_net/torch/backend/unstable_to_stable_backend.py
@@ -1,5 +1,6 @@
 import os
 import torch
+import torch.nn.functional as F
 import sys
 import inspect
 from .graph_compiler_backend import GraphCompilerBackend
@@ -123,6 +124,37 @@ class UnstableToStableBackend(GraphCompilerBackend):
 
         # Recompile the graph
         gm.recompile()
+
+        return gm
+
+    def _impl_unstable_to_stable_one_hot(self, gm):
+        """
+        Convert torch._C._nn.one_hot to torch.nn.functional.one_hot
+        """
+
+        def replace_in_graph(graph_mod):
+            # Update graph nodes: replace torch._C._nn.one_hot with F.one_hot
+            for node in graph_mod.graph.nodes:
+                if node.op == "call_function":
+                    # Match for all forms of target names
+                    if "one_hot" in str(node.target) and "torch._C._nn" in str(
+                        node.target
+                    ):
+                        # Directly point target to Python layer function
+                        node.target = F.one_hot
+            # Validate and recompile the graph
+            graph_mod.graph.lint()
+            graph_mod.recompile()
+
+        # Process main gm and all nested GraphModules
+        modules = [gm]
+        modules += [
+            m
+            for _, m in gm.named_modules()
+            if isinstance(m, torch.fx.GraphModule) and m is not gm
+        ]
+        for m in modules:
+            replace_in_graph(m)
 
         return gm
 

--- a/graph_net/torch/fx_graph_serialize_util.py
+++ b/graph_net/torch/fx_graph_serialize_util.py
@@ -21,6 +21,7 @@ def serialize_graph_module_to_str(gm: torch.fx.GraphModule) -> str:
     # Replace torch._C._nn.avg_pool2d with torch.nn.functional.avg_pool2d
     replacements = [
         (r"torch\._C\._nn\.avg_pool2d\(", "torch.nn.functional.avg_pool2d("),
+        (r"torch\._C\._nn\.one_hot\(", "torch.nn.functional.one_hot("),
         (r"torch\._C\._fft\.fft_irfft\(", "torch.fft.irfft("),
         (r"torch\._C\._fft\.fft_rfft\(", "torch.fft.rfft("),
         (r"torch\._C\._fft\.fft_fftn\(", "torch.fft.fftn("),


### PR DESCRIPTION
* Replace torch._C._nn.one_hot with torch.nn.functional.one_hot in serialization utility.
* Implement a method to update graph modules for one-hot encoding conversion in the unstable to stable backend.
<img width="3529" height="2158" alt="image" src="https://github.com/user-attachments/assets/cb6b8032-8f30-4ecc-ab98-1327efc35c4a" />
