### PR TITLE
[Feature Enhancement] Add original_name in meta for 29 paddle samples.

### DIFF
--- a/paddle_samples/PaddleX/DETR-R50/subgraph_11/input_meta.py
+++ b/paddle_samples/PaddleX/DETR-R50/subgraph_11/input_meta.py
@@ -1,5 +1,6 @@
 class Program_weight_tensor_data_0:
     name = "data_0"
+    original_name = "param_111"
     shape = [256, 768]
     dtype = "float32"
     min_val = float("-1.62911")
@@ -11,6 +12,7 @@ class Program_weight_tensor_data_0:
 
 class Program_weight_tensor_data_1:
     name = "data_1"
+    original_name = "param_112"
     shape = [768]
     dtype = "float32"
     min_val = float("-0.207838")
@@ -22,6 +24,7 @@ class Program_weight_tensor_data_1:
 
 class Program_weight_tensor_data_2:
     name = "data_2"
+    original_name = "param_113"
     shape = [256, 768]
     dtype = "float32"
     min_val = float("-0.61818")
@@ -33,6 +36,7 @@ class Program_weight_tensor_data_2:
 
 class Program_weight_tensor_data_3:
     name = "data_3"
+    original_name = "param_114"
     shape = [768]
     dtype = "float32"
     min_val = float("-0.0816622")
@@ -44,6 +48,7 @@ class Program_weight_tensor_data_3:
 
 class Program_weight_tensor_data_4:
     name = "data_4"
+    original_name = "param_115"
     shape = [256, 768]
     dtype = "float32"
     min_val = float("-1.209")
@@ -55,6 +60,7 @@ class Program_weight_tensor_data_4:
 
 class Program_weight_tensor_data_5:
     name = "data_5"
+    original_name = "param_116"
     shape = [768]
     dtype = "float32"
     min_val = float("-0.100471")
@@ -66,6 +72,7 @@ class Program_weight_tensor_data_5:
 
 class Program_weight_tensor_data_6:
     name = "data_6"
+    original_name = "param_117"
     shape = [256, 768]
     dtype = "float32"
     min_val = float("-1.53473")
@@ -77,6 +84,7 @@ class Program_weight_tensor_data_6:
 
 class Program_weight_tensor_data_7:
     name = "data_7"
+    original_name = "param_118"
     shape = [768]
     dtype = "float32"
     min_val = float("-0.15172")
@@ -88,6 +96,7 @@ class Program_weight_tensor_data_7:
 
 class Program_weight_tensor_data_8:
     name = "data_8"
+    original_name = "param_119"
     shape = [256, 768]
     dtype = "float32"
     min_val = float("-1.36483")
@@ -99,6 +108,7 @@ class Program_weight_tensor_data_8:
 
 class Program_weight_tensor_data_9:
     name = "data_9"
+    original_name = "param_120"
     shape = [768]
     dtype = "float32"
     min_val = float("-0.0746685")
@@ -110,6 +120,7 @@ class Program_weight_tensor_data_9:
 
 class Program_weight_tensor_data_10:
     name = "data_10"
+    original_name = "param_121"
     shape = [256, 768]
     dtype = "float32"
     min_val = float("-1.53118")
@@ -121,6 +132,7 @@ class Program_weight_tensor_data_10:
 
 class Program_weight_tensor_data_11:
     name = "data_11"
+    original_name = "param_122"
     shape = [768]
     dtype = "float32"
     min_val = float("-0.0552873")
@@ -132,6 +144,7 @@ class Program_weight_tensor_data_11:
 
 class Program_weight_tensor_data_12:
     name = "data_12"
+    original_name = "param_123"
     shape = [100, 256]
     dtype = "float32"
     min_val = float("-4.02637")
@@ -143,6 +156,7 @@ class Program_weight_tensor_data_12:
 
 class Program_weight_tensor_data_13:
     name = "data_13"
+    original_name = "param_124"
     shape = [256, 768]
     dtype = "float32"
     min_val = float("-0.227613")
@@ -154,6 +168,7 @@ class Program_weight_tensor_data_13:
 
 class Program_weight_tensor_data_14:
     name = "data_14"
+    original_name = "param_125"
     shape = [768]
     dtype = "float32"
     min_val = float("-0.306495")
@@ -165,6 +180,7 @@ class Program_weight_tensor_data_14:
 
 class Program_weight_tensor_data_15:
     name = "data_15"
+    original_name = "param_126"
     shape = [256, 768]
     dtype = "float32"
     min_val = float("-1.2844")
@@ -176,6 +192,7 @@ class Program_weight_tensor_data_15:
 
 class Program_weight_tensor_data_16:
     name = "data_16"
+    original_name = "param_127"
     shape = [768]
     dtype = "float32"
     min_val = float("-0.405472")
@@ -187,6 +204,7 @@ class Program_weight_tensor_data_16:
 
 class Program_weight_tensor_data_17:
     name = "data_17"
+    original_name = "param_128"
     shape = [256, 768]
     dtype = "float32"
     min_val = float("-0.526879")
@@ -198,6 +216,7 @@ class Program_weight_tensor_data_17:
 
 class Program_weight_tensor_data_18:
     name = "data_18"
+    original_name = "param_129"
     shape = [768]
     dtype = "float32"
     min_val = float("-0.19053")
@@ -209,6 +228,7 @@ class Program_weight_tensor_data_18:
 
 class Program_weight_tensor_data_19:
     name = "data_19"
+    original_name = "param_130"
     shape = [256, 768]
     dtype = "float32"
     min_val = float("-1.84815")
@@ -220,6 +240,7 @@ class Program_weight_tensor_data_19:
 
 class Program_weight_tensor_data_20:
     name = "data_20"
+    original_name = "param_131"
     shape = [768]
     dtype = "float32"
     min_val = float("-0.368145")
@@ -231,6 +252,7 @@ class Program_weight_tensor_data_20:
 
 class Program_weight_tensor_data_21:
     name = "data_21"
+    original_name = "param_132"
     shape = [256, 768]
     dtype = "float32"
     min_val = float("-0.727683")
@@ -242,6 +264,7 @@ class Program_weight_tensor_data_21:
 
 class Program_weight_tensor_data_22:
     name = "data_22"
+    original_name = "param_133"
     shape = [768]
     dtype = "float32"
     min_val = float("-0.138786")
@@ -253,6 +276,7 @@ class Program_weight_tensor_data_22:
 
 class Program_weight_tensor_data_23:
     name = "data_23"
+    original_name = "param_134"
     shape = [256, 768]
     dtype = "float32"
     min_val = float("-2.28676")
@@ -264,6 +288,7 @@ class Program_weight_tensor_data_23:
 
 class Program_weight_tensor_data_24:
     name = "data_24"
+    original_name = "param_135"
     shape = [768]
     dtype = "float32"
     min_val = float("-0.41317")
@@ -275,6 +300,7 @@ class Program_weight_tensor_data_24:
 
 class Program_weight_tensor_data_25:
     name = "data_25"
+    original_name = "param_136"
     shape = [256, 768]
     dtype = "float32"
     min_val = float("-0.469093")
@@ -286,6 +312,7 @@ class Program_weight_tensor_data_25:
 
 class Program_weight_tensor_data_26:
     name = "data_26"
+    original_name = "param_137"
     shape = [768]
     dtype = "float32"
     min_val = float("-0.229076")
@@ -297,6 +324,7 @@ class Program_weight_tensor_data_26:
 
 class Program_weight_tensor_data_27:
     name = "data_27"
+    original_name = "param_138"
     shape = [256, 768]
     dtype = "float32"
     min_val = float("-1.69536")
@@ -308,6 +336,7 @@ class Program_weight_tensor_data_27:
 
 class Program_weight_tensor_data_28:
     name = "data_28"
+    original_name = "param_139"
     shape = [768]
     dtype = "float32"
     min_val = float("-0.461248")
@@ -319,6 +348,7 @@ class Program_weight_tensor_data_28:
 
 class Program_weight_tensor_data_29:
     name = "data_29"
+    original_name = "param_140"
     shape = [256, 768]
     dtype = "float32"
     min_val = float("-0.669767")
@@ -330,6 +360,7 @@ class Program_weight_tensor_data_29:
 
 class Program_weight_tensor_data_30:
     name = "data_30"
+    original_name = "param_141"
     shape = [768]
     dtype = "float32"
     min_val = float("-0.201717")
@@ -341,6 +372,7 @@ class Program_weight_tensor_data_30:
 
 class Program_weight_tensor_data_31:
     name = "data_31"
+    original_name = "param_142"
     shape = [256, 768]
     dtype = "float32"
     min_val = float("-2.39615")
@@ -352,6 +384,7 @@ class Program_weight_tensor_data_31:
 
 class Program_weight_tensor_data_32:
     name = "data_32"
+    original_name = "param_143"
     shape = [768]
     dtype = "float32"
     min_val = float("-0.344924")
@@ -363,6 +396,7 @@ class Program_weight_tensor_data_32:
 
 class Program_weight_tensor_data_33:
     name = "data_33"
+    original_name = "param_144"
     shape = [256, 768]
     dtype = "float32"
     min_val = float("-0.408574")
@@ -374,6 +408,7 @@ class Program_weight_tensor_data_33:
 
 class Program_weight_tensor_data_34:
     name = "data_34"
+    original_name = "param_145"
     shape = [768]
     dtype = "float32"
     min_val = float("-0.317686")
@@ -385,6 +420,7 @@ class Program_weight_tensor_data_34:
 
 class Program_weight_tensor_data_35:
     name = "data_35"
+    original_name = "param_146"
     shape = [256, 768]
     dtype = "float32"
     min_val = float("-2.3181")
@@ -396,6 +432,7 @@ class Program_weight_tensor_data_35:
 
 class Program_weight_tensor_data_36:
     name = "data_36"
+    original_name = "param_147"
     shape = [768]
     dtype = "float32"
     min_val = float("-0.44711")
@@ -407,6 +444,7 @@ class Program_weight_tensor_data_36:
 
 class Program_weight_tensor_data_37:
     name = "data_37"
+    original_name = "var_4405"
     shape = [4, 3, 1089, 1007]
     dtype = "float32"
     min_val = float("-2.1179")
@@ -418,8 +456,10 @@ class Program_weight_tensor_data_37:
 
 class Program_weight_tensor_data_38:
     name = "data_38"
+    original_name = "var_4408"
     shape = [4, 1089, 1007]
     dtype = "float32"
+    min_val = float("0.0")
     max_val = float("1.0")
     mean = float("0.60675")
     std = float("0.488472")

--- a/paddle_samples/PaddleX/DETR-R50/subgraph_11/weight_meta.py
+++ b/paddle_samples/PaddleX/DETR-R50/subgraph_11/weight_meta.py
@@ -1,5 +1,6 @@
 class Program_weight_tensor_parameter_0:
     name = "parameter_0"
+    original_name = "layer_norm_4.b_0_deepcopy_179"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.393606")
@@ -11,6 +12,7 @@ class Program_weight_tensor_parameter_0:
 
 class Program_weight_tensor_parameter_1:
     name = "parameter_1"
+    original_name = "layer_norm_4.w_0_deepcopy_178"
     shape = [256]
     dtype = "float32"
     min_val = float("0.534183")
@@ -22,6 +24,7 @@ class Program_weight_tensor_parameter_1:
 
 class Program_weight_tensor_parameter_2:
     name = "parameter_2"
+    original_name = "linear_6.b_0_deepcopy_173"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.0930677")
@@ -33,6 +36,7 @@ class Program_weight_tensor_parameter_2:
 
 class Program_weight_tensor_parameter_3:
     name = "parameter_3"
+    original_name = "linear_6.w_0_deepcopy_172"
     shape = [2048, 256]
     dtype = "float32"
     min_val = float("-0.687348")
@@ -44,6 +48,7 @@ class Program_weight_tensor_parameter_3:
 
 class Program_weight_tensor_parameter_4:
     name = "parameter_4"
+    original_name = "linear_5.b_0_deepcopy_171"
     shape = [2048]
     dtype = "float32"
     min_val = float("-0.302835")
@@ -55,6 +60,7 @@ class Program_weight_tensor_parameter_4:
 
 class Program_weight_tensor_parameter_5:
     name = "parameter_5"
+    original_name = "linear_5.w_0_deepcopy_170"
     shape = [256, 2048]
     dtype = "float32"
     min_val = float("-0.561115")
@@ -66,6 +72,7 @@ class Program_weight_tensor_parameter_5:
 
 class Program_weight_tensor_parameter_6:
     name = "parameter_6"
+    original_name = "layer_norm_3.b_0_deepcopy_177"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.09289")
@@ -77,6 +84,7 @@ class Program_weight_tensor_parameter_6:
 
 class Program_weight_tensor_parameter_7:
     name = "parameter_7"
+    original_name = "layer_norm_3.w_0_deepcopy_176"
     shape = [256]
     dtype = "float32"
     min_val = float("0.789222")
@@ -88,6 +96,7 @@ class Program_weight_tensor_parameter_7:
 
 class Program_weight_tensor_parameter_8:
     name = "parameter_8"
+    original_name = "linear_4.b_0_deepcopy_169"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.207467")
@@ -99,6 +108,7 @@ class Program_weight_tensor_parameter_8:
 
 class Program_weight_tensor_parameter_9:
     name = "parameter_9"
+    original_name = "linear_4.w_0_deepcopy_168"
     shape = [256, 256]
     dtype = "float32"
     min_val = float("-0.508002")
@@ -110,6 +120,7 @@ class Program_weight_tensor_parameter_9:
 
 class Program_weight_tensor_parameter_10:
     name = "parameter_10"
+    original_name = "layer_norm_2.b_0_deepcopy_175"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.774813")
@@ -121,6 +132,7 @@ class Program_weight_tensor_parameter_10:
 
 class Program_weight_tensor_parameter_11:
     name = "parameter_11"
+    original_name = "layer_norm_2.w_0_deepcopy_174"
     shape = [256]
     dtype = "float32"
     min_val = float("1.37211")
@@ -132,6 +144,7 @@ class Program_weight_tensor_parameter_11:
 
 class Program_weight_tensor_parameter_12:
     name = "parameter_12"
+    original_name = "linear_3.b_0_deepcopy_165"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.0270297")
@@ -143,6 +156,7 @@ class Program_weight_tensor_parameter_12:
 
 class Program_weight_tensor_parameter_13:
     name = "parameter_13"
+    original_name = "linear_3.w_0_deepcopy_164"
     shape = [256, 256]
     dtype = "float32"
     min_val = float("-0.233458")
@@ -154,6 +168,7 @@ class Program_weight_tensor_parameter_13:
 
 class Program_weight_tensor_parameter_14:
     name = "parameter_14"
+    original_name = "layer_norm_4.b_0_deepcopy_161"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.437509")
@@ -165,6 +180,7 @@ class Program_weight_tensor_parameter_14:
 
 class Program_weight_tensor_parameter_15:
     name = "parameter_15"
+    original_name = "layer_norm_4.w_0_deepcopy_160"
     shape = [256]
     dtype = "float32"
     min_val = float("0.509808")
@@ -176,6 +192,7 @@ class Program_weight_tensor_parameter_15:
 
 class Program_weight_tensor_parameter_16:
     name = "parameter_16"
+    original_name = "linear_6.b_0_deepcopy_155"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.172888")
@@ -187,6 +204,7 @@ class Program_weight_tensor_parameter_16:
 
 class Program_weight_tensor_parameter_17:
     name = "parameter_17"
+    original_name = "linear_6.w_0_deepcopy_154"
     shape = [2048, 256]
     dtype = "float32"
     min_val = float("-0.749737")
@@ -198,6 +216,7 @@ class Program_weight_tensor_parameter_17:
 
 class Program_weight_tensor_parameter_18:
     name = "parameter_18"
+    original_name = "linear_5.b_0_deepcopy_153"
     shape = [2048]
     dtype = "float32"
     min_val = float("-0.307084")
@@ -209,6 +228,7 @@ class Program_weight_tensor_parameter_18:
 
 class Program_weight_tensor_parameter_19:
     name = "parameter_19"
+    original_name = "linear_5.w_0_deepcopy_152"
     shape = [256, 2048]
     dtype = "float32"
     min_val = float("-0.645936")
@@ -220,6 +240,7 @@ class Program_weight_tensor_parameter_19:
 
 class Program_weight_tensor_parameter_20:
     name = "parameter_20"
+    original_name = "layer_norm_3.b_0_deepcopy_159"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.42907")
@@ -231,6 +252,7 @@ class Program_weight_tensor_parameter_20:
 
 class Program_weight_tensor_parameter_21:
     name = "parameter_21"
+    original_name = "layer_norm_3.w_0_deepcopy_158"
     shape = [256]
     dtype = "float32"
     min_val = float("0.654022")
@@ -242,6 +264,7 @@ class Program_weight_tensor_parameter_21:
 
 class Program_weight_tensor_parameter_22:
     name = "parameter_22"
+    original_name = "linear_4.b_0_deepcopy_151"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.31666")
@@ -253,6 +276,7 @@ class Program_weight_tensor_parameter_22:
 
 class Program_weight_tensor_parameter_23:
     name = "parameter_23"
+    original_name = "linear_4.w_0_deepcopy_150"
     shape = [256, 256]
     dtype = "float32"
     min_val = float("-0.502922")
@@ -264,6 +288,7 @@ class Program_weight_tensor_parameter_23:
 
 class Program_weight_tensor_parameter_24:
     name = "parameter_24"
+    original_name = "layer_norm_2.b_0_deepcopy_157"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.99306")
@@ -275,6 +300,7 @@ class Program_weight_tensor_parameter_24:
 
 class Program_weight_tensor_parameter_25:
     name = "parameter_25"
+    original_name = "layer_norm_2.w_0_deepcopy_156"
     shape = [256]
     dtype = "float32"
     min_val = float("1.46486")
@@ -286,6 +312,7 @@ class Program_weight_tensor_parameter_25:
 
 class Program_weight_tensor_parameter_26:
     name = "parameter_26"
+    original_name = "linear_3.b_0_deepcopy_147"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.053566")
@@ -297,6 +324,7 @@ class Program_weight_tensor_parameter_26:
 
 class Program_weight_tensor_parameter_27:
     name = "parameter_27"
+    original_name = "linear_3.w_0_deepcopy_146"
     shape = [256, 256]
     dtype = "float32"
     min_val = float("-0.20228")
@@ -308,6 +336,7 @@ class Program_weight_tensor_parameter_27:
 
 class Program_weight_tensor_parameter_28:
     name = "parameter_28"
+    original_name = "layer_norm_4.b_0_deepcopy_143"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.677336")
@@ -319,6 +348,7 @@ class Program_weight_tensor_parameter_28:
 
 class Program_weight_tensor_parameter_29:
     name = "parameter_29"
+    original_name = "layer_norm_4.w_0_deepcopy_142"
     shape = [256]
     dtype = "float32"
     min_val = float("0.560339")
@@ -330,6 +360,7 @@ class Program_weight_tensor_parameter_29:
 
 class Program_weight_tensor_parameter_30:
     name = "parameter_30"
+    original_name = "linear_6.b_0_deepcopy_137"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.255957")
@@ -341,6 +372,7 @@ class Program_weight_tensor_parameter_30:
 
 class Program_weight_tensor_parameter_31:
     name = "parameter_31"
+    original_name = "linear_6.w_0_deepcopy_136"
     shape = [2048, 256]
     dtype = "float32"
     min_val = float("-0.829293")
@@ -352,6 +384,7 @@ class Program_weight_tensor_parameter_31:
 
 class Program_weight_tensor_parameter_32:
     name = "parameter_32"
+    original_name = "linear_5.b_0_deepcopy_135"
     shape = [2048]
     dtype = "float32"
     min_val = float("-0.345106")
@@ -363,6 +396,7 @@ class Program_weight_tensor_parameter_32:
 
 class Program_weight_tensor_parameter_33:
     name = "parameter_33"
+    original_name = "linear_5.w_0_deepcopy_134"
     shape = [256, 2048]
     dtype = "float32"
     min_val = float("-0.597944")
@@ -374,6 +408,7 @@ class Program_weight_tensor_parameter_33:
 
 class Program_weight_tensor_parameter_34:
     name = "parameter_34"
+    original_name = "layer_norm_3.b_0_deepcopy_141"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.46915")
@@ -385,6 +420,7 @@ class Program_weight_tensor_parameter_34:
 
 class Program_weight_tensor_parameter_35:
     name = "parameter_35"
+    original_name = "layer_norm_3.w_0_deepcopy_140"
     shape = [256]
     dtype = "float32"
     min_val = float("0.656565")
@@ -396,6 +432,7 @@ class Program_weight_tensor_parameter_35:
 
 class Program_weight_tensor_parameter_36:
     name = "parameter_36"
+    original_name = "linear_4.b_0_deepcopy_133"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.49468")
@@ -407,6 +444,7 @@ class Program_weight_tensor_parameter_36:
 
 class Program_weight_tensor_parameter_37:
     name = "parameter_37"
+    original_name = "linear_4.w_0_deepcopy_132"
     shape = [256, 256]
     dtype = "float32"
     min_val = float("-0.479399")
@@ -418,6 +456,7 @@ class Program_weight_tensor_parameter_37:
 
 class Program_weight_tensor_parameter_38:
     name = "parameter_38"
+    original_name = "layer_norm_2.b_0_deepcopy_139"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.885259")
@@ -429,6 +468,7 @@ class Program_weight_tensor_parameter_38:
 
 class Program_weight_tensor_parameter_39:
     name = "parameter_39"
+    original_name = "layer_norm_2.w_0_deepcopy_138"
     shape = [256]
     dtype = "float32"
     min_val = float("1.08333")
@@ -440,6 +480,7 @@ class Program_weight_tensor_parameter_39:
 
 class Program_weight_tensor_parameter_40:
     name = "parameter_40"
+    original_name = "linear_3.b_0_deepcopy_129"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.0893112")
@@ -451,6 +492,7 @@ class Program_weight_tensor_parameter_40:
 
 class Program_weight_tensor_parameter_41:
     name = "parameter_41"
+    original_name = "linear_3.w_0_deepcopy_128"
     shape = [256, 256]
     dtype = "float32"
     min_val = float("-0.278605")
@@ -462,6 +504,7 @@ class Program_weight_tensor_parameter_41:
 
 class Program_weight_tensor_parameter_42:
     name = "parameter_42"
+    original_name = "layer_norm_4.b_0_deepcopy_125"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.44724")
@@ -473,6 +516,7 @@ class Program_weight_tensor_parameter_42:
 
 class Program_weight_tensor_parameter_43:
     name = "parameter_43"
+    original_name = "layer_norm_4.w_0_deepcopy_124"
     shape = [256]
     dtype = "float32"
     min_val = float("0.466204")
@@ -484,6 +528,7 @@ class Program_weight_tensor_parameter_43:
 
 class Program_weight_tensor_parameter_44:
     name = "parameter_44"
+    original_name = "linear_6.b_0_deepcopy_119"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.324835")
@@ -495,6 +540,7 @@ class Program_weight_tensor_parameter_44:
 
 class Program_weight_tensor_parameter_45:
     name = "parameter_45"
+    original_name = "linear_6.w_0_deepcopy_118"
     shape = [2048, 256]
     dtype = "float32"
     min_val = float("-0.505099")
@@ -506,6 +552,7 @@ class Program_weight_tensor_parameter_45:
 
 class Program_weight_tensor_parameter_46:
     name = "parameter_46"
+    original_name = "linear_5.b_0_deepcopy_117"
     shape = [2048]
     dtype = "float32"
     min_val = float("-0.327804")
@@ -517,6 +564,7 @@ class Program_weight_tensor_parameter_46:
 
 class Program_weight_tensor_parameter_47:
     name = "parameter_47"
+    original_name = "linear_5.w_0_deepcopy_116"
     shape = [256, 2048]
     dtype = "float32"
     min_val = float("-0.650782")
@@ -528,6 +576,7 @@ class Program_weight_tensor_parameter_47:
 
 class Program_weight_tensor_parameter_48:
     name = "parameter_48"
+    original_name = "layer_norm_3.b_0_deepcopy_123"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.65818")
@@ -539,6 +588,7 @@ class Program_weight_tensor_parameter_48:
 
 class Program_weight_tensor_parameter_49:
     name = "parameter_49"
+    original_name = "layer_norm_3.w_0_deepcopy_122"
     shape = [256]
     dtype = "float32"
     min_val = float("0.628174")
@@ -550,6 +600,7 @@ class Program_weight_tensor_parameter_49:
 
 class Program_weight_tensor_parameter_50:
     name = "parameter_50"
+    original_name = "linear_4.b_0_deepcopy_115"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.581043")
@@ -561,6 +612,7 @@ class Program_weight_tensor_parameter_50:
 
 class Program_weight_tensor_parameter_51:
     name = "parameter_51"
+    original_name = "linear_4.w_0_deepcopy_114"
     shape = [256, 256]
     dtype = "float32"
     min_val = float("-0.50434")
@@ -572,6 +624,7 @@ class Program_weight_tensor_parameter_51:
 
 class Program_weight_tensor_parameter_52:
     name = "parameter_52"
+    original_name = "layer_norm_2.b_0_deepcopy_121"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.912334")
@@ -583,6 +636,7 @@ class Program_weight_tensor_parameter_52:
 
 class Program_weight_tensor_parameter_53:
     name = "parameter_53"
+    original_name = "layer_norm_2.w_0_deepcopy_120"
     shape = [256]
     dtype = "float32"
     min_val = float("0.939834")
@@ -594,6 +648,7 @@ class Program_weight_tensor_parameter_53:
 
 class Program_weight_tensor_parameter_54:
     name = "parameter_54"
+    original_name = "linear_3.b_0_deepcopy_111"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.110461")
@@ -605,6 +660,7 @@ class Program_weight_tensor_parameter_54:
 
 class Program_weight_tensor_parameter_55:
     name = "parameter_55"
+    original_name = "linear_3.w_0_deepcopy_110"
     shape = [256, 256]
     dtype = "float32"
     min_val = float("-0.220587")
@@ -616,6 +672,7 @@ class Program_weight_tensor_parameter_55:
 
 class Program_weight_tensor_parameter_56:
     name = "parameter_56"
+    original_name = "layer_norm_4.b_0_deepcopy_107"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.637754")
@@ -627,6 +684,7 @@ class Program_weight_tensor_parameter_56:
 
 class Program_weight_tensor_parameter_57:
     name = "parameter_57"
+    original_name = "layer_norm_4.w_0_deepcopy_106"
     shape = [256]
     dtype = "float32"
     min_val = float("0.397157")
@@ -638,6 +696,7 @@ class Program_weight_tensor_parameter_57:
 
 class Program_weight_tensor_parameter_58:
     name = "parameter_58"
+    original_name = "linear_6.b_0_deepcopy_101"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.428762")
@@ -649,6 +708,7 @@ class Program_weight_tensor_parameter_58:
 
 class Program_weight_tensor_parameter_59:
     name = "parameter_59"
+    original_name = "linear_6.w_0_deepcopy_100"
     shape = [2048, 256]
     dtype = "float32"
     min_val = float("-0.603618")
@@ -660,6 +720,7 @@ class Program_weight_tensor_parameter_59:
 
 class Program_weight_tensor_parameter_60:
     name = "parameter_60"
+    original_name = "linear_5.b_0_deepcopy_99"
     shape = [2048]
     dtype = "float32"
     min_val = float("-0.375293")
@@ -671,6 +732,7 @@ class Program_weight_tensor_parameter_60:
 
 class Program_weight_tensor_parameter_61:
     name = "parameter_61"
+    original_name = "linear_5.w_0_deepcopy_98"
     shape = [256, 2048]
     dtype = "float32"
     min_val = float("-0.53905")
@@ -682,6 +744,7 @@ class Program_weight_tensor_parameter_61:
 
 class Program_weight_tensor_parameter_62:
     name = "parameter_62"
+    original_name = "layer_norm_3.b_0_deepcopy_105"
     shape = [256]
     dtype = "float32"
     min_val = float("-2.10573")
@@ -693,6 +756,7 @@ class Program_weight_tensor_parameter_62:
 
 class Program_weight_tensor_parameter_63:
     name = "parameter_63"
+    original_name = "layer_norm_3.w_0_deepcopy_104"
     shape = [256]
     dtype = "float32"
     min_val = float("0.531896")
@@ -704,6 +768,7 @@ class Program_weight_tensor_parameter_63:
 
 class Program_weight_tensor_parameter_64:
     name = "parameter_64"
+    original_name = "linear_4.b_0_deepcopy_97"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.543146")
@@ -715,6 +780,7 @@ class Program_weight_tensor_parameter_64:
 
 class Program_weight_tensor_parameter_65:
     name = "parameter_65"
+    original_name = "linear_4.w_0_deepcopy_96"
     shape = [256, 256]
     dtype = "float32"
     min_val = float("-0.584439")
@@ -726,6 +792,7 @@ class Program_weight_tensor_parameter_65:
 
 class Program_weight_tensor_parameter_66:
     name = "parameter_66"
+    original_name = "layer_norm_2.b_0_deepcopy_103"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.960698")
@@ -737,6 +804,7 @@ class Program_weight_tensor_parameter_66:
 
 class Program_weight_tensor_parameter_67:
     name = "parameter_67"
+    original_name = "layer_norm_2.w_0_deepcopy_102"
     shape = [256]
     dtype = "float32"
     min_val = float("0.476036")
@@ -748,6 +816,7 @@ class Program_weight_tensor_parameter_67:
 
 class Program_weight_tensor_parameter_68:
     name = "parameter_68"
+    original_name = "linear_3.b_0_deepcopy_93"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.198888")
@@ -759,6 +828,7 @@ class Program_weight_tensor_parameter_68:
 
 class Program_weight_tensor_parameter_69:
     name = "parameter_69"
+    original_name = "linear_3.w_0_deepcopy_92"
     shape = [256, 256]
     dtype = "float32"
     min_val = float("-0.406782")
@@ -770,6 +840,7 @@ class Program_weight_tensor_parameter_69:
 
 class Program_weight_tensor_parameter_70:
     name = "parameter_70"
+    original_name = "layer_norm_5.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.498012")
@@ -781,6 +852,7 @@ class Program_weight_tensor_parameter_70:
 
 class Program_weight_tensor_parameter_71:
     name = "parameter_71"
+    original_name = "layer_norm_5.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.105142")
@@ -792,6 +864,7 @@ class Program_weight_tensor_parameter_71:
 
 class Program_weight_tensor_parameter_72:
     name = "parameter_72"
+    original_name = "layer_norm_4.b_0_deepcopy_89"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.56306")
@@ -803,6 +876,7 @@ class Program_weight_tensor_parameter_72:
 
 class Program_weight_tensor_parameter_73:
     name = "parameter_73"
+    original_name = "layer_norm_4.w_0_deepcopy_88"
     shape = [256]
     dtype = "float32"
     min_val = float("0.153433")
@@ -814,6 +888,7 @@ class Program_weight_tensor_parameter_73:
 
 class Program_weight_tensor_parameter_74:
     name = "parameter_74"
+    original_name = "linear_6.b_0_deepcopy_83"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.92351")
@@ -825,6 +900,7 @@ class Program_weight_tensor_parameter_74:
 
 class Program_weight_tensor_parameter_75:
     name = "parameter_75"
+    original_name = "linear_6.w_0_deepcopy_82"
     shape = [2048, 256]
     dtype = "float32"
     min_val = float("-0.957782")
@@ -836,6 +912,7 @@ class Program_weight_tensor_parameter_75:
 
 class Program_weight_tensor_parameter_76:
     name = "parameter_76"
+    original_name = "linear_5.b_0_deepcopy_81"
     shape = [2048]
     dtype = "float32"
     min_val = float("-0.281342")
@@ -847,6 +924,7 @@ class Program_weight_tensor_parameter_76:
 
 class Program_weight_tensor_parameter_77:
     name = "parameter_77"
+    original_name = "linear_5.w_0_deepcopy_80"
     shape = [256, 2048]
     dtype = "float32"
     min_val = float("-1.16998")
@@ -858,6 +936,7 @@ class Program_weight_tensor_parameter_77:
 
 class Program_weight_tensor_parameter_78:
     name = "parameter_78"
+    original_name = "layer_norm_3.b_0_deepcopy_87"
     shape = [256]
     dtype = "float32"
     min_val = float("-2.54761")
@@ -869,6 +948,7 @@ class Program_weight_tensor_parameter_78:
 
 class Program_weight_tensor_parameter_79:
     name = "parameter_79"
+    original_name = "layer_norm_3.w_0_deepcopy_86"
     shape = [256]
     dtype = "float32"
     min_val = float("0.43429")
@@ -880,6 +960,7 @@ class Program_weight_tensor_parameter_79:
 
 class Program_weight_tensor_parameter_80:
     name = "parameter_80"
+    original_name = "linear_4.b_0_deepcopy_79"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.572173")
@@ -891,6 +972,7 @@ class Program_weight_tensor_parameter_80:
 
 class Program_weight_tensor_parameter_81:
     name = "parameter_81"
+    original_name = "linear_4.w_0_deepcopy_78"
     shape = [256, 256]
     dtype = "float32"
     min_val = float("-0.972572")
@@ -902,6 +984,7 @@ class Program_weight_tensor_parameter_81:
 
 class Program_weight_tensor_parameter_82:
     name = "parameter_82"
+    original_name = "layer_norm_2.b_0_deepcopy_85"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.12158")
@@ -913,6 +996,7 @@ class Program_weight_tensor_parameter_82:
 
 class Program_weight_tensor_parameter_83:
     name = "parameter_83"
+    original_name = "layer_norm_2.w_0_deepcopy_84"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.0289606")
@@ -924,6 +1008,7 @@ class Program_weight_tensor_parameter_83:
 
 class Program_weight_tensor_parameter_84:
     name = "parameter_84"
+    original_name = "linear_3.b_0_deepcopy_75"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.59156")
@@ -935,6 +1020,7 @@ class Program_weight_tensor_parameter_84:
 
 class Program_weight_tensor_parameter_85:
     name = "parameter_85"
+    original_name = "linear_3.w_0_deepcopy_74"
     shape = [256, 256]
     dtype = "float32"
     min_val = float("-2.14517")
@@ -946,6 +1032,7 @@ class Program_weight_tensor_parameter_85:
 
 class Program_weight_tensor_parameter_86:
     name = "parameter_86"
+    original_name = "layer_norm_1.b_0_deepcopy_71"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.06961")
@@ -957,6 +1044,7 @@ class Program_weight_tensor_parameter_86:
 
 class Program_weight_tensor_parameter_87:
     name = "parameter_87"
+    original_name = "layer_norm_1.w_0_deepcopy_70"
     shape = [256]
     dtype = "float32"
     min_val = float("0.00117219")
@@ -968,6 +1056,7 @@ class Program_weight_tensor_parameter_87:
 
 class Program_weight_tensor_parameter_88:
     name = "parameter_88"
+    original_name = "linear_2.b_0_deepcopy_67"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.18949")
@@ -979,6 +1068,7 @@ class Program_weight_tensor_parameter_88:
 
 class Program_weight_tensor_parameter_89:
     name = "parameter_89"
+    original_name = "linear_2.w_0_deepcopy_66"
     shape = [2048, 256]
     dtype = "float32"
     min_val = float("-1.09642")
@@ -990,6 +1080,7 @@ class Program_weight_tensor_parameter_89:
 
 class Program_weight_tensor_parameter_90:
     name = "parameter_90"
+    original_name = "linear_1.b_0_deepcopy_65"
     shape = [2048]
     dtype = "float32"
     min_val = float("-0.182248")
@@ -1001,6 +1092,7 @@ class Program_weight_tensor_parameter_90:
 
 class Program_weight_tensor_parameter_91:
     name = "parameter_91"
+    original_name = "linear_1.w_0_deepcopy_64"
     shape = [256, 2048]
     dtype = "float32"
     min_val = float("-0.635699")
@@ -1012,6 +1104,7 @@ class Program_weight_tensor_parameter_91:
 
 class Program_weight_tensor_parameter_92:
     name = "parameter_92"
+    original_name = "layer_norm_0.b_0_deepcopy_69"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.50176")
@@ -1023,6 +1116,7 @@ class Program_weight_tensor_parameter_92:
 
 class Program_weight_tensor_parameter_93:
     name = "parameter_93"
+    original_name = "layer_norm_0.w_0_deepcopy_68"
     shape = [256]
     dtype = "float32"
     min_val = float("0.344257")
@@ -1034,6 +1128,7 @@ class Program_weight_tensor_parameter_93:
 
 class Program_weight_tensor_parameter_94:
     name = "parameter_94"
+    original_name = "linear_0.b_0_deepcopy_63"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.224362")
@@ -1045,6 +1140,7 @@ class Program_weight_tensor_parameter_94:
 
 class Program_weight_tensor_parameter_95:
     name = "parameter_95"
+    original_name = "linear_0.w_0_deepcopy_62"
     shape = [256, 256]
     dtype = "float32"
     min_val = float("-0.573256")
@@ -1056,6 +1152,7 @@ class Program_weight_tensor_parameter_95:
 
 class Program_weight_tensor_parameter_96:
     name = "parameter_96"
+    original_name = "layer_norm_1.b_0_deepcopy_59"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.400476")
@@ -1067,6 +1164,7 @@ class Program_weight_tensor_parameter_96:
 
 class Program_weight_tensor_parameter_97:
     name = "parameter_97"
+    original_name = "layer_norm_1.w_0_deepcopy_58"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.0106021")
@@ -1078,6 +1176,7 @@ class Program_weight_tensor_parameter_97:
 
 class Program_weight_tensor_parameter_98:
     name = "parameter_98"
+    original_name = "linear_2.b_0_deepcopy_55"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.380283")
@@ -1089,6 +1188,7 @@ class Program_weight_tensor_parameter_98:
 
 class Program_weight_tensor_parameter_99:
     name = "parameter_99"
+    original_name = "linear_2.w_0_deepcopy_54"
     shape = [2048, 256]
     dtype = "float32"
     min_val = float("-1.42454")
@@ -1100,6 +1200,7 @@ class Program_weight_tensor_parameter_99:
 
 class Program_weight_tensor_parameter_100:
     name = "parameter_100"
+    original_name = "linear_1.b_0_deepcopy_53"
     shape = [2048]
     dtype = "float32"
     min_val = float("-0.168541")
@@ -1111,6 +1212,7 @@ class Program_weight_tensor_parameter_100:
 
 class Program_weight_tensor_parameter_101:
     name = "parameter_101"
+    original_name = "linear_1.w_0_deepcopy_52"
     shape = [256, 2048]
     dtype = "float32"
     min_val = float("-0.672177")
@@ -1122,6 +1224,7 @@ class Program_weight_tensor_parameter_101:
 
 class Program_weight_tensor_parameter_102:
     name = "parameter_102"
+    original_name = "layer_norm_0.b_0_deepcopy_57"
     shape = [256]
     dtype = "float32"
     min_val = float("-2.06637")
@@ -1133,6 +1236,7 @@ class Program_weight_tensor_parameter_102:
 
 class Program_weight_tensor_parameter_103:
     name = "parameter_103"
+    original_name = "layer_norm_0.w_0_deepcopy_56"
     shape = [256]
     dtype = "float32"
     min_val = float("0.09338")
@@ -1144,6 +1248,7 @@ class Program_weight_tensor_parameter_103:
 
 class Program_weight_tensor_parameter_104:
     name = "parameter_104"
+    original_name = "linear_0.b_0_deepcopy_51"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.726799")
@@ -1155,6 +1260,7 @@ class Program_weight_tensor_parameter_104:
 
 class Program_weight_tensor_parameter_105:
     name = "parameter_105"
+    original_name = "linear_0.w_0_deepcopy_50"
     shape = [256, 256]
     dtype = "float32"
     min_val = float("-0.439525")
@@ -1166,6 +1272,7 @@ class Program_weight_tensor_parameter_105:
 
 class Program_weight_tensor_parameter_106:
     name = "parameter_106"
+    original_name = "layer_norm_1.b_0_deepcopy_47"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.753734")
@@ -1177,6 +1284,7 @@ class Program_weight_tensor_parameter_106:
 
 class Program_weight_tensor_parameter_107:
     name = "parameter_107"
+    original_name = "layer_norm_1.w_0_deepcopy_46"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.0042221")
@@ -1188,6 +1296,7 @@ class Program_weight_tensor_parameter_107:
 
 class Program_weight_tensor_parameter_108:
     name = "parameter_108"
+    original_name = "linear_2.b_0_deepcopy_43"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.512378")
@@ -1199,6 +1308,7 @@ class Program_weight_tensor_parameter_108:
 
 class Program_weight_tensor_parameter_109:
     name = "parameter_109"
+    original_name = "linear_2.w_0_deepcopy_42"
     shape = [2048, 256]
     dtype = "float32"
     min_val = float("-1.47297")
@@ -1210,6 +1320,7 @@ class Program_weight_tensor_parameter_109:
 
 class Program_weight_tensor_parameter_110:
     name = "parameter_110"
+    original_name = "linear_1.b_0_deepcopy_41"
     shape = [2048]
     dtype = "float32"
     min_val = float("-0.157579")
@@ -1221,6 +1332,7 @@ class Program_weight_tensor_parameter_110:
 
 class Program_weight_tensor_parameter_111:
     name = "parameter_111"
+    original_name = "linear_1.w_0_deepcopy_40"
     shape = [256, 2048]
     dtype = "float32"
     min_val = float("-0.559903")
@@ -1232,6 +1344,7 @@ class Program_weight_tensor_parameter_111:
 
 class Program_weight_tensor_parameter_112:
     name = "parameter_112"
+    original_name = "layer_norm_0.b_0_deepcopy_45"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.91219")
@@ -1243,6 +1356,7 @@ class Program_weight_tensor_parameter_112:
 
 class Program_weight_tensor_parameter_113:
     name = "parameter_113"
+    original_name = "layer_norm_0.w_0_deepcopy_44"
     shape = [256]
     dtype = "float32"
     min_val = float("0.1281")
@@ -1254,6 +1368,7 @@ class Program_weight_tensor_parameter_113:
 
 class Program_weight_tensor_parameter_114:
     name = "parameter_114"
+    original_name = "linear_0.b_0_deepcopy_39"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.806181")
@@ -1265,6 +1380,7 @@ class Program_weight_tensor_parameter_114:
 
 class Program_weight_tensor_parameter_115:
     name = "parameter_115"
+    original_name = "linear_0.w_0_deepcopy_38"
     shape = [256, 256]
     dtype = "float32"
     min_val = float("-0.588744")
@@ -1276,6 +1392,7 @@ class Program_weight_tensor_parameter_115:
 
 class Program_weight_tensor_parameter_116:
     name = "parameter_116"
+    original_name = "layer_norm_1.b_0_deepcopy_35"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.00989")
@@ -1287,6 +1404,7 @@ class Program_weight_tensor_parameter_116:
 
 class Program_weight_tensor_parameter_117:
     name = "parameter_117"
+    original_name = "layer_norm_1.w_0_deepcopy_34"
     shape = [256]
     dtype = "float32"
     min_val = float("0.00390956")
@@ -1298,6 +1416,7 @@ class Program_weight_tensor_parameter_117:
 
 class Program_weight_tensor_parameter_118:
     name = "parameter_118"
+    original_name = "linear_2.b_0_deepcopy_31"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.587601")
@@ -1309,6 +1428,7 @@ class Program_weight_tensor_parameter_118:
 
 class Program_weight_tensor_parameter_119:
     name = "parameter_119"
+    original_name = "linear_2.w_0_deepcopy_30"
     shape = [2048, 256]
     dtype = "float32"
     min_val = float("-1.27436")
@@ -1320,6 +1440,7 @@ class Program_weight_tensor_parameter_119:
 
 class Program_weight_tensor_parameter_120:
     name = "parameter_120"
+    original_name = "linear_1.b_0_deepcopy_29"
     shape = [2048]
     dtype = "float32"
     min_val = float("-0.174539")
@@ -1331,6 +1452,7 @@ class Program_weight_tensor_parameter_120:
 
 class Program_weight_tensor_parameter_121:
     name = "parameter_121"
+    original_name = "linear_1.w_0_deepcopy_28"
     shape = [256, 2048]
     dtype = "float32"
     min_val = float("-0.689368")
@@ -1342,6 +1464,7 @@ class Program_weight_tensor_parameter_121:
 
 class Program_weight_tensor_parameter_122:
     name = "parameter_122"
+    original_name = "layer_norm_0.b_0_deepcopy_33"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.76535")
@@ -1353,6 +1476,7 @@ class Program_weight_tensor_parameter_122:
 
 class Program_weight_tensor_parameter_123:
     name = "parameter_123"
+    original_name = "layer_norm_0.w_0_deepcopy_32"
     shape = [256]
     dtype = "float32"
     min_val = float("0.232512")
@@ -1364,6 +1488,7 @@ class Program_weight_tensor_parameter_123:
 
 class Program_weight_tensor_parameter_124:
     name = "parameter_124"
+    original_name = "linear_0.b_0_deepcopy_27"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.705961")
@@ -1375,6 +1500,7 @@ class Program_weight_tensor_parameter_124:
 
 class Program_weight_tensor_parameter_125:
     name = "parameter_125"
+    original_name = "linear_0.w_0_deepcopy_26"
     shape = [256, 256]
     dtype = "float32"
     min_val = float("-0.440233")
@@ -1386,6 +1512,7 @@ class Program_weight_tensor_parameter_125:
 
 class Program_weight_tensor_parameter_126:
     name = "parameter_126"
+    original_name = "layer_norm_1.b_0_deepcopy_23"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.922987")
@@ -1397,6 +1524,7 @@ class Program_weight_tensor_parameter_126:
 
 class Program_weight_tensor_parameter_127:
     name = "parameter_127"
+    original_name = "layer_norm_1.w_0_deepcopy_22"
     shape = [256]
     dtype = "float32"
     min_val = float("0.00548535")
@@ -1408,6 +1536,7 @@ class Program_weight_tensor_parameter_127:
 
 class Program_weight_tensor_parameter_128:
     name = "parameter_128"
+    original_name = "linear_2.b_0_deepcopy_19"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.704669")
@@ -1419,6 +1548,7 @@ class Program_weight_tensor_parameter_128:
 
 class Program_weight_tensor_parameter_129:
     name = "parameter_129"
+    original_name = "linear_2.w_0_deepcopy_18"
     shape = [2048, 256]
     dtype = "float32"
     min_val = float("-1.67542")
@@ -1430,6 +1560,7 @@ class Program_weight_tensor_parameter_129:
 
 class Program_weight_tensor_parameter_130:
     name = "parameter_130"
+    original_name = "linear_1.b_0_deepcopy_17"
     shape = [2048]
     dtype = "float32"
     min_val = float("-0.157592")
@@ -1441,6 +1572,7 @@ class Program_weight_tensor_parameter_130:
 
 class Program_weight_tensor_parameter_131:
     name = "parameter_131"
+    original_name = "linear_1.w_0_deepcopy_16"
     shape = [256, 2048]
     dtype = "float32"
     min_val = float("-0.724592")
@@ -1452,6 +1584,7 @@ class Program_weight_tensor_parameter_131:
 
 class Program_weight_tensor_parameter_132:
     name = "parameter_132"
+    original_name = "layer_norm_0.b_0_deepcopy_21"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.83753")
@@ -1463,6 +1596,7 @@ class Program_weight_tensor_parameter_132:
 
 class Program_weight_tensor_parameter_133:
     name = "parameter_133"
+    original_name = "layer_norm_0.w_0_deepcopy_20"
     shape = [256]
     dtype = "float32"
     min_val = float("0.231114")
@@ -1474,6 +1608,7 @@ class Program_weight_tensor_parameter_133:
 
 class Program_weight_tensor_parameter_134:
     name = "parameter_134"
+    original_name = "linear_0.b_0_deepcopy_15"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.725201")
@@ -1485,6 +1620,7 @@ class Program_weight_tensor_parameter_134:
 
 class Program_weight_tensor_parameter_135:
     name = "parameter_135"
+    original_name = "linear_0.w_0_deepcopy_14"
     shape = [256, 256]
     dtype = "float32"
     min_val = float("-0.412943")
@@ -1496,6 +1632,7 @@ class Program_weight_tensor_parameter_135:
 
 class Program_weight_tensor_parameter_136:
     name = "parameter_136"
+    original_name = "layer_norm_1.b_0_deepcopy_11"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.800024")
@@ -1507,6 +1644,7 @@ class Program_weight_tensor_parameter_136:
 
 class Program_weight_tensor_parameter_137:
     name = "parameter_137"
+    original_name = "layer_norm_1.w_0_deepcopy_10"
     shape = [256]
     dtype = "float32"
     min_val = float("0.187009")
@@ -1518,6 +1656,7 @@ class Program_weight_tensor_parameter_137:
 
 class Program_weight_tensor_parameter_138:
     name = "parameter_138"
+    original_name = "linear_2.b_0_deepcopy_7"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.461249")
@@ -1529,6 +1668,7 @@ class Program_weight_tensor_parameter_138:
 
 class Program_weight_tensor_parameter_139:
     name = "parameter_139"
+    original_name = "linear_2.w_0_deepcopy_6"
     shape = [2048, 256]
     dtype = "float32"
     min_val = float("-1.5039")
@@ -1540,6 +1680,7 @@ class Program_weight_tensor_parameter_139:
 
 class Program_weight_tensor_parameter_140:
     name = "parameter_140"
+    original_name = "linear_1.b_0_deepcopy_5"
     shape = [2048]
     dtype = "float32"
     min_val = float("-0.174725")
@@ -1551,6 +1692,7 @@ class Program_weight_tensor_parameter_140:
 
 class Program_weight_tensor_parameter_141:
     name = "parameter_141"
+    original_name = "linear_1.w_0_deepcopy_4"
     shape = [256, 2048]
     dtype = "float32"
     min_val = float("-0.664555")
@@ -1562,6 +1704,7 @@ class Program_weight_tensor_parameter_141:
 
 class Program_weight_tensor_parameter_142:
     name = "parameter_142"
+    original_name = "layer_norm_0.b_0_deepcopy_9"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.50014")
@@ -1573,6 +1716,7 @@ class Program_weight_tensor_parameter_142:
 
 class Program_weight_tensor_parameter_143:
     name = "parameter_143"
+    original_name = "layer_norm_0.w_0_deepcopy_8"
     shape = [256]
     dtype = "float32"
     min_val = float("0.437227")
@@ -1584,6 +1728,7 @@ class Program_weight_tensor_parameter_143:
 
 class Program_weight_tensor_parameter_144:
     name = "parameter_144"
+    original_name = "linear_0.b_0_deepcopy_3"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.798674")
@@ -1595,6 +1740,7 @@ class Program_weight_tensor_parameter_144:
 
 class Program_weight_tensor_parameter_145:
     name = "parameter_145"
+    original_name = "linear_0.w_0_deepcopy_2"
     shape = [256, 256]
     dtype = "float32"
     min_val = float("-0.583947")
@@ -1606,6 +1752,7 @@ class Program_weight_tensor_parameter_145:
 
 class Program_weight_tensor_parameter_146:
     name = "parameter_146"
+    original_name = "conv2d_53.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.344535")
@@ -1617,6 +1764,7 @@ class Program_weight_tensor_parameter_146:
 
 class Program_weight_tensor_parameter_147:
     name = "parameter_147"
+    original_name = "conv2d_53.w_0"
     shape = [256, 2048, 1, 1]
     dtype = "float32"
     min_val = float("-1.03344")
@@ -1628,6 +1776,7 @@ class Program_weight_tensor_parameter_147:
 
 class Program_weight_tensor_parameter_148:
     name = "parameter_148"
+    original_name = "batch_norm2d_52.b_0"
     shape = [2048]
     dtype = "float32"
     min_val = float("-0.150417")
@@ -1639,6 +1788,7 @@ class Program_weight_tensor_parameter_148:
 
 class Program_weight_tensor_parameter_149:
     name = "parameter_149"
+    original_name = "batch_norm2d_52.w_0"
     shape = [2048]
     dtype = "float32"
     min_val = float("0.112357")
@@ -1650,6 +1800,7 @@ class Program_weight_tensor_parameter_149:
 
 class Program_weight_tensor_parameter_150:
     name = "parameter_150"
+    original_name = "batch_norm2d_52.w_2"
     shape = [2048]
     dtype = "float32"
     min_val = float("4.58401e-05")
@@ -1661,6 +1812,7 @@ class Program_weight_tensor_parameter_150:
 
 class Program_weight_tensor_parameter_151:
     name = "parameter_151"
+    original_name = "batch_norm2d_52.w_1"
     shape = [2048]
     dtype = "float32"
     min_val = float("-0.0298089")
@@ -1672,6 +1824,7 @@ class Program_weight_tensor_parameter_151:
 
 class Program_weight_tensor_parameter_152:
     name = "parameter_152"
+    original_name = "conv2d_52.w_0"
     shape = [2048, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.152876")
@@ -1683,6 +1836,7 @@ class Program_weight_tensor_parameter_152:
 
 class Program_weight_tensor_parameter_153:
     name = "parameter_153"
+    original_name = "batch_norm2d_51.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.293918")
@@ -1694,6 +1848,7 @@ class Program_weight_tensor_parameter_153:
 
 class Program_weight_tensor_parameter_154:
     name = "parameter_154"
+    original_name = "batch_norm2d_51.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("0.134363")
@@ -1705,6 +1860,7 @@ class Program_weight_tensor_parameter_154:
 
 class Program_weight_tensor_parameter_155:
     name = "parameter_155"
+    original_name = "batch_norm2d_51.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("0.00773641")
@@ -1716,6 +1872,7 @@ class Program_weight_tensor_parameter_155:
 
 class Program_weight_tensor_parameter_156:
     name = "parameter_156"
+    original_name = "batch_norm2d_51.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.148122")
@@ -1727,6 +1884,7 @@ class Program_weight_tensor_parameter_156:
 
 class Program_weight_tensor_parameter_157:
     name = "parameter_157"
+    original_name = "conv2d_51.w_0"
     shape = [512, 512, 3, 3]
     dtype = "float32"
     min_val = float("-0.166308")
@@ -1738,6 +1896,7 @@ class Program_weight_tensor_parameter_157:
 
 class Program_weight_tensor_parameter_158:
     name = "parameter_158"
+    original_name = "batch_norm2d_50.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.334689")
@@ -1749,6 +1908,7 @@ class Program_weight_tensor_parameter_158:
 
 class Program_weight_tensor_parameter_159:
     name = "parameter_159"
+    original_name = "batch_norm2d_50.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("0.112843")
@@ -1760,6 +1920,7 @@ class Program_weight_tensor_parameter_159:
 
 class Program_weight_tensor_parameter_160:
     name = "parameter_160"
+    original_name = "batch_norm2d_50.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("0.189317")
@@ -1771,6 +1932,7 @@ class Program_weight_tensor_parameter_160:
 
 class Program_weight_tensor_parameter_161:
     name = "parameter_161"
+    original_name = "batch_norm2d_50.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.987256")
@@ -1782,6 +1944,7 @@ class Program_weight_tensor_parameter_161:
 
 class Program_weight_tensor_parameter_162:
     name = "parameter_162"
+    original_name = "conv2d_50.w_0"
     shape = [512, 2048, 1, 1]
     dtype = "float32"
     min_val = float("-0.362403")
@@ -1793,6 +1956,7 @@ class Program_weight_tensor_parameter_162:
 
 class Program_weight_tensor_parameter_163:
     name = "parameter_163"
+    original_name = "batch_norm2d_49.b_0"
     shape = [2048]
     dtype = "float32"
     min_val = float("-0.21598")
@@ -1804,6 +1968,7 @@ class Program_weight_tensor_parameter_163:
 
 class Program_weight_tensor_parameter_164:
     name = "parameter_164"
+    original_name = "batch_norm2d_49.w_0"
     shape = [2048]
     dtype = "float32"
     min_val = float("0.129696")
@@ -1815,6 +1980,7 @@ class Program_weight_tensor_parameter_164:
 
 class Program_weight_tensor_parameter_165:
     name = "parameter_165"
+    original_name = "batch_norm2d_49.w_2"
     shape = [2048]
     dtype = "float32"
     min_val = float("0.000190455")
@@ -1826,6 +1992,7 @@ class Program_weight_tensor_parameter_165:
 
 class Program_weight_tensor_parameter_166:
     name = "parameter_166"
+    original_name = "batch_norm2d_49.w_1"
     shape = [2048]
     dtype = "float32"
     min_val = float("-0.156046")
@@ -1837,6 +2004,7 @@ class Program_weight_tensor_parameter_166:
 
 class Program_weight_tensor_parameter_167:
     name = "parameter_167"
+    original_name = "conv2d_49.w_0"
     shape = [2048, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.187602")
@@ -1848,6 +2016,7 @@ class Program_weight_tensor_parameter_167:
 
 class Program_weight_tensor_parameter_168:
     name = "parameter_168"
+    original_name = "batch_norm2d_48.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.347685")
@@ -1859,6 +2028,7 @@ class Program_weight_tensor_parameter_168:
 
 class Program_weight_tensor_parameter_169:
     name = "parameter_169"
+    original_name = "batch_norm2d_48.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("0.147304")
@@ -1870,6 +2040,7 @@ class Program_weight_tensor_parameter_169:
 
 class Program_weight_tensor_parameter_170:
     name = "parameter_170"
+    original_name = "batch_norm2d_48.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("0.00819833")
@@ -1881,6 +2052,7 @@ class Program_weight_tensor_parameter_170:
 
 class Program_weight_tensor_parameter_171:
     name = "parameter_171"
+    original_name = "batch_norm2d_48.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.37926")
@@ -1892,6 +2064,7 @@ class Program_weight_tensor_parameter_171:
 
 class Program_weight_tensor_parameter_172:
     name = "parameter_172"
+    original_name = "conv2d_48.w_0"
     shape = [512, 512, 3, 3]
     dtype = "float32"
     min_val = float("-0.242766")
@@ -1903,6 +2076,7 @@ class Program_weight_tensor_parameter_172:
 
 class Program_weight_tensor_parameter_173:
     name = "parameter_173"
+    original_name = "batch_norm2d_47.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.319738")
@@ -1914,6 +2088,7 @@ class Program_weight_tensor_parameter_173:
 
 class Program_weight_tensor_parameter_174:
     name = "parameter_174"
+    original_name = "batch_norm2d_47.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("0.0941531")
@@ -1925,6 +2100,7 @@ class Program_weight_tensor_parameter_174:
 
 class Program_weight_tensor_parameter_175:
     name = "parameter_175"
+    original_name = "batch_norm2d_47.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("0.0888968")
@@ -1936,6 +2112,7 @@ class Program_weight_tensor_parameter_175:
 
 class Program_weight_tensor_parameter_176:
     name = "parameter_176"
+    original_name = "batch_norm2d_47.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.878403")
@@ -1947,6 +2124,7 @@ class Program_weight_tensor_parameter_176:
 
 class Program_weight_tensor_parameter_177:
     name = "parameter_177"
+    original_name = "conv2d_47.w_0"
     shape = [512, 2048, 1, 1]
     dtype = "float32"
     min_val = float("-0.389196")
@@ -1958,6 +2136,7 @@ class Program_weight_tensor_parameter_177:
 
 class Program_weight_tensor_parameter_178:
     name = "parameter_178"
+    original_name = "batch_norm2d_46.b_0"
     shape = [2048]
     dtype = "float32"
     min_val = float("-0.140877")
@@ -1969,6 +2148,7 @@ class Program_weight_tensor_parameter_178:
 
 class Program_weight_tensor_parameter_179:
     name = "parameter_179"
+    original_name = "batch_norm2d_46.w_0"
     shape = [2048]
     dtype = "float32"
     min_val = float("0.11185")
@@ -1980,6 +2160,7 @@ class Program_weight_tensor_parameter_179:
 
 class Program_weight_tensor_parameter_180:
     name = "parameter_180"
+    original_name = "batch_norm2d_46.w_2"
     shape = [2048]
     dtype = "float32"
     min_val = float("0.00030292")
@@ -1991,6 +2172,7 @@ class Program_weight_tensor_parameter_180:
 
 class Program_weight_tensor_parameter_181:
     name = "parameter_181"
+    original_name = "batch_norm2d_46.w_1"
     shape = [2048]
     dtype = "float32"
     min_val = float("-0.0978358")
@@ -2002,6 +2184,7 @@ class Program_weight_tensor_parameter_181:
 
 class Program_weight_tensor_parameter_182:
     name = "parameter_182"
+    original_name = "conv2d_46.w_0"
     shape = [2048, 1024, 1, 1]
     dtype = "float32"
     min_val = float("-0.365452")
@@ -2013,6 +2196,7 @@ class Program_weight_tensor_parameter_182:
 
 class Program_weight_tensor_parameter_183:
     name = "parameter_183"
+    original_name = "batch_norm2d_45.b_0"
     shape = [2048]
     dtype = "float32"
     min_val = float("-0.140877")
@@ -2024,6 +2208,7 @@ class Program_weight_tensor_parameter_183:
 
 class Program_weight_tensor_parameter_184:
     name = "parameter_184"
+    original_name = "batch_norm2d_45.w_0"
     shape = [2048]
     dtype = "float32"
     min_val = float("0.0343876")
@@ -2035,6 +2220,7 @@ class Program_weight_tensor_parameter_184:
 
 class Program_weight_tensor_parameter_185:
     name = "parameter_185"
+    original_name = "batch_norm2d_45.w_2"
     shape = [2048]
     dtype = "float32"
     min_val = float("0.000190366")
@@ -2046,6 +2232,7 @@ class Program_weight_tensor_parameter_185:
 
 class Program_weight_tensor_parameter_186:
     name = "parameter_186"
+    original_name = "batch_norm2d_45.w_1"
     shape = [2048]
     dtype = "float32"
     min_val = float("-0.124208")
@@ -2057,6 +2244,7 @@ class Program_weight_tensor_parameter_186:
 
 class Program_weight_tensor_parameter_187:
     name = "parameter_187"
+    original_name = "conv2d_45.w_0"
     shape = [2048, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.232874")
@@ -2068,6 +2256,7 @@ class Program_weight_tensor_parameter_187:
 
 class Program_weight_tensor_parameter_188:
     name = "parameter_188"
+    original_name = "batch_norm2d_44.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.187468")
@@ -2079,6 +2268,7 @@ class Program_weight_tensor_parameter_188:
 
 class Program_weight_tensor_parameter_189:
     name = "parameter_189"
+    original_name = "batch_norm2d_44.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("0.14926")
@@ -2090,6 +2280,7 @@ class Program_weight_tensor_parameter_189:
 
 class Program_weight_tensor_parameter_190:
     name = "parameter_190"
+    original_name = "batch_norm2d_44.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("0.00845713")
@@ -2101,6 +2292,7 @@ class Program_weight_tensor_parameter_190:
 
 class Program_weight_tensor_parameter_191:
     name = "parameter_191"
+    original_name = "batch_norm2d_44.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.14583")
@@ -2112,6 +2304,7 @@ class Program_weight_tensor_parameter_191:
 
 class Program_weight_tensor_parameter_192:
     name = "parameter_192"
+    original_name = "conv2d_44.w_0"
     shape = [512, 512, 3, 3]
     dtype = "float32"
     min_val = float("-0.355212")
@@ -2123,6 +2316,7 @@ class Program_weight_tensor_parameter_192:
 
 class Program_weight_tensor_parameter_193:
     name = "parameter_193"
+    original_name = "batch_norm2d_43.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.350172")
@@ -2134,6 +2328,7 @@ class Program_weight_tensor_parameter_193:
 
 class Program_weight_tensor_parameter_194:
     name = "parameter_194"
+    original_name = "batch_norm2d_43.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("0.106705")
@@ -2145,6 +2340,7 @@ class Program_weight_tensor_parameter_194:
 
 class Program_weight_tensor_parameter_195:
     name = "parameter_195"
+    original_name = "batch_norm2d_43.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("0.00811289")
@@ -2156,6 +2352,7 @@ class Program_weight_tensor_parameter_195:
 
 class Program_weight_tensor_parameter_196:
     name = "parameter_196"
+    original_name = "batch_norm2d_43.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.20864")
@@ -2167,6 +2364,7 @@ class Program_weight_tensor_parameter_196:
 
 class Program_weight_tensor_parameter_197:
     name = "parameter_197"
+    original_name = "conv2d_43.w_0"
     shape = [512, 1024, 1, 1]
     dtype = "float32"
     min_val = float("-0.355225")
@@ -2178,6 +2376,7 @@ class Program_weight_tensor_parameter_197:
 
 class Program_weight_tensor_parameter_198:
     name = "parameter_198"
+    original_name = "batch_norm2d_42.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.370779")
@@ -2189,6 +2388,7 @@ class Program_weight_tensor_parameter_198:
 
 class Program_weight_tensor_parameter_199:
     name = "parameter_199"
+    original_name = "batch_norm2d_42.w_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.0664216")
@@ -2200,6 +2400,7 @@ class Program_weight_tensor_parameter_199:
 
 class Program_weight_tensor_parameter_200:
     name = "parameter_200"
+    original_name = "batch_norm2d_42.w_2"
     shape = [1024]
     dtype = "float32"
     min_val = float("0.000187986")
@@ -2211,6 +2412,7 @@ class Program_weight_tensor_parameter_200:
 
 class Program_weight_tensor_parameter_201:
     name = "parameter_201"
+    original_name = "batch_norm2d_42.w_1"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.112668")
@@ -2222,6 +2424,7 @@ class Program_weight_tensor_parameter_201:
 
 class Program_weight_tensor_parameter_202:
     name = "parameter_202"
+    original_name = "conv2d_42.w_0"
     shape = [1024, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.274568")
@@ -2233,6 +2436,7 @@ class Program_weight_tensor_parameter_202:
 
 class Program_weight_tensor_parameter_203:
     name = "parameter_203"
+    original_name = "batch_norm2d_41.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.399307")
@@ -2244,6 +2448,7 @@ class Program_weight_tensor_parameter_203:
 
 class Program_weight_tensor_parameter_204:
     name = "parameter_204"
+    original_name = "batch_norm2d_41.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.124237")
@@ -2255,6 +2460,7 @@ class Program_weight_tensor_parameter_204:
 
 class Program_weight_tensor_parameter_205:
     name = "parameter_205"
+    original_name = "batch_norm2d_41.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.00573658")
@@ -2266,6 +2472,7 @@ class Program_weight_tensor_parameter_205:
 
 class Program_weight_tensor_parameter_206:
     name = "parameter_206"
+    original_name = "batch_norm2d_41.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.223885")
@@ -2277,6 +2484,7 @@ class Program_weight_tensor_parameter_206:
 
 class Program_weight_tensor_parameter_207:
     name = "parameter_207"
+    original_name = "conv2d_41.w_0"
     shape = [256, 256, 3, 3]
     dtype = "float32"
     min_val = float("-0.230977")
@@ -2288,6 +2496,7 @@ class Program_weight_tensor_parameter_207:
 
 class Program_weight_tensor_parameter_208:
     name = "parameter_208"
+    original_name = "batch_norm2d_40.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.314365")
@@ -2299,6 +2508,7 @@ class Program_weight_tensor_parameter_208:
 
 class Program_weight_tensor_parameter_209:
     name = "parameter_209"
+    original_name = "batch_norm2d_40.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.0896673")
@@ -2310,6 +2520,7 @@ class Program_weight_tensor_parameter_209:
 
 class Program_weight_tensor_parameter_210:
     name = "parameter_210"
+    original_name = "batch_norm2d_40.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.00800373")
@@ -2321,6 +2532,7 @@ class Program_weight_tensor_parameter_210:
 
 class Program_weight_tensor_parameter_211:
     name = "parameter_211"
+    original_name = "batch_norm2d_40.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.183551")
@@ -2332,6 +2544,7 @@ class Program_weight_tensor_parameter_211:
 
 class Program_weight_tensor_parameter_212:
     name = "parameter_212"
+    original_name = "conv2d_40.w_0"
     shape = [256, 1024, 1, 1]
     dtype = "float32"
     min_val = float("-0.230979")
@@ -2343,6 +2556,7 @@ class Program_weight_tensor_parameter_212:
 
 class Program_weight_tensor_parameter_213:
     name = "parameter_213"
+    original_name = "batch_norm2d_39.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.316103")
@@ -2354,6 +2568,7 @@ class Program_weight_tensor_parameter_213:
 
 class Program_weight_tensor_parameter_214:
     name = "parameter_214"
+    original_name = "batch_norm2d_39.w_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.048939")
@@ -2365,6 +2580,7 @@ class Program_weight_tensor_parameter_214:
 
 class Program_weight_tensor_parameter_215:
     name = "parameter_215"
+    original_name = "batch_norm2d_39.w_2"
     shape = [1024]
     dtype = "float32"
     min_val = float("7.44126e-05")
@@ -2376,6 +2592,7 @@ class Program_weight_tensor_parameter_215:
 
 class Program_weight_tensor_parameter_216:
     name = "parameter_216"
+    original_name = "batch_norm2d_39.w_1"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.102078")
@@ -2387,6 +2604,7 @@ class Program_weight_tensor_parameter_216:
 
 class Program_weight_tensor_parameter_217:
     name = "parameter_217"
+    original_name = "conv2d_39.w_0"
     shape = [1024, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.223261")
@@ -2398,6 +2616,7 @@ class Program_weight_tensor_parameter_217:
 
 class Program_weight_tensor_parameter_218:
     name = "parameter_218"
+    original_name = "batch_norm2d_38.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.329938")
@@ -2409,6 +2628,7 @@ class Program_weight_tensor_parameter_218:
 
 class Program_weight_tensor_parameter_219:
     name = "parameter_219"
+    original_name = "batch_norm2d_38.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.0993624")
@@ -2420,6 +2640,7 @@ class Program_weight_tensor_parameter_219:
 
 class Program_weight_tensor_parameter_220:
     name = "parameter_220"
+    original_name = "batch_norm2d_38.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.00524586")
@@ -2431,6 +2652,7 @@ class Program_weight_tensor_parameter_220:
 
 class Program_weight_tensor_parameter_221:
     name = "parameter_221"
+    original_name = "batch_norm2d_38.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.214452")
@@ -2442,6 +2664,7 @@ class Program_weight_tensor_parameter_221:
 
 class Program_weight_tensor_parameter_222:
     name = "parameter_222"
+    original_name = "conv2d_38.w_0"
     shape = [256, 256, 3, 3]
     dtype = "float32"
     min_val = float("-0.198759")
@@ -2453,6 +2676,7 @@ class Program_weight_tensor_parameter_222:
 
 class Program_weight_tensor_parameter_223:
     name = "parameter_223"
+    original_name = "batch_norm2d_37.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.324492")
@@ -2464,6 +2688,7 @@ class Program_weight_tensor_parameter_223:
 
 class Program_weight_tensor_parameter_224:
     name = "parameter_224"
+    original_name = "batch_norm2d_37.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.0949062")
@@ -2475,6 +2700,7 @@ class Program_weight_tensor_parameter_224:
 
 class Program_weight_tensor_parameter_225:
     name = "parameter_225"
+    original_name = "batch_norm2d_37.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.00832382")
@@ -2486,6 +2712,7 @@ class Program_weight_tensor_parameter_225:
 
 class Program_weight_tensor_parameter_226:
     name = "parameter_226"
+    original_name = "batch_norm2d_37.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.241107")
@@ -2497,6 +2724,7 @@ class Program_weight_tensor_parameter_226:
 
 class Program_weight_tensor_parameter_227:
     name = "parameter_227"
+    original_name = "conv2d_37.w_0"
     shape = [256, 1024, 1, 1]
     dtype = "float32"
     min_val = float("-0.214365")
@@ -2508,6 +2736,7 @@ class Program_weight_tensor_parameter_227:
 
 class Program_weight_tensor_parameter_228:
     name = "parameter_228"
+    original_name = "batch_norm2d_36.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.225174")
@@ -2519,6 +2748,7 @@ class Program_weight_tensor_parameter_228:
 
 class Program_weight_tensor_parameter_229:
     name = "parameter_229"
+    original_name = "batch_norm2d_36.w_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.0301997")
@@ -2530,6 +2760,7 @@ class Program_weight_tensor_parameter_229:
 
 class Program_weight_tensor_parameter_230:
     name = "parameter_230"
+    original_name = "batch_norm2d_36.w_2"
     shape = [1024]
     dtype = "float32"
     min_val = float("3.12528e-11")
@@ -2541,6 +2772,7 @@ class Program_weight_tensor_parameter_230:
 
 class Program_weight_tensor_parameter_231:
     name = "parameter_231"
+    original_name = "batch_norm2d_36.w_1"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.0749364")
@@ -2552,6 +2784,7 @@ class Program_weight_tensor_parameter_231:
 
 class Program_weight_tensor_parameter_232:
     name = "parameter_232"
+    original_name = "conv2d_36.w_0"
     shape = [1024, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.249474")
@@ -2563,6 +2796,7 @@ class Program_weight_tensor_parameter_232:
 
 class Program_weight_tensor_parameter_233:
     name = "parameter_233"
+    original_name = "batch_norm2d_35.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.208314")
@@ -2574,6 +2808,7 @@ class Program_weight_tensor_parameter_233:
 
 class Program_weight_tensor_parameter_234:
     name = "parameter_234"
+    original_name = "batch_norm2d_35.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.0967561")
@@ -2585,6 +2820,7 @@ class Program_weight_tensor_parameter_234:
 
 class Program_weight_tensor_parameter_235:
     name = "parameter_235"
+    original_name = "batch_norm2d_35.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.00534462")
@@ -2596,6 +2832,7 @@ class Program_weight_tensor_parameter_235:
 
 class Program_weight_tensor_parameter_236:
     name = "parameter_236"
+    original_name = "batch_norm2d_35.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.162661")
@@ -2607,6 +2844,7 @@ class Program_weight_tensor_parameter_236:
 
 class Program_weight_tensor_parameter_237:
     name = "parameter_237"
+    original_name = "conv2d_35.w_0"
     shape = [256, 256, 3, 3]
     dtype = "float32"
     min_val = float("-0.173493")
@@ -2618,6 +2856,7 @@ class Program_weight_tensor_parameter_237:
 
 class Program_weight_tensor_parameter_238:
     name = "parameter_238"
+    original_name = "batch_norm2d_34.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.259401")
@@ -2629,6 +2868,7 @@ class Program_weight_tensor_parameter_238:
 
 class Program_weight_tensor_parameter_239:
     name = "parameter_239"
+    original_name = "batch_norm2d_34.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.0953832")
@@ -2640,6 +2880,7 @@ class Program_weight_tensor_parameter_239:
 
 class Program_weight_tensor_parameter_240:
     name = "parameter_240"
+    original_name = "batch_norm2d_34.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.00862938")
@@ -2651,6 +2892,7 @@ class Program_weight_tensor_parameter_240:
 
 class Program_weight_tensor_parameter_241:
     name = "parameter_241"
+    original_name = "batch_norm2d_34.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.262802")
@@ -2662,6 +2904,7 @@ class Program_weight_tensor_parameter_241:
 
 class Program_weight_tensor_parameter_242:
     name = "parameter_242"
+    original_name = "conv2d_34.w_0"
     shape = [256, 1024, 1, 1]
     dtype = "float32"
     min_val = float("-0.227981")
@@ -2673,6 +2916,7 @@ class Program_weight_tensor_parameter_242:
 
 class Program_weight_tensor_parameter_243:
     name = "parameter_243"
+    original_name = "batch_norm2d_33.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.262605")
@@ -2684,6 +2928,7 @@ class Program_weight_tensor_parameter_243:
 
 class Program_weight_tensor_parameter_244:
     name = "parameter_244"
+    original_name = "batch_norm2d_33.w_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.0341974")
@@ -2695,6 +2940,7 @@ class Program_weight_tensor_parameter_244:
 
 class Program_weight_tensor_parameter_245:
     name = "parameter_245"
+    original_name = "batch_norm2d_33.w_2"
     shape = [1024]
     dtype = "float32"
     min_val = float("7.40606e-11")
@@ -2706,6 +2952,7 @@ class Program_weight_tensor_parameter_245:
 
 class Program_weight_tensor_parameter_246:
     name = "parameter_246"
+    original_name = "batch_norm2d_33.w_1"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.114872")
@@ -2717,6 +2964,7 @@ class Program_weight_tensor_parameter_246:
 
 class Program_weight_tensor_parameter_247:
     name = "parameter_247"
+    original_name = "conv2d_33.w_0"
     shape = [1024, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.398561")
@@ -2728,6 +2976,7 @@ class Program_weight_tensor_parameter_247:
 
 class Program_weight_tensor_parameter_248:
     name = "parameter_248"
+    original_name = "batch_norm2d_32.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.220177")
@@ -2739,6 +2988,7 @@ class Program_weight_tensor_parameter_248:
 
 class Program_weight_tensor_parameter_249:
     name = "parameter_249"
+    original_name = "batch_norm2d_32.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.096898")
@@ -2750,6 +3000,7 @@ class Program_weight_tensor_parameter_249:
 
 class Program_weight_tensor_parameter_250:
     name = "parameter_250"
+    original_name = "batch_norm2d_32.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.00716861")
@@ -2761,6 +3012,7 @@ class Program_weight_tensor_parameter_250:
 
 class Program_weight_tensor_parameter_251:
     name = "parameter_251"
+    original_name = "batch_norm2d_32.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.33006")
@@ -2772,6 +3024,7 @@ class Program_weight_tensor_parameter_251:
 
 class Program_weight_tensor_parameter_252:
     name = "parameter_252"
+    original_name = "conv2d_32.w_0"
     shape = [256, 256, 3, 3]
     dtype = "float32"
     min_val = float("-0.243483")
@@ -2783,6 +3036,7 @@ class Program_weight_tensor_parameter_252:
 
 class Program_weight_tensor_parameter_253:
     name = "parameter_253"
+    original_name = "batch_norm2d_31.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.231612")
@@ -2794,6 +3048,7 @@ class Program_weight_tensor_parameter_253:
 
 class Program_weight_tensor_parameter_254:
     name = "parameter_254"
+    original_name = "batch_norm2d_31.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.0980205")
@@ -2805,6 +3060,7 @@ class Program_weight_tensor_parameter_254:
 
 class Program_weight_tensor_parameter_255:
     name = "parameter_255"
+    original_name = "batch_norm2d_31.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.0081298")
@@ -2816,6 +3072,7 @@ class Program_weight_tensor_parameter_255:
 
 class Program_weight_tensor_parameter_256:
     name = "parameter_256"
+    original_name = "batch_norm2d_31.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.219663")
@@ -2827,6 +3084,7 @@ class Program_weight_tensor_parameter_256:
 
 class Program_weight_tensor_parameter_257:
     name = "parameter_257"
+    original_name = "conv2d_31.w_0"
     shape = [256, 1024, 1, 1]
     dtype = "float32"
     min_val = float("-0.223998")
@@ -2838,6 +3096,7 @@ class Program_weight_tensor_parameter_257:
 
 class Program_weight_tensor_parameter_258:
     name = "parameter_258"
+    original_name = "batch_norm2d_30.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.214667")
@@ -2849,6 +3108,7 @@ class Program_weight_tensor_parameter_258:
 
 class Program_weight_tensor_parameter_259:
     name = "parameter_259"
+    original_name = "batch_norm2d_30.w_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.014802")
@@ -2860,6 +3120,7 @@ class Program_weight_tensor_parameter_259:
 
 class Program_weight_tensor_parameter_260:
     name = "parameter_260"
+    original_name = "batch_norm2d_30.w_2"
     shape = [1024]
     dtype = "float32"
     min_val = float("2.17905e-11")
@@ -2871,6 +3132,7 @@ class Program_weight_tensor_parameter_260:
 
 class Program_weight_tensor_parameter_261:
     name = "parameter_261"
+    original_name = "batch_norm2d_30.w_1"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.154766")
@@ -2882,6 +3144,7 @@ class Program_weight_tensor_parameter_261:
 
 class Program_weight_tensor_parameter_262:
     name = "parameter_262"
+    original_name = "conv2d_30.w_0"
     shape = [1024, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.516348")
@@ -2893,6 +3156,7 @@ class Program_weight_tensor_parameter_262:
 
 class Program_weight_tensor_parameter_263:
     name = "parameter_263"
+    original_name = "batch_norm2d_29.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.384297")
@@ -2904,6 +3168,7 @@ class Program_weight_tensor_parameter_263:
 
 class Program_weight_tensor_parameter_264:
     name = "parameter_264"
+    original_name = "batch_norm2d_29.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.101814")
@@ -2915,6 +3180,7 @@ class Program_weight_tensor_parameter_264:
 
 class Program_weight_tensor_parameter_265:
     name = "parameter_265"
+    original_name = "batch_norm2d_29.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.00926883")
@@ -2926,6 +3192,7 @@ class Program_weight_tensor_parameter_265:
 
 class Program_weight_tensor_parameter_266:
     name = "parameter_266"
+    original_name = "batch_norm2d_29.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.897196")
@@ -2937,6 +3204,7 @@ class Program_weight_tensor_parameter_266:
 
 class Program_weight_tensor_parameter_267:
     name = "parameter_267"
+    original_name = "conv2d_29.w_0"
     shape = [256, 256, 3, 3]
     dtype = "float32"
     min_val = float("-0.244331")
@@ -2948,6 +3216,7 @@ class Program_weight_tensor_parameter_267:
 
 class Program_weight_tensor_parameter_268:
     name = "parameter_268"
+    original_name = "batch_norm2d_28.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.154157")
@@ -2959,6 +3228,7 @@ class Program_weight_tensor_parameter_268:
 
 class Program_weight_tensor_parameter_269:
     name = "parameter_269"
+    original_name = "batch_norm2d_28.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.0953903")
@@ -2970,6 +3240,7 @@ class Program_weight_tensor_parameter_269:
 
 class Program_weight_tensor_parameter_270:
     name = "parameter_270"
+    original_name = "batch_norm2d_28.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.00848757")
@@ -2981,6 +3252,7 @@ class Program_weight_tensor_parameter_270:
 
 class Program_weight_tensor_parameter_271:
     name = "parameter_271"
+    original_name = "batch_norm2d_28.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.883407")
@@ -2992,6 +3264,7 @@ class Program_weight_tensor_parameter_271:
 
 class Program_weight_tensor_parameter_272:
     name = "parameter_272"
+    original_name = "conv2d_28.w_0"
     shape = [256, 1024, 1, 1]
     dtype = "float32"
     min_val = float("-0.219916")
@@ -3003,6 +3276,7 @@ class Program_weight_tensor_parameter_272:
 
 class Program_weight_tensor_parameter_273:
     name = "parameter_273"
+    original_name = "batch_norm2d_27.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.123107")
@@ -3014,6 +3288,7 @@ class Program_weight_tensor_parameter_273:
 
 class Program_weight_tensor_parameter_274:
     name = "parameter_274"
+    original_name = "batch_norm2d_27.w_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.0802479")
@@ -3025,6 +3300,7 @@ class Program_weight_tensor_parameter_274:
 
 class Program_weight_tensor_parameter_275:
     name = "parameter_275"
+    original_name = "batch_norm2d_27.w_2"
     shape = [1024]
     dtype = "float32"
     min_val = float("2.12427e-14")
@@ -3036,6 +3312,7 @@ class Program_weight_tensor_parameter_275:
 
 class Program_weight_tensor_parameter_276:
     name = "parameter_276"
+    original_name = "batch_norm2d_27.w_1"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.312993")
@@ -3047,6 +3324,7 @@ class Program_weight_tensor_parameter_276:
 
 class Program_weight_tensor_parameter_277:
     name = "parameter_277"
+    original_name = "conv2d_27.w_0"
     shape = [1024, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.337797")
@@ -3058,6 +3336,7 @@ class Program_weight_tensor_parameter_277:
 
 class Program_weight_tensor_parameter_278:
     name = "parameter_278"
+    original_name = "batch_norm2d_26.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.123107")
@@ -3069,6 +3348,7 @@ class Program_weight_tensor_parameter_278:
 
 class Program_weight_tensor_parameter_279:
     name = "parameter_279"
+    original_name = "batch_norm2d_26.w_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.00172916")
@@ -3080,6 +3360,7 @@ class Program_weight_tensor_parameter_279:
 
 class Program_weight_tensor_parameter_280:
     name = "parameter_280"
+    original_name = "batch_norm2d_26.w_2"
     shape = [1024]
     dtype = "float32"
     min_val = float("1.97651e-14")
@@ -3091,6 +3372,7 @@ class Program_weight_tensor_parameter_280:
 
 class Program_weight_tensor_parameter_281:
     name = "parameter_281"
+    original_name = "batch_norm2d_26.w_1"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.320953")
@@ -3102,6 +3384,7 @@ class Program_weight_tensor_parameter_281:
 
 class Program_weight_tensor_parameter_282:
     name = "parameter_282"
+    original_name = "conv2d_26.w_0"
     shape = [1024, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.306494")
@@ -3113,6 +3396,7 @@ class Program_weight_tensor_parameter_282:
 
 class Program_weight_tensor_parameter_283:
     name = "parameter_283"
+    original_name = "batch_norm2d_25.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.177343")
@@ -3124,6 +3408,7 @@ class Program_weight_tensor_parameter_283:
 
 class Program_weight_tensor_parameter_284:
     name = "parameter_284"
+    original_name = "batch_norm2d_25.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.126972")
@@ -3135,6 +3420,7 @@ class Program_weight_tensor_parameter_284:
 
 class Program_weight_tensor_parameter_285:
     name = "parameter_285"
+    original_name = "batch_norm2d_25.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.0155667")
@@ -3146,6 +3432,7 @@ class Program_weight_tensor_parameter_285:
 
 class Program_weight_tensor_parameter_286:
     name = "parameter_286"
+    original_name = "batch_norm2d_25.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.280367")
@@ -3157,6 +3444,7 @@ class Program_weight_tensor_parameter_286:
 
 class Program_weight_tensor_parameter_287:
     name = "parameter_287"
+    original_name = "conv2d_25.w_0"
     shape = [256, 256, 3, 3]
     dtype = "float32"
     min_val = float("-0.222083")
@@ -3168,6 +3456,7 @@ class Program_weight_tensor_parameter_287:
 
 class Program_weight_tensor_parameter_288:
     name = "parameter_288"
+    original_name = "batch_norm2d_24.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.378746")
@@ -3179,6 +3468,7 @@ class Program_weight_tensor_parameter_288:
 
 class Program_weight_tensor_parameter_289:
     name = "parameter_289"
+    original_name = "batch_norm2d_24.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.144833")
@@ -3190,6 +3480,7 @@ class Program_weight_tensor_parameter_289:
 
 class Program_weight_tensor_parameter_290:
     name = "parameter_290"
+    original_name = "batch_norm2d_24.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.0157244")
@@ -3201,6 +3492,7 @@ class Program_weight_tensor_parameter_290:
 
 class Program_weight_tensor_parameter_291:
     name = "parameter_291"
+    original_name = "batch_norm2d_24.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.390806")
@@ -3212,6 +3504,7 @@ class Program_weight_tensor_parameter_291:
 
 class Program_weight_tensor_parameter_292:
     name = "parameter_292"
+    original_name = "conv2d_24.w_0"
     shape = [256, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.384462")
@@ -3223,6 +3516,7 @@ class Program_weight_tensor_parameter_292:
 
 class Program_weight_tensor_parameter_293:
     name = "parameter_293"
+    original_name = "batch_norm2d_23.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.212643")
@@ -3234,6 +3528,7 @@ class Program_weight_tensor_parameter_293:
 
 class Program_weight_tensor_parameter_294:
     name = "parameter_294"
+    original_name = "batch_norm2d_23.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.0505015")
@@ -3245,6 +3540,7 @@ class Program_weight_tensor_parameter_294:
 
 class Program_weight_tensor_parameter_295:
     name = "parameter_295"
+    original_name = "batch_norm2d_23.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("5.65136e-05")
@@ -3256,6 +3552,7 @@ class Program_weight_tensor_parameter_295:
 
 class Program_weight_tensor_parameter_296:
     name = "parameter_296"
+    original_name = "batch_norm2d_23.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.141983")
@@ -3267,6 +3564,7 @@ class Program_weight_tensor_parameter_296:
 
 class Program_weight_tensor_parameter_297:
     name = "parameter_297"
+    original_name = "conv2d_23.w_0"
     shape = [512, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.289083")
@@ -3278,6 +3576,7 @@ class Program_weight_tensor_parameter_297:
 
 class Program_weight_tensor_parameter_298:
     name = "parameter_298"
+    original_name = "batch_norm2d_22.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.217842")
@@ -3289,6 +3588,7 @@ class Program_weight_tensor_parameter_298:
 
 class Program_weight_tensor_parameter_299:
     name = "parameter_299"
+    original_name = "batch_norm2d_22.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.121171")
@@ -3300,6 +3600,7 @@ class Program_weight_tensor_parameter_299:
 
 class Program_weight_tensor_parameter_300:
     name = "parameter_300"
+    original_name = "batch_norm2d_22.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.00802759")
@@ -3311,6 +3612,7 @@ class Program_weight_tensor_parameter_300:
 
 class Program_weight_tensor_parameter_301:
     name = "parameter_301"
+    original_name = "batch_norm2d_22.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.202194")
@@ -3322,6 +3624,7 @@ class Program_weight_tensor_parameter_301:
 
 class Program_weight_tensor_parameter_302:
     name = "parameter_302"
+    original_name = "conv2d_22.w_0"
     shape = [128, 128, 3, 3]
     dtype = "float32"
     min_val = float("-0.196273")
@@ -3333,6 +3636,7 @@ class Program_weight_tensor_parameter_302:
 
 class Program_weight_tensor_parameter_303:
     name = "parameter_303"
+    original_name = "batch_norm2d_21.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.234581")
@@ -3344,6 +3648,7 @@ class Program_weight_tensor_parameter_303:
 
 class Program_weight_tensor_parameter_304:
     name = "parameter_304"
+    original_name = "batch_norm2d_21.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.118987")
@@ -3355,6 +3660,7 @@ class Program_weight_tensor_parameter_304:
 
 class Program_weight_tensor_parameter_305:
     name = "parameter_305"
+    original_name = "batch_norm2d_21.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.00940187")
@@ -3366,6 +3672,7 @@ class Program_weight_tensor_parameter_305:
 
 class Program_weight_tensor_parameter_306:
     name = "parameter_306"
+    original_name = "batch_norm2d_21.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.277056")
@@ -3377,6 +3684,7 @@ class Program_weight_tensor_parameter_306:
 
 class Program_weight_tensor_parameter_307:
     name = "parameter_307"
+    original_name = "conv2d_21.w_0"
     shape = [128, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.221919")
@@ -3388,6 +3696,7 @@ class Program_weight_tensor_parameter_307:
 
 class Program_weight_tensor_parameter_308:
     name = "parameter_308"
+    original_name = "batch_norm2d_20.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.269087")
@@ -3399,6 +3708,7 @@ class Program_weight_tensor_parameter_308:
 
 class Program_weight_tensor_parameter_309:
     name = "parameter_309"
+    original_name = "batch_norm2d_20.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.0647098")
@@ -3410,6 +3720,7 @@ class Program_weight_tensor_parameter_309:
 
 class Program_weight_tensor_parameter_310:
     name = "parameter_310"
+    original_name = "batch_norm2d_20.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("0.00010973")
@@ -3421,6 +3732,7 @@ class Program_weight_tensor_parameter_310:
 
 class Program_weight_tensor_parameter_311:
     name = "parameter_311"
+    original_name = "batch_norm2d_20.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.0957676")
@@ -3432,6 +3744,7 @@ class Program_weight_tensor_parameter_311:
 
 class Program_weight_tensor_parameter_312:
     name = "parameter_312"
+    original_name = "conv2d_20.w_0"
     shape = [512, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.27502")
@@ -3443,6 +3756,7 @@ class Program_weight_tensor_parameter_312:
 
 class Program_weight_tensor_parameter_313:
     name = "parameter_313"
+    original_name = "batch_norm2d_19.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.17257")
@@ -3454,6 +3768,7 @@ class Program_weight_tensor_parameter_313:
 
 class Program_weight_tensor_parameter_314:
     name = "parameter_314"
+    original_name = "batch_norm2d_19.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.108321")
@@ -3465,6 +3780,7 @@ class Program_weight_tensor_parameter_314:
 
 class Program_weight_tensor_parameter_315:
     name = "parameter_315"
+    original_name = "batch_norm2d_19.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.0071571")
@@ -3476,6 +3792,7 @@ class Program_weight_tensor_parameter_315:
 
 class Program_weight_tensor_parameter_316:
     name = "parameter_316"
+    original_name = "batch_norm2d_19.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.345635")
@@ -3487,6 +3804,7 @@ class Program_weight_tensor_parameter_316:
 
 class Program_weight_tensor_parameter_317:
     name = "parameter_317"
+    original_name = "conv2d_19.w_0"
     shape = [128, 128, 3, 3]
     dtype = "float32"
     min_val = float("-0.229707")
@@ -3498,6 +3816,7 @@ class Program_weight_tensor_parameter_317:
 
 class Program_weight_tensor_parameter_318:
     name = "parameter_318"
+    original_name = "batch_norm2d_18.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.202003")
@@ -3509,6 +3828,7 @@ class Program_weight_tensor_parameter_318:
 
 class Program_weight_tensor_parameter_319:
     name = "parameter_319"
+    original_name = "batch_norm2d_18.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.106726")
@@ -3520,6 +3840,7 @@ class Program_weight_tensor_parameter_319:
 
 class Program_weight_tensor_parameter_320:
     name = "parameter_320"
+    original_name = "batch_norm2d_18.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.00987741")
@@ -3531,6 +3852,7 @@ class Program_weight_tensor_parameter_320:
 
 class Program_weight_tensor_parameter_321:
     name = "parameter_321"
+    original_name = "batch_norm2d_18.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.342662")
@@ -3542,6 +3864,7 @@ class Program_weight_tensor_parameter_321:
 
 class Program_weight_tensor_parameter_322:
     name = "parameter_322"
+    original_name = "conv2d_18.w_0"
     shape = [128, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.253342")
@@ -3553,6 +3876,7 @@ class Program_weight_tensor_parameter_322:
 
 class Program_weight_tensor_parameter_323:
     name = "parameter_323"
+    original_name = "batch_norm2d_17.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.238356")
@@ -3564,6 +3888,7 @@ class Program_weight_tensor_parameter_323:
 
 class Program_weight_tensor_parameter_324:
     name = "parameter_324"
+    original_name = "batch_norm2d_17.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.0709823")
@@ -3575,6 +3900,7 @@ class Program_weight_tensor_parameter_324:
 
 class Program_weight_tensor_parameter_325:
     name = "parameter_325"
+    original_name = "batch_norm2d_17.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("6.22571e-13")
@@ -3586,6 +3912,7 @@ class Program_weight_tensor_parameter_325:
 
 class Program_weight_tensor_parameter_326:
     name = "parameter_326"
+    original_name = "batch_norm2d_17.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.204187")
@@ -3597,6 +3924,7 @@ class Program_weight_tensor_parameter_326:
 
 class Program_weight_tensor_parameter_327:
     name = "parameter_327"
+    original_name = "conv2d_17.w_0"
     shape = [512, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.312413")
@@ -3608,6 +3936,7 @@ class Program_weight_tensor_parameter_327:
 
 class Program_weight_tensor_parameter_328:
     name = "parameter_328"
+    original_name = "batch_norm2d_16.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.182477")
@@ -3619,6 +3948,7 @@ class Program_weight_tensor_parameter_328:
 
 class Program_weight_tensor_parameter_329:
     name = "parameter_329"
+    original_name = "batch_norm2d_16.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.0796995")
@@ -3630,6 +3960,7 @@ class Program_weight_tensor_parameter_329:
 
 class Program_weight_tensor_parameter_330:
     name = "parameter_330"
+    original_name = "batch_norm2d_16.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.00281317")
@@ -3641,6 +3972,7 @@ class Program_weight_tensor_parameter_330:
 
 class Program_weight_tensor_parameter_331:
     name = "parameter_331"
+    original_name = "batch_norm2d_16.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.669941")
@@ -3652,6 +3984,7 @@ class Program_weight_tensor_parameter_331:
 
 class Program_weight_tensor_parameter_332:
     name = "parameter_332"
+    original_name = "conv2d_16.w_0"
     shape = [128, 128, 3, 3]
     dtype = "float32"
     min_val = float("-0.243798")
@@ -3663,6 +3996,7 @@ class Program_weight_tensor_parameter_332:
 
 class Program_weight_tensor_parameter_333:
     name = "parameter_333"
+    original_name = "batch_norm2d_15.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.186717")
@@ -3674,6 +4008,7 @@ class Program_weight_tensor_parameter_333:
 
 class Program_weight_tensor_parameter_334:
     name = "parameter_334"
+    original_name = "batch_norm2d_15.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.0506482")
@@ -3685,6 +4020,7 @@ class Program_weight_tensor_parameter_334:
 
 class Program_weight_tensor_parameter_335:
     name = "parameter_335"
+    original_name = "batch_norm2d_15.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.00210212")
@@ -3696,6 +4032,7 @@ class Program_weight_tensor_parameter_335:
 
 class Program_weight_tensor_parameter_336:
     name = "parameter_336"
+    original_name = "batch_norm2d_15.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.322583")
@@ -3707,6 +4044,7 @@ class Program_weight_tensor_parameter_336:
 
 class Program_weight_tensor_parameter_337:
     name = "parameter_337"
+    original_name = "conv2d_15.w_0"
     shape = [128, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.201565")
@@ -3718,6 +4056,7 @@ class Program_weight_tensor_parameter_337:
 
 class Program_weight_tensor_parameter_338:
     name = "parameter_338"
+    original_name = "batch_norm2d_14.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.171144")
@@ -3729,6 +4068,7 @@ class Program_weight_tensor_parameter_338:
 
 class Program_weight_tensor_parameter_339:
     name = "parameter_339"
+    original_name = "batch_norm2d_14.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.019481")
@@ -3740,6 +4080,7 @@ class Program_weight_tensor_parameter_339:
 
 class Program_weight_tensor_parameter_340:
     name = "parameter_340"
+    original_name = "batch_norm2d_14.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("1.17727e-15")
@@ -3751,6 +4092,7 @@ class Program_weight_tensor_parameter_340:
 
 class Program_weight_tensor_parameter_341:
     name = "parameter_341"
+    original_name = "batch_norm2d_14.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.497702")
@@ -3762,6 +4104,7 @@ class Program_weight_tensor_parameter_341:
 
 class Program_weight_tensor_parameter_342:
     name = "parameter_342"
+    original_name = "conv2d_14.w_0"
     shape = [512, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.34401")
@@ -3773,6 +4116,7 @@ class Program_weight_tensor_parameter_342:
 
 class Program_weight_tensor_parameter_343:
     name = "parameter_343"
+    original_name = "batch_norm2d_13.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.171144")
@@ -3784,6 +4128,7 @@ class Program_weight_tensor_parameter_343:
 
 class Program_weight_tensor_parameter_344:
     name = "parameter_344"
+    original_name = "batch_norm2d_13.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.0356742")
@@ -3795,6 +4140,7 @@ class Program_weight_tensor_parameter_344:
 
 class Program_weight_tensor_parameter_345:
     name = "parameter_345"
+    original_name = "batch_norm2d_13.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("6.20582e-16")
@@ -3806,6 +4152,7 @@ class Program_weight_tensor_parameter_345:
 
 class Program_weight_tensor_parameter_346:
     name = "parameter_346"
+    original_name = "batch_norm2d_13.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.28852")
@@ -3817,6 +4164,7 @@ class Program_weight_tensor_parameter_346:
 
 class Program_weight_tensor_parameter_347:
     name = "parameter_347"
+    original_name = "conv2d_13.w_0"
     shape = [512, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.377596")
@@ -3828,6 +4176,7 @@ class Program_weight_tensor_parameter_347:
 
 class Program_weight_tensor_parameter_348:
     name = "parameter_348"
+    original_name = "batch_norm2d_12.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.316086")
@@ -3839,6 +4188,7 @@ class Program_weight_tensor_parameter_348:
 
 class Program_weight_tensor_parameter_349:
     name = "parameter_349"
+    original_name = "batch_norm2d_12.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.14483")
@@ -3850,6 +4200,7 @@ class Program_weight_tensor_parameter_349:
 
 class Program_weight_tensor_parameter_350:
     name = "parameter_350"
+    original_name = "batch_norm2d_12.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.0130226")
@@ -3861,6 +4212,7 @@ class Program_weight_tensor_parameter_350:
 
 class Program_weight_tensor_parameter_351:
     name = "parameter_351"
+    original_name = "batch_norm2d_12.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.267364")
@@ -3872,6 +4224,7 @@ class Program_weight_tensor_parameter_351:
 
 class Program_weight_tensor_parameter_352:
     name = "parameter_352"
+    original_name = "conv2d_12.w_0"
     shape = [128, 128, 3, 3]
     dtype = "float32"
     min_val = float("-0.314578")
@@ -3883,6 +4236,7 @@ class Program_weight_tensor_parameter_352:
 
 class Program_weight_tensor_parameter_353:
     name = "parameter_353"
+    original_name = "batch_norm2d_11.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.303521")
@@ -3894,6 +4248,7 @@ class Program_weight_tensor_parameter_353:
 
 class Program_weight_tensor_parameter_354:
     name = "parameter_354"
+    original_name = "batch_norm2d_11.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.107636")
@@ -3905,6 +4260,7 @@ class Program_weight_tensor_parameter_354:
 
 class Program_weight_tensor_parameter_355:
     name = "parameter_355"
+    original_name = "batch_norm2d_11.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.00341849")
@@ -3916,6 +4272,7 @@ class Program_weight_tensor_parameter_355:
 
 class Program_weight_tensor_parameter_356:
     name = "parameter_356"
+    original_name = "batch_norm2d_11.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.400316")
@@ -3927,6 +4284,7 @@ class Program_weight_tensor_parameter_356:
 
 class Program_weight_tensor_parameter_357:
     name = "parameter_357"
+    original_name = "conv2d_11.w_0"
     shape = [128, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.290714")
@@ -3938,6 +4296,7 @@ class Program_weight_tensor_parameter_357:
 
 class Program_weight_tensor_parameter_358:
     name = "parameter_358"
+    original_name = "batch_norm2d_10.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.168371")
@@ -3949,6 +4308,7 @@ class Program_weight_tensor_parameter_358:
 
 class Program_weight_tensor_parameter_359:
     name = "parameter_359"
+    original_name = "batch_norm2d_10.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.0978827")
@@ -3960,6 +4320,7 @@ class Program_weight_tensor_parameter_359:
 
 class Program_weight_tensor_parameter_360:
     name = "parameter_360"
+    original_name = "batch_norm2d_10.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("5.57019e-05")
@@ -3971,6 +4332,7 @@ class Program_weight_tensor_parameter_360:
 
 class Program_weight_tensor_parameter_361:
     name = "parameter_361"
+    original_name = "batch_norm2d_10.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.124307")
@@ -3982,6 +4344,7 @@ class Program_weight_tensor_parameter_361:
 
 class Program_weight_tensor_parameter_362:
     name = "parameter_362"
+    original_name = "conv2d_10.w_0"
     shape = [256, 64, 1, 1]
     dtype = "float32"
     min_val = float("-0.216772")
@@ -3993,6 +4356,7 @@ class Program_weight_tensor_parameter_362:
 
 class Program_weight_tensor_parameter_363:
     name = "parameter_363"
+    original_name = "batch_norm2d_9.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -4002,6 +4366,7 @@ class Program_weight_tensor_parameter_363:
 
 class Program_weight_tensor_parameter_364:
     name = "parameter_364"
+    original_name = "batch_norm2d_9.w_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -4011,6 +4376,7 @@ class Program_weight_tensor_parameter_364:
 
 class Program_weight_tensor_parameter_365:
     name = "parameter_365"
+    original_name = "batch_norm2d_9.w_2"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -4020,6 +4386,7 @@ class Program_weight_tensor_parameter_365:
 
 class Program_weight_tensor_parameter_366:
     name = "parameter_366"
+    original_name = "batch_norm2d_9.w_1"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -4029,6 +4396,7 @@ class Program_weight_tensor_parameter_366:
 
 class Program_weight_tensor_parameter_367:
     name = "parameter_367"
+    original_name = "conv2d_9.w_0"
     shape = [64, 64, 3, 3]
     dtype = "float32"
     min_val = float("-0.225002")
@@ -4040,6 +4408,7 @@ class Program_weight_tensor_parameter_367:
 
 class Program_weight_tensor_parameter_368:
     name = "parameter_368"
+    original_name = "batch_norm2d_8.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -4049,6 +4418,7 @@ class Program_weight_tensor_parameter_368:
 
 class Program_weight_tensor_parameter_369:
     name = "parameter_369"
+    original_name = "batch_norm2d_8.w_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -4058,6 +4428,7 @@ class Program_weight_tensor_parameter_369:
 
 class Program_weight_tensor_parameter_370:
     name = "parameter_370"
+    original_name = "batch_norm2d_8.w_2"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -4067,6 +4438,7 @@ class Program_weight_tensor_parameter_370:
 
 class Program_weight_tensor_parameter_371:
     name = "parameter_371"
+    original_name = "batch_norm2d_8.w_1"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -4076,6 +4448,7 @@ class Program_weight_tensor_parameter_371:
 
 class Program_weight_tensor_parameter_372:
     name = "parameter_372"
+    original_name = "conv2d_8.w_0"
     shape = [64, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.192067")
@@ -4087,6 +4460,7 @@ class Program_weight_tensor_parameter_372:
 
 class Program_weight_tensor_parameter_373:
     name = "parameter_373"
+    original_name = "batch_norm2d_7.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.148338")
@@ -4098,6 +4472,7 @@ class Program_weight_tensor_parameter_373:
 
 class Program_weight_tensor_parameter_374:
     name = "parameter_374"
+    original_name = "batch_norm2d_7.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.113668")
@@ -4109,6 +4484,7 @@ class Program_weight_tensor_parameter_374:
 
 class Program_weight_tensor_parameter_375:
     name = "parameter_375"
+    original_name = "batch_norm2d_7.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("7.11989e-15")
@@ -4120,6 +4496,7 @@ class Program_weight_tensor_parameter_375:
 
 class Program_weight_tensor_parameter_376:
     name = "parameter_376"
+    original_name = "batch_norm2d_7.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.104816")
@@ -4131,6 +4508,7 @@ class Program_weight_tensor_parameter_376:
 
 class Program_weight_tensor_parameter_377:
     name = "parameter_377"
+    original_name = "conv2d_7.w_0"
     shape = [256, 64, 1, 1]
     dtype = "float32"
     min_val = float("-0.294627")
@@ -4142,6 +4520,7 @@ class Program_weight_tensor_parameter_377:
 
 class Program_weight_tensor_parameter_378:
     name = "parameter_378"
+    original_name = "batch_norm2d_6.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -4151,6 +4530,7 @@ class Program_weight_tensor_parameter_378:
 
 class Program_weight_tensor_parameter_379:
     name = "parameter_379"
+    original_name = "batch_norm2d_6.w_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -4160,6 +4540,7 @@ class Program_weight_tensor_parameter_379:
 
 class Program_weight_tensor_parameter_380:
     name = "parameter_380"
+    original_name = "batch_norm2d_6.w_2"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -4169,6 +4550,7 @@ class Program_weight_tensor_parameter_380:
 
 class Program_weight_tensor_parameter_381:
     name = "parameter_381"
+    original_name = "batch_norm2d_6.w_1"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -4178,6 +4560,7 @@ class Program_weight_tensor_parameter_381:
 
 class Program_weight_tensor_parameter_382:
     name = "parameter_382"
+    original_name = "conv2d_6.w_0"
     shape = [64, 64, 3, 3]
     dtype = "float32"
     min_val = float("-0.403462")
@@ -4189,6 +4572,7 @@ class Program_weight_tensor_parameter_382:
 
 class Program_weight_tensor_parameter_383:
     name = "parameter_383"
+    original_name = "batch_norm2d_5.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -4198,6 +4582,7 @@ class Program_weight_tensor_parameter_383:
 
 class Program_weight_tensor_parameter_384:
     name = "parameter_384"
+    original_name = "batch_norm2d_5.w_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -4207,6 +4592,7 @@ class Program_weight_tensor_parameter_384:
 
 class Program_weight_tensor_parameter_385:
     name = "parameter_385"
+    original_name = "batch_norm2d_5.w_2"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -4216,6 +4602,7 @@ class Program_weight_tensor_parameter_385:
 
 class Program_weight_tensor_parameter_386:
     name = "parameter_386"
+    original_name = "batch_norm2d_5.w_1"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -4225,6 +4612,7 @@ class Program_weight_tensor_parameter_386:
 
 class Program_weight_tensor_parameter_387:
     name = "parameter_387"
+    original_name = "conv2d_5.w_0"
     shape = [64, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.20172")
@@ -4236,6 +4624,7 @@ class Program_weight_tensor_parameter_387:
 
 class Program_weight_tensor_parameter_388:
     name = "parameter_388"
+    original_name = "batch_norm2d_4.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.307381")
@@ -4247,6 +4636,7 @@ class Program_weight_tensor_parameter_388:
 
 class Program_weight_tensor_parameter_389:
     name = "parameter_389"
+    original_name = "batch_norm2d_4.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.0421494")
@@ -4258,6 +4648,7 @@ class Program_weight_tensor_parameter_389:
 
 class Program_weight_tensor_parameter_390:
     name = "parameter_390"
+    original_name = "batch_norm2d_4.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("4.73803e-14")
@@ -4269,6 +4660,7 @@ class Program_weight_tensor_parameter_390:
 
 class Program_weight_tensor_parameter_391:
     name = "parameter_391"
+    original_name = "batch_norm2d_4.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.03252")
@@ -4280,6 +4672,7 @@ class Program_weight_tensor_parameter_391:
 
 class Program_weight_tensor_parameter_392:
     name = "parameter_392"
+    original_name = "conv2d_4.w_0"
     shape = [256, 64, 1, 1]
     dtype = "float32"
     min_val = float("-0.744444")
@@ -4291,6 +4684,7 @@ class Program_weight_tensor_parameter_392:
 
 class Program_weight_tensor_parameter_393:
     name = "parameter_393"
+    original_name = "batch_norm2d_3.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.307381")
@@ -4302,6 +4696,7 @@ class Program_weight_tensor_parameter_393:
 
 class Program_weight_tensor_parameter_394:
     name = "parameter_394"
+    original_name = "batch_norm2d_3.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.112764")
@@ -4313,6 +4708,7 @@ class Program_weight_tensor_parameter_394:
 
 class Program_weight_tensor_parameter_395:
     name = "parameter_395"
+    original_name = "batch_norm2d_3.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("1.26218e-14")
@@ -4324,6 +4720,7 @@ class Program_weight_tensor_parameter_395:
 
 class Program_weight_tensor_parameter_396:
     name = "parameter_396"
+    original_name = "batch_norm2d_3.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.223334")
@@ -4335,6 +4732,7 @@ class Program_weight_tensor_parameter_396:
 
 class Program_weight_tensor_parameter_397:
     name = "parameter_397"
+    original_name = "conv2d_3.w_0"
     shape = [256, 64, 1, 1]
     dtype = "float32"
     min_val = float("-0.363424")
@@ -4346,6 +4744,7 @@ class Program_weight_tensor_parameter_397:
 
 class Program_weight_tensor_parameter_398:
     name = "parameter_398"
+    original_name = "batch_norm2d_2.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -4355,6 +4754,7 @@ class Program_weight_tensor_parameter_398:
 
 class Program_weight_tensor_parameter_399:
     name = "parameter_399"
+    original_name = "batch_norm2d_2.w_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -4364,6 +4764,7 @@ class Program_weight_tensor_parameter_399:
 
 class Program_weight_tensor_parameter_400:
     name = "parameter_400"
+    original_name = "batch_norm2d_2.w_2"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -4373,6 +4774,7 @@ class Program_weight_tensor_parameter_400:
 
 class Program_weight_tensor_parameter_401:
     name = "parameter_401"
+    original_name = "batch_norm2d_2.w_1"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -4382,6 +4784,7 @@ class Program_weight_tensor_parameter_401:
 
 class Program_weight_tensor_parameter_402:
     name = "parameter_402"
+    original_name = "conv2d_2.w_0"
     shape = [64, 64, 3, 3]
     dtype = "float32"
     min_val = float("-0.467864")
@@ -4393,6 +4796,7 @@ class Program_weight_tensor_parameter_402:
 
 class Program_weight_tensor_parameter_403:
     name = "parameter_403"
+    original_name = "batch_norm2d_1.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -4402,6 +4806,7 @@ class Program_weight_tensor_parameter_403:
 
 class Program_weight_tensor_parameter_404:
     name = "parameter_404"
+    original_name = "batch_norm2d_1.w_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -4411,6 +4816,7 @@ class Program_weight_tensor_parameter_404:
 
 class Program_weight_tensor_parameter_405:
     name = "parameter_405"
+    original_name = "batch_norm2d_1.w_2"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -4420,6 +4826,7 @@ class Program_weight_tensor_parameter_405:
 
 class Program_weight_tensor_parameter_406:
     name = "parameter_406"
+    original_name = "batch_norm2d_1.w_1"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -4429,6 +4836,7 @@ class Program_weight_tensor_parameter_406:
 
 class Program_weight_tensor_parameter_407:
     name = "parameter_407"
+    original_name = "conv2d_1.w_0"
     shape = [64, 64, 1, 1]
     dtype = "float32"
     min_val = float("-0.726628")
@@ -4440,6 +4848,7 @@ class Program_weight_tensor_parameter_407:
 
 class Program_weight_tensor_parameter_408:
     name = "parameter_408"
+    original_name = "batch_norm2d_0.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -4449,6 +4858,7 @@ class Program_weight_tensor_parameter_408:
 
 class Program_weight_tensor_parameter_409:
     name = "parameter_409"
+    original_name = "batch_norm2d_0.w_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -4458,6 +4868,7 @@ class Program_weight_tensor_parameter_409:
 
 class Program_weight_tensor_parameter_410:
     name = "parameter_410"
+    original_name = "batch_norm2d_0.w_2"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -4467,6 +4878,7 @@ class Program_weight_tensor_parameter_410:
 
 class Program_weight_tensor_parameter_411:
     name = "parameter_411"
+    original_name = "batch_norm2d_0.w_1"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -4476,6 +4888,7 @@ class Program_weight_tensor_parameter_411:
 
 class Program_weight_tensor_parameter_412:
     name = "parameter_412"
+    original_name = "conv2d_0.w_0"
     shape = [64, 3, 7, 7]
     dtype = "float32"
     min_val = float("-0.781721")

--- a/paddle_samples/PaddleX/DETR-R50/subgraph_22/input_meta.py
+++ b/paddle_samples/PaddleX/DETR-R50/subgraph_22/input_meta.py
@@ -1,5 +1,6 @@
 class Program_weight_tensor_data_0:
     name = "data_0"
+    original_name = "param_100"
     shape = [768]
     dtype = "float32"
     min_val = float("-0.228984")
@@ -11,6 +12,7 @@ class Program_weight_tensor_data_0:
 
 class Program_weight_tensor_data_1:
     name = "data_1"
+    original_name = "param_101"
     shape = [256, 768]
     dtype = "float32"
     min_val = float("-1.69526")
@@ -22,6 +24,7 @@ class Program_weight_tensor_data_1:
 
 class Program_weight_tensor_data_2:
     name = "data_2"
+    original_name = "param_102"
     shape = [768]
     dtype = "float32"
     min_val = float("-0.461151")
@@ -33,6 +36,7 @@ class Program_weight_tensor_data_2:
 
 class Program_weight_tensor_data_3:
     name = "data_3"
+    original_name = "param_103"
     shape = [256, 768]
     dtype = "float32"
     min_val = float("-0.669706")
@@ -44,6 +48,7 @@ class Program_weight_tensor_data_3:
 
 class Program_weight_tensor_data_4:
     name = "data_4"
+    original_name = "param_104"
     shape = [768]
     dtype = "float32"
     min_val = float("-0.201804")
@@ -55,6 +60,7 @@ class Program_weight_tensor_data_4:
 
 class Program_weight_tensor_data_5:
     name = "data_5"
+    original_name = "param_105"
     shape = [256, 768]
     dtype = "float32"
     min_val = float("-2.39623")
@@ -66,6 +72,7 @@ class Program_weight_tensor_data_5:
 
 class Program_weight_tensor_data_6:
     name = "data_6"
+    original_name = "param_106"
     shape = [768]
     dtype = "float32"
     min_val = float("-0.344833")
@@ -77,6 +84,7 @@ class Program_weight_tensor_data_6:
 
 class Program_weight_tensor_data_7:
     name = "data_7"
+    original_name = "param_107"
     shape = [256, 768]
     dtype = "float32"
     min_val = float("-0.408485")
@@ -88,6 +96,7 @@ class Program_weight_tensor_data_7:
 
 class Program_weight_tensor_data_8:
     name = "data_8"
+    original_name = "param_108"
     shape = [768]
     dtype = "float32"
     min_val = float("-0.317629")
@@ -99,6 +108,7 @@ class Program_weight_tensor_data_8:
 
 class Program_weight_tensor_data_9:
     name = "data_9"
+    original_name = "param_109"
     shape = [256, 768]
     dtype = "float32"
     min_val = float("-2.31802")
@@ -110,6 +120,7 @@ class Program_weight_tensor_data_9:
 
 class Program_weight_tensor_data_10:
     name = "data_10"
+    original_name = "param_110"
     shape = [768]
     dtype = "float32"
     min_val = float("-0.447075")
@@ -121,6 +132,7 @@ class Program_weight_tensor_data_10:
 
 class Program_weight_tensor_data_11:
     name = "data_11"
+    original_name = "param_74"
     shape = [256, 768]
     dtype = "float32"
     min_val = float("-1.62901")
@@ -132,6 +144,7 @@ class Program_weight_tensor_data_11:
 
 class Program_weight_tensor_data_12:
     name = "data_12"
+    original_name = "param_75"
     shape = [768]
     dtype = "float32"
     min_val = float("-0.207938")
@@ -143,6 +156,7 @@ class Program_weight_tensor_data_12:
 
 class Program_weight_tensor_data_13:
     name = "data_13"
+    original_name = "param_76"
     shape = [256, 768]
     dtype = "float32"
     min_val = float("-0.618279")
@@ -154,6 +168,7 @@ class Program_weight_tensor_data_13:
 
 class Program_weight_tensor_data_14:
     name = "data_14"
+    original_name = "param_77"
     shape = [768]
     dtype = "float32"
     min_val = float("-0.0817621")
@@ -165,6 +180,7 @@ class Program_weight_tensor_data_14:
 
 class Program_weight_tensor_data_15:
     name = "data_15"
+    original_name = "param_78"
     shape = [256, 768]
     dtype = "float32"
     min_val = float("-1.2091")
@@ -176,6 +192,7 @@ class Program_weight_tensor_data_15:
 
 class Program_weight_tensor_data_16:
     name = "data_16"
+    original_name = "param_79"
     shape = [768]
     dtype = "float32"
     min_val = float("-0.100571")
@@ -187,6 +204,7 @@ class Program_weight_tensor_data_16:
 
 class Program_weight_tensor_data_17:
     name = "data_17"
+    original_name = "param_80"
     shape = [256, 768]
     dtype = "float32"
     min_val = float("-1.53463")
@@ -198,6 +216,7 @@ class Program_weight_tensor_data_17:
 
 class Program_weight_tensor_data_18:
     name = "data_18"
+    original_name = "param_81"
     shape = [768]
     dtype = "float32"
     min_val = float("-0.15162")
@@ -209,6 +228,7 @@ class Program_weight_tensor_data_18:
 
 class Program_weight_tensor_data_19:
     name = "data_19"
+    original_name = "param_82"
     shape = [256, 768]
     dtype = "float32"
     min_val = float("-1.36493")
@@ -220,6 +240,7 @@ class Program_weight_tensor_data_19:
 
 class Program_weight_tensor_data_20:
     name = "data_20"
+    original_name = "param_83"
     shape = [768]
     dtype = "float32"
     min_val = float("-0.0747685")
@@ -231,6 +252,7 @@ class Program_weight_tensor_data_20:
 
 class Program_weight_tensor_data_21:
     name = "data_21"
+    original_name = "param_84"
     shape = [256, 768]
     dtype = "float32"
     min_val = float("-1.53108")
@@ -242,6 +264,7 @@ class Program_weight_tensor_data_21:
 
 class Program_weight_tensor_data_22:
     name = "data_22"
+    original_name = "param_85"
     shape = [768]
     dtype = "float32"
     min_val = float("-0.0553872")
@@ -253,6 +276,7 @@ class Program_weight_tensor_data_22:
 
 class Program_weight_tensor_data_23:
     name = "data_23"
+    original_name = "param_86"
     shape = [100, 256]
     dtype = "float32"
     min_val = float("-4.0263")
@@ -264,6 +288,7 @@ class Program_weight_tensor_data_23:
 
 class Program_weight_tensor_data_24:
     name = "data_24"
+    original_name = "param_87"
     shape = [256, 768]
     dtype = "float32"
     min_val = float("-0.227614")
@@ -275,6 +300,7 @@ class Program_weight_tensor_data_24:
 
 class Program_weight_tensor_data_25:
     name = "data_25"
+    original_name = "param_88"
     shape = [768]
     dtype = "float32"
     min_val = float("-0.306585")
@@ -286,6 +312,7 @@ class Program_weight_tensor_data_25:
 
 class Program_weight_tensor_data_26:
     name = "data_26"
+    original_name = "param_89"
     shape = [256, 768]
     dtype = "float32"
     min_val = float("-1.2845")
@@ -297,6 +324,7 @@ class Program_weight_tensor_data_26:
 
 class Program_weight_tensor_data_27:
     name = "data_27"
+    original_name = "param_90"
     shape = [768]
     dtype = "float32"
     min_val = float("-0.405572")
@@ -308,6 +336,7 @@ class Program_weight_tensor_data_27:
 
 class Program_weight_tensor_data_28:
     name = "data_28"
+    original_name = "param_91"
     shape = [256, 768]
     dtype = "float32"
     min_val = float("-0.526977")
@@ -319,6 +348,7 @@ class Program_weight_tensor_data_28:
 
 class Program_weight_tensor_data_29:
     name = "data_29"
+    original_name = "param_92"
     shape = [768]
     dtype = "float32"
     min_val = float("-0.190626")
@@ -330,6 +360,7 @@ class Program_weight_tensor_data_29:
 
 class Program_weight_tensor_data_30:
     name = "data_30"
+    original_name = "param_93"
     shape = [256, 768]
     dtype = "float32"
     min_val = float("-1.84811")
@@ -341,6 +372,7 @@ class Program_weight_tensor_data_30:
 
 class Program_weight_tensor_data_31:
     name = "data_31"
+    original_name = "param_94"
     shape = [768]
     dtype = "float32"
     min_val = float("-0.368047")
@@ -352,6 +384,7 @@ class Program_weight_tensor_data_31:
 
 class Program_weight_tensor_data_32:
     name = "data_32"
+    original_name = "param_95"
     shape = [256, 768]
     dtype = "float32"
     min_val = float("-0.727782")
@@ -363,6 +396,7 @@ class Program_weight_tensor_data_32:
 
 class Program_weight_tensor_data_33:
     name = "data_33"
+    original_name = "param_96"
     shape = [768]
     dtype = "float32"
     min_val = float("-0.138692")
@@ -374,6 +408,7 @@ class Program_weight_tensor_data_33:
 
 class Program_weight_tensor_data_34:
     name = "data_34"
+    original_name = "param_97"
     shape = [256, 768]
     dtype = "float32"
     min_val = float("-2.28685")
@@ -385,6 +420,7 @@ class Program_weight_tensor_data_34:
 
 class Program_weight_tensor_data_35:
     name = "data_35"
+    original_name = "param_98"
     shape = [768]
     dtype = "float32"
     min_val = float("-0.413075")
@@ -396,6 +432,7 @@ class Program_weight_tensor_data_35:
 
 class Program_weight_tensor_data_36:
     name = "data_36"
+    original_name = "param_99"
     shape = [256, 768]
     dtype = "float32"
     min_val = float("-0.468995")
@@ -407,6 +444,7 @@ class Program_weight_tensor_data_36:
 
 class Program_weight_tensor_data_37:
     name = "data_37"
+    original_name = "var_1897"
     shape = [4, 3, 853, 672]
     dtype = "float32"
     min_val = float("-2.1179")
@@ -418,8 +456,10 @@ class Program_weight_tensor_data_37:
 
 class Program_weight_tensor_data_38:
     name = "data_38"
+    original_name = "var_1900"
     shape = [4, 853, 672]
     dtype = "float32"
+    min_val = float("0.0")
     max_val = float("1.0")
     mean = float("0.812887")
     std = float("0.390002")

--- a/paddle_samples/PaddleX/DETR-R50/subgraph_22/weight_meta.py
+++ b/paddle_samples/PaddleX/DETR-R50/subgraph_22/weight_meta.py
@@ -1,5 +1,6 @@
 class Program_weight_tensor_parameter_0:
     name = "parameter_0"
+    original_name = "layer_norm_4.b_0_deepcopy_179"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.393705")
@@ -11,6 +12,7 @@ class Program_weight_tensor_parameter_0:
 
 class Program_weight_tensor_parameter_1:
     name = "parameter_1"
+    original_name = "layer_norm_4.w_0_deepcopy_178"
     shape = [256]
     dtype = "float32"
     min_val = float("0.534084")
@@ -22,6 +24,7 @@ class Program_weight_tensor_parameter_1:
 
 class Program_weight_tensor_parameter_2:
     name = "parameter_2"
+    original_name = "linear_6.b_0_deepcopy_173"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.0931587")
@@ -33,6 +36,7 @@ class Program_weight_tensor_parameter_2:
 
 class Program_weight_tensor_parameter_3:
     name = "parameter_3"
+    original_name = "linear_6.w_0_deepcopy_172"
     shape = [2048, 256]
     dtype = "float32"
     min_val = float("-0.687304")
@@ -44,6 +48,7 @@ class Program_weight_tensor_parameter_3:
 
 class Program_weight_tensor_parameter_4:
     name = "parameter_4"
+    original_name = "linear_5.b_0_deepcopy_171"
     shape = [2048]
     dtype = "float32"
     min_val = float("-0.302835")
@@ -55,6 +60,7 @@ class Program_weight_tensor_parameter_4:
 
 class Program_weight_tensor_parameter_5:
     name = "parameter_5"
+    original_name = "linear_5.w_0_deepcopy_170"
     shape = [256, 2048]
     dtype = "float32"
     min_val = float("-0.561115")
@@ -66,6 +72,7 @@ class Program_weight_tensor_parameter_5:
 
 class Program_weight_tensor_parameter_6:
     name = "parameter_6"
+    original_name = "layer_norm_3.b_0_deepcopy_177"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.0928")
@@ -77,6 +84,7 @@ class Program_weight_tensor_parameter_6:
 
 class Program_weight_tensor_parameter_7:
     name = "parameter_7"
+    original_name = "layer_norm_3.w_0_deepcopy_176"
     shape = [256]
     dtype = "float32"
     min_val = float("0.789126")
@@ -88,6 +96,7 @@ class Program_weight_tensor_parameter_7:
 
 class Program_weight_tensor_parameter_8:
     name = "parameter_8"
+    original_name = "linear_4.b_0_deepcopy_169"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.207533")
@@ -99,6 +108,7 @@ class Program_weight_tensor_parameter_8:
 
 class Program_weight_tensor_parameter_9:
     name = "parameter_9"
+    original_name = "linear_4.w_0_deepcopy_168"
     shape = [256, 256]
     dtype = "float32"
     min_val = float("-0.507973")
@@ -110,6 +120,7 @@ class Program_weight_tensor_parameter_9:
 
 class Program_weight_tensor_parameter_10:
     name = "parameter_10"
+    original_name = "layer_norm_2.b_0_deepcopy_175"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.774714")
@@ -121,6 +132,7 @@ class Program_weight_tensor_parameter_10:
 
 class Program_weight_tensor_parameter_11:
     name = "parameter_11"
+    original_name = "layer_norm_2.w_0_deepcopy_174"
     shape = [256]
     dtype = "float32"
     min_val = float("1.37221")
@@ -132,6 +144,7 @@ class Program_weight_tensor_parameter_11:
 
 class Program_weight_tensor_parameter_12:
     name = "parameter_12"
+    original_name = "linear_3.b_0_deepcopy_165"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.0269334")
@@ -143,6 +156,7 @@ class Program_weight_tensor_parameter_12:
 
 class Program_weight_tensor_parameter_13:
     name = "parameter_13"
+    original_name = "linear_3.w_0_deepcopy_164"
     shape = [256, 256]
     dtype = "float32"
     min_val = float("-0.233367")
@@ -154,6 +168,7 @@ class Program_weight_tensor_parameter_13:
 
 class Program_weight_tensor_parameter_14:
     name = "parameter_14"
+    original_name = "layer_norm_4.b_0_deepcopy_161"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.437609")
@@ -165,6 +180,7 @@ class Program_weight_tensor_parameter_14:
 
 class Program_weight_tensor_parameter_15:
     name = "parameter_15"
+    original_name = "layer_norm_4.w_0_deepcopy_160"
     shape = [256]
     dtype = "float32"
     min_val = float("0.509709")
@@ -176,6 +192,7 @@ class Program_weight_tensor_parameter_15:
 
 class Program_weight_tensor_parameter_16:
     name = "parameter_16"
+    original_name = "linear_6.b_0_deepcopy_155"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.17298")
@@ -187,6 +204,7 @@ class Program_weight_tensor_parameter_16:
 
 class Program_weight_tensor_parameter_17:
     name = "parameter_17"
+    original_name = "linear_6.w_0_deepcopy_154"
     shape = [2048, 256]
     dtype = "float32"
     min_val = float("-0.749645")
@@ -198,6 +216,7 @@ class Program_weight_tensor_parameter_17:
 
 class Program_weight_tensor_parameter_18:
     name = "parameter_18"
+    original_name = "linear_5.b_0_deepcopy_153"
     shape = [2048]
     dtype = "float32"
     min_val = float("-0.307084")
@@ -209,6 +228,7 @@ class Program_weight_tensor_parameter_18:
 
 class Program_weight_tensor_parameter_19:
     name = "parameter_19"
+    original_name = "linear_5.w_0_deepcopy_152"
     shape = [256, 2048]
     dtype = "float32"
     min_val = float("-0.645936")
@@ -220,6 +240,7 @@ class Program_weight_tensor_parameter_19:
 
 class Program_weight_tensor_parameter_20:
     name = "parameter_20"
+    original_name = "layer_norm_3.b_0_deepcopy_159"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.42897")
@@ -231,6 +252,7 @@ class Program_weight_tensor_parameter_20:
 
 class Program_weight_tensor_parameter_21:
     name = "parameter_21"
+    original_name = "layer_norm_3.w_0_deepcopy_158"
     shape = [256]
     dtype = "float32"
     min_val = float("0.653936")
@@ -242,6 +264,7 @@ class Program_weight_tensor_parameter_21:
 
 class Program_weight_tensor_parameter_22:
     name = "parameter_22"
+    original_name = "linear_4.b_0_deepcopy_151"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.316756")
@@ -253,6 +276,7 @@ class Program_weight_tensor_parameter_22:
 
 class Program_weight_tensor_parameter_23:
     name = "parameter_23"
+    original_name = "linear_4.w_0_deepcopy_150"
     shape = [256, 256]
     dtype = "float32"
     min_val = float("-0.503013")
@@ -264,6 +288,7 @@ class Program_weight_tensor_parameter_23:
 
 class Program_weight_tensor_parameter_24:
     name = "parameter_24"
+    original_name = "layer_norm_2.b_0_deepcopy_157"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.992961")
@@ -275,6 +300,7 @@ class Program_weight_tensor_parameter_24:
 
 class Program_weight_tensor_parameter_25:
     name = "parameter_25"
+    original_name = "layer_norm_2.w_0_deepcopy_156"
     shape = [256]
     dtype = "float32"
     min_val = float("1.46496")
@@ -286,6 +312,7 @@ class Program_weight_tensor_parameter_25:
 
 class Program_weight_tensor_parameter_26:
     name = "parameter_26"
+    original_name = "linear_3.b_0_deepcopy_147"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.053665")
@@ -297,6 +324,7 @@ class Program_weight_tensor_parameter_26:
 
 class Program_weight_tensor_parameter_27:
     name = "parameter_27"
+    original_name = "linear_3.w_0_deepcopy_146"
     shape = [256, 256]
     dtype = "float32"
     min_val = float("-0.202348")
@@ -308,6 +336,7 @@ class Program_weight_tensor_parameter_27:
 
 class Program_weight_tensor_parameter_28:
     name = "parameter_28"
+    original_name = "layer_norm_4.b_0_deepcopy_143"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.677249")
@@ -319,6 +348,7 @@ class Program_weight_tensor_parameter_28:
 
 class Program_weight_tensor_parameter_29:
     name = "parameter_29"
+    original_name = "layer_norm_4.w_0_deepcopy_142"
     shape = [256]
     dtype = "float32"
     min_val = float("0.560256")
@@ -330,6 +360,7 @@ class Program_weight_tensor_parameter_29:
 
 class Program_weight_tensor_parameter_30:
     name = "parameter_30"
+    original_name = "linear_6.b_0_deepcopy_137"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.255858")
@@ -341,6 +372,7 @@ class Program_weight_tensor_parameter_30:
 
 class Program_weight_tensor_parameter_31:
     name = "parameter_31"
+    original_name = "linear_6.w_0_deepcopy_136"
     shape = [2048, 256]
     dtype = "float32"
     min_val = float("-0.829315")
@@ -352,6 +384,7 @@ class Program_weight_tensor_parameter_31:
 
 class Program_weight_tensor_parameter_32:
     name = "parameter_32"
+    original_name = "linear_5.b_0_deepcopy_135"
     shape = [2048]
     dtype = "float32"
     min_val = float("-0.345106")
@@ -363,6 +396,7 @@ class Program_weight_tensor_parameter_32:
 
 class Program_weight_tensor_parameter_33:
     name = "parameter_33"
+    original_name = "linear_5.w_0_deepcopy_134"
     shape = [256, 2048]
     dtype = "float32"
     min_val = float("-0.597944")
@@ -374,6 +408,7 @@ class Program_weight_tensor_parameter_33:
 
 class Program_weight_tensor_parameter_34:
     name = "parameter_34"
+    original_name = "layer_norm_3.b_0_deepcopy_141"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.46905")
@@ -385,6 +420,7 @@ class Program_weight_tensor_parameter_34:
 
 class Program_weight_tensor_parameter_35:
     name = "parameter_35"
+    original_name = "layer_norm_3.w_0_deepcopy_140"
     shape = [256]
     dtype = "float32"
     min_val = float("0.656466")
@@ -396,6 +432,7 @@ class Program_weight_tensor_parameter_35:
 
 class Program_weight_tensor_parameter_36:
     name = "parameter_36"
+    original_name = "linear_4.b_0_deepcopy_133"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.494582")
@@ -407,6 +444,7 @@ class Program_weight_tensor_parameter_36:
 
 class Program_weight_tensor_parameter_37:
     name = "parameter_37"
+    original_name = "linear_4.w_0_deepcopy_132"
     shape = [256, 256]
     dtype = "float32"
     min_val = float("-0.479309")
@@ -418,6 +456,7 @@ class Program_weight_tensor_parameter_37:
 
 class Program_weight_tensor_parameter_38:
     name = "parameter_38"
+    original_name = "layer_norm_2.b_0_deepcopy_139"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.885359")
@@ -429,6 +468,7 @@ class Program_weight_tensor_parameter_38:
 
 class Program_weight_tensor_parameter_39:
     name = "parameter_39"
+    original_name = "layer_norm_2.w_0_deepcopy_138"
     shape = [256]
     dtype = "float32"
     min_val = float("1.08342")
@@ -440,6 +480,7 @@ class Program_weight_tensor_parameter_39:
 
 class Program_weight_tensor_parameter_40:
     name = "parameter_40"
+    original_name = "linear_3.b_0_deepcopy_129"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.0892119")
@@ -451,6 +492,7 @@ class Program_weight_tensor_parameter_40:
 
 class Program_weight_tensor_parameter_41:
     name = "parameter_41"
+    original_name = "linear_3.w_0_deepcopy_128"
     shape = [256, 256]
     dtype = "float32"
     min_val = float("-0.278704")
@@ -462,6 +504,7 @@ class Program_weight_tensor_parameter_41:
 
 class Program_weight_tensor_parameter_42:
     name = "parameter_42"
+    original_name = "layer_norm_4.b_0_deepcopy_125"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.44714")
@@ -473,6 +516,7 @@ class Program_weight_tensor_parameter_42:
 
 class Program_weight_tensor_parameter_43:
     name = "parameter_43"
+    original_name = "layer_norm_4.w_0_deepcopy_124"
     shape = [256]
     dtype = "float32"
     min_val = float("0.466304")
@@ -484,6 +528,7 @@ class Program_weight_tensor_parameter_43:
 
 class Program_weight_tensor_parameter_44:
     name = "parameter_44"
+    original_name = "linear_6.b_0_deepcopy_119"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.324735")
@@ -495,6 +540,7 @@ class Program_weight_tensor_parameter_44:
 
 class Program_weight_tensor_parameter_45:
     name = "parameter_45"
+    original_name = "linear_6.w_0_deepcopy_118"
     shape = [2048, 256]
     dtype = "float32"
     min_val = float("-0.505096")
@@ -506,6 +552,7 @@ class Program_weight_tensor_parameter_45:
 
 class Program_weight_tensor_parameter_46:
     name = "parameter_46"
+    original_name = "linear_5.b_0_deepcopy_117"
     shape = [2048]
     dtype = "float32"
     min_val = float("-0.327804")
@@ -517,6 +564,7 @@ class Program_weight_tensor_parameter_46:
 
 class Program_weight_tensor_parameter_47:
     name = "parameter_47"
+    original_name = "linear_5.w_0_deepcopy_116"
     shape = [256, 2048]
     dtype = "float32"
     min_val = float("-0.650782")
@@ -528,6 +576,7 @@ class Program_weight_tensor_parameter_47:
 
 class Program_weight_tensor_parameter_48:
     name = "parameter_48"
+    original_name = "layer_norm_3.b_0_deepcopy_123"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.65808")
@@ -539,6 +588,7 @@ class Program_weight_tensor_parameter_48:
 
 class Program_weight_tensor_parameter_49:
     name = "parameter_49"
+    original_name = "layer_norm_3.w_0_deepcopy_122"
     shape = [256]
     dtype = "float32"
     min_val = float("0.628074")
@@ -550,6 +600,7 @@ class Program_weight_tensor_parameter_49:
 
 class Program_weight_tensor_parameter_50:
     name = "parameter_50"
+    original_name = "linear_4.b_0_deepcopy_115"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.580944")
@@ -561,6 +612,7 @@ class Program_weight_tensor_parameter_50:
 
 class Program_weight_tensor_parameter_51:
     name = "parameter_51"
+    original_name = "linear_4.w_0_deepcopy_114"
     shape = [256, 256]
     dtype = "float32"
     min_val = float("-0.504439")
@@ -572,6 +624,7 @@ class Program_weight_tensor_parameter_51:
 
 class Program_weight_tensor_parameter_52:
     name = "parameter_52"
+    original_name = "layer_norm_2.b_0_deepcopy_121"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.912433")
@@ -583,6 +636,7 @@ class Program_weight_tensor_parameter_52:
 
 class Program_weight_tensor_parameter_53:
     name = "parameter_53"
+    original_name = "layer_norm_2.w_0_deepcopy_120"
     shape = [256]
     dtype = "float32"
     min_val = float("0.939735")
@@ -594,6 +648,7 @@ class Program_weight_tensor_parameter_53:
 
 class Program_weight_tensor_parameter_54:
     name = "parameter_54"
+    original_name = "linear_3.b_0_deepcopy_111"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.110561")
@@ -605,6 +660,7 @@ class Program_weight_tensor_parameter_54:
 
 class Program_weight_tensor_parameter_55:
     name = "parameter_55"
+    original_name = "linear_3.w_0_deepcopy_110"
     shape = [256, 256]
     dtype = "float32"
     min_val = float("-0.220489")
@@ -616,6 +672,7 @@ class Program_weight_tensor_parameter_55:
 
 class Program_weight_tensor_parameter_56:
     name = "parameter_56"
+    original_name = "layer_norm_4.b_0_deepcopy_107"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.637654")
@@ -627,6 +684,7 @@ class Program_weight_tensor_parameter_56:
 
 class Program_weight_tensor_parameter_57:
     name = "parameter_57"
+    original_name = "layer_norm_4.w_0_deepcopy_106"
     shape = [256]
     dtype = "float32"
     min_val = float("0.397138")
@@ -638,6 +696,7 @@ class Program_weight_tensor_parameter_57:
 
 class Program_weight_tensor_parameter_58:
     name = "parameter_58"
+    original_name = "linear_6.b_0_deepcopy_101"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.428663")
@@ -649,6 +708,7 @@ class Program_weight_tensor_parameter_58:
 
 class Program_weight_tensor_parameter_59:
     name = "parameter_59"
+    original_name = "linear_6.w_0_deepcopy_100"
     shape = [2048, 256]
     dtype = "float32"
     min_val = float("-0.603618")
@@ -660,6 +720,7 @@ class Program_weight_tensor_parameter_59:
 
 class Program_weight_tensor_parameter_60:
     name = "parameter_60"
+    original_name = "linear_5.b_0_deepcopy_99"
     shape = [2048]
     dtype = "float32"
     min_val = float("-0.375293")
@@ -671,6 +732,7 @@ class Program_weight_tensor_parameter_60:
 
 class Program_weight_tensor_parameter_61:
     name = "parameter_61"
+    original_name = "linear_5.w_0_deepcopy_98"
     shape = [256, 2048]
     dtype = "float32"
     min_val = float("-0.53905")
@@ -682,6 +744,7 @@ class Program_weight_tensor_parameter_61:
 
 class Program_weight_tensor_parameter_62:
     name = "parameter_62"
+    original_name = "layer_norm_3.b_0_deepcopy_105"
     shape = [256]
     dtype = "float32"
     min_val = float("-2.10583")
@@ -693,6 +756,7 @@ class Program_weight_tensor_parameter_62:
 
 class Program_weight_tensor_parameter_63:
     name = "parameter_63"
+    original_name = "layer_norm_3.w_0_deepcopy_104"
     shape = [256]
     dtype = "float32"
     min_val = float("0.531996")
@@ -704,6 +768,7 @@ class Program_weight_tensor_parameter_63:
 
 class Program_weight_tensor_parameter_64:
     name = "parameter_64"
+    original_name = "linear_4.b_0_deepcopy_97"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.543047")
@@ -715,6 +780,7 @@ class Program_weight_tensor_parameter_64:
 
 class Program_weight_tensor_parameter_65:
     name = "parameter_65"
+    original_name = "linear_4.w_0_deepcopy_96"
     shape = [256, 256]
     dtype = "float32"
     min_val = float("-0.58434")
@@ -726,6 +792,7 @@ class Program_weight_tensor_parameter_65:
 
 class Program_weight_tensor_parameter_66:
     name = "parameter_66"
+    original_name = "layer_norm_2.b_0_deepcopy_103"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.960798")
@@ -737,6 +804,7 @@ class Program_weight_tensor_parameter_66:
 
 class Program_weight_tensor_parameter_67:
     name = "parameter_67"
+    original_name = "layer_norm_2.w_0_deepcopy_102"
     shape = [256]
     dtype = "float32"
     min_val = float("0.475936")
@@ -748,6 +816,7 @@ class Program_weight_tensor_parameter_67:
 
 class Program_weight_tensor_parameter_68:
     name = "parameter_68"
+    original_name = "linear_3.b_0_deepcopy_93"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.198981")
@@ -759,6 +828,7 @@ class Program_weight_tensor_parameter_68:
 
 class Program_weight_tensor_parameter_69:
     name = "parameter_69"
+    original_name = "linear_3.w_0_deepcopy_92"
     shape = [256, 256]
     dtype = "float32"
     min_val = float("-0.406683")
@@ -770,6 +840,7 @@ class Program_weight_tensor_parameter_69:
 
 class Program_weight_tensor_parameter_70:
     name = "parameter_70"
+    original_name = "layer_norm_5.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.498112")
@@ -781,6 +852,7 @@ class Program_weight_tensor_parameter_70:
 
 class Program_weight_tensor_parameter_71:
     name = "parameter_71"
+    original_name = "layer_norm_5.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.105241")
@@ -792,6 +864,7 @@ class Program_weight_tensor_parameter_71:
 
 class Program_weight_tensor_parameter_72:
     name = "parameter_72"
+    original_name = "layer_norm_4.b_0_deepcopy_89"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.56296")
@@ -803,6 +876,7 @@ class Program_weight_tensor_parameter_72:
 
 class Program_weight_tensor_parameter_73:
     name = "parameter_73"
+    original_name = "layer_norm_4.w_0_deepcopy_88"
     shape = [256]
     dtype = "float32"
     min_val = float("0.153333")
@@ -814,6 +888,7 @@ class Program_weight_tensor_parameter_73:
 
 class Program_weight_tensor_parameter_74:
     name = "parameter_74"
+    original_name = "linear_6.b_0_deepcopy_83"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.923423")
@@ -825,6 +900,7 @@ class Program_weight_tensor_parameter_74:
 
 class Program_weight_tensor_parameter_75:
     name = "parameter_75"
+    original_name = "linear_6.w_0_deepcopy_82"
     shape = [2048, 256]
     dtype = "float32"
     min_val = float("-0.957782")
@@ -836,6 +912,7 @@ class Program_weight_tensor_parameter_75:
 
 class Program_weight_tensor_parameter_76:
     name = "parameter_76"
+    original_name = "linear_5.b_0_deepcopy_81"
     shape = [2048]
     dtype = "float32"
     min_val = float("-0.281287")
@@ -847,6 +924,7 @@ class Program_weight_tensor_parameter_76:
 
 class Program_weight_tensor_parameter_77:
     name = "parameter_77"
+    original_name = "linear_5.w_0_deepcopy_80"
     shape = [256, 2048]
     dtype = "float32"
     min_val = float("-1.17008")
@@ -858,6 +936,7 @@ class Program_weight_tensor_parameter_77:
 
 class Program_weight_tensor_parameter_78:
     name = "parameter_78"
+    original_name = "layer_norm_3.b_0_deepcopy_87"
     shape = [256]
     dtype = "float32"
     min_val = float("-2.54771")
@@ -869,6 +948,7 @@ class Program_weight_tensor_parameter_78:
 
 class Program_weight_tensor_parameter_79:
     name = "parameter_79"
+    original_name = "layer_norm_3.w_0_deepcopy_86"
     shape = [256]
     dtype = "float32"
     min_val = float("0.43419")
@@ -880,6 +960,7 @@ class Program_weight_tensor_parameter_79:
 
 class Program_weight_tensor_parameter_80:
     name = "parameter_80"
+    original_name = "linear_4.b_0_deepcopy_79"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.572273")
@@ -891,6 +972,7 @@ class Program_weight_tensor_parameter_80:
 
 class Program_weight_tensor_parameter_81:
     name = "parameter_81"
+    original_name = "linear_4.w_0_deepcopy_78"
     shape = [256, 256]
     dtype = "float32"
     min_val = float("-0.972671")
@@ -902,6 +984,7 @@ class Program_weight_tensor_parameter_81:
 
 class Program_weight_tensor_parameter_82:
     name = "parameter_82"
+    original_name = "layer_norm_2.b_0_deepcopy_85"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.12168")
@@ -913,6 +996,7 @@ class Program_weight_tensor_parameter_82:
 
 class Program_weight_tensor_parameter_83:
     name = "parameter_83"
+    original_name = "layer_norm_2.w_0_deepcopy_84"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.0288819")
@@ -924,6 +1008,7 @@ class Program_weight_tensor_parameter_83:
 
 class Program_weight_tensor_parameter_84:
     name = "parameter_84"
+    original_name = "linear_3.b_0_deepcopy_75"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.59146")
@@ -935,6 +1020,7 @@ class Program_weight_tensor_parameter_84:
 
 class Program_weight_tensor_parameter_85:
     name = "parameter_85"
+    original_name = "linear_3.w_0_deepcopy_74"
     shape = [256, 256]
     dtype = "float32"
     min_val = float("-2.14507")
@@ -946,6 +1032,7 @@ class Program_weight_tensor_parameter_85:
 
 class Program_weight_tensor_parameter_86:
     name = "parameter_86"
+    original_name = "layer_norm_1.b_0_deepcopy_71"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.06951")
@@ -957,6 +1044,7 @@ class Program_weight_tensor_parameter_86:
 
 class Program_weight_tensor_parameter_87:
     name = "parameter_87"
+    original_name = "layer_norm_1.w_0_deepcopy_70"
     shape = [256]
     dtype = "float32"
     min_val = float("0.00127215")
@@ -968,6 +1056,7 @@ class Program_weight_tensor_parameter_87:
 
 class Program_weight_tensor_parameter_88:
     name = "parameter_88"
+    original_name = "linear_2.b_0_deepcopy_67"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.18939")
@@ -979,6 +1068,7 @@ class Program_weight_tensor_parameter_88:
 
 class Program_weight_tensor_parameter_89:
     name = "parameter_89"
+    original_name = "linear_2.w_0_deepcopy_66"
     shape = [2048, 256]
     dtype = "float32"
     min_val = float("-1.09652")
@@ -990,6 +1080,7 @@ class Program_weight_tensor_parameter_89:
 
 class Program_weight_tensor_parameter_90:
     name = "parameter_90"
+    original_name = "linear_1.b_0_deepcopy_65"
     shape = [2048]
     dtype = "float32"
     min_val = float("-0.182248")
@@ -1001,6 +1092,7 @@ class Program_weight_tensor_parameter_90:
 
 class Program_weight_tensor_parameter_91:
     name = "parameter_91"
+    original_name = "linear_1.w_0_deepcopy_64"
     shape = [256, 2048]
     dtype = "float32"
     min_val = float("-0.635799")
@@ -1012,6 +1104,7 @@ class Program_weight_tensor_parameter_91:
 
 class Program_weight_tensor_parameter_92:
     name = "parameter_92"
+    original_name = "layer_norm_0.b_0_deepcopy_69"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.50186")
@@ -1023,6 +1116,7 @@ class Program_weight_tensor_parameter_92:
 
 class Program_weight_tensor_parameter_93:
     name = "parameter_93"
+    original_name = "layer_norm_0.w_0_deepcopy_68"
     shape = [256]
     dtype = "float32"
     min_val = float("0.344353")
@@ -1034,6 +1128,7 @@ class Program_weight_tensor_parameter_93:
 
 class Program_weight_tensor_parameter_94:
     name = "parameter_94"
+    original_name = "linear_0.b_0_deepcopy_63"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.224462")
@@ -1045,6 +1140,7 @@ class Program_weight_tensor_parameter_94:
 
 class Program_weight_tensor_parameter_95:
     name = "parameter_95"
+    original_name = "linear_0.w_0_deepcopy_62"
     shape = [256, 256]
     dtype = "float32"
     min_val = float("-0.573158")
@@ -1056,6 +1152,7 @@ class Program_weight_tensor_parameter_95:
 
 class Program_weight_tensor_parameter_96:
     name = "parameter_96"
+    original_name = "layer_norm_1.b_0_deepcopy_59"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.400377")
@@ -1067,6 +1164,7 @@ class Program_weight_tensor_parameter_96:
 
 class Program_weight_tensor_parameter_97:
     name = "parameter_97"
+    original_name = "layer_norm_1.w_0_deepcopy_58"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.010702")
@@ -1078,6 +1176,7 @@ class Program_weight_tensor_parameter_97:
 
 class Program_weight_tensor_parameter_98:
     name = "parameter_98"
+    original_name = "linear_2.b_0_deepcopy_55"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.380183")
@@ -1089,6 +1188,7 @@ class Program_weight_tensor_parameter_98:
 
 class Program_weight_tensor_parameter_99:
     name = "parameter_99"
+    original_name = "linear_2.w_0_deepcopy_54"
     shape = [2048, 256]
     dtype = "float32"
     min_val = float("-1.42445")
@@ -1100,6 +1200,7 @@ class Program_weight_tensor_parameter_99:
 
 class Program_weight_tensor_parameter_100:
     name = "parameter_100"
+    original_name = "linear_1.b_0_deepcopy_53"
     shape = [2048]
     dtype = "float32"
     min_val = float("-0.168442")
@@ -1111,6 +1212,7 @@ class Program_weight_tensor_parameter_100:
 
 class Program_weight_tensor_parameter_101:
     name = "parameter_101"
+    original_name = "linear_1.w_0_deepcopy_52"
     shape = [256, 2048]
     dtype = "float32"
     min_val = float("-0.672108")
@@ -1122,6 +1224,7 @@ class Program_weight_tensor_parameter_101:
 
 class Program_weight_tensor_parameter_102:
     name = "parameter_102"
+    original_name = "layer_norm_0.b_0_deepcopy_57"
     shape = [256]
     dtype = "float32"
     min_val = float("-2.06646")
@@ -1133,6 +1236,7 @@ class Program_weight_tensor_parameter_102:
 
 class Program_weight_tensor_parameter_103:
     name = "parameter_103"
+    original_name = "layer_norm_0.w_0_deepcopy_56"
     shape = [256]
     dtype = "float32"
     min_val = float("0.0932801")
@@ -1144,6 +1248,7 @@ class Program_weight_tensor_parameter_103:
 
 class Program_weight_tensor_parameter_104:
     name = "parameter_104"
+    original_name = "linear_0.b_0_deepcopy_51"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.7267")
@@ -1155,6 +1260,7 @@ class Program_weight_tensor_parameter_104:
 
 class Program_weight_tensor_parameter_105:
     name = "parameter_105"
+    original_name = "linear_0.w_0_deepcopy_50"
     shape = [256, 256]
     dtype = "float32"
     min_val = float("-0.439426")
@@ -1166,6 +1272,7 @@ class Program_weight_tensor_parameter_105:
 
 class Program_weight_tensor_parameter_106:
     name = "parameter_106"
+    original_name = "layer_norm_1.b_0_deepcopy_47"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.753834")
@@ -1177,6 +1284,7 @@ class Program_weight_tensor_parameter_106:
 
 class Program_weight_tensor_parameter_107:
     name = "parameter_107"
+    original_name = "layer_norm_1.w_0_deepcopy_46"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.00412211")
@@ -1188,6 +1296,7 @@ class Program_weight_tensor_parameter_107:
 
 class Program_weight_tensor_parameter_108:
     name = "parameter_108"
+    original_name = "linear_2.b_0_deepcopy_43"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.512278")
@@ -1199,6 +1308,7 @@ class Program_weight_tensor_parameter_108:
 
 class Program_weight_tensor_parameter_109:
     name = "parameter_109"
+    original_name = "linear_2.w_0_deepcopy_42"
     shape = [2048, 256]
     dtype = "float32"
     min_val = float("-1.47307")
@@ -1210,6 +1320,7 @@ class Program_weight_tensor_parameter_109:
 
 class Program_weight_tensor_parameter_110:
     name = "parameter_110"
+    original_name = "linear_1.b_0_deepcopy_41"
     shape = [2048]
     dtype = "float32"
     min_val = float("-0.157579")
@@ -1221,6 +1332,7 @@ class Program_weight_tensor_parameter_110:
 
 class Program_weight_tensor_parameter_111:
     name = "parameter_111"
+    original_name = "linear_1.w_0_deepcopy_40"
     shape = [256, 2048]
     dtype = "float32"
     min_val = float("-0.559803")
@@ -1232,6 +1344,7 @@ class Program_weight_tensor_parameter_111:
 
 class Program_weight_tensor_parameter_112:
     name = "parameter_112"
+    original_name = "layer_norm_0.b_0_deepcopy_45"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.91229")
@@ -1243,6 +1356,7 @@ class Program_weight_tensor_parameter_112:
 
 class Program_weight_tensor_parameter_113:
     name = "parameter_113"
+    original_name = "layer_norm_0.w_0_deepcopy_44"
     shape = [256]
     dtype = "float32"
     min_val = float("0.128")
@@ -1254,6 +1368,7 @@ class Program_weight_tensor_parameter_113:
 
 class Program_weight_tensor_parameter_114:
     name = "parameter_114"
+    original_name = "linear_0.b_0_deepcopy_39"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.806081")
@@ -1265,6 +1380,7 @@ class Program_weight_tensor_parameter_114:
 
 class Program_weight_tensor_parameter_115:
     name = "parameter_115"
+    original_name = "linear_0.w_0_deepcopy_38"
     shape = [256, 256]
     dtype = "float32"
     min_val = float("-0.588644")
@@ -1276,6 +1392,7 @@ class Program_weight_tensor_parameter_115:
 
 class Program_weight_tensor_parameter_116:
     name = "parameter_116"
+    original_name = "layer_norm_1.b_0_deepcopy_35"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.00999")
@@ -1287,6 +1404,7 @@ class Program_weight_tensor_parameter_116:
 
 class Program_weight_tensor_parameter_117:
     name = "parameter_117"
+    original_name = "layer_norm_1.w_0_deepcopy_34"
     shape = [256]
     dtype = "float32"
     min_val = float("0.00380956")
@@ -1298,6 +1416,7 @@ class Program_weight_tensor_parameter_117:
 
 class Program_weight_tensor_parameter_118:
     name = "parameter_118"
+    original_name = "linear_2.b_0_deepcopy_31"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.5877")
@@ -1309,6 +1428,7 @@ class Program_weight_tensor_parameter_118:
 
 class Program_weight_tensor_parameter_119:
     name = "parameter_119"
+    original_name = "linear_2.w_0_deepcopy_30"
     shape = [2048, 256]
     dtype = "float32"
     min_val = float("-1.27426")
@@ -1320,6 +1440,7 @@ class Program_weight_tensor_parameter_119:
 
 class Program_weight_tensor_parameter_120:
     name = "parameter_120"
+    original_name = "linear_1.b_0_deepcopy_29"
     shape = [2048]
     dtype = "float32"
     min_val = float("-0.17444")
@@ -1331,6 +1452,7 @@ class Program_weight_tensor_parameter_120:
 
 class Program_weight_tensor_parameter_121:
     name = "parameter_121"
+    original_name = "linear_1.w_0_deepcopy_28"
     shape = [256, 2048]
     dtype = "float32"
     min_val = float("-0.689465")
@@ -1342,6 +1464,7 @@ class Program_weight_tensor_parameter_121:
 
 class Program_weight_tensor_parameter_122:
     name = "parameter_122"
+    original_name = "layer_norm_0.b_0_deepcopy_33"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.76525")
@@ -1353,6 +1476,7 @@ class Program_weight_tensor_parameter_122:
 
 class Program_weight_tensor_parameter_123:
     name = "parameter_123"
+    original_name = "layer_norm_0.w_0_deepcopy_32"
     shape = [256]
     dtype = "float32"
     min_val = float("0.232611")
@@ -1364,6 +1488,7 @@ class Program_weight_tensor_parameter_123:
 
 class Program_weight_tensor_parameter_124:
     name = "parameter_124"
+    original_name = "linear_0.b_0_deepcopy_27"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.705862")
@@ -1375,6 +1500,7 @@ class Program_weight_tensor_parameter_124:
 
 class Program_weight_tensor_parameter_125:
     name = "parameter_125"
+    original_name = "linear_0.w_0_deepcopy_26"
     shape = [256, 256]
     dtype = "float32"
     min_val = float("-0.440333")
@@ -1386,6 +1512,7 @@ class Program_weight_tensor_parameter_125:
 
 class Program_weight_tensor_parameter_126:
     name = "parameter_126"
+    original_name = "layer_norm_1.b_0_deepcopy_23"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.922886")
@@ -1397,6 +1524,7 @@ class Program_weight_tensor_parameter_126:
 
 class Program_weight_tensor_parameter_127:
     name = "parameter_127"
+    original_name = "layer_norm_1.w_0_deepcopy_22"
     shape = [256]
     dtype = "float32"
     min_val = float("0.00558528")
@@ -1408,6 +1536,7 @@ class Program_weight_tensor_parameter_127:
 
 class Program_weight_tensor_parameter_128:
     name = "parameter_128"
+    original_name = "linear_2.b_0_deepcopy_19"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.704768")
@@ -1419,6 +1548,7 @@ class Program_weight_tensor_parameter_128:
 
 class Program_weight_tensor_parameter_129:
     name = "parameter_129"
+    original_name = "linear_2.w_0_deepcopy_18"
     shape = [2048, 256]
     dtype = "float32"
     min_val = float("-1.67532")
@@ -1430,6 +1560,7 @@ class Program_weight_tensor_parameter_129:
 
 class Program_weight_tensor_parameter_130:
     name = "parameter_130"
+    original_name = "linear_1.b_0_deepcopy_17"
     shape = [2048]
     dtype = "float32"
     min_val = float("-0.157592")
@@ -1441,6 +1572,7 @@ class Program_weight_tensor_parameter_130:
 
 class Program_weight_tensor_parameter_131:
     name = "parameter_131"
+    original_name = "linear_1.w_0_deepcopy_16"
     shape = [256, 2048]
     dtype = "float32"
     min_val = float("-0.724598")
@@ -1452,6 +1584,7 @@ class Program_weight_tensor_parameter_131:
 
 class Program_weight_tensor_parameter_132:
     name = "parameter_132"
+    original_name = "layer_norm_0.b_0_deepcopy_21"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.83743")
@@ -1463,6 +1596,7 @@ class Program_weight_tensor_parameter_132:
 
 class Program_weight_tensor_parameter_133:
     name = "parameter_133"
+    original_name = "layer_norm_0.w_0_deepcopy_20"
     shape = [256]
     dtype = "float32"
     min_val = float("0.231014")
@@ -1474,6 +1608,7 @@ class Program_weight_tensor_parameter_133:
 
 class Program_weight_tensor_parameter_134:
     name = "parameter_134"
+    original_name = "linear_0.b_0_deepcopy_15"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.725101")
@@ -1485,6 +1620,7 @@ class Program_weight_tensor_parameter_134:
 
 class Program_weight_tensor_parameter_135:
     name = "parameter_135"
+    original_name = "linear_0.w_0_deepcopy_14"
     shape = [256, 256]
     dtype = "float32"
     min_val = float("-0.413043")
@@ -1496,6 +1632,7 @@ class Program_weight_tensor_parameter_135:
 
 class Program_weight_tensor_parameter_136:
     name = "parameter_136"
+    original_name = "layer_norm_1.b_0_deepcopy_11"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.800124")
@@ -1507,6 +1644,7 @@ class Program_weight_tensor_parameter_136:
 
 class Program_weight_tensor_parameter_137:
     name = "parameter_137"
+    original_name = "layer_norm_1.w_0_deepcopy_10"
     shape = [256]
     dtype = "float32"
     min_val = float("0.186909")
@@ -1518,6 +1656,7 @@ class Program_weight_tensor_parameter_137:
 
 class Program_weight_tensor_parameter_138:
     name = "parameter_138"
+    original_name = "linear_2.b_0_deepcopy_7"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.461149")
@@ -1529,6 +1668,7 @@ class Program_weight_tensor_parameter_138:
 
 class Program_weight_tensor_parameter_139:
     name = "parameter_139"
+    original_name = "linear_2.w_0_deepcopy_6"
     shape = [2048, 256]
     dtype = "float32"
     min_val = float("-1.504")
@@ -1540,6 +1680,7 @@ class Program_weight_tensor_parameter_139:
 
 class Program_weight_tensor_parameter_140:
     name = "parameter_140"
+    original_name = "linear_1.b_0_deepcopy_5"
     shape = [2048]
     dtype = "float32"
     min_val = float("-0.174725")
@@ -1551,6 +1692,7 @@ class Program_weight_tensor_parameter_140:
 
 class Program_weight_tensor_parameter_141:
     name = "parameter_141"
+    original_name = "linear_1.w_0_deepcopy_4"
     shape = [256, 2048]
     dtype = "float32"
     min_val = float("-0.664555")
@@ -1562,6 +1704,7 @@ class Program_weight_tensor_parameter_141:
 
 class Program_weight_tensor_parameter_142:
     name = "parameter_142"
+    original_name = "layer_norm_0.b_0_deepcopy_9"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.50004")
@@ -1573,6 +1716,7 @@ class Program_weight_tensor_parameter_142:
 
 class Program_weight_tensor_parameter_143:
     name = "parameter_143"
+    original_name = "layer_norm_0.w_0_deepcopy_8"
     shape = [256]
     dtype = "float32"
     min_val = float("0.437127")
@@ -1584,6 +1728,7 @@ class Program_weight_tensor_parameter_143:
 
 class Program_weight_tensor_parameter_144:
     name = "parameter_144"
+    original_name = "linear_0.b_0_deepcopy_3"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.798574")
@@ -1595,6 +1740,7 @@ class Program_weight_tensor_parameter_144:
 
 class Program_weight_tensor_parameter_145:
     name = "parameter_145"
+    original_name = "linear_0.w_0_deepcopy_2"
     shape = [256, 256]
     dtype = "float32"
     min_val = float("-0.583847")
@@ -1606,6 +1752,7 @@ class Program_weight_tensor_parameter_145:
 
 class Program_weight_tensor_parameter_146:
     name = "parameter_146"
+    original_name = "conv2d_53.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.344435")
@@ -1617,6 +1764,7 @@ class Program_weight_tensor_parameter_146:
 
 class Program_weight_tensor_parameter_147:
     name = "parameter_147"
+    original_name = "conv2d_53.w_0"
     shape = [256, 2048, 1, 1]
     dtype = "float32"
     min_val = float("-1.03354")
@@ -1628,6 +1776,7 @@ class Program_weight_tensor_parameter_147:
 
 class Program_weight_tensor_parameter_148:
     name = "parameter_148"
+    original_name = "batch_norm2d_52.b_0"
     shape = [2048]
     dtype = "float32"
     min_val = float("-0.150417")
@@ -1639,6 +1788,7 @@ class Program_weight_tensor_parameter_148:
 
 class Program_weight_tensor_parameter_149:
     name = "parameter_149"
+    original_name = "batch_norm2d_52.w_0"
     shape = [2048]
     dtype = "float32"
     min_val = float("0.112357")
@@ -1650,6 +1800,7 @@ class Program_weight_tensor_parameter_149:
 
 class Program_weight_tensor_parameter_150:
     name = "parameter_150"
+    original_name = "batch_norm2d_52.w_2"
     shape = [2048]
     dtype = "float32"
     min_val = float("4.58401e-05")
@@ -1661,6 +1812,7 @@ class Program_weight_tensor_parameter_150:
 
 class Program_weight_tensor_parameter_151:
     name = "parameter_151"
+    original_name = "batch_norm2d_52.w_1"
     shape = [2048]
     dtype = "float32"
     min_val = float("-0.0298089")
@@ -1672,6 +1824,7 @@ class Program_weight_tensor_parameter_151:
 
 class Program_weight_tensor_parameter_152:
     name = "parameter_152"
+    original_name = "conv2d_52.w_0"
     shape = [2048, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.152886")
@@ -1683,6 +1836,7 @@ class Program_weight_tensor_parameter_152:
 
 class Program_weight_tensor_parameter_153:
     name = "parameter_153"
+    original_name = "batch_norm2d_51.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.293918")
@@ -1694,6 +1848,7 @@ class Program_weight_tensor_parameter_153:
 
 class Program_weight_tensor_parameter_154:
     name = "parameter_154"
+    original_name = "batch_norm2d_51.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("0.134363")
@@ -1705,6 +1860,7 @@ class Program_weight_tensor_parameter_154:
 
 class Program_weight_tensor_parameter_155:
     name = "parameter_155"
+    original_name = "batch_norm2d_51.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("0.00773641")
@@ -1716,6 +1872,7 @@ class Program_weight_tensor_parameter_155:
 
 class Program_weight_tensor_parameter_156:
     name = "parameter_156"
+    original_name = "batch_norm2d_51.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.148122")
@@ -1727,6 +1884,7 @@ class Program_weight_tensor_parameter_156:
 
 class Program_weight_tensor_parameter_157:
     name = "parameter_157"
+    original_name = "conv2d_51.w_0"
     shape = [512, 512, 3, 3]
     dtype = "float32"
     min_val = float("-0.166298")
@@ -1738,6 +1896,7 @@ class Program_weight_tensor_parameter_157:
 
 class Program_weight_tensor_parameter_158:
     name = "parameter_158"
+    original_name = "batch_norm2d_50.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.334689")
@@ -1749,6 +1908,7 @@ class Program_weight_tensor_parameter_158:
 
 class Program_weight_tensor_parameter_159:
     name = "parameter_159"
+    original_name = "batch_norm2d_50.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("0.112843")
@@ -1760,6 +1920,7 @@ class Program_weight_tensor_parameter_159:
 
 class Program_weight_tensor_parameter_160:
     name = "parameter_160"
+    original_name = "batch_norm2d_50.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("0.189317")
@@ -1771,6 +1932,7 @@ class Program_weight_tensor_parameter_160:
 
 class Program_weight_tensor_parameter_161:
     name = "parameter_161"
+    original_name = "batch_norm2d_50.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.987256")
@@ -1782,6 +1944,7 @@ class Program_weight_tensor_parameter_161:
 
 class Program_weight_tensor_parameter_162:
     name = "parameter_162"
+    original_name = "conv2d_50.w_0"
     shape = [512, 2048, 1, 1]
     dtype = "float32"
     min_val = float("-0.362413")
@@ -1793,6 +1956,7 @@ class Program_weight_tensor_parameter_162:
 
 class Program_weight_tensor_parameter_163:
     name = "parameter_163"
+    original_name = "batch_norm2d_49.b_0"
     shape = [2048]
     dtype = "float32"
     min_val = float("-0.21598")
@@ -1804,6 +1968,7 @@ class Program_weight_tensor_parameter_163:
 
 class Program_weight_tensor_parameter_164:
     name = "parameter_164"
+    original_name = "batch_norm2d_49.w_0"
     shape = [2048]
     dtype = "float32"
     min_val = float("0.129696")
@@ -1815,6 +1980,7 @@ class Program_weight_tensor_parameter_164:
 
 class Program_weight_tensor_parameter_165:
     name = "parameter_165"
+    original_name = "batch_norm2d_49.w_2"
     shape = [2048]
     dtype = "float32"
     min_val = float("0.000190455")
@@ -1826,6 +1992,7 @@ class Program_weight_tensor_parameter_165:
 
 class Program_weight_tensor_parameter_166:
     name = "parameter_166"
+    original_name = "batch_norm2d_49.w_1"
     shape = [2048]
     dtype = "float32"
     min_val = float("-0.156046")
@@ -1837,6 +2004,7 @@ class Program_weight_tensor_parameter_166:
 
 class Program_weight_tensor_parameter_167:
     name = "parameter_167"
+    original_name = "conv2d_49.w_0"
     shape = [2048, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.187602")
@@ -1848,6 +2016,7 @@ class Program_weight_tensor_parameter_167:
 
 class Program_weight_tensor_parameter_168:
     name = "parameter_168"
+    original_name = "batch_norm2d_48.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.347685")
@@ -1859,6 +2028,7 @@ class Program_weight_tensor_parameter_168:
 
 class Program_weight_tensor_parameter_169:
     name = "parameter_169"
+    original_name = "batch_norm2d_48.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("0.147304")
@@ -1870,6 +2040,7 @@ class Program_weight_tensor_parameter_169:
 
 class Program_weight_tensor_parameter_170:
     name = "parameter_170"
+    original_name = "batch_norm2d_48.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("0.00819833")
@@ -1881,6 +2052,7 @@ class Program_weight_tensor_parameter_170:
 
 class Program_weight_tensor_parameter_171:
     name = "parameter_171"
+    original_name = "batch_norm2d_48.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.37926")
@@ -1892,6 +2064,7 @@ class Program_weight_tensor_parameter_171:
 
 class Program_weight_tensor_parameter_172:
     name = "parameter_172"
+    original_name = "conv2d_48.w_0"
     shape = [512, 512, 3, 3]
     dtype = "float32"
     min_val = float("-0.242756")
@@ -1903,6 +2076,7 @@ class Program_weight_tensor_parameter_172:
 
 class Program_weight_tensor_parameter_173:
     name = "parameter_173"
+    original_name = "batch_norm2d_47.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.319738")
@@ -1914,6 +2088,7 @@ class Program_weight_tensor_parameter_173:
 
 class Program_weight_tensor_parameter_174:
     name = "parameter_174"
+    original_name = "batch_norm2d_47.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("0.0941531")
@@ -1925,6 +2100,7 @@ class Program_weight_tensor_parameter_174:
 
 class Program_weight_tensor_parameter_175:
     name = "parameter_175"
+    original_name = "batch_norm2d_47.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("0.0888968")
@@ -1936,6 +2112,7 @@ class Program_weight_tensor_parameter_175:
 
 class Program_weight_tensor_parameter_176:
     name = "parameter_176"
+    original_name = "batch_norm2d_47.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.878403")
@@ -1947,6 +2124,7 @@ class Program_weight_tensor_parameter_176:
 
 class Program_weight_tensor_parameter_177:
     name = "parameter_177"
+    original_name = "conv2d_47.w_0"
     shape = [512, 2048, 1, 1]
     dtype = "float32"
     min_val = float("-0.389186")
@@ -1958,6 +2136,7 @@ class Program_weight_tensor_parameter_177:
 
 class Program_weight_tensor_parameter_178:
     name = "parameter_178"
+    original_name = "batch_norm2d_46.b_0"
     shape = [2048]
     dtype = "float32"
     min_val = float("-0.140877")
@@ -1969,6 +2148,7 @@ class Program_weight_tensor_parameter_178:
 
 class Program_weight_tensor_parameter_179:
     name = "parameter_179"
+    original_name = "batch_norm2d_46.w_0"
     shape = [2048]
     dtype = "float32"
     min_val = float("0.11185")
@@ -1980,6 +2160,7 @@ class Program_weight_tensor_parameter_179:
 
 class Program_weight_tensor_parameter_180:
     name = "parameter_180"
+    original_name = "batch_norm2d_46.w_2"
     shape = [2048]
     dtype = "float32"
     min_val = float("0.00030292")
@@ -1991,6 +2172,7 @@ class Program_weight_tensor_parameter_180:
 
 class Program_weight_tensor_parameter_181:
     name = "parameter_181"
+    original_name = "batch_norm2d_46.w_1"
     shape = [2048]
     dtype = "float32"
     min_val = float("-0.0978358")
@@ -2002,6 +2184,7 @@ class Program_weight_tensor_parameter_181:
 
 class Program_weight_tensor_parameter_182:
     name = "parameter_182"
+    original_name = "conv2d_46.w_0"
     shape = [2048, 1024, 1, 1]
     dtype = "float32"
     min_val = float("-0.365442")
@@ -2013,6 +2196,7 @@ class Program_weight_tensor_parameter_182:
 
 class Program_weight_tensor_parameter_183:
     name = "parameter_183"
+    original_name = "batch_norm2d_45.b_0"
     shape = [2048]
     dtype = "float32"
     min_val = float("-0.140877")
@@ -2024,6 +2208,7 @@ class Program_weight_tensor_parameter_183:
 
 class Program_weight_tensor_parameter_184:
     name = "parameter_184"
+    original_name = "batch_norm2d_45.w_0"
     shape = [2048]
     dtype = "float32"
     min_val = float("0.0343876")
@@ -2035,6 +2220,7 @@ class Program_weight_tensor_parameter_184:
 
 class Program_weight_tensor_parameter_185:
     name = "parameter_185"
+    original_name = "batch_norm2d_45.w_2"
     shape = [2048]
     dtype = "float32"
     min_val = float("0.000190366")
@@ -2046,6 +2232,7 @@ class Program_weight_tensor_parameter_185:
 
 class Program_weight_tensor_parameter_186:
     name = "parameter_186"
+    original_name = "batch_norm2d_45.w_1"
     shape = [2048]
     dtype = "float32"
     min_val = float("-0.124208")
@@ -2057,6 +2244,7 @@ class Program_weight_tensor_parameter_186:
 
 class Program_weight_tensor_parameter_187:
     name = "parameter_187"
+    original_name = "conv2d_45.w_0"
     shape = [2048, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.232864")
@@ -2068,6 +2256,7 @@ class Program_weight_tensor_parameter_187:
 
 class Program_weight_tensor_parameter_188:
     name = "parameter_188"
+    original_name = "batch_norm2d_44.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.187468")
@@ -2079,6 +2268,7 @@ class Program_weight_tensor_parameter_188:
 
 class Program_weight_tensor_parameter_189:
     name = "parameter_189"
+    original_name = "batch_norm2d_44.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("0.14926")
@@ -2090,6 +2280,7 @@ class Program_weight_tensor_parameter_189:
 
 class Program_weight_tensor_parameter_190:
     name = "parameter_190"
+    original_name = "batch_norm2d_44.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("0.00845713")
@@ -2101,6 +2292,7 @@ class Program_weight_tensor_parameter_190:
 
 class Program_weight_tensor_parameter_191:
     name = "parameter_191"
+    original_name = "batch_norm2d_44.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.14583")
@@ -2112,6 +2304,7 @@ class Program_weight_tensor_parameter_191:
 
 class Program_weight_tensor_parameter_192:
     name = "parameter_192"
+    original_name = "conv2d_44.w_0"
     shape = [512, 512, 3, 3]
     dtype = "float32"
     min_val = float("-0.355202")
@@ -2123,6 +2316,7 @@ class Program_weight_tensor_parameter_192:
 
 class Program_weight_tensor_parameter_193:
     name = "parameter_193"
+    original_name = "batch_norm2d_43.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.350172")
@@ -2134,6 +2328,7 @@ class Program_weight_tensor_parameter_193:
 
 class Program_weight_tensor_parameter_194:
     name = "parameter_194"
+    original_name = "batch_norm2d_43.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("0.106705")
@@ -2145,6 +2340,7 @@ class Program_weight_tensor_parameter_194:
 
 class Program_weight_tensor_parameter_195:
     name = "parameter_195"
+    original_name = "batch_norm2d_43.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("0.00811289")
@@ -2156,6 +2352,7 @@ class Program_weight_tensor_parameter_195:
 
 class Program_weight_tensor_parameter_196:
     name = "parameter_196"
+    original_name = "batch_norm2d_43.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.20864")
@@ -2167,6 +2364,7 @@ class Program_weight_tensor_parameter_196:
 
 class Program_weight_tensor_parameter_197:
     name = "parameter_197"
+    original_name = "conv2d_43.w_0"
     shape = [512, 1024, 1, 1]
     dtype = "float32"
     min_val = float("-0.355235")
@@ -2178,6 +2376,7 @@ class Program_weight_tensor_parameter_197:
 
 class Program_weight_tensor_parameter_198:
     name = "parameter_198"
+    original_name = "batch_norm2d_42.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.370779")
@@ -2189,6 +2388,7 @@ class Program_weight_tensor_parameter_198:
 
 class Program_weight_tensor_parameter_199:
     name = "parameter_199"
+    original_name = "batch_norm2d_42.w_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.0664216")
@@ -2200,6 +2400,7 @@ class Program_weight_tensor_parameter_199:
 
 class Program_weight_tensor_parameter_200:
     name = "parameter_200"
+    original_name = "batch_norm2d_42.w_2"
     shape = [1024]
     dtype = "float32"
     min_val = float("0.000187986")
@@ -2211,6 +2412,7 @@ class Program_weight_tensor_parameter_200:
 
 class Program_weight_tensor_parameter_201:
     name = "parameter_201"
+    original_name = "batch_norm2d_42.w_1"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.112668")
@@ -2222,6 +2424,7 @@ class Program_weight_tensor_parameter_201:
 
 class Program_weight_tensor_parameter_202:
     name = "parameter_202"
+    original_name = "conv2d_42.w_0"
     shape = [1024, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.274578")
@@ -2233,6 +2436,7 @@ class Program_weight_tensor_parameter_202:
 
 class Program_weight_tensor_parameter_203:
     name = "parameter_203"
+    original_name = "batch_norm2d_41.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.399307")
@@ -2244,6 +2448,7 @@ class Program_weight_tensor_parameter_203:
 
 class Program_weight_tensor_parameter_204:
     name = "parameter_204"
+    original_name = "batch_norm2d_41.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.124237")
@@ -2255,6 +2460,7 @@ class Program_weight_tensor_parameter_204:
 
 class Program_weight_tensor_parameter_205:
     name = "parameter_205"
+    original_name = "batch_norm2d_41.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.00573658")
@@ -2266,6 +2472,7 @@ class Program_weight_tensor_parameter_205:
 
 class Program_weight_tensor_parameter_206:
     name = "parameter_206"
+    original_name = "batch_norm2d_41.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.223885")
@@ -2277,6 +2484,7 @@ class Program_weight_tensor_parameter_206:
 
 class Program_weight_tensor_parameter_207:
     name = "parameter_207"
+    original_name = "conv2d_41.w_0"
     shape = [256, 256, 3, 3]
     dtype = "float32"
     min_val = float("-0.230967")
@@ -2288,6 +2496,7 @@ class Program_weight_tensor_parameter_207:
 
 class Program_weight_tensor_parameter_208:
     name = "parameter_208"
+    original_name = "batch_norm2d_40.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.314365")
@@ -2299,6 +2508,7 @@ class Program_weight_tensor_parameter_208:
 
 class Program_weight_tensor_parameter_209:
     name = "parameter_209"
+    original_name = "batch_norm2d_40.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.0896673")
@@ -2310,6 +2520,7 @@ class Program_weight_tensor_parameter_209:
 
 class Program_weight_tensor_parameter_210:
     name = "parameter_210"
+    original_name = "batch_norm2d_40.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.00800373")
@@ -2321,6 +2532,7 @@ class Program_weight_tensor_parameter_210:
 
 class Program_weight_tensor_parameter_211:
     name = "parameter_211"
+    original_name = "batch_norm2d_40.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.183551")
@@ -2332,6 +2544,7 @@ class Program_weight_tensor_parameter_211:
 
 class Program_weight_tensor_parameter_212:
     name = "parameter_212"
+    original_name = "conv2d_40.w_0"
     shape = [256, 1024, 1, 1]
     dtype = "float32"
     min_val = float("-0.230989")
@@ -2343,6 +2556,7 @@ class Program_weight_tensor_parameter_212:
 
 class Program_weight_tensor_parameter_213:
     name = "parameter_213"
+    original_name = "batch_norm2d_39.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.316103")
@@ -2354,6 +2568,7 @@ class Program_weight_tensor_parameter_213:
 
 class Program_weight_tensor_parameter_214:
     name = "parameter_214"
+    original_name = "batch_norm2d_39.w_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.048939")
@@ -2365,6 +2580,7 @@ class Program_weight_tensor_parameter_214:
 
 class Program_weight_tensor_parameter_215:
     name = "parameter_215"
+    original_name = "batch_norm2d_39.w_2"
     shape = [1024]
     dtype = "float32"
     min_val = float("7.44126e-05")
@@ -2376,6 +2592,7 @@ class Program_weight_tensor_parameter_215:
 
 class Program_weight_tensor_parameter_216:
     name = "parameter_216"
+    original_name = "batch_norm2d_39.w_1"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.102078")
@@ -2387,6 +2604,7 @@ class Program_weight_tensor_parameter_216:
 
 class Program_weight_tensor_parameter_217:
     name = "parameter_217"
+    original_name = "conv2d_39.w_0"
     shape = [1024, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.223271")
@@ -2398,6 +2616,7 @@ class Program_weight_tensor_parameter_217:
 
 class Program_weight_tensor_parameter_218:
     name = "parameter_218"
+    original_name = "batch_norm2d_38.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.329938")
@@ -2409,6 +2628,7 @@ class Program_weight_tensor_parameter_218:
 
 class Program_weight_tensor_parameter_219:
     name = "parameter_219"
+    original_name = "batch_norm2d_38.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.0993624")
@@ -2420,6 +2640,7 @@ class Program_weight_tensor_parameter_219:
 
 class Program_weight_tensor_parameter_220:
     name = "parameter_220"
+    original_name = "batch_norm2d_38.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.00524586")
@@ -2431,6 +2652,7 @@ class Program_weight_tensor_parameter_220:
 
 class Program_weight_tensor_parameter_221:
     name = "parameter_221"
+    original_name = "batch_norm2d_38.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.214452")
@@ -2442,6 +2664,7 @@ class Program_weight_tensor_parameter_221:
 
 class Program_weight_tensor_parameter_222:
     name = "parameter_222"
+    original_name = "conv2d_38.w_0"
     shape = [256, 256, 3, 3]
     dtype = "float32"
     min_val = float("-0.198749")
@@ -2453,6 +2676,7 @@ class Program_weight_tensor_parameter_222:
 
 class Program_weight_tensor_parameter_223:
     name = "parameter_223"
+    original_name = "batch_norm2d_37.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.324492")
@@ -2464,6 +2688,7 @@ class Program_weight_tensor_parameter_223:
 
 class Program_weight_tensor_parameter_224:
     name = "parameter_224"
+    original_name = "batch_norm2d_37.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.0949062")
@@ -2475,6 +2700,7 @@ class Program_weight_tensor_parameter_224:
 
 class Program_weight_tensor_parameter_225:
     name = "parameter_225"
+    original_name = "batch_norm2d_37.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.00832382")
@@ -2486,6 +2712,7 @@ class Program_weight_tensor_parameter_225:
 
 class Program_weight_tensor_parameter_226:
     name = "parameter_226"
+    original_name = "batch_norm2d_37.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.241107")
@@ -2497,6 +2724,7 @@ class Program_weight_tensor_parameter_226:
 
 class Program_weight_tensor_parameter_227:
     name = "parameter_227"
+    original_name = "conv2d_37.w_0"
     shape = [256, 1024, 1, 1]
     dtype = "float32"
     min_val = float("-0.214375")
@@ -2508,6 +2736,7 @@ class Program_weight_tensor_parameter_227:
 
 class Program_weight_tensor_parameter_228:
     name = "parameter_228"
+    original_name = "batch_norm2d_36.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.225174")
@@ -2519,6 +2748,7 @@ class Program_weight_tensor_parameter_228:
 
 class Program_weight_tensor_parameter_229:
     name = "parameter_229"
+    original_name = "batch_norm2d_36.w_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.0301997")
@@ -2530,6 +2760,7 @@ class Program_weight_tensor_parameter_229:
 
 class Program_weight_tensor_parameter_230:
     name = "parameter_230"
+    original_name = "batch_norm2d_36.w_2"
     shape = [1024]
     dtype = "float32"
     min_val = float("3.12528e-11")
@@ -2541,6 +2772,7 @@ class Program_weight_tensor_parameter_230:
 
 class Program_weight_tensor_parameter_231:
     name = "parameter_231"
+    original_name = "batch_norm2d_36.w_1"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.0749364")
@@ -2552,6 +2784,7 @@ class Program_weight_tensor_parameter_231:
 
 class Program_weight_tensor_parameter_232:
     name = "parameter_232"
+    original_name = "conv2d_36.w_0"
     shape = [1024, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.249464")
@@ -2563,6 +2796,7 @@ class Program_weight_tensor_parameter_232:
 
 class Program_weight_tensor_parameter_233:
     name = "parameter_233"
+    original_name = "batch_norm2d_35.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.208314")
@@ -2574,6 +2808,7 @@ class Program_weight_tensor_parameter_233:
 
 class Program_weight_tensor_parameter_234:
     name = "parameter_234"
+    original_name = "batch_norm2d_35.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.0967561")
@@ -2585,6 +2820,7 @@ class Program_weight_tensor_parameter_234:
 
 class Program_weight_tensor_parameter_235:
     name = "parameter_235"
+    original_name = "batch_norm2d_35.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.00534462")
@@ -2596,6 +2832,7 @@ class Program_weight_tensor_parameter_235:
 
 class Program_weight_tensor_parameter_236:
     name = "parameter_236"
+    original_name = "batch_norm2d_35.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.162661")
@@ -2607,6 +2844,7 @@ class Program_weight_tensor_parameter_236:
 
 class Program_weight_tensor_parameter_237:
     name = "parameter_237"
+    original_name = "conv2d_35.w_0"
     shape = [256, 256, 3, 3]
     dtype = "float32"
     min_val = float("-0.173503")
@@ -2618,6 +2856,7 @@ class Program_weight_tensor_parameter_237:
 
 class Program_weight_tensor_parameter_238:
     name = "parameter_238"
+    original_name = "batch_norm2d_34.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.259401")
@@ -2629,6 +2868,7 @@ class Program_weight_tensor_parameter_238:
 
 class Program_weight_tensor_parameter_239:
     name = "parameter_239"
+    original_name = "batch_norm2d_34.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.0953832")
@@ -2640,6 +2880,7 @@ class Program_weight_tensor_parameter_239:
 
 class Program_weight_tensor_parameter_240:
     name = "parameter_240"
+    original_name = "batch_norm2d_34.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.00862938")
@@ -2651,6 +2892,7 @@ class Program_weight_tensor_parameter_240:
 
 class Program_weight_tensor_parameter_241:
     name = "parameter_241"
+    original_name = "batch_norm2d_34.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.262802")
@@ -2662,6 +2904,7 @@ class Program_weight_tensor_parameter_241:
 
 class Program_weight_tensor_parameter_242:
     name = "parameter_242"
+    original_name = "conv2d_34.w_0"
     shape = [256, 1024, 1, 1]
     dtype = "float32"
     min_val = float("-0.227972")
@@ -2673,6 +2916,7 @@ class Program_weight_tensor_parameter_242:
 
 class Program_weight_tensor_parameter_243:
     name = "parameter_243"
+    original_name = "batch_norm2d_33.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.262605")
@@ -2684,6 +2928,7 @@ class Program_weight_tensor_parameter_243:
 
 class Program_weight_tensor_parameter_244:
     name = "parameter_244"
+    original_name = "batch_norm2d_33.w_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.0341974")
@@ -2695,6 +2940,7 @@ class Program_weight_tensor_parameter_244:
 
 class Program_weight_tensor_parameter_245:
     name = "parameter_245"
+    original_name = "batch_norm2d_33.w_2"
     shape = [1024]
     dtype = "float32"
     min_val = float("7.40606e-11")
@@ -2706,6 +2952,7 @@ class Program_weight_tensor_parameter_245:
 
 class Program_weight_tensor_parameter_246:
     name = "parameter_246"
+    original_name = "batch_norm2d_33.w_1"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.114872")
@@ -2717,6 +2964,7 @@ class Program_weight_tensor_parameter_246:
 
 class Program_weight_tensor_parameter_247:
     name = "parameter_247"
+    original_name = "conv2d_33.w_0"
     shape = [1024, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.398551")
@@ -2728,6 +2976,7 @@ class Program_weight_tensor_parameter_247:
 
 class Program_weight_tensor_parameter_248:
     name = "parameter_248"
+    original_name = "batch_norm2d_32.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.220177")
@@ -2739,6 +2988,7 @@ class Program_weight_tensor_parameter_248:
 
 class Program_weight_tensor_parameter_249:
     name = "parameter_249"
+    original_name = "batch_norm2d_32.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.096898")
@@ -2750,6 +3000,7 @@ class Program_weight_tensor_parameter_249:
 
 class Program_weight_tensor_parameter_250:
     name = "parameter_250"
+    original_name = "batch_norm2d_32.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.00716861")
@@ -2761,6 +3012,7 @@ class Program_weight_tensor_parameter_250:
 
 class Program_weight_tensor_parameter_251:
     name = "parameter_251"
+    original_name = "batch_norm2d_32.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.33006")
@@ -2772,6 +3024,7 @@ class Program_weight_tensor_parameter_251:
 
 class Program_weight_tensor_parameter_252:
     name = "parameter_252"
+    original_name = "conv2d_32.w_0"
     shape = [256, 256, 3, 3]
     dtype = "float32"
     min_val = float("-0.243493")
@@ -2783,6 +3036,7 @@ class Program_weight_tensor_parameter_252:
 
 class Program_weight_tensor_parameter_253:
     name = "parameter_253"
+    original_name = "batch_norm2d_31.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.231612")
@@ -2794,6 +3048,7 @@ class Program_weight_tensor_parameter_253:
 
 class Program_weight_tensor_parameter_254:
     name = "parameter_254"
+    original_name = "batch_norm2d_31.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.0980205")
@@ -2805,6 +3060,7 @@ class Program_weight_tensor_parameter_254:
 
 class Program_weight_tensor_parameter_255:
     name = "parameter_255"
+    original_name = "batch_norm2d_31.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.0081298")
@@ -2816,6 +3072,7 @@ class Program_weight_tensor_parameter_255:
 
 class Program_weight_tensor_parameter_256:
     name = "parameter_256"
+    original_name = "batch_norm2d_31.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.219663")
@@ -2827,6 +3084,7 @@ class Program_weight_tensor_parameter_256:
 
 class Program_weight_tensor_parameter_257:
     name = "parameter_257"
+    original_name = "conv2d_31.w_0"
     shape = [256, 1024, 1, 1]
     dtype = "float32"
     min_val = float("-0.223988")
@@ -2838,6 +3096,7 @@ class Program_weight_tensor_parameter_257:
 
 class Program_weight_tensor_parameter_258:
     name = "parameter_258"
+    original_name = "batch_norm2d_30.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.214667")
@@ -2849,6 +3108,7 @@ class Program_weight_tensor_parameter_258:
 
 class Program_weight_tensor_parameter_259:
     name = "parameter_259"
+    original_name = "batch_norm2d_30.w_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.014802")
@@ -2860,6 +3120,7 @@ class Program_weight_tensor_parameter_259:
 
 class Program_weight_tensor_parameter_260:
     name = "parameter_260"
+    original_name = "batch_norm2d_30.w_2"
     shape = [1024]
     dtype = "float32"
     min_val = float("2.17905e-11")
@@ -2871,6 +3132,7 @@ class Program_weight_tensor_parameter_260:
 
 class Program_weight_tensor_parameter_261:
     name = "parameter_261"
+    original_name = "batch_norm2d_30.w_1"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.154766")
@@ -2882,6 +3144,7 @@ class Program_weight_tensor_parameter_261:
 
 class Program_weight_tensor_parameter_262:
     name = "parameter_262"
+    original_name = "conv2d_30.w_0"
     shape = [1024, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.516358")
@@ -2893,6 +3156,7 @@ class Program_weight_tensor_parameter_262:
 
 class Program_weight_tensor_parameter_263:
     name = "parameter_263"
+    original_name = "batch_norm2d_29.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.384297")
@@ -2904,6 +3168,7 @@ class Program_weight_tensor_parameter_263:
 
 class Program_weight_tensor_parameter_264:
     name = "parameter_264"
+    original_name = "batch_norm2d_29.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.101814")
@@ -2915,6 +3180,7 @@ class Program_weight_tensor_parameter_264:
 
 class Program_weight_tensor_parameter_265:
     name = "parameter_265"
+    original_name = "batch_norm2d_29.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.00926883")
@@ -2926,6 +3192,7 @@ class Program_weight_tensor_parameter_265:
 
 class Program_weight_tensor_parameter_266:
     name = "parameter_266"
+    original_name = "batch_norm2d_29.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.897196")
@@ -2937,6 +3204,7 @@ class Program_weight_tensor_parameter_266:
 
 class Program_weight_tensor_parameter_267:
     name = "parameter_267"
+    original_name = "conv2d_29.w_0"
     shape = [256, 256, 3, 3]
     dtype = "float32"
     min_val = float("-0.244341")
@@ -2948,6 +3216,7 @@ class Program_weight_tensor_parameter_267:
 
 class Program_weight_tensor_parameter_268:
     name = "parameter_268"
+    original_name = "batch_norm2d_28.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.154157")
@@ -2959,6 +3228,7 @@ class Program_weight_tensor_parameter_268:
 
 class Program_weight_tensor_parameter_269:
     name = "parameter_269"
+    original_name = "batch_norm2d_28.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.0953903")
@@ -2970,6 +3240,7 @@ class Program_weight_tensor_parameter_269:
 
 class Program_weight_tensor_parameter_270:
     name = "parameter_270"
+    original_name = "batch_norm2d_28.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.00848757")
@@ -2981,6 +3252,7 @@ class Program_weight_tensor_parameter_270:
 
 class Program_weight_tensor_parameter_271:
     name = "parameter_271"
+    original_name = "batch_norm2d_28.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.883407")
@@ -2992,6 +3264,7 @@ class Program_weight_tensor_parameter_271:
 
 class Program_weight_tensor_parameter_272:
     name = "parameter_272"
+    original_name = "conv2d_28.w_0"
     shape = [256, 1024, 1, 1]
     dtype = "float32"
     min_val = float("-0.219926")
@@ -3003,6 +3276,7 @@ class Program_weight_tensor_parameter_272:
 
 class Program_weight_tensor_parameter_273:
     name = "parameter_273"
+    original_name = "batch_norm2d_27.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.123107")
@@ -3014,6 +3288,7 @@ class Program_weight_tensor_parameter_273:
 
 class Program_weight_tensor_parameter_274:
     name = "parameter_274"
+    original_name = "batch_norm2d_27.w_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.0802479")
@@ -3025,6 +3300,7 @@ class Program_weight_tensor_parameter_274:
 
 class Program_weight_tensor_parameter_275:
     name = "parameter_275"
+    original_name = "batch_norm2d_27.w_2"
     shape = [1024]
     dtype = "float32"
     min_val = float("2.12427e-14")
@@ -3036,6 +3312,7 @@ class Program_weight_tensor_parameter_275:
 
 class Program_weight_tensor_parameter_276:
     name = "parameter_276"
+    original_name = "batch_norm2d_27.w_1"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.312993")
@@ -3047,6 +3324,7 @@ class Program_weight_tensor_parameter_276:
 
 class Program_weight_tensor_parameter_277:
     name = "parameter_277"
+    original_name = "conv2d_27.w_0"
     shape = [1024, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.337787")
@@ -3058,6 +3336,7 @@ class Program_weight_tensor_parameter_277:
 
 class Program_weight_tensor_parameter_278:
     name = "parameter_278"
+    original_name = "batch_norm2d_26.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.123107")
@@ -3069,6 +3348,7 @@ class Program_weight_tensor_parameter_278:
 
 class Program_weight_tensor_parameter_279:
     name = "parameter_279"
+    original_name = "batch_norm2d_26.w_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.00172916")
@@ -3080,6 +3360,7 @@ class Program_weight_tensor_parameter_279:
 
 class Program_weight_tensor_parameter_280:
     name = "parameter_280"
+    original_name = "batch_norm2d_26.w_2"
     shape = [1024]
     dtype = "float32"
     min_val = float("1.97651e-14")
@@ -3091,6 +3372,7 @@ class Program_weight_tensor_parameter_280:
 
 class Program_weight_tensor_parameter_281:
     name = "parameter_281"
+    original_name = "batch_norm2d_26.w_1"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.320953")
@@ -3102,6 +3384,7 @@ class Program_weight_tensor_parameter_281:
 
 class Program_weight_tensor_parameter_282:
     name = "parameter_282"
+    original_name = "conv2d_26.w_0"
     shape = [1024, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.306504")
@@ -3113,6 +3396,7 @@ class Program_weight_tensor_parameter_282:
 
 class Program_weight_tensor_parameter_283:
     name = "parameter_283"
+    original_name = "batch_norm2d_25.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.177343")
@@ -3124,6 +3408,7 @@ class Program_weight_tensor_parameter_283:
 
 class Program_weight_tensor_parameter_284:
     name = "parameter_284"
+    original_name = "batch_norm2d_25.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.126972")
@@ -3135,6 +3420,7 @@ class Program_weight_tensor_parameter_284:
 
 class Program_weight_tensor_parameter_285:
     name = "parameter_285"
+    original_name = "batch_norm2d_25.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.0155667")
@@ -3146,6 +3432,7 @@ class Program_weight_tensor_parameter_285:
 
 class Program_weight_tensor_parameter_286:
     name = "parameter_286"
+    original_name = "batch_norm2d_25.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.280367")
@@ -3157,6 +3444,7 @@ class Program_weight_tensor_parameter_286:
 
 class Program_weight_tensor_parameter_287:
     name = "parameter_287"
+    original_name = "conv2d_25.w_0"
     shape = [256, 256, 3, 3]
     dtype = "float32"
     min_val = float("-0.222093")
@@ -3168,6 +3456,7 @@ class Program_weight_tensor_parameter_287:
 
 class Program_weight_tensor_parameter_288:
     name = "parameter_288"
+    original_name = "batch_norm2d_24.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.378746")
@@ -3179,6 +3468,7 @@ class Program_weight_tensor_parameter_288:
 
 class Program_weight_tensor_parameter_289:
     name = "parameter_289"
+    original_name = "batch_norm2d_24.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.144833")
@@ -3190,6 +3480,7 @@ class Program_weight_tensor_parameter_289:
 
 class Program_weight_tensor_parameter_290:
     name = "parameter_290"
+    original_name = "batch_norm2d_24.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.0157244")
@@ -3201,6 +3492,7 @@ class Program_weight_tensor_parameter_290:
 
 class Program_weight_tensor_parameter_291:
     name = "parameter_291"
+    original_name = "batch_norm2d_24.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.390806")
@@ -3212,6 +3504,7 @@ class Program_weight_tensor_parameter_291:
 
 class Program_weight_tensor_parameter_292:
     name = "parameter_292"
+    original_name = "conv2d_24.w_0"
     shape = [256, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.384472")
@@ -3223,6 +3516,7 @@ class Program_weight_tensor_parameter_292:
 
 class Program_weight_tensor_parameter_293:
     name = "parameter_293"
+    original_name = "batch_norm2d_23.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.212643")
@@ -3234,6 +3528,7 @@ class Program_weight_tensor_parameter_293:
 
 class Program_weight_tensor_parameter_294:
     name = "parameter_294"
+    original_name = "batch_norm2d_23.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.0505015")
@@ -3245,6 +3540,7 @@ class Program_weight_tensor_parameter_294:
 
 class Program_weight_tensor_parameter_295:
     name = "parameter_295"
+    original_name = "batch_norm2d_23.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("5.65136e-05")
@@ -3256,6 +3552,7 @@ class Program_weight_tensor_parameter_295:
 
 class Program_weight_tensor_parameter_296:
     name = "parameter_296"
+    original_name = "batch_norm2d_23.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.141983")
@@ -3267,6 +3564,7 @@ class Program_weight_tensor_parameter_296:
 
 class Program_weight_tensor_parameter_297:
     name = "parameter_297"
+    original_name = "conv2d_23.w_0"
     shape = [512, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.289093")
@@ -3278,6 +3576,7 @@ class Program_weight_tensor_parameter_297:
 
 class Program_weight_tensor_parameter_298:
     name = "parameter_298"
+    original_name = "batch_norm2d_22.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.217842")
@@ -3289,6 +3588,7 @@ class Program_weight_tensor_parameter_298:
 
 class Program_weight_tensor_parameter_299:
     name = "parameter_299"
+    original_name = "batch_norm2d_22.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.121171")
@@ -3300,6 +3600,7 @@ class Program_weight_tensor_parameter_299:
 
 class Program_weight_tensor_parameter_300:
     name = "parameter_300"
+    original_name = "batch_norm2d_22.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.00802759")
@@ -3311,6 +3612,7 @@ class Program_weight_tensor_parameter_300:
 
 class Program_weight_tensor_parameter_301:
     name = "parameter_301"
+    original_name = "batch_norm2d_22.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.202194")
@@ -3322,6 +3624,7 @@ class Program_weight_tensor_parameter_301:
 
 class Program_weight_tensor_parameter_302:
     name = "parameter_302"
+    original_name = "conv2d_22.w_0"
     shape = [128, 128, 3, 3]
     dtype = "float32"
     min_val = float("-0.196283")
@@ -3333,6 +3636,7 @@ class Program_weight_tensor_parameter_302:
 
 class Program_weight_tensor_parameter_303:
     name = "parameter_303"
+    original_name = "batch_norm2d_21.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.234581")
@@ -3344,6 +3648,7 @@ class Program_weight_tensor_parameter_303:
 
 class Program_weight_tensor_parameter_304:
     name = "parameter_304"
+    original_name = "batch_norm2d_21.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.118987")
@@ -3355,6 +3660,7 @@ class Program_weight_tensor_parameter_304:
 
 class Program_weight_tensor_parameter_305:
     name = "parameter_305"
+    original_name = "batch_norm2d_21.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.00940187")
@@ -3366,6 +3672,7 @@ class Program_weight_tensor_parameter_305:
 
 class Program_weight_tensor_parameter_306:
     name = "parameter_306"
+    original_name = "batch_norm2d_21.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.277056")
@@ -3377,6 +3684,7 @@ class Program_weight_tensor_parameter_306:
 
 class Program_weight_tensor_parameter_307:
     name = "parameter_307"
+    original_name = "conv2d_21.w_0"
     shape = [128, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.221929")
@@ -3388,6 +3696,7 @@ class Program_weight_tensor_parameter_307:
 
 class Program_weight_tensor_parameter_308:
     name = "parameter_308"
+    original_name = "batch_norm2d_20.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.269087")
@@ -3399,6 +3708,7 @@ class Program_weight_tensor_parameter_308:
 
 class Program_weight_tensor_parameter_309:
     name = "parameter_309"
+    original_name = "batch_norm2d_20.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.0647098")
@@ -3410,6 +3720,7 @@ class Program_weight_tensor_parameter_309:
 
 class Program_weight_tensor_parameter_310:
     name = "parameter_310"
+    original_name = "batch_norm2d_20.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("0.00010973")
@@ -3421,6 +3732,7 @@ class Program_weight_tensor_parameter_310:
 
 class Program_weight_tensor_parameter_311:
     name = "parameter_311"
+    original_name = "batch_norm2d_20.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.0957676")
@@ -3432,6 +3744,7 @@ class Program_weight_tensor_parameter_311:
 
 class Program_weight_tensor_parameter_312:
     name = "parameter_312"
+    original_name = "conv2d_20.w_0"
     shape = [512, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.27503")
@@ -3443,6 +3756,7 @@ class Program_weight_tensor_parameter_312:
 
 class Program_weight_tensor_parameter_313:
     name = "parameter_313"
+    original_name = "batch_norm2d_19.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.17257")
@@ -3454,6 +3768,7 @@ class Program_weight_tensor_parameter_313:
 
 class Program_weight_tensor_parameter_314:
     name = "parameter_314"
+    original_name = "batch_norm2d_19.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.108321")
@@ -3465,6 +3780,7 @@ class Program_weight_tensor_parameter_314:
 
 class Program_weight_tensor_parameter_315:
     name = "parameter_315"
+    original_name = "batch_norm2d_19.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.0071571")
@@ -3476,6 +3792,7 @@ class Program_weight_tensor_parameter_315:
 
 class Program_weight_tensor_parameter_316:
     name = "parameter_316"
+    original_name = "batch_norm2d_19.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.345635")
@@ -3487,6 +3804,7 @@ class Program_weight_tensor_parameter_316:
 
 class Program_weight_tensor_parameter_317:
     name = "parameter_317"
+    original_name = "conv2d_19.w_0"
     shape = [128, 128, 3, 3]
     dtype = "float32"
     min_val = float("-0.229717")
@@ -3498,6 +3816,7 @@ class Program_weight_tensor_parameter_317:
 
 class Program_weight_tensor_parameter_318:
     name = "parameter_318"
+    original_name = "batch_norm2d_18.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.202003")
@@ -3509,6 +3828,7 @@ class Program_weight_tensor_parameter_318:
 
 class Program_weight_tensor_parameter_319:
     name = "parameter_319"
+    original_name = "batch_norm2d_18.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.106726")
@@ -3520,6 +3840,7 @@ class Program_weight_tensor_parameter_319:
 
 class Program_weight_tensor_parameter_320:
     name = "parameter_320"
+    original_name = "batch_norm2d_18.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.00987741")
@@ -3531,6 +3852,7 @@ class Program_weight_tensor_parameter_320:
 
 class Program_weight_tensor_parameter_321:
     name = "parameter_321"
+    original_name = "batch_norm2d_18.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.342662")
@@ -3542,6 +3864,7 @@ class Program_weight_tensor_parameter_321:
 
 class Program_weight_tensor_parameter_322:
     name = "parameter_322"
+    original_name = "conv2d_18.w_0"
     shape = [128, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.253332")
@@ -3553,6 +3876,7 @@ class Program_weight_tensor_parameter_322:
 
 class Program_weight_tensor_parameter_323:
     name = "parameter_323"
+    original_name = "batch_norm2d_17.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.238356")
@@ -3564,6 +3888,7 @@ class Program_weight_tensor_parameter_323:
 
 class Program_weight_tensor_parameter_324:
     name = "parameter_324"
+    original_name = "batch_norm2d_17.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.0709823")
@@ -3575,6 +3900,7 @@ class Program_weight_tensor_parameter_324:
 
 class Program_weight_tensor_parameter_325:
     name = "parameter_325"
+    original_name = "batch_norm2d_17.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("6.22571e-13")
@@ -3586,6 +3912,7 @@ class Program_weight_tensor_parameter_325:
 
 class Program_weight_tensor_parameter_326:
     name = "parameter_326"
+    original_name = "batch_norm2d_17.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.204187")
@@ -3597,6 +3924,7 @@ class Program_weight_tensor_parameter_326:
 
 class Program_weight_tensor_parameter_327:
     name = "parameter_327"
+    original_name = "conv2d_17.w_0"
     shape = [512, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.312423")
@@ -3608,6 +3936,7 @@ class Program_weight_tensor_parameter_327:
 
 class Program_weight_tensor_parameter_328:
     name = "parameter_328"
+    original_name = "batch_norm2d_16.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.182477")
@@ -3619,6 +3948,7 @@ class Program_weight_tensor_parameter_328:
 
 class Program_weight_tensor_parameter_329:
     name = "parameter_329"
+    original_name = "batch_norm2d_16.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.0796995")
@@ -3630,6 +3960,7 @@ class Program_weight_tensor_parameter_329:
 
 class Program_weight_tensor_parameter_330:
     name = "parameter_330"
+    original_name = "batch_norm2d_16.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.00281317")
@@ -3641,6 +3972,7 @@ class Program_weight_tensor_parameter_330:
 
 class Program_weight_tensor_parameter_331:
     name = "parameter_331"
+    original_name = "batch_norm2d_16.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.669941")
@@ -3652,6 +3984,7 @@ class Program_weight_tensor_parameter_331:
 
 class Program_weight_tensor_parameter_332:
     name = "parameter_332"
+    original_name = "conv2d_16.w_0"
     shape = [128, 128, 3, 3]
     dtype = "float32"
     min_val = float("-0.243788")
@@ -3663,6 +3996,7 @@ class Program_weight_tensor_parameter_332:
 
 class Program_weight_tensor_parameter_333:
     name = "parameter_333"
+    original_name = "batch_norm2d_15.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.186717")
@@ -3674,6 +4008,7 @@ class Program_weight_tensor_parameter_333:
 
 class Program_weight_tensor_parameter_334:
     name = "parameter_334"
+    original_name = "batch_norm2d_15.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.0506482")
@@ -3685,6 +4020,7 @@ class Program_weight_tensor_parameter_334:
 
 class Program_weight_tensor_parameter_335:
     name = "parameter_335"
+    original_name = "batch_norm2d_15.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.00210212")
@@ -3696,6 +4032,7 @@ class Program_weight_tensor_parameter_335:
 
 class Program_weight_tensor_parameter_336:
     name = "parameter_336"
+    original_name = "batch_norm2d_15.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.322583")
@@ -3707,6 +4044,7 @@ class Program_weight_tensor_parameter_336:
 
 class Program_weight_tensor_parameter_337:
     name = "parameter_337"
+    original_name = "conv2d_15.w_0"
     shape = [128, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.201555")
@@ -3718,6 +4056,7 @@ class Program_weight_tensor_parameter_337:
 
 class Program_weight_tensor_parameter_338:
     name = "parameter_338"
+    original_name = "batch_norm2d_14.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.171144")
@@ -3729,6 +4068,7 @@ class Program_weight_tensor_parameter_338:
 
 class Program_weight_tensor_parameter_339:
     name = "parameter_339"
+    original_name = "batch_norm2d_14.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.019481")
@@ -3740,6 +4080,7 @@ class Program_weight_tensor_parameter_339:
 
 class Program_weight_tensor_parameter_340:
     name = "parameter_340"
+    original_name = "batch_norm2d_14.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("1.17727e-15")
@@ -3751,6 +4092,7 @@ class Program_weight_tensor_parameter_340:
 
 class Program_weight_tensor_parameter_341:
     name = "parameter_341"
+    original_name = "batch_norm2d_14.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.497702")
@@ -3762,6 +4104,7 @@ class Program_weight_tensor_parameter_341:
 
 class Program_weight_tensor_parameter_342:
     name = "parameter_342"
+    original_name = "conv2d_14.w_0"
     shape = [512, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.344")
@@ -3773,6 +4116,7 @@ class Program_weight_tensor_parameter_342:
 
 class Program_weight_tensor_parameter_343:
     name = "parameter_343"
+    original_name = "batch_norm2d_13.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.171144")
@@ -3784,6 +4128,7 @@ class Program_weight_tensor_parameter_343:
 
 class Program_weight_tensor_parameter_344:
     name = "parameter_344"
+    original_name = "batch_norm2d_13.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.0356742")
@@ -3795,6 +4140,7 @@ class Program_weight_tensor_parameter_344:
 
 class Program_weight_tensor_parameter_345:
     name = "parameter_345"
+    original_name = "batch_norm2d_13.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("6.20582e-16")
@@ -3806,6 +4152,7 @@ class Program_weight_tensor_parameter_345:
 
 class Program_weight_tensor_parameter_346:
     name = "parameter_346"
+    original_name = "batch_norm2d_13.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.28852")
@@ -3817,6 +4164,7 @@ class Program_weight_tensor_parameter_346:
 
 class Program_weight_tensor_parameter_347:
     name = "parameter_347"
+    original_name = "conv2d_13.w_0"
     shape = [512, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.377586")
@@ -3828,6 +4176,7 @@ class Program_weight_tensor_parameter_347:
 
 class Program_weight_tensor_parameter_348:
     name = "parameter_348"
+    original_name = "batch_norm2d_12.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.316086")
@@ -3839,6 +4188,7 @@ class Program_weight_tensor_parameter_348:
 
 class Program_weight_tensor_parameter_349:
     name = "parameter_349"
+    original_name = "batch_norm2d_12.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.14483")
@@ -3850,6 +4200,7 @@ class Program_weight_tensor_parameter_349:
 
 class Program_weight_tensor_parameter_350:
     name = "parameter_350"
+    original_name = "batch_norm2d_12.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.0130226")
@@ -3861,6 +4212,7 @@ class Program_weight_tensor_parameter_350:
 
 class Program_weight_tensor_parameter_351:
     name = "parameter_351"
+    original_name = "batch_norm2d_12.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.267364")
@@ -3872,6 +4224,7 @@ class Program_weight_tensor_parameter_351:
 
 class Program_weight_tensor_parameter_352:
     name = "parameter_352"
+    original_name = "conv2d_12.w_0"
     shape = [128, 128, 3, 3]
     dtype = "float32"
     min_val = float("-0.314588")
@@ -3883,6 +4236,7 @@ class Program_weight_tensor_parameter_352:
 
 class Program_weight_tensor_parameter_353:
     name = "parameter_353"
+    original_name = "batch_norm2d_11.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.303521")
@@ -3894,6 +4248,7 @@ class Program_weight_tensor_parameter_353:
 
 class Program_weight_tensor_parameter_354:
     name = "parameter_354"
+    original_name = "batch_norm2d_11.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.107636")
@@ -3905,6 +4260,7 @@ class Program_weight_tensor_parameter_354:
 
 class Program_weight_tensor_parameter_355:
     name = "parameter_355"
+    original_name = "batch_norm2d_11.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.00341849")
@@ -3916,6 +4272,7 @@ class Program_weight_tensor_parameter_355:
 
 class Program_weight_tensor_parameter_356:
     name = "parameter_356"
+    original_name = "batch_norm2d_11.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.400316")
@@ -3927,6 +4284,7 @@ class Program_weight_tensor_parameter_356:
 
 class Program_weight_tensor_parameter_357:
     name = "parameter_357"
+    original_name = "conv2d_11.w_0"
     shape = [128, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.290704")
@@ -3938,6 +4296,7 @@ class Program_weight_tensor_parameter_357:
 
 class Program_weight_tensor_parameter_358:
     name = "parameter_358"
+    original_name = "batch_norm2d_10.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.168371")
@@ -3949,6 +4308,7 @@ class Program_weight_tensor_parameter_358:
 
 class Program_weight_tensor_parameter_359:
     name = "parameter_359"
+    original_name = "batch_norm2d_10.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.0978827")
@@ -3960,6 +4320,7 @@ class Program_weight_tensor_parameter_359:
 
 class Program_weight_tensor_parameter_360:
     name = "parameter_360"
+    original_name = "batch_norm2d_10.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("5.57019e-05")
@@ -3971,6 +4332,7 @@ class Program_weight_tensor_parameter_360:
 
 class Program_weight_tensor_parameter_361:
     name = "parameter_361"
+    original_name = "batch_norm2d_10.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.124307")
@@ -3982,6 +4344,7 @@ class Program_weight_tensor_parameter_361:
 
 class Program_weight_tensor_parameter_362:
     name = "parameter_362"
+    original_name = "conv2d_10.w_0"
     shape = [256, 64, 1, 1]
     dtype = "float32"
     min_val = float("-0.216772")
@@ -3993,6 +4356,7 @@ class Program_weight_tensor_parameter_362:
 
 class Program_weight_tensor_parameter_363:
     name = "parameter_363"
+    original_name = "batch_norm2d_9.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -4002,6 +4366,7 @@ class Program_weight_tensor_parameter_363:
 
 class Program_weight_tensor_parameter_364:
     name = "parameter_364"
+    original_name = "batch_norm2d_9.w_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -4011,6 +4376,7 @@ class Program_weight_tensor_parameter_364:
 
 class Program_weight_tensor_parameter_365:
     name = "parameter_365"
+    original_name = "batch_norm2d_9.w_2"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -4020,6 +4386,7 @@ class Program_weight_tensor_parameter_365:
 
 class Program_weight_tensor_parameter_366:
     name = "parameter_366"
+    original_name = "batch_norm2d_9.w_1"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -4029,6 +4396,7 @@ class Program_weight_tensor_parameter_366:
 
 class Program_weight_tensor_parameter_367:
     name = "parameter_367"
+    original_name = "conv2d_9.w_0"
     shape = [64, 64, 3, 3]
     dtype = "float32"
     min_val = float("-0.225002")
@@ -4040,6 +4408,7 @@ class Program_weight_tensor_parameter_367:
 
 class Program_weight_tensor_parameter_368:
     name = "parameter_368"
+    original_name = "batch_norm2d_8.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -4049,6 +4418,7 @@ class Program_weight_tensor_parameter_368:
 
 class Program_weight_tensor_parameter_369:
     name = "parameter_369"
+    original_name = "batch_norm2d_8.w_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -4058,6 +4428,7 @@ class Program_weight_tensor_parameter_369:
 
 class Program_weight_tensor_parameter_370:
     name = "parameter_370"
+    original_name = "batch_norm2d_8.w_2"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -4067,6 +4438,7 @@ class Program_weight_tensor_parameter_370:
 
 class Program_weight_tensor_parameter_371:
     name = "parameter_371"
+    original_name = "batch_norm2d_8.w_1"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -4076,6 +4448,7 @@ class Program_weight_tensor_parameter_371:
 
 class Program_weight_tensor_parameter_372:
     name = "parameter_372"
+    original_name = "conv2d_8.w_0"
     shape = [64, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.192067")
@@ -4087,6 +4460,7 @@ class Program_weight_tensor_parameter_372:
 
 class Program_weight_tensor_parameter_373:
     name = "parameter_373"
+    original_name = "batch_norm2d_7.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.148338")
@@ -4098,6 +4472,7 @@ class Program_weight_tensor_parameter_373:
 
 class Program_weight_tensor_parameter_374:
     name = "parameter_374"
+    original_name = "batch_norm2d_7.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.113668")
@@ -4109,6 +4484,7 @@ class Program_weight_tensor_parameter_374:
 
 class Program_weight_tensor_parameter_375:
     name = "parameter_375"
+    original_name = "batch_norm2d_7.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("7.11989e-15")
@@ -4120,6 +4496,7 @@ class Program_weight_tensor_parameter_375:
 
 class Program_weight_tensor_parameter_376:
     name = "parameter_376"
+    original_name = "batch_norm2d_7.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.104816")
@@ -4131,6 +4508,7 @@ class Program_weight_tensor_parameter_376:
 
 class Program_weight_tensor_parameter_377:
     name = "parameter_377"
+    original_name = "conv2d_7.w_0"
     shape = [256, 64, 1, 1]
     dtype = "float32"
     min_val = float("-0.294627")
@@ -4142,6 +4520,7 @@ class Program_weight_tensor_parameter_377:
 
 class Program_weight_tensor_parameter_378:
     name = "parameter_378"
+    original_name = "batch_norm2d_6.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -4151,6 +4530,7 @@ class Program_weight_tensor_parameter_378:
 
 class Program_weight_tensor_parameter_379:
     name = "parameter_379"
+    original_name = "batch_norm2d_6.w_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -4160,6 +4540,7 @@ class Program_weight_tensor_parameter_379:
 
 class Program_weight_tensor_parameter_380:
     name = "parameter_380"
+    original_name = "batch_norm2d_6.w_2"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -4169,6 +4550,7 @@ class Program_weight_tensor_parameter_380:
 
 class Program_weight_tensor_parameter_381:
     name = "parameter_381"
+    original_name = "batch_norm2d_6.w_1"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -4178,6 +4560,7 @@ class Program_weight_tensor_parameter_381:
 
 class Program_weight_tensor_parameter_382:
     name = "parameter_382"
+    original_name = "conv2d_6.w_0"
     shape = [64, 64, 3, 3]
     dtype = "float32"
     min_val = float("-0.403462")
@@ -4189,6 +4572,7 @@ class Program_weight_tensor_parameter_382:
 
 class Program_weight_tensor_parameter_383:
     name = "parameter_383"
+    original_name = "batch_norm2d_5.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -4198,6 +4582,7 @@ class Program_weight_tensor_parameter_383:
 
 class Program_weight_tensor_parameter_384:
     name = "parameter_384"
+    original_name = "batch_norm2d_5.w_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -4207,6 +4592,7 @@ class Program_weight_tensor_parameter_384:
 
 class Program_weight_tensor_parameter_385:
     name = "parameter_385"
+    original_name = "batch_norm2d_5.w_2"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -4216,6 +4602,7 @@ class Program_weight_tensor_parameter_385:
 
 class Program_weight_tensor_parameter_386:
     name = "parameter_386"
+    original_name = "batch_norm2d_5.w_1"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -4225,6 +4612,7 @@ class Program_weight_tensor_parameter_386:
 
 class Program_weight_tensor_parameter_387:
     name = "parameter_387"
+    original_name = "conv2d_5.w_0"
     shape = [64, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.20172")
@@ -4236,6 +4624,7 @@ class Program_weight_tensor_parameter_387:
 
 class Program_weight_tensor_parameter_388:
     name = "parameter_388"
+    original_name = "batch_norm2d_4.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.307381")
@@ -4247,6 +4636,7 @@ class Program_weight_tensor_parameter_388:
 
 class Program_weight_tensor_parameter_389:
     name = "parameter_389"
+    original_name = "batch_norm2d_4.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.0421494")
@@ -4258,6 +4648,7 @@ class Program_weight_tensor_parameter_389:
 
 class Program_weight_tensor_parameter_390:
     name = "parameter_390"
+    original_name = "batch_norm2d_4.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("4.73803e-14")
@@ -4269,6 +4660,7 @@ class Program_weight_tensor_parameter_390:
 
 class Program_weight_tensor_parameter_391:
     name = "parameter_391"
+    original_name = "batch_norm2d_4.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.03252")
@@ -4280,6 +4672,7 @@ class Program_weight_tensor_parameter_391:
 
 class Program_weight_tensor_parameter_392:
     name = "parameter_392"
+    original_name = "conv2d_4.w_0"
     shape = [256, 64, 1, 1]
     dtype = "float32"
     min_val = float("-0.744444")
@@ -4291,6 +4684,7 @@ class Program_weight_tensor_parameter_392:
 
 class Program_weight_tensor_parameter_393:
     name = "parameter_393"
+    original_name = "batch_norm2d_3.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.307381")
@@ -4302,6 +4696,7 @@ class Program_weight_tensor_parameter_393:
 
 class Program_weight_tensor_parameter_394:
     name = "parameter_394"
+    original_name = "batch_norm2d_3.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.112764")
@@ -4313,6 +4708,7 @@ class Program_weight_tensor_parameter_394:
 
 class Program_weight_tensor_parameter_395:
     name = "parameter_395"
+    original_name = "batch_norm2d_3.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("1.26218e-14")
@@ -4324,6 +4720,7 @@ class Program_weight_tensor_parameter_395:
 
 class Program_weight_tensor_parameter_396:
     name = "parameter_396"
+    original_name = "batch_norm2d_3.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.223334")
@@ -4335,6 +4732,7 @@ class Program_weight_tensor_parameter_396:
 
 class Program_weight_tensor_parameter_397:
     name = "parameter_397"
+    original_name = "conv2d_3.w_0"
     shape = [256, 64, 1, 1]
     dtype = "float32"
     min_val = float("-0.363424")
@@ -4346,6 +4744,7 @@ class Program_weight_tensor_parameter_397:
 
 class Program_weight_tensor_parameter_398:
     name = "parameter_398"
+    original_name = "batch_norm2d_2.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -4355,6 +4754,7 @@ class Program_weight_tensor_parameter_398:
 
 class Program_weight_tensor_parameter_399:
     name = "parameter_399"
+    original_name = "batch_norm2d_2.w_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -4364,6 +4764,7 @@ class Program_weight_tensor_parameter_399:
 
 class Program_weight_tensor_parameter_400:
     name = "parameter_400"
+    original_name = "batch_norm2d_2.w_2"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -4373,6 +4774,7 @@ class Program_weight_tensor_parameter_400:
 
 class Program_weight_tensor_parameter_401:
     name = "parameter_401"
+    original_name = "batch_norm2d_2.w_1"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -4382,6 +4784,7 @@ class Program_weight_tensor_parameter_401:
 
 class Program_weight_tensor_parameter_402:
     name = "parameter_402"
+    original_name = "conv2d_2.w_0"
     shape = [64, 64, 3, 3]
     dtype = "float32"
     min_val = float("-0.467864")
@@ -4393,6 +4796,7 @@ class Program_weight_tensor_parameter_402:
 
 class Program_weight_tensor_parameter_403:
     name = "parameter_403"
+    original_name = "batch_norm2d_1.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -4402,6 +4806,7 @@ class Program_weight_tensor_parameter_403:
 
 class Program_weight_tensor_parameter_404:
     name = "parameter_404"
+    original_name = "batch_norm2d_1.w_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -4411,6 +4816,7 @@ class Program_weight_tensor_parameter_404:
 
 class Program_weight_tensor_parameter_405:
     name = "parameter_405"
+    original_name = "batch_norm2d_1.w_2"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -4420,6 +4826,7 @@ class Program_weight_tensor_parameter_405:
 
 class Program_weight_tensor_parameter_406:
     name = "parameter_406"
+    original_name = "batch_norm2d_1.w_1"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -4429,6 +4836,7 @@ class Program_weight_tensor_parameter_406:
 
 class Program_weight_tensor_parameter_407:
     name = "parameter_407"
+    original_name = "conv2d_1.w_0"
     shape = [64, 64, 1, 1]
     dtype = "float32"
     min_val = float("-0.726628")
@@ -4440,6 +4848,7 @@ class Program_weight_tensor_parameter_407:
 
 class Program_weight_tensor_parameter_408:
     name = "parameter_408"
+    original_name = "batch_norm2d_0.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -4449,6 +4858,7 @@ class Program_weight_tensor_parameter_408:
 
 class Program_weight_tensor_parameter_409:
     name = "parameter_409"
+    original_name = "batch_norm2d_0.w_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -4458,6 +4868,7 @@ class Program_weight_tensor_parameter_409:
 
 class Program_weight_tensor_parameter_410:
     name = "parameter_410"
+    original_name = "batch_norm2d_0.w_2"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -4467,6 +4878,7 @@ class Program_weight_tensor_parameter_410:
 
 class Program_weight_tensor_parameter_411:
     name = "parameter_411"
+    original_name = "batch_norm2d_0.w_1"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -4476,6 +4888,7 @@ class Program_weight_tensor_parameter_411:
 
 class Program_weight_tensor_parameter_412:
     name = "parameter_412"
+    original_name = "conv2d_0.w_0"
     shape = [64, 3, 7, 7]
     dtype = "float32"
     min_val = float("-0.781721")

--- a/paddle_samples/PaddleX/FasterRCNN-ResNet101/subgraph_1/input_meta.py
+++ b/paddle_samples/PaddleX/FasterRCNN-ResNet101/subgraph_1/input_meta.py
@@ -1,5 +1,6 @@
 class Program_weight_tensor_data_0:
     name = "data_0"
+    original_name = "var_5820"
     shape = [1, 3, 800, 1322]
     dtype = "float32"
     min_val = float("-2.1179")
@@ -11,6 +12,7 @@ class Program_weight_tensor_data_0:
 
 class Program_weight_tensor_data_1:
     name = "data_1"
+    original_name = "var_5821"
     shape = [1, 2]
     dtype = "float32"
     data = [800.0, 1322.0]
@@ -18,6 +20,7 @@ class Program_weight_tensor_data_1:
 
 class Program_weight_tensor_data_2:
     name = "data_2"
+    original_name = "var_6143"
     shape = [15, 4]
     dtype = "float32"
     data = [

--- a/paddle_samples/PaddleX/FasterRCNN-ResNet101/subgraph_1/weight_meta.py
+++ b/paddle_samples/PaddleX/FasterRCNN-ResNet101/subgraph_1/weight_meta.py
@@ -1,5 +1,6 @@
 class Program_weight_tensor_parameter_0:
     name = "parameter_0"
+    original_name = "linear_1.b_0"
     shape = [16]
     dtype = "float32"
     min_val = float("0")
@@ -9,6 +10,7 @@ class Program_weight_tensor_parameter_0:
 
 class Program_weight_tensor_parameter_1:
     name = "parameter_1"
+    original_name = "linear_1.w_0"
     shape = [2048, 16]
     dtype = "float32"
     min_val = float("-0.0180824")
@@ -20,6 +22,7 @@ class Program_weight_tensor_parameter_1:
 
 class Program_weight_tensor_parameter_2:
     name = "parameter_2"
+    original_name = "linear_0.b_0"
     shape = [5]
     dtype = "float32"
     min_val = float("0")
@@ -29,6 +32,7 @@ class Program_weight_tensor_parameter_2:
 
 class Program_weight_tensor_parameter_3:
     name = "parameter_3"
+    original_name = "linear_0.w_0"
     shape = [2048, 5]
     dtype = "float32"
     min_val = float("-0.0473299")
@@ -40,6 +44,7 @@ class Program_weight_tensor_parameter_3:
 
 class Program_weight_tensor_parameter_4:
     name = "parameter_4"
+    original_name = "batch_norm2d_103.b_0"
     shape = [2048]
     dtype = "float32"
     min_val = float("-0.187529")
@@ -51,6 +56,7 @@ class Program_weight_tensor_parameter_4:
 
 class Program_weight_tensor_parameter_5:
     name = "parameter_5"
+    original_name = "batch_norm2d_103.w_0"
     shape = [2048]
     dtype = "float32"
     min_val = float("0.0248782")
@@ -62,6 +68,7 @@ class Program_weight_tensor_parameter_5:
 
 class Program_weight_tensor_parameter_6:
     name = "parameter_6"
+    original_name = "batch_norm2d_103.w_2"
     shape = [2048]
     dtype = "float32"
     min_val = float("5.79425e-06")
@@ -73,6 +80,7 @@ class Program_weight_tensor_parameter_6:
 
 class Program_weight_tensor_parameter_7:
     name = "parameter_7"
+    original_name = "batch_norm2d_103.w_1"
     shape = [2048]
     dtype = "float32"
     min_val = float("-0.0136735")
@@ -84,6 +92,7 @@ class Program_weight_tensor_parameter_7:
 
 class Program_weight_tensor_parameter_8:
     name = "parameter_8"
+    original_name = "conv2d_106.w_0"
     shape = [2048, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.256529")
@@ -95,6 +104,7 @@ class Program_weight_tensor_parameter_8:
 
 class Program_weight_tensor_parameter_9:
     name = "parameter_9"
+    original_name = "batch_norm2d_102.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.214844")
@@ -106,6 +116,7 @@ class Program_weight_tensor_parameter_9:
 
 class Program_weight_tensor_parameter_10:
     name = "parameter_10"
+    original_name = "batch_norm2d_102.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("0.132966")
@@ -117,6 +128,7 @@ class Program_weight_tensor_parameter_10:
 
 class Program_weight_tensor_parameter_11:
     name = "parameter_11"
+    original_name = "batch_norm2d_102.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("0.00600148")
@@ -128,6 +140,7 @@ class Program_weight_tensor_parameter_11:
 
 class Program_weight_tensor_parameter_12:
     name = "parameter_12"
+    original_name = "batch_norm2d_102.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.12121")
@@ -139,6 +152,7 @@ class Program_weight_tensor_parameter_12:
 
 class Program_weight_tensor_parameter_13:
     name = "parameter_13"
+    original_name = "conv2d_105.w_0"
     shape = [512, 512, 3, 3]
     dtype = "float32"
     min_val = float("-0.115329")
@@ -150,6 +164,7 @@ class Program_weight_tensor_parameter_13:
 
 class Program_weight_tensor_parameter_14:
     name = "parameter_14"
+    original_name = "batch_norm2d_101.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.351861")
@@ -161,6 +176,7 @@ class Program_weight_tensor_parameter_14:
 
 class Program_weight_tensor_parameter_15:
     name = "parameter_15"
+    original_name = "batch_norm2d_101.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("0.0859938")
@@ -172,6 +188,7 @@ class Program_weight_tensor_parameter_15:
 
 class Program_weight_tensor_parameter_16:
     name = "parameter_16"
+    original_name = "batch_norm2d_101.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("0.255796")
@@ -183,6 +200,7 @@ class Program_weight_tensor_parameter_16:
 
 class Program_weight_tensor_parameter_17:
     name = "parameter_17"
+    original_name = "batch_norm2d_101.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.749944")
@@ -194,6 +212,7 @@ class Program_weight_tensor_parameter_17:
 
 class Program_weight_tensor_parameter_18:
     name = "parameter_18"
+    original_name = "conv2d_104.w_0"
     shape = [512, 2048, 1, 1]
     dtype = "float32"
     min_val = float("-0.155074")
@@ -205,6 +224,7 @@ class Program_weight_tensor_parameter_18:
 
 class Program_weight_tensor_parameter_19:
     name = "parameter_19"
+    original_name = "batch_norm2d_100.b_0"
     shape = [2048]
     dtype = "float32"
     min_val = float("-0.0873599")
@@ -216,6 +236,7 @@ class Program_weight_tensor_parameter_19:
 
 class Program_weight_tensor_parameter_20:
     name = "parameter_20"
+    original_name = "batch_norm2d_100.w_0"
     shape = [2048]
     dtype = "float32"
     min_val = float("0.0576972")
@@ -227,6 +248,7 @@ class Program_weight_tensor_parameter_20:
 
 class Program_weight_tensor_parameter_21:
     name = "parameter_21"
+    original_name = "batch_norm2d_100.w_2"
     shape = [2048]
     dtype = "float32"
     min_val = float("7.15697e-05")
@@ -238,6 +260,7 @@ class Program_weight_tensor_parameter_21:
 
 class Program_weight_tensor_parameter_22:
     name = "parameter_22"
+    original_name = "batch_norm2d_100.w_1"
     shape = [2048]
     dtype = "float32"
     min_val = float("-0.210507")
@@ -249,6 +272,7 @@ class Program_weight_tensor_parameter_22:
 
 class Program_weight_tensor_parameter_23:
     name = "parameter_23"
+    original_name = "conv2d_103.w_0"
     shape = [2048, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.193209")
@@ -260,6 +284,7 @@ class Program_weight_tensor_parameter_23:
 
 class Program_weight_tensor_parameter_24:
     name = "parameter_24"
+    original_name = "batch_norm2d_99.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.195035")
@@ -271,6 +296,7 @@ class Program_weight_tensor_parameter_24:
 
 class Program_weight_tensor_parameter_25:
     name = "parameter_25"
+    original_name = "batch_norm2d_99.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("0.152092")
@@ -282,6 +308,7 @@ class Program_weight_tensor_parameter_25:
 
 class Program_weight_tensor_parameter_26:
     name = "parameter_26"
+    original_name = "batch_norm2d_99.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("0.00601953")
@@ -293,6 +320,7 @@ class Program_weight_tensor_parameter_26:
 
 class Program_weight_tensor_parameter_27:
     name = "parameter_27"
+    original_name = "batch_norm2d_99.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.253796")
@@ -304,6 +332,7 @@ class Program_weight_tensor_parameter_27:
 
 class Program_weight_tensor_parameter_28:
     name = "parameter_28"
+    original_name = "conv2d_102.w_0"
     shape = [512, 512, 3, 3]
     dtype = "float32"
     min_val = float("-0.216444")
@@ -315,6 +344,7 @@ class Program_weight_tensor_parameter_28:
 
 class Program_weight_tensor_parameter_29:
     name = "parameter_29"
+    original_name = "batch_norm2d_98.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.196503")
@@ -326,6 +356,7 @@ class Program_weight_tensor_parameter_29:
 
 class Program_weight_tensor_parameter_30:
     name = "parameter_30"
+    original_name = "batch_norm2d_98.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("0.102265")
@@ -337,6 +368,7 @@ class Program_weight_tensor_parameter_30:
 
 class Program_weight_tensor_parameter_31:
     name = "parameter_31"
+    original_name = "batch_norm2d_98.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("0.12314")
@@ -348,6 +380,7 @@ class Program_weight_tensor_parameter_31:
 
 class Program_weight_tensor_parameter_32:
     name = "parameter_32"
+    original_name = "batch_norm2d_98.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.644533")
@@ -359,6 +392,7 @@ class Program_weight_tensor_parameter_32:
 
 class Program_weight_tensor_parameter_33:
     name = "parameter_33"
+    original_name = "conv2d_101.w_0"
     shape = [512, 2048, 1, 1]
     dtype = "float32"
     min_val = float("-0.104353")
@@ -370,6 +404,7 @@ class Program_weight_tensor_parameter_33:
 
 class Program_weight_tensor_parameter_34:
     name = "parameter_34"
+    original_name = "batch_norm2d_97.b_0"
     shape = [2048]
     dtype = "float32"
     min_val = float("-0.0928293")
@@ -381,6 +416,7 @@ class Program_weight_tensor_parameter_34:
 
 class Program_weight_tensor_parameter_35:
     name = "parameter_35"
+    original_name = "batch_norm2d_97.w_0"
     shape = [2048]
     dtype = "float32"
     min_val = float("0.0706514")
@@ -392,6 +428,7 @@ class Program_weight_tensor_parameter_35:
 
 class Program_weight_tensor_parameter_36:
     name = "parameter_36"
+    original_name = "batch_norm2d_97.w_2"
     shape = [2048]
     dtype = "float32"
     min_val = float("0.000196833")
@@ -403,6 +440,7 @@ class Program_weight_tensor_parameter_36:
 
 class Program_weight_tensor_parameter_37:
     name = "parameter_37"
+    original_name = "batch_norm2d_97.w_1"
     shape = [2048]
     dtype = "float32"
     min_val = float("-0.276438")
@@ -414,6 +452,7 @@ class Program_weight_tensor_parameter_37:
 
 class Program_weight_tensor_parameter_38:
     name = "parameter_38"
+    original_name = "conv2d_100.w_0"
     shape = [2048, 1024, 1, 1]
     dtype = "float32"
     min_val = float("-0.128148")
@@ -425,6 +464,7 @@ class Program_weight_tensor_parameter_38:
 
 class Program_weight_tensor_parameter_39:
     name = "parameter_39"
+    original_name = "batch_norm2d_96.b_0"
     shape = [2048]
     dtype = "float32"
     min_val = float("-0.0928293")
@@ -436,6 +476,7 @@ class Program_weight_tensor_parameter_39:
 
 class Program_weight_tensor_parameter_40:
     name = "parameter_40"
+    original_name = "batch_norm2d_96.w_0"
     shape = [2048]
     dtype = "float32"
     min_val = float("-0.0263877")
@@ -447,6 +488,7 @@ class Program_weight_tensor_parameter_40:
 
 class Program_weight_tensor_parameter_41:
     name = "parameter_41"
+    original_name = "batch_norm2d_96.w_2"
     shape = [2048]
     dtype = "float32"
     min_val = float("2.13464e-06")
@@ -458,6 +500,7 @@ class Program_weight_tensor_parameter_41:
 
 class Program_weight_tensor_parameter_42:
     name = "parameter_42"
+    original_name = "batch_norm2d_96.w_1"
     shape = [2048]
     dtype = "float32"
     min_val = float("-0.033919")
@@ -469,6 +512,7 @@ class Program_weight_tensor_parameter_42:
 
 class Program_weight_tensor_parameter_43:
     name = "parameter_43"
+    original_name = "conv2d_99.w_0"
     shape = [2048, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.201201")
@@ -480,6 +524,7 @@ class Program_weight_tensor_parameter_43:
 
 class Program_weight_tensor_parameter_44:
     name = "parameter_44"
+    original_name = "batch_norm2d_95.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.239081")
@@ -491,6 +536,7 @@ class Program_weight_tensor_parameter_44:
 
 class Program_weight_tensor_parameter_45:
     name = "parameter_45"
+    original_name = "batch_norm2d_95.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("0.130887")
@@ -502,6 +548,7 @@ class Program_weight_tensor_parameter_45:
 
 class Program_weight_tensor_parameter_46:
     name = "parameter_46"
+    original_name = "batch_norm2d_95.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("0.00453731")
@@ -513,6 +560,7 @@ class Program_weight_tensor_parameter_46:
 
 class Program_weight_tensor_parameter_47:
     name = "parameter_47"
+    original_name = "batch_norm2d_95.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.0876581")
@@ -524,6 +572,7 @@ class Program_weight_tensor_parameter_47:
 
 class Program_weight_tensor_parameter_48:
     name = "parameter_48"
+    original_name = "conv2d_98.w_0"
     shape = [512, 512, 3, 3]
     dtype = "float32"
     min_val = float("-0.189498")
@@ -535,6 +584,7 @@ class Program_weight_tensor_parameter_48:
 
 class Program_weight_tensor_parameter_49:
     name = "parameter_49"
+    original_name = "batch_norm2d_94.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.331638")
@@ -546,6 +596,7 @@ class Program_weight_tensor_parameter_49:
 
 class Program_weight_tensor_parameter_50:
     name = "parameter_50"
+    original_name = "batch_norm2d_94.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("0.132994")
@@ -557,6 +608,7 @@ class Program_weight_tensor_parameter_50:
 
 class Program_weight_tensor_parameter_51:
     name = "parameter_51"
+    original_name = "batch_norm2d_94.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("0.00795988")
@@ -568,6 +620,7 @@ class Program_weight_tensor_parameter_51:
 
 class Program_weight_tensor_parameter_52:
     name = "parameter_52"
+    original_name = "batch_norm2d_94.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.191306")
@@ -579,6 +632,7 @@ class Program_weight_tensor_parameter_52:
 
 class Program_weight_tensor_parameter_53:
     name = "parameter_53"
+    original_name = "conv2d_97.w_0"
     shape = [512, 1024, 1, 1]
     dtype = "float32"
     min_val = float("-0.149382")
@@ -590,6 +644,7 @@ class Program_weight_tensor_parameter_53:
 
 class Program_weight_tensor_parameter_54:
     name = "parameter_54"
+    original_name = "conv2d_96.b_0"
     shape = [60]
     dtype = "float32"
     min_val = float("0")
@@ -599,6 +654,7 @@ class Program_weight_tensor_parameter_54:
 
 class Program_weight_tensor_parameter_55:
     name = "parameter_55"
+    original_name = "conv2d_96.w_0"
     shape = [60, 1024, 1, 1]
     dtype = "float32"
     min_val = float("-0.132915")
@@ -610,6 +666,7 @@ class Program_weight_tensor_parameter_55:
 
 class Program_weight_tensor_parameter_56:
     name = "parameter_56"
+    original_name = "conv2d_95.b_0"
     shape = [15]
     dtype = "float32"
     min_val = float("0")
@@ -619,6 +676,7 @@ class Program_weight_tensor_parameter_56:
 
 class Program_weight_tensor_parameter_57:
     name = "parameter_57"
+    original_name = "conv2d_95.w_0"
     shape = [15, 1024, 1, 1]
     dtype = "float32"
     min_val = float("-0.295808")
@@ -630,6 +688,7 @@ class Program_weight_tensor_parameter_57:
 
 class Program_weight_tensor_parameter_58:
     name = "parameter_58"
+    original_name = "conv2d_94.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.0408673")
@@ -641,6 +700,7 @@ class Program_weight_tensor_parameter_58:
 
 class Program_weight_tensor_parameter_59:
     name = "parameter_59"
+    original_name = "conv2d_94.w_0"
     shape = [1024, 1024, 3, 3]
     dtype = "float32"
     min_val = float("-0.0898285")
@@ -652,6 +712,7 @@ class Program_weight_tensor_parameter_59:
 
 class Program_weight_tensor_parameter_60:
     name = "parameter_60"
+    original_name = "batch_norm2d_93.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.185539")
@@ -663,6 +724,7 @@ class Program_weight_tensor_parameter_60:
 
 class Program_weight_tensor_parameter_61:
     name = "parameter_61"
+    original_name = "batch_norm2d_93.w_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.15151")
@@ -674,6 +736,7 @@ class Program_weight_tensor_parameter_61:
 
 class Program_weight_tensor_parameter_62:
     name = "parameter_62"
+    original_name = "batch_norm2d_93.w_2"
     shape = [1024]
     dtype = "float32"
     min_val = float("6.52912e-06")
@@ -685,6 +748,7 @@ class Program_weight_tensor_parameter_62:
 
 class Program_weight_tensor_parameter_63:
     name = "parameter_63"
+    original_name = "batch_norm2d_93.w_1"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.0529734")
@@ -696,6 +760,7 @@ class Program_weight_tensor_parameter_63:
 
 class Program_weight_tensor_parameter_64:
     name = "parameter_64"
+    original_name = "conv2d_93.w_0"
     shape = [1024, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.156086")
@@ -707,6 +772,7 @@ class Program_weight_tensor_parameter_64:
 
 class Program_weight_tensor_parameter_65:
     name = "parameter_65"
+    original_name = "batch_norm2d_92.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.173203")
@@ -718,6 +784,7 @@ class Program_weight_tensor_parameter_65:
 
 class Program_weight_tensor_parameter_66:
     name = "parameter_66"
+    original_name = "batch_norm2d_92.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.114129")
@@ -729,6 +796,7 @@ class Program_weight_tensor_parameter_66:
 
 class Program_weight_tensor_parameter_67:
     name = "parameter_67"
+    original_name = "batch_norm2d_92.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.00111104")
@@ -740,6 +808,7 @@ class Program_weight_tensor_parameter_67:
 
 class Program_weight_tensor_parameter_68:
     name = "parameter_68"
+    original_name = "batch_norm2d_92.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.0856441")
@@ -751,6 +820,7 @@ class Program_weight_tensor_parameter_68:
 
 class Program_weight_tensor_parameter_69:
     name = "parameter_69"
+    original_name = "conv2d_92.w_0"
     shape = [256, 256, 3, 3]
     dtype = "float32"
     min_val = float("-0.2254")
@@ -762,6 +832,7 @@ class Program_weight_tensor_parameter_69:
 
 class Program_weight_tensor_parameter_70:
     name = "parameter_70"
+    original_name = "batch_norm2d_91.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.199063")
@@ -773,6 +844,7 @@ class Program_weight_tensor_parameter_70:
 
 class Program_weight_tensor_parameter_71:
     name = "parameter_71"
+    original_name = "batch_norm2d_91.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.0853295")
@@ -784,6 +856,7 @@ class Program_weight_tensor_parameter_71:
 
 class Program_weight_tensor_parameter_72:
     name = "parameter_72"
+    original_name = "batch_norm2d_91.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.00530829")
@@ -795,6 +868,7 @@ class Program_weight_tensor_parameter_72:
 
 class Program_weight_tensor_parameter_73:
     name = "parameter_73"
+    original_name = "batch_norm2d_91.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.673336")
@@ -806,6 +880,7 @@ class Program_weight_tensor_parameter_73:
 
 class Program_weight_tensor_parameter_74:
     name = "parameter_74"
+    original_name = "conv2d_91.w_0"
     shape = [256, 1024, 1, 1]
     dtype = "float32"
     min_val = float("-0.232778")
@@ -817,6 +892,7 @@ class Program_weight_tensor_parameter_74:
 
 class Program_weight_tensor_parameter_75:
     name = "parameter_75"
+    original_name = "batch_norm2d_90.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.178753")
@@ -828,6 +904,7 @@ class Program_weight_tensor_parameter_75:
 
 class Program_weight_tensor_parameter_76:
     name = "parameter_76"
+    original_name = "batch_norm2d_90.w_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.150151")
@@ -839,6 +916,7 @@ class Program_weight_tensor_parameter_76:
 
 class Program_weight_tensor_parameter_77:
     name = "parameter_77"
+    original_name = "batch_norm2d_90.w_2"
     shape = [1024]
     dtype = "float32"
     min_val = float("5.09849e-06")
@@ -850,6 +928,7 @@ class Program_weight_tensor_parameter_77:
 
 class Program_weight_tensor_parameter_78:
     name = "parameter_78"
+    original_name = "batch_norm2d_90.w_1"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.0657701")
@@ -861,6 +940,7 @@ class Program_weight_tensor_parameter_78:
 
 class Program_weight_tensor_parameter_79:
     name = "parameter_79"
+    original_name = "conv2d_90.w_0"
     shape = [1024, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.127161")
@@ -872,6 +952,7 @@ class Program_weight_tensor_parameter_79:
 
 class Program_weight_tensor_parameter_80:
     name = "parameter_80"
+    original_name = "batch_norm2d_89.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.219602")
@@ -883,6 +964,7 @@ class Program_weight_tensor_parameter_80:
 
 class Program_weight_tensor_parameter_81:
     name = "parameter_81"
+    original_name = "batch_norm2d_89.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.109899")
@@ -894,6 +976,7 @@ class Program_weight_tensor_parameter_81:
 
 class Program_weight_tensor_parameter_82:
     name = "parameter_82"
+    original_name = "batch_norm2d_89.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.000960966")
@@ -905,6 +988,7 @@ class Program_weight_tensor_parameter_82:
 
 class Program_weight_tensor_parameter_83:
     name = "parameter_83"
+    original_name = "batch_norm2d_89.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.0740873")
@@ -916,6 +1000,7 @@ class Program_weight_tensor_parameter_83:
 
 class Program_weight_tensor_parameter_84:
     name = "parameter_84"
+    original_name = "conv2d_89.w_0"
     shape = [256, 256, 3, 3]
     dtype = "float32"
     min_val = float("-0.20945")
@@ -927,6 +1012,7 @@ class Program_weight_tensor_parameter_84:
 
 class Program_weight_tensor_parameter_85:
     name = "parameter_85"
+    original_name = "batch_norm2d_88.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.214884")
@@ -938,6 +1024,7 @@ class Program_weight_tensor_parameter_85:
 
 class Program_weight_tensor_parameter_86:
     name = "parameter_86"
+    original_name = "batch_norm2d_88.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.10138")
@@ -949,6 +1036,7 @@ class Program_weight_tensor_parameter_86:
 
 class Program_weight_tensor_parameter_87:
     name = "parameter_87"
+    original_name = "batch_norm2d_88.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.00545475")
@@ -960,6 +1048,7 @@ class Program_weight_tensor_parameter_87:
 
 class Program_weight_tensor_parameter_88:
     name = "parameter_88"
+    original_name = "batch_norm2d_88.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.377712")
@@ -971,6 +1060,7 @@ class Program_weight_tensor_parameter_88:
 
 class Program_weight_tensor_parameter_89:
     name = "parameter_89"
+    original_name = "conv2d_88.w_0"
     shape = [256, 1024, 1, 1]
     dtype = "float32"
     min_val = float("-0.153441")
@@ -982,6 +1072,7 @@ class Program_weight_tensor_parameter_89:
 
 class Program_weight_tensor_parameter_90:
     name = "parameter_90"
+    original_name = "batch_norm2d_87.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.1703")
@@ -993,6 +1084,7 @@ class Program_weight_tensor_parameter_90:
 
 class Program_weight_tensor_parameter_91:
     name = "parameter_91"
+    original_name = "batch_norm2d_87.w_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.155283")
@@ -1004,6 +1096,7 @@ class Program_weight_tensor_parameter_91:
 
 class Program_weight_tensor_parameter_92:
     name = "parameter_92"
+    original_name = "batch_norm2d_87.w_2"
     shape = [1024]
     dtype = "float32"
     min_val = float("7.13583e-06")
@@ -1015,6 +1108,7 @@ class Program_weight_tensor_parameter_92:
 
 class Program_weight_tensor_parameter_93:
     name = "parameter_93"
+    original_name = "batch_norm2d_87.w_1"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.0383555")
@@ -1026,6 +1120,7 @@ class Program_weight_tensor_parameter_93:
 
 class Program_weight_tensor_parameter_94:
     name = "parameter_94"
+    original_name = "conv2d_87.w_0"
     shape = [1024, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.122466")
@@ -1037,6 +1132,7 @@ class Program_weight_tensor_parameter_94:
 
 class Program_weight_tensor_parameter_95:
     name = "parameter_95"
+    original_name = "batch_norm2d_86.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.161884")
@@ -1048,6 +1144,7 @@ class Program_weight_tensor_parameter_95:
 
 class Program_weight_tensor_parameter_96:
     name = "parameter_96"
+    original_name = "batch_norm2d_86.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.107956")
@@ -1059,6 +1156,7 @@ class Program_weight_tensor_parameter_96:
 
 class Program_weight_tensor_parameter_97:
     name = "parameter_97"
+    original_name = "batch_norm2d_86.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.000916581")
@@ -1070,6 +1168,7 @@ class Program_weight_tensor_parameter_97:
 
 class Program_weight_tensor_parameter_98:
     name = "parameter_98"
+    original_name = "batch_norm2d_86.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.0779411")
@@ -1081,6 +1180,7 @@ class Program_weight_tensor_parameter_98:
 
 class Program_weight_tensor_parameter_99:
     name = "parameter_99"
+    original_name = "conv2d_86.w_0"
     shape = [256, 256, 3, 3]
     dtype = "float32"
     min_val = float("-0.255197")
@@ -1092,6 +1192,7 @@ class Program_weight_tensor_parameter_99:
 
 class Program_weight_tensor_parameter_100:
     name = "parameter_100"
+    original_name = "batch_norm2d_85.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.209937")
@@ -1103,6 +1204,7 @@ class Program_weight_tensor_parameter_100:
 
 class Program_weight_tensor_parameter_101:
     name = "parameter_101"
+    original_name = "batch_norm2d_85.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.117184")
@@ -1114,6 +1216,7 @@ class Program_weight_tensor_parameter_101:
 
 class Program_weight_tensor_parameter_102:
     name = "parameter_102"
+    original_name = "batch_norm2d_85.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.00547455")
@@ -1125,6 +1228,7 @@ class Program_weight_tensor_parameter_102:
 
 class Program_weight_tensor_parameter_103:
     name = "parameter_103"
+    original_name = "batch_norm2d_85.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.219326")
@@ -1136,6 +1240,7 @@ class Program_weight_tensor_parameter_103:
 
 class Program_weight_tensor_parameter_104:
     name = "parameter_104"
+    original_name = "conv2d_85.w_0"
     shape = [256, 1024, 1, 1]
     dtype = "float32"
     min_val = float("-0.101673")
@@ -1147,6 +1252,7 @@ class Program_weight_tensor_parameter_104:
 
 class Program_weight_tensor_parameter_105:
     name = "parameter_105"
+    original_name = "batch_norm2d_84.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.125546")
@@ -1158,6 +1264,7 @@ class Program_weight_tensor_parameter_105:
 
 class Program_weight_tensor_parameter_106:
     name = "parameter_106"
+    original_name = "batch_norm2d_84.w_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.13717")
@@ -1169,6 +1276,7 @@ class Program_weight_tensor_parameter_106:
 
 class Program_weight_tensor_parameter_107:
     name = "parameter_107"
+    original_name = "batch_norm2d_84.w_2"
     shape = [1024]
     dtype = "float32"
     min_val = float("7.58797e-06")
@@ -1180,6 +1288,7 @@ class Program_weight_tensor_parameter_107:
 
 class Program_weight_tensor_parameter_108:
     name = "parameter_108"
+    original_name = "batch_norm2d_84.w_1"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.0303983")
@@ -1191,6 +1300,7 @@ class Program_weight_tensor_parameter_108:
 
 class Program_weight_tensor_parameter_109:
     name = "parameter_109"
+    original_name = "conv2d_84.w_0"
     shape = [1024, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.176148")
@@ -1202,6 +1312,7 @@ class Program_weight_tensor_parameter_109:
 
 class Program_weight_tensor_parameter_110:
     name = "parameter_110"
+    original_name = "batch_norm2d_83.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.189977")
@@ -1213,6 +1324,7 @@ class Program_weight_tensor_parameter_110:
 
 class Program_weight_tensor_parameter_111:
     name = "parameter_111"
+    original_name = "batch_norm2d_83.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.0974469")
@@ -1224,6 +1336,7 @@ class Program_weight_tensor_parameter_111:
 
 class Program_weight_tensor_parameter_112:
     name = "parameter_112"
+    original_name = "batch_norm2d_83.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.000793947")
@@ -1235,6 +1348,7 @@ class Program_weight_tensor_parameter_112:
 
 class Program_weight_tensor_parameter_113:
     name = "parameter_113"
+    original_name = "batch_norm2d_83.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.0588311")
@@ -1246,6 +1360,7 @@ class Program_weight_tensor_parameter_113:
 
 class Program_weight_tensor_parameter_114:
     name = "parameter_114"
+    original_name = "conv2d_83.w_0"
     shape = [256, 256, 3, 3]
     dtype = "float32"
     min_val = float("-0.310282")
@@ -1257,6 +1372,7 @@ class Program_weight_tensor_parameter_114:
 
 class Program_weight_tensor_parameter_115:
     name = "parameter_115"
+    original_name = "batch_norm2d_82.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.207876")
@@ -1268,6 +1384,7 @@ class Program_weight_tensor_parameter_115:
 
 class Program_weight_tensor_parameter_116:
     name = "parameter_116"
+    original_name = "batch_norm2d_82.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.11424")
@@ -1279,6 +1396,7 @@ class Program_weight_tensor_parameter_116:
 
 class Program_weight_tensor_parameter_117:
     name = "parameter_117"
+    original_name = "batch_norm2d_82.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.00579108")
@@ -1290,6 +1408,7 @@ class Program_weight_tensor_parameter_117:
 
 class Program_weight_tensor_parameter_118:
     name = "parameter_118"
+    original_name = "batch_norm2d_82.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.292558")
@@ -1301,6 +1420,7 @@ class Program_weight_tensor_parameter_118:
 
 class Program_weight_tensor_parameter_119:
     name = "parameter_119"
+    original_name = "conv2d_82.w_0"
     shape = [256, 1024, 1, 1]
     dtype = "float32"
     min_val = float("-0.096533")
@@ -1312,6 +1432,7 @@ class Program_weight_tensor_parameter_119:
 
 class Program_weight_tensor_parameter_120:
     name = "parameter_120"
+    original_name = "batch_norm2d_81.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.144983")
@@ -1323,6 +1444,7 @@ class Program_weight_tensor_parameter_120:
 
 class Program_weight_tensor_parameter_121:
     name = "parameter_121"
+    original_name = "batch_norm2d_81.w_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.137949")
@@ -1334,6 +1456,7 @@ class Program_weight_tensor_parameter_121:
 
 class Program_weight_tensor_parameter_122:
     name = "parameter_122"
+    original_name = "batch_norm2d_81.w_2"
     shape = [1024]
     dtype = "float32"
     min_val = float("8.66004e-06")
@@ -1345,6 +1468,7 @@ class Program_weight_tensor_parameter_122:
 
 class Program_weight_tensor_parameter_123:
     name = "parameter_123"
+    original_name = "batch_norm2d_81.w_1"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.0320241")
@@ -1356,6 +1480,7 @@ class Program_weight_tensor_parameter_123:
 
 class Program_weight_tensor_parameter_124:
     name = "parameter_124"
+    original_name = "conv2d_81.w_0"
     shape = [1024, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.171266")
@@ -1367,6 +1492,7 @@ class Program_weight_tensor_parameter_124:
 
 class Program_weight_tensor_parameter_125:
     name = "parameter_125"
+    original_name = "batch_norm2d_80.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.198168")
@@ -1378,6 +1504,7 @@ class Program_weight_tensor_parameter_125:
 
 class Program_weight_tensor_parameter_126:
     name = "parameter_126"
+    original_name = "batch_norm2d_80.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.102805")
@@ -1389,6 +1516,7 @@ class Program_weight_tensor_parameter_126:
 
 class Program_weight_tensor_parameter_127:
     name = "parameter_127"
+    original_name = "batch_norm2d_80.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.00084611")
@@ -1400,6 +1528,7 @@ class Program_weight_tensor_parameter_127:
 
 class Program_weight_tensor_parameter_128:
     name = "parameter_128"
+    original_name = "batch_norm2d_80.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.0591028")
@@ -1411,6 +1540,7 @@ class Program_weight_tensor_parameter_128:
 
 class Program_weight_tensor_parameter_129:
     name = "parameter_129"
+    original_name = "conv2d_80.w_0"
     shape = [256, 256, 3, 3]
     dtype = "float32"
     min_val = float("-0.222083")
@@ -1422,6 +1552,7 @@ class Program_weight_tensor_parameter_129:
 
 class Program_weight_tensor_parameter_130:
     name = "parameter_130"
+    original_name = "batch_norm2d_79.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.206188")
@@ -1433,6 +1564,7 @@ class Program_weight_tensor_parameter_130:
 
 class Program_weight_tensor_parameter_131:
     name = "parameter_131"
+    original_name = "batch_norm2d_79.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.108899")
@@ -1444,6 +1576,7 @@ class Program_weight_tensor_parameter_131:
 
 class Program_weight_tensor_parameter_132:
     name = "parameter_132"
+    original_name = "batch_norm2d_79.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.00559263")
@@ -1455,6 +1588,7 @@ class Program_weight_tensor_parameter_132:
 
 class Program_weight_tensor_parameter_133:
     name = "parameter_133"
+    original_name = "batch_norm2d_79.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.213021")
@@ -1466,6 +1600,7 @@ class Program_weight_tensor_parameter_133:
 
 class Program_weight_tensor_parameter_134:
     name = "parameter_134"
+    original_name = "conv2d_79.w_0"
     shape = [256, 1024, 1, 1]
     dtype = "float32"
     min_val = float("-0.188505")
@@ -1477,6 +1612,7 @@ class Program_weight_tensor_parameter_134:
 
 class Program_weight_tensor_parameter_135:
     name = "parameter_135"
+    original_name = "batch_norm2d_78.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.181122")
@@ -1488,6 +1624,7 @@ class Program_weight_tensor_parameter_135:
 
 class Program_weight_tensor_parameter_136:
     name = "parameter_136"
+    original_name = "batch_norm2d_78.w_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.145373")
@@ -1499,6 +1636,7 @@ class Program_weight_tensor_parameter_136:
 
 class Program_weight_tensor_parameter_137:
     name = "parameter_137"
+    original_name = "batch_norm2d_78.w_2"
     shape = [1024]
     dtype = "float32"
     min_val = float("1.08898e-05")
@@ -1510,6 +1648,7 @@ class Program_weight_tensor_parameter_137:
 
 class Program_weight_tensor_parameter_138:
     name = "parameter_138"
+    original_name = "batch_norm2d_78.w_1"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.0353485")
@@ -1521,6 +1660,7 @@ class Program_weight_tensor_parameter_138:
 
 class Program_weight_tensor_parameter_139:
     name = "parameter_139"
+    original_name = "conv2d_78.w_0"
     shape = [1024, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.220901")
@@ -1532,6 +1672,7 @@ class Program_weight_tensor_parameter_139:
 
 class Program_weight_tensor_parameter_140:
     name = "parameter_140"
+    original_name = "batch_norm2d_77.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.202712")
@@ -1543,6 +1684,7 @@ class Program_weight_tensor_parameter_140:
 
 class Program_weight_tensor_parameter_141:
     name = "parameter_141"
+    original_name = "batch_norm2d_77.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.0763934")
@@ -1554,6 +1696,7 @@ class Program_weight_tensor_parameter_141:
 
 class Program_weight_tensor_parameter_142:
     name = "parameter_142"
+    original_name = "batch_norm2d_77.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.000963988")
@@ -1565,6 +1708,7 @@ class Program_weight_tensor_parameter_142:
 
 class Program_weight_tensor_parameter_143:
     name = "parameter_143"
+    original_name = "batch_norm2d_77.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.0708342")
@@ -1576,6 +1720,7 @@ class Program_weight_tensor_parameter_143:
 
 class Program_weight_tensor_parameter_144:
     name = "parameter_144"
+    original_name = "conv2d_77.w_0"
     shape = [256, 256, 3, 3]
     dtype = "float32"
     min_val = float("-0.228344")
@@ -1587,6 +1732,7 @@ class Program_weight_tensor_parameter_144:
 
 class Program_weight_tensor_parameter_145:
     name = "parameter_145"
+    original_name = "batch_norm2d_76.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.239451")
@@ -1598,6 +1744,7 @@ class Program_weight_tensor_parameter_145:
 
 class Program_weight_tensor_parameter_146:
     name = "parameter_146"
+    original_name = "batch_norm2d_76.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.0775438")
@@ -1609,6 +1756,7 @@ class Program_weight_tensor_parameter_146:
 
 class Program_weight_tensor_parameter_147:
     name = "parameter_147"
+    original_name = "batch_norm2d_76.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.00587883")
@@ -1620,6 +1768,7 @@ class Program_weight_tensor_parameter_147:
 
 class Program_weight_tensor_parameter_148:
     name = "parameter_148"
+    original_name = "batch_norm2d_76.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.279282")
@@ -1631,6 +1780,7 @@ class Program_weight_tensor_parameter_148:
 
 class Program_weight_tensor_parameter_149:
     name = "parameter_149"
+    original_name = "conv2d_76.w_0"
     shape = [256, 1024, 1, 1]
     dtype = "float32"
     min_val = float("-0.146159")
@@ -1642,6 +1792,7 @@ class Program_weight_tensor_parameter_149:
 
 class Program_weight_tensor_parameter_150:
     name = "parameter_150"
+    original_name = "batch_norm2d_75.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.310629")
@@ -1653,6 +1804,7 @@ class Program_weight_tensor_parameter_150:
 
 class Program_weight_tensor_parameter_151:
     name = "parameter_151"
+    original_name = "batch_norm2d_75.w_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.138146")
@@ -1664,6 +1816,7 @@ class Program_weight_tensor_parameter_151:
 
 class Program_weight_tensor_parameter_152:
     name = "parameter_152"
+    original_name = "batch_norm2d_75.w_2"
     shape = [1024]
     dtype = "float32"
     min_val = float("4.95912e-06")
@@ -1675,6 +1828,7 @@ class Program_weight_tensor_parameter_152:
 
 class Program_weight_tensor_parameter_153:
     name = "parameter_153"
+    original_name = "batch_norm2d_75.w_1"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.0451512")
@@ -1686,6 +1840,7 @@ class Program_weight_tensor_parameter_153:
 
 class Program_weight_tensor_parameter_154:
     name = "parameter_154"
+    original_name = "conv2d_75.w_0"
     shape = [1024, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.233892")
@@ -1697,6 +1852,7 @@ class Program_weight_tensor_parameter_154:
 
 class Program_weight_tensor_parameter_155:
     name = "parameter_155"
+    original_name = "batch_norm2d_74.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.172584")
@@ -1708,6 +1864,7 @@ class Program_weight_tensor_parameter_155:
 
 class Program_weight_tensor_parameter_156:
     name = "parameter_156"
+    original_name = "batch_norm2d_74.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.0603789")
@@ -1719,6 +1876,7 @@ class Program_weight_tensor_parameter_156:
 
 class Program_weight_tensor_parameter_157:
     name = "parameter_157"
+    original_name = "batch_norm2d_74.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.000760807")
@@ -1730,6 +1888,7 @@ class Program_weight_tensor_parameter_157:
 
 class Program_weight_tensor_parameter_158:
     name = "parameter_158"
+    original_name = "batch_norm2d_74.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.0930041")
@@ -1741,6 +1900,7 @@ class Program_weight_tensor_parameter_158:
 
 class Program_weight_tensor_parameter_159:
     name = "parameter_159"
+    original_name = "conv2d_74.w_0"
     shape = [256, 256, 3, 3]
     dtype = "float32"
     min_val = float("-0.257786")
@@ -1752,6 +1912,7 @@ class Program_weight_tensor_parameter_159:
 
 class Program_weight_tensor_parameter_160:
     name = "parameter_160"
+    original_name = "batch_norm2d_73.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.188166")
@@ -1763,6 +1924,7 @@ class Program_weight_tensor_parameter_160:
 
 class Program_weight_tensor_parameter_161:
     name = "parameter_161"
+    original_name = "batch_norm2d_73.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.0726036")
@@ -1774,6 +1936,7 @@ class Program_weight_tensor_parameter_161:
 
 class Program_weight_tensor_parameter_162:
     name = "parameter_162"
+    original_name = "batch_norm2d_73.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.00493726")
@@ -1785,6 +1948,7 @@ class Program_weight_tensor_parameter_162:
 
 class Program_weight_tensor_parameter_163:
     name = "parameter_163"
+    original_name = "batch_norm2d_73.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.260304")
@@ -1796,6 +1960,7 @@ class Program_weight_tensor_parameter_163:
 
 class Program_weight_tensor_parameter_164:
     name = "parameter_164"
+    original_name = "conv2d_73.w_0"
     shape = [256, 1024, 1, 1]
     dtype = "float32"
     min_val = float("-0.312267")
@@ -1807,6 +1972,7 @@ class Program_weight_tensor_parameter_164:
 
 class Program_weight_tensor_parameter_165:
     name = "parameter_165"
+    original_name = "batch_norm2d_72.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.148636")
@@ -1818,6 +1984,7 @@ class Program_weight_tensor_parameter_165:
 
 class Program_weight_tensor_parameter_166:
     name = "parameter_166"
+    original_name = "batch_norm2d_72.w_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.141259")
@@ -1829,6 +1996,7 @@ class Program_weight_tensor_parameter_166:
 
 class Program_weight_tensor_parameter_167:
     name = "parameter_167"
+    original_name = "batch_norm2d_72.w_2"
     shape = [1024]
     dtype = "float32"
     min_val = float("5.43185e-06")
@@ -1840,6 +2008,7 @@ class Program_weight_tensor_parameter_167:
 
 class Program_weight_tensor_parameter_168:
     name = "parameter_168"
+    original_name = "batch_norm2d_72.w_1"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.03162")
@@ -1851,6 +2020,7 @@ class Program_weight_tensor_parameter_168:
 
 class Program_weight_tensor_parameter_169:
     name = "parameter_169"
+    original_name = "conv2d_72.w_0"
     shape = [1024, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.22121")
@@ -1862,6 +2032,7 @@ class Program_weight_tensor_parameter_169:
 
 class Program_weight_tensor_parameter_170:
     name = "parameter_170"
+    original_name = "batch_norm2d_71.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.18168")
@@ -1873,6 +2044,7 @@ class Program_weight_tensor_parameter_170:
 
 class Program_weight_tensor_parameter_171:
     name = "parameter_171"
+    original_name = "batch_norm2d_71.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.0786765")
@@ -1884,6 +2056,7 @@ class Program_weight_tensor_parameter_171:
 
 class Program_weight_tensor_parameter_172:
     name = "parameter_172"
+    original_name = "batch_norm2d_71.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.000687754")
@@ -1895,6 +2068,7 @@ class Program_weight_tensor_parameter_172:
 
 class Program_weight_tensor_parameter_173:
     name = "parameter_173"
+    original_name = "batch_norm2d_71.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.0647085")
@@ -1906,6 +2080,7 @@ class Program_weight_tensor_parameter_173:
 
 class Program_weight_tensor_parameter_174:
     name = "parameter_174"
+    original_name = "conv2d_71.w_0"
     shape = [256, 256, 3, 3]
     dtype = "float32"
     min_val = float("-0.341731")
@@ -1917,6 +2092,7 @@ class Program_weight_tensor_parameter_174:
 
 class Program_weight_tensor_parameter_175:
     name = "parameter_175"
+    original_name = "batch_norm2d_70.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.192519")
@@ -1928,6 +2104,7 @@ class Program_weight_tensor_parameter_175:
 
 class Program_weight_tensor_parameter_176:
     name = "parameter_176"
+    original_name = "batch_norm2d_70.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.069175")
@@ -1939,6 +2116,7 @@ class Program_weight_tensor_parameter_176:
 
 class Program_weight_tensor_parameter_177:
     name = "parameter_177"
+    original_name = "batch_norm2d_70.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.00495853")
@@ -1950,6 +2128,7 @@ class Program_weight_tensor_parameter_177:
 
 class Program_weight_tensor_parameter_178:
     name = "parameter_178"
+    original_name = "batch_norm2d_70.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.479151")
@@ -1961,6 +2140,7 @@ class Program_weight_tensor_parameter_178:
 
 class Program_weight_tensor_parameter_179:
     name = "parameter_179"
+    original_name = "conv2d_70.w_0"
     shape = [256, 1024, 1, 1]
     dtype = "float32"
     min_val = float("-0.262533")
@@ -1972,6 +2152,7 @@ class Program_weight_tensor_parameter_179:
 
 class Program_weight_tensor_parameter_180:
     name = "parameter_180"
+    original_name = "batch_norm2d_69.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.193909")
@@ -1983,6 +2164,7 @@ class Program_weight_tensor_parameter_180:
 
 class Program_weight_tensor_parameter_181:
     name = "parameter_181"
+    original_name = "batch_norm2d_69.w_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.138217")
@@ -1994,6 +2176,7 @@ class Program_weight_tensor_parameter_181:
 
 class Program_weight_tensor_parameter_182:
     name = "parameter_182"
+    original_name = "batch_norm2d_69.w_2"
     shape = [1024]
     dtype = "float32"
     min_val = float("6.24548e-06")
@@ -2005,6 +2188,7 @@ class Program_weight_tensor_parameter_182:
 
 class Program_weight_tensor_parameter_183:
     name = "parameter_183"
+    original_name = "batch_norm2d_69.w_1"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.0310979")
@@ -2016,6 +2200,7 @@ class Program_weight_tensor_parameter_183:
 
 class Program_weight_tensor_parameter_184:
     name = "parameter_184"
+    original_name = "conv2d_69.w_0"
     shape = [1024, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.198004")
@@ -2027,6 +2212,7 @@ class Program_weight_tensor_parameter_184:
 
 class Program_weight_tensor_parameter_185:
     name = "parameter_185"
+    original_name = "batch_norm2d_68.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.190172")
@@ -2038,6 +2224,7 @@ class Program_weight_tensor_parameter_185:
 
 class Program_weight_tensor_parameter_186:
     name = "parameter_186"
+    original_name = "batch_norm2d_68.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.0498696")
@@ -2049,6 +2236,7 @@ class Program_weight_tensor_parameter_186:
 
 class Program_weight_tensor_parameter_187:
     name = "parameter_187"
+    original_name = "batch_norm2d_68.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.000762434")
@@ -2060,6 +2248,7 @@ class Program_weight_tensor_parameter_187:
 
 class Program_weight_tensor_parameter_188:
     name = "parameter_188"
+    original_name = "batch_norm2d_68.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.092693")
@@ -2071,6 +2260,7 @@ class Program_weight_tensor_parameter_188:
 
 class Program_weight_tensor_parameter_189:
     name = "parameter_189"
+    original_name = "conv2d_68.w_0"
     shape = [256, 256, 3, 3]
     dtype = "float32"
     min_val = float("-0.141964")
@@ -2082,6 +2272,7 @@ class Program_weight_tensor_parameter_189:
 
 class Program_weight_tensor_parameter_190:
     name = "parameter_190"
+    original_name = "batch_norm2d_67.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.17389")
@@ -2093,6 +2284,7 @@ class Program_weight_tensor_parameter_190:
 
 class Program_weight_tensor_parameter_191:
     name = "parameter_191"
+    original_name = "batch_norm2d_67.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.0755592")
@@ -2104,6 +2296,7 @@ class Program_weight_tensor_parameter_191:
 
 class Program_weight_tensor_parameter_192:
     name = "parameter_192"
+    original_name = "batch_norm2d_67.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.00429851")
@@ -2115,6 +2308,7 @@ class Program_weight_tensor_parameter_192:
 
 class Program_weight_tensor_parameter_193:
     name = "parameter_193"
+    original_name = "batch_norm2d_67.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.181446")
@@ -2126,6 +2320,7 @@ class Program_weight_tensor_parameter_193:
 
 class Program_weight_tensor_parameter_194:
     name = "parameter_194"
+    original_name = "conv2d_67.w_0"
     shape = [256, 1024, 1, 1]
     dtype = "float32"
     min_val = float("-0.183962")
@@ -2137,6 +2332,7 @@ class Program_weight_tensor_parameter_194:
 
 class Program_weight_tensor_parameter_195:
     name = "parameter_195"
+    original_name = "batch_norm2d_66.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.253488")
@@ -2148,6 +2344,7 @@ class Program_weight_tensor_parameter_195:
 
 class Program_weight_tensor_parameter_196:
     name = "parameter_196"
+    original_name = "batch_norm2d_66.w_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.124794")
@@ -2159,6 +2356,7 @@ class Program_weight_tensor_parameter_196:
 
 class Program_weight_tensor_parameter_197:
     name = "parameter_197"
+    original_name = "batch_norm2d_66.w_2"
     shape = [1024]
     dtype = "float32"
     min_val = float("6.39378e-06")
@@ -2170,6 +2368,7 @@ class Program_weight_tensor_parameter_197:
 
 class Program_weight_tensor_parameter_198:
     name = "parameter_198"
+    original_name = "batch_norm2d_66.w_1"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.0375304")
@@ -2181,6 +2380,7 @@ class Program_weight_tensor_parameter_198:
 
 class Program_weight_tensor_parameter_199:
     name = "parameter_199"
+    original_name = "conv2d_66.w_0"
     shape = [1024, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.227128")
@@ -2192,6 +2392,7 @@ class Program_weight_tensor_parameter_199:
 
 class Program_weight_tensor_parameter_200:
     name = "parameter_200"
+    original_name = "batch_norm2d_65.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.156207")
@@ -2203,6 +2404,7 @@ class Program_weight_tensor_parameter_200:
 
 class Program_weight_tensor_parameter_201:
     name = "parameter_201"
+    original_name = "batch_norm2d_65.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.0622247")
@@ -2214,6 +2416,7 @@ class Program_weight_tensor_parameter_201:
 
 class Program_weight_tensor_parameter_202:
     name = "parameter_202"
+    original_name = "batch_norm2d_65.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.000753361")
@@ -2225,6 +2428,7 @@ class Program_weight_tensor_parameter_202:
 
 class Program_weight_tensor_parameter_203:
     name = "parameter_203"
+    original_name = "batch_norm2d_65.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.0939348")
@@ -2236,6 +2440,7 @@ class Program_weight_tensor_parameter_203:
 
 class Program_weight_tensor_parameter_204:
     name = "parameter_204"
+    original_name = "conv2d_65.w_0"
     shape = [256, 256, 3, 3]
     dtype = "float32"
     min_val = float("-0.132033")
@@ -2247,6 +2452,7 @@ class Program_weight_tensor_parameter_204:
 
 class Program_weight_tensor_parameter_205:
     name = "parameter_205"
+    original_name = "batch_norm2d_64.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.171042")
@@ -2258,6 +2464,7 @@ class Program_weight_tensor_parameter_205:
 
 class Program_weight_tensor_parameter_206:
     name = "parameter_206"
+    original_name = "batch_norm2d_64.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.0526623")
@@ -2269,6 +2476,7 @@ class Program_weight_tensor_parameter_206:
 
 class Program_weight_tensor_parameter_207:
     name = "parameter_207"
+    original_name = "batch_norm2d_64.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.00350379")
@@ -2280,6 +2488,7 @@ class Program_weight_tensor_parameter_207:
 
 class Program_weight_tensor_parameter_208:
     name = "parameter_208"
+    original_name = "batch_norm2d_64.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.299507")
@@ -2291,6 +2500,7 @@ class Program_weight_tensor_parameter_208:
 
 class Program_weight_tensor_parameter_209:
     name = "parameter_209"
+    original_name = "conv2d_64.w_0"
     shape = [256, 1024, 1, 1]
     dtype = "float32"
     min_val = float("-0.169499")
@@ -2302,6 +2512,7 @@ class Program_weight_tensor_parameter_209:
 
 class Program_weight_tensor_parameter_210:
     name = "parameter_210"
+    original_name = "batch_norm2d_63.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.211417")
@@ -2313,6 +2524,7 @@ class Program_weight_tensor_parameter_210:
 
 class Program_weight_tensor_parameter_211:
     name = "parameter_211"
+    original_name = "batch_norm2d_63.w_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.120856")
@@ -2324,6 +2536,7 @@ class Program_weight_tensor_parameter_211:
 
 class Program_weight_tensor_parameter_212:
     name = "parameter_212"
+    original_name = "batch_norm2d_63.w_2"
     shape = [1024]
     dtype = "float32"
     min_val = float("5.53608e-06")
@@ -2335,6 +2548,7 @@ class Program_weight_tensor_parameter_212:
 
 class Program_weight_tensor_parameter_213:
     name = "parameter_213"
+    original_name = "batch_norm2d_63.w_1"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.0597337")
@@ -2346,6 +2560,7 @@ class Program_weight_tensor_parameter_213:
 
 class Program_weight_tensor_parameter_214:
     name = "parameter_214"
+    original_name = "conv2d_63.w_0"
     shape = [1024, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.310881")
@@ -2357,6 +2572,7 @@ class Program_weight_tensor_parameter_214:
 
 class Program_weight_tensor_parameter_215:
     name = "parameter_215"
+    original_name = "batch_norm2d_62.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.163316")
@@ -2368,6 +2584,7 @@ class Program_weight_tensor_parameter_215:
 
 class Program_weight_tensor_parameter_216:
     name = "parameter_216"
+    original_name = "batch_norm2d_62.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.0746887")
@@ -2379,6 +2596,7 @@ class Program_weight_tensor_parameter_216:
 
 class Program_weight_tensor_parameter_217:
     name = "parameter_217"
+    original_name = "batch_norm2d_62.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.000601658")
@@ -2390,6 +2608,7 @@ class Program_weight_tensor_parameter_217:
 
 class Program_weight_tensor_parameter_218:
     name = "parameter_218"
+    original_name = "batch_norm2d_62.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.132378")
@@ -2401,6 +2620,7 @@ class Program_weight_tensor_parameter_218:
 
 class Program_weight_tensor_parameter_219:
     name = "parameter_219"
+    original_name = "conv2d_62.w_0"
     shape = [256, 256, 3, 3]
     dtype = "float32"
     min_val = float("-0.135128")
@@ -2412,6 +2632,7 @@ class Program_weight_tensor_parameter_219:
 
 class Program_weight_tensor_parameter_220:
     name = "parameter_220"
+    original_name = "batch_norm2d_61.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.177842")
@@ -2423,6 +2644,7 @@ class Program_weight_tensor_parameter_220:
 
 class Program_weight_tensor_parameter_221:
     name = "parameter_221"
+    original_name = "batch_norm2d_61.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.0755452")
@@ -2434,6 +2656,7 @@ class Program_weight_tensor_parameter_221:
 
 class Program_weight_tensor_parameter_222:
     name = "parameter_222"
+    original_name = "batch_norm2d_61.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.003121")
@@ -2445,6 +2668,7 @@ class Program_weight_tensor_parameter_222:
 
 class Program_weight_tensor_parameter_223:
     name = "parameter_223"
+    original_name = "batch_norm2d_61.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.237717")
@@ -2456,6 +2680,7 @@ class Program_weight_tensor_parameter_223:
 
 class Program_weight_tensor_parameter_224:
     name = "parameter_224"
+    original_name = "conv2d_61.w_0"
     shape = [256, 1024, 1, 1]
     dtype = "float32"
     min_val = float("-0.147657")
@@ -2467,6 +2692,7 @@ class Program_weight_tensor_parameter_224:
 
 class Program_weight_tensor_parameter_225:
     name = "parameter_225"
+    original_name = "batch_norm2d_60.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.126319")
@@ -2478,6 +2704,7 @@ class Program_weight_tensor_parameter_225:
 
 class Program_weight_tensor_parameter_226:
     name = "parameter_226"
+    original_name = "batch_norm2d_60.w_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.128895")
@@ -2489,6 +2716,7 @@ class Program_weight_tensor_parameter_226:
 
 class Program_weight_tensor_parameter_227:
     name = "parameter_227"
+    original_name = "batch_norm2d_60.w_2"
     shape = [1024]
     dtype = "float32"
     min_val = float("4.63147e-06")
@@ -2500,6 +2728,7 @@ class Program_weight_tensor_parameter_227:
 
 class Program_weight_tensor_parameter_228:
     name = "parameter_228"
+    original_name = "batch_norm2d_60.w_1"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.0322771")
@@ -2511,6 +2740,7 @@ class Program_weight_tensor_parameter_228:
 
 class Program_weight_tensor_parameter_229:
     name = "parameter_229"
+    original_name = "conv2d_60.w_0"
     shape = [1024, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.194955")
@@ -2522,6 +2752,7 @@ class Program_weight_tensor_parameter_229:
 
 class Program_weight_tensor_parameter_230:
     name = "parameter_230"
+    original_name = "batch_norm2d_59.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.167313")
@@ -2533,6 +2764,7 @@ class Program_weight_tensor_parameter_230:
 
 class Program_weight_tensor_parameter_231:
     name = "parameter_231"
+    original_name = "batch_norm2d_59.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.0733046")
@@ -2544,6 +2776,7 @@ class Program_weight_tensor_parameter_231:
 
 class Program_weight_tensor_parameter_232:
     name = "parameter_232"
+    original_name = "batch_norm2d_59.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.000667906")
@@ -2555,6 +2788,7 @@ class Program_weight_tensor_parameter_232:
 
 class Program_weight_tensor_parameter_233:
     name = "parameter_233"
+    original_name = "batch_norm2d_59.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.148904")
@@ -2566,6 +2800,7 @@ class Program_weight_tensor_parameter_233:
 
 class Program_weight_tensor_parameter_234:
     name = "parameter_234"
+    original_name = "conv2d_59.w_0"
     shape = [256, 256, 3, 3]
     dtype = "float32"
     min_val = float("-0.130859")
@@ -2577,6 +2812,7 @@ class Program_weight_tensor_parameter_234:
 
 class Program_weight_tensor_parameter_235:
     name = "parameter_235"
+    original_name = "batch_norm2d_58.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.173763")
@@ -2588,6 +2824,7 @@ class Program_weight_tensor_parameter_235:
 
 class Program_weight_tensor_parameter_236:
     name = "parameter_236"
+    original_name = "batch_norm2d_58.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.0666068")
@@ -2599,6 +2836,7 @@ class Program_weight_tensor_parameter_236:
 
 class Program_weight_tensor_parameter_237:
     name = "parameter_237"
+    original_name = "batch_norm2d_58.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.00312008")
@@ -2610,6 +2848,7 @@ class Program_weight_tensor_parameter_237:
 
 class Program_weight_tensor_parameter_238:
     name = "parameter_238"
+    original_name = "batch_norm2d_58.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.30751")
@@ -2621,6 +2860,7 @@ class Program_weight_tensor_parameter_238:
 
 class Program_weight_tensor_parameter_239:
     name = "parameter_239"
+    original_name = "conv2d_58.w_0"
     shape = [256, 1024, 1, 1]
     dtype = "float32"
     min_val = float("-0.115584")
@@ -2632,6 +2872,7 @@ class Program_weight_tensor_parameter_239:
 
 class Program_weight_tensor_parameter_240:
     name = "parameter_240"
+    original_name = "batch_norm2d_57.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.119933")
@@ -2643,6 +2884,7 @@ class Program_weight_tensor_parameter_240:
 
 class Program_weight_tensor_parameter_241:
     name = "parameter_241"
+    original_name = "batch_norm2d_57.w_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.116181")
@@ -2654,6 +2896,7 @@ class Program_weight_tensor_parameter_241:
 
 class Program_weight_tensor_parameter_242:
     name = "parameter_242"
+    original_name = "batch_norm2d_57.w_2"
     shape = [1024]
     dtype = "float32"
     min_val = float("5.72313e-06")
@@ -2665,6 +2908,7 @@ class Program_weight_tensor_parameter_242:
 
 class Program_weight_tensor_parameter_243:
     name = "parameter_243"
+    original_name = "batch_norm2d_57.w_1"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.0419524")
@@ -2676,6 +2920,7 @@ class Program_weight_tensor_parameter_243:
 
 class Program_weight_tensor_parameter_244:
     name = "parameter_244"
+    original_name = "conv2d_57.w_0"
     shape = [1024, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.14805")
@@ -2687,6 +2932,7 @@ class Program_weight_tensor_parameter_244:
 
 class Program_weight_tensor_parameter_245:
     name = "parameter_245"
+    original_name = "batch_norm2d_56.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.20508")
@@ -2698,6 +2944,7 @@ class Program_weight_tensor_parameter_245:
 
 class Program_weight_tensor_parameter_246:
     name = "parameter_246"
+    original_name = "batch_norm2d_56.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.0810124")
@@ -2709,6 +2956,7 @@ class Program_weight_tensor_parameter_246:
 
 class Program_weight_tensor_parameter_247:
     name = "parameter_247"
+    original_name = "batch_norm2d_56.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.000611006")
@@ -2720,6 +2968,7 @@ class Program_weight_tensor_parameter_247:
 
 class Program_weight_tensor_parameter_248:
     name = "parameter_248"
+    original_name = "batch_norm2d_56.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.104777")
@@ -2731,6 +2980,7 @@ class Program_weight_tensor_parameter_248:
 
 class Program_weight_tensor_parameter_249:
     name = "parameter_249"
+    original_name = "conv2d_56.w_0"
     shape = [256, 256, 3, 3]
     dtype = "float32"
     min_val = float("-0.125223")
@@ -2742,6 +2992,7 @@ class Program_weight_tensor_parameter_249:
 
 class Program_weight_tensor_parameter_250:
     name = "parameter_250"
+    original_name = "batch_norm2d_55.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.243507")
@@ -2753,6 +3004,7 @@ class Program_weight_tensor_parameter_250:
 
 class Program_weight_tensor_parameter_251:
     name = "parameter_251"
+    original_name = "batch_norm2d_55.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.065066")
@@ -2764,6 +3016,7 @@ class Program_weight_tensor_parameter_251:
 
 class Program_weight_tensor_parameter_252:
     name = "parameter_252"
+    original_name = "batch_norm2d_55.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.00405772")
@@ -2775,6 +3028,7 @@ class Program_weight_tensor_parameter_252:
 
 class Program_weight_tensor_parameter_253:
     name = "parameter_253"
+    original_name = "batch_norm2d_55.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.218554")
@@ -2786,6 +3040,7 @@ class Program_weight_tensor_parameter_253:
 
 class Program_weight_tensor_parameter_254:
     name = "parameter_254"
+    original_name = "conv2d_55.w_0"
     shape = [256, 1024, 1, 1]
     dtype = "float32"
     min_val = float("-0.122758")
@@ -2797,6 +3052,7 @@ class Program_weight_tensor_parameter_254:
 
 class Program_weight_tensor_parameter_255:
     name = "parameter_255"
+    original_name = "batch_norm2d_54.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.152402")
@@ -2808,6 +3064,7 @@ class Program_weight_tensor_parameter_255:
 
 class Program_weight_tensor_parameter_256:
     name = "parameter_256"
+    original_name = "batch_norm2d_54.w_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.129227")
@@ -2819,6 +3076,7 @@ class Program_weight_tensor_parameter_256:
 
 class Program_weight_tensor_parameter_257:
     name = "parameter_257"
+    original_name = "batch_norm2d_54.w_2"
     shape = [1024]
     dtype = "float32"
     min_val = float("3.37996e-06")
@@ -2830,6 +3088,7 @@ class Program_weight_tensor_parameter_257:
 
 class Program_weight_tensor_parameter_258:
     name = "parameter_258"
+    original_name = "batch_norm2d_54.w_1"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.0442738")
@@ -2841,6 +3100,7 @@ class Program_weight_tensor_parameter_258:
 
 class Program_weight_tensor_parameter_259:
     name = "parameter_259"
+    original_name = "conv2d_54.w_0"
     shape = [1024, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.157289")
@@ -2852,6 +3112,7 @@ class Program_weight_tensor_parameter_259:
 
 class Program_weight_tensor_parameter_260:
     name = "parameter_260"
+    original_name = "batch_norm2d_53.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.214222")
@@ -2863,6 +3124,7 @@ class Program_weight_tensor_parameter_260:
 
 class Program_weight_tensor_parameter_261:
     name = "parameter_261"
+    original_name = "batch_norm2d_53.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.083162")
@@ -2874,6 +3136,7 @@ class Program_weight_tensor_parameter_261:
 
 class Program_weight_tensor_parameter_262:
     name = "parameter_262"
+    original_name = "batch_norm2d_53.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.00147176")
@@ -2885,6 +3148,7 @@ class Program_weight_tensor_parameter_262:
 
 class Program_weight_tensor_parameter_263:
     name = "parameter_263"
+    original_name = "batch_norm2d_53.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.124527")
@@ -2896,6 +3160,7 @@ class Program_weight_tensor_parameter_263:
 
 class Program_weight_tensor_parameter_264:
     name = "parameter_264"
+    original_name = "conv2d_53.w_0"
     shape = [256, 256, 3, 3]
     dtype = "float32"
     min_val = float("-0.0855654")
@@ -2907,6 +3172,7 @@ class Program_weight_tensor_parameter_264:
 
 class Program_weight_tensor_parameter_265:
     name = "parameter_265"
+    original_name = "batch_norm2d_52.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.230885")
@@ -2918,6 +3184,7 @@ class Program_weight_tensor_parameter_265:
 
 class Program_weight_tensor_parameter_266:
     name = "parameter_266"
+    original_name = "batch_norm2d_52.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.0675117")
@@ -2929,6 +3196,7 @@ class Program_weight_tensor_parameter_266:
 
 class Program_weight_tensor_parameter_267:
     name = "parameter_267"
+    original_name = "batch_norm2d_52.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.00537478")
@@ -2940,6 +3208,7 @@ class Program_weight_tensor_parameter_267:
 
 class Program_weight_tensor_parameter_268:
     name = "parameter_268"
+    original_name = "batch_norm2d_52.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.220865")
@@ -2951,6 +3220,7 @@ class Program_weight_tensor_parameter_268:
 
 class Program_weight_tensor_parameter_269:
     name = "parameter_269"
+    original_name = "conv2d_52.w_0"
     shape = [256, 1024, 1, 1]
     dtype = "float32"
     min_val = float("-0.116207")
@@ -2962,6 +3232,7 @@ class Program_weight_tensor_parameter_269:
 
 class Program_weight_tensor_parameter_270:
     name = "parameter_270"
+    original_name = "batch_norm2d_51.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.165148")
@@ -2973,6 +3244,7 @@ class Program_weight_tensor_parameter_270:
 
 class Program_weight_tensor_parameter_271:
     name = "parameter_271"
+    original_name = "batch_norm2d_51.w_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.147604")
@@ -2984,6 +3256,7 @@ class Program_weight_tensor_parameter_271:
 
 class Program_weight_tensor_parameter_272:
     name = "parameter_272"
+    original_name = "batch_norm2d_51.w_2"
     shape = [1024]
     dtype = "float32"
     min_val = float("1.17329e-06")
@@ -2995,6 +3268,7 @@ class Program_weight_tensor_parameter_272:
 
 class Program_weight_tensor_parameter_273:
     name = "parameter_273"
+    original_name = "batch_norm2d_51.w_1"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.0424746")
@@ -3006,6 +3280,7 @@ class Program_weight_tensor_parameter_273:
 
 class Program_weight_tensor_parameter_274:
     name = "parameter_274"
+    original_name = "conv2d_51.w_0"
     shape = [1024, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.161922")
@@ -3017,6 +3292,7 @@ class Program_weight_tensor_parameter_274:
 
 class Program_weight_tensor_parameter_275:
     name = "parameter_275"
+    original_name = "batch_norm2d_50.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.215184")
@@ -3028,6 +3304,7 @@ class Program_weight_tensor_parameter_275:
 
 class Program_weight_tensor_parameter_276:
     name = "parameter_276"
+    original_name = "batch_norm2d_50.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.0914712")
@@ -3039,6 +3316,7 @@ class Program_weight_tensor_parameter_276:
 
 class Program_weight_tensor_parameter_277:
     name = "parameter_277"
+    original_name = "batch_norm2d_50.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.00129181")
@@ -3050,6 +3328,7 @@ class Program_weight_tensor_parameter_277:
 
 class Program_weight_tensor_parameter_278:
     name = "parameter_278"
+    original_name = "batch_norm2d_50.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.103572")
@@ -3061,6 +3340,7 @@ class Program_weight_tensor_parameter_278:
 
 class Program_weight_tensor_parameter_279:
     name = "parameter_279"
+    original_name = "conv2d_50.w_0"
     shape = [256, 256, 3, 3]
     dtype = "float32"
     min_val = float("-0.110592")
@@ -3072,6 +3352,7 @@ class Program_weight_tensor_parameter_279:
 
 class Program_weight_tensor_parameter_280:
     name = "parameter_280"
+    original_name = "batch_norm2d_49.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.209288")
@@ -3083,6 +3364,7 @@ class Program_weight_tensor_parameter_280:
 
 class Program_weight_tensor_parameter_281:
     name = "parameter_281"
+    original_name = "batch_norm2d_49.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.0720223")
@@ -3094,6 +3376,7 @@ class Program_weight_tensor_parameter_281:
 
 class Program_weight_tensor_parameter_282:
     name = "parameter_282"
+    original_name = "batch_norm2d_49.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.00511033")
@@ -3105,6 +3388,7 @@ class Program_weight_tensor_parameter_282:
 
 class Program_weight_tensor_parameter_283:
     name = "parameter_283"
+    original_name = "batch_norm2d_49.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.277127")
@@ -3116,6 +3400,7 @@ class Program_weight_tensor_parameter_283:
 
 class Program_weight_tensor_parameter_284:
     name = "parameter_284"
+    original_name = "conv2d_49.w_0"
     shape = [256, 1024, 1, 1]
     dtype = "float32"
     min_val = float("-0.161483")
@@ -3127,6 +3412,7 @@ class Program_weight_tensor_parameter_284:
 
 class Program_weight_tensor_parameter_285:
     name = "parameter_285"
+    original_name = "batch_norm2d_48.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.240391")
@@ -3138,6 +3424,7 @@ class Program_weight_tensor_parameter_285:
 
 class Program_weight_tensor_parameter_286:
     name = "parameter_286"
+    original_name = "batch_norm2d_48.w_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.156487")
@@ -3149,6 +3436,7 @@ class Program_weight_tensor_parameter_286:
 
 class Program_weight_tensor_parameter_287:
     name = "parameter_287"
+    original_name = "batch_norm2d_48.w_2"
     shape = [1024]
     dtype = "float32"
     min_val = float("4.04274e-07")
@@ -3160,6 +3448,7 @@ class Program_weight_tensor_parameter_287:
 
 class Program_weight_tensor_parameter_288:
     name = "parameter_288"
+    original_name = "batch_norm2d_48.w_1"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.0727822")
@@ -3171,6 +3460,7 @@ class Program_weight_tensor_parameter_288:
 
 class Program_weight_tensor_parameter_289:
     name = "parameter_289"
+    original_name = "conv2d_48.w_0"
     shape = [1024, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.174736")
@@ -3182,6 +3472,7 @@ class Program_weight_tensor_parameter_289:
 
 class Program_weight_tensor_parameter_290:
     name = "parameter_290"
+    original_name = "batch_norm2d_47.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.20359")
@@ -3193,6 +3484,7 @@ class Program_weight_tensor_parameter_290:
 
 class Program_weight_tensor_parameter_291:
     name = "parameter_291"
+    original_name = "batch_norm2d_47.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.0785741")
@@ -3204,6 +3496,7 @@ class Program_weight_tensor_parameter_291:
 
 class Program_weight_tensor_parameter_292:
     name = "parameter_292"
+    original_name = "batch_norm2d_47.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.00174302")
@@ -3215,6 +3508,7 @@ class Program_weight_tensor_parameter_292:
 
 class Program_weight_tensor_parameter_293:
     name = "parameter_293"
+    original_name = "batch_norm2d_47.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.177519")
@@ -3226,6 +3520,7 @@ class Program_weight_tensor_parameter_293:
 
 class Program_weight_tensor_parameter_294:
     name = "parameter_294"
+    original_name = "conv2d_47.w_0"
     shape = [256, 256, 3, 3]
     dtype = "float32"
     min_val = float("-0.101101")
@@ -3237,6 +3532,7 @@ class Program_weight_tensor_parameter_294:
 
 class Program_weight_tensor_parameter_295:
     name = "parameter_295"
+    original_name = "batch_norm2d_46.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.221902")
@@ -3248,6 +3544,7 @@ class Program_weight_tensor_parameter_295:
 
 class Program_weight_tensor_parameter_296:
     name = "parameter_296"
+    original_name = "batch_norm2d_46.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.0721614")
@@ -3259,6 +3556,7 @@ class Program_weight_tensor_parameter_296:
 
 class Program_weight_tensor_parameter_297:
     name = "parameter_297"
+    original_name = "batch_norm2d_46.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.00304618")
@@ -3270,6 +3568,7 @@ class Program_weight_tensor_parameter_297:
 
 class Program_weight_tensor_parameter_298:
     name = "parameter_298"
+    original_name = "batch_norm2d_46.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.161046")
@@ -3281,6 +3580,7 @@ class Program_weight_tensor_parameter_298:
 
 class Program_weight_tensor_parameter_299:
     name = "parameter_299"
+    original_name = "conv2d_46.w_0"
     shape = [256, 1024, 1, 1]
     dtype = "float32"
     min_val = float("-0.137639")
@@ -3292,6 +3592,7 @@ class Program_weight_tensor_parameter_299:
 
 class Program_weight_tensor_parameter_300:
     name = "parameter_300"
+    original_name = "batch_norm2d_45.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.13357")
@@ -3303,6 +3604,7 @@ class Program_weight_tensor_parameter_300:
 
 class Program_weight_tensor_parameter_301:
     name = "parameter_301"
+    original_name = "batch_norm2d_45.w_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.172899")
@@ -3314,6 +3616,7 @@ class Program_weight_tensor_parameter_301:
 
 class Program_weight_tensor_parameter_302:
     name = "parameter_302"
+    original_name = "batch_norm2d_45.w_2"
     shape = [1024]
     dtype = "float32"
     min_val = float("3.2612e-07")
@@ -3325,6 +3628,7 @@ class Program_weight_tensor_parameter_302:
 
 class Program_weight_tensor_parameter_303:
     name = "parameter_303"
+    original_name = "batch_norm2d_45.w_1"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.0507962")
@@ -3336,6 +3640,7 @@ class Program_weight_tensor_parameter_303:
 
 class Program_weight_tensor_parameter_304:
     name = "parameter_304"
+    original_name = "conv2d_45.w_0"
     shape = [1024, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.169217")
@@ -3347,6 +3652,7 @@ class Program_weight_tensor_parameter_304:
 
 class Program_weight_tensor_parameter_305:
     name = "parameter_305"
+    original_name = "batch_norm2d_44.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.185415")
@@ -3358,6 +3664,7 @@ class Program_weight_tensor_parameter_305:
 
 class Program_weight_tensor_parameter_306:
     name = "parameter_306"
+    original_name = "batch_norm2d_44.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.0882016")
@@ -3369,6 +3676,7 @@ class Program_weight_tensor_parameter_306:
 
 class Program_weight_tensor_parameter_307:
     name = "parameter_307"
+    original_name = "batch_norm2d_44.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.00211616")
@@ -3380,6 +3688,7 @@ class Program_weight_tensor_parameter_307:
 
 class Program_weight_tensor_parameter_308:
     name = "parameter_308"
+    original_name = "batch_norm2d_44.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.101167")
@@ -3391,6 +3700,7 @@ class Program_weight_tensor_parameter_308:
 
 class Program_weight_tensor_parameter_309:
     name = "parameter_309"
+    original_name = "conv2d_44.w_0"
     shape = [256, 256, 3, 3]
     dtype = "float32"
     min_val = float("-0.102754")
@@ -3402,6 +3712,7 @@ class Program_weight_tensor_parameter_309:
 
 class Program_weight_tensor_parameter_310:
     name = "parameter_310"
+    original_name = "batch_norm2d_43.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.206417")
@@ -3413,6 +3724,7 @@ class Program_weight_tensor_parameter_310:
 
 class Program_weight_tensor_parameter_311:
     name = "parameter_311"
+    original_name = "batch_norm2d_43.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.0661517")
@@ -3424,6 +3736,7 @@ class Program_weight_tensor_parameter_311:
 
 class Program_weight_tensor_parameter_312:
     name = "parameter_312"
+    original_name = "batch_norm2d_43.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.00251232")
@@ -3435,6 +3748,7 @@ class Program_weight_tensor_parameter_312:
 
 class Program_weight_tensor_parameter_313:
     name = "parameter_313"
+    original_name = "batch_norm2d_43.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.194756")
@@ -3446,6 +3760,7 @@ class Program_weight_tensor_parameter_313:
 
 class Program_weight_tensor_parameter_314:
     name = "parameter_314"
+    original_name = "conv2d_43.w_0"
     shape = [256, 1024, 1, 1]
     dtype = "float32"
     min_val = float("-0.128768")
@@ -3457,6 +3772,7 @@ class Program_weight_tensor_parameter_314:
 
 class Program_weight_tensor_parameter_315:
     name = "parameter_315"
+    original_name = "batch_norm2d_42.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.183517")
@@ -3468,6 +3784,7 @@ class Program_weight_tensor_parameter_315:
 
 class Program_weight_tensor_parameter_316:
     name = "parameter_316"
+    original_name = "batch_norm2d_42.w_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.175905")
@@ -3479,6 +3796,7 @@ class Program_weight_tensor_parameter_316:
 
 class Program_weight_tensor_parameter_317:
     name = "parameter_317"
+    original_name = "batch_norm2d_42.w_2"
     shape = [1024]
     dtype = "float32"
     min_val = float("1.28957e-07")
@@ -3490,6 +3808,7 @@ class Program_weight_tensor_parameter_317:
 
 class Program_weight_tensor_parameter_318:
     name = "parameter_318"
+    original_name = "batch_norm2d_42.w_1"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.054914")
@@ -3501,6 +3820,7 @@ class Program_weight_tensor_parameter_318:
 
 class Program_weight_tensor_parameter_319:
     name = "parameter_319"
+    original_name = "conv2d_42.w_0"
     shape = [1024, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.184543")
@@ -3512,6 +3832,7 @@ class Program_weight_tensor_parameter_319:
 
 class Program_weight_tensor_parameter_320:
     name = "parameter_320"
+    original_name = "batch_norm2d_41.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.220034")
@@ -3523,6 +3844,7 @@ class Program_weight_tensor_parameter_320:
 
 class Program_weight_tensor_parameter_321:
     name = "parameter_321"
+    original_name = "batch_norm2d_41.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.0904205")
@@ -3534,6 +3856,7 @@ class Program_weight_tensor_parameter_321:
 
 class Program_weight_tensor_parameter_322:
     name = "parameter_322"
+    original_name = "batch_norm2d_41.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.00202106")
@@ -3545,6 +3868,7 @@ class Program_weight_tensor_parameter_322:
 
 class Program_weight_tensor_parameter_323:
     name = "parameter_323"
+    original_name = "batch_norm2d_41.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.18565")
@@ -3556,6 +3880,7 @@ class Program_weight_tensor_parameter_323:
 
 class Program_weight_tensor_parameter_324:
     name = "parameter_324"
+    original_name = "conv2d_41.w_0"
     shape = [256, 256, 3, 3]
     dtype = "float32"
     min_val = float("-0.116671")
@@ -3567,6 +3892,7 @@ class Program_weight_tensor_parameter_324:
 
 class Program_weight_tensor_parameter_325:
     name = "parameter_325"
+    original_name = "batch_norm2d_40.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.253702")
@@ -3578,6 +3904,7 @@ class Program_weight_tensor_parameter_325:
 
 class Program_weight_tensor_parameter_326:
     name = "parameter_326"
+    original_name = "batch_norm2d_40.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.05592e-09")
@@ -3589,6 +3916,7 @@ class Program_weight_tensor_parameter_326:
 
 class Program_weight_tensor_parameter_327:
     name = "parameter_327"
+    original_name = "batch_norm2d_40.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("7.32171e-16")
@@ -3600,6 +3928,7 @@ class Program_weight_tensor_parameter_327:
 
 class Program_weight_tensor_parameter_328:
     name = "parameter_328"
+    original_name = "batch_norm2d_40.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.402519")
@@ -3611,6 +3940,7 @@ class Program_weight_tensor_parameter_328:
 
 class Program_weight_tensor_parameter_329:
     name = "parameter_329"
+    original_name = "conv2d_40.w_0"
     shape = [256, 1024, 1, 1]
     dtype = "float32"
     min_val = float("-0.169552")
@@ -3622,6 +3952,7 @@ class Program_weight_tensor_parameter_329:
 
 class Program_weight_tensor_parameter_330:
     name = "parameter_330"
+    original_name = "batch_norm2d_39.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.211239")
@@ -3633,6 +3964,7 @@ class Program_weight_tensor_parameter_330:
 
 class Program_weight_tensor_parameter_331:
     name = "parameter_331"
+    original_name = "batch_norm2d_39.w_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.185733")
@@ -3644,6 +3976,7 @@ class Program_weight_tensor_parameter_331:
 
 class Program_weight_tensor_parameter_332:
     name = "parameter_332"
+    original_name = "batch_norm2d_39.w_2"
     shape = [1024]
     dtype = "float32"
     min_val = float("2.45689e-12")
@@ -3655,6 +3988,7 @@ class Program_weight_tensor_parameter_332:
 
 class Program_weight_tensor_parameter_333:
     name = "parameter_333"
+    original_name = "batch_norm2d_39.w_1"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.0733265")
@@ -3666,6 +4000,7 @@ class Program_weight_tensor_parameter_333:
 
 class Program_weight_tensor_parameter_334:
     name = "parameter_334"
+    original_name = "conv2d_39.w_0"
     shape = [1024, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.285383")
@@ -3677,6 +4012,7 @@ class Program_weight_tensor_parameter_334:
 
 class Program_weight_tensor_parameter_335:
     name = "parameter_335"
+    original_name = "batch_norm2d_38.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.368835")
@@ -3688,6 +4024,7 @@ class Program_weight_tensor_parameter_335:
 
 class Program_weight_tensor_parameter_336:
     name = "parameter_336"
+    original_name = "batch_norm2d_38.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("4.87519e-09")
@@ -3699,6 +4036,7 @@ class Program_weight_tensor_parameter_336:
 
 class Program_weight_tensor_parameter_337:
     name = "parameter_337"
+    original_name = "batch_norm2d_38.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("1.0498e-15")
@@ -3710,6 +4048,7 @@ class Program_weight_tensor_parameter_337:
 
 class Program_weight_tensor_parameter_338:
     name = "parameter_338"
+    original_name = "batch_norm2d_38.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.156661")
@@ -3721,6 +4060,7 @@ class Program_weight_tensor_parameter_338:
 
 class Program_weight_tensor_parameter_339:
     name = "parameter_339"
+    original_name = "conv2d_38.w_0"
     shape = [256, 256, 3, 3]
     dtype = "float32"
     min_val = float("-0.0928331")
@@ -3732,6 +4072,7 @@ class Program_weight_tensor_parameter_339:
 
 class Program_weight_tensor_parameter_340:
     name = "parameter_340"
+    original_name = "batch_norm2d_37.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.190766")
@@ -3743,6 +4084,7 @@ class Program_weight_tensor_parameter_340:
 
 class Program_weight_tensor_parameter_341:
     name = "parameter_341"
+    original_name = "batch_norm2d_37.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-3.91253e-09")
@@ -3754,6 +4096,7 @@ class Program_weight_tensor_parameter_341:
 
 class Program_weight_tensor_parameter_342:
     name = "parameter_342"
+    original_name = "batch_norm2d_37.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("7.43149e-16")
@@ -3765,6 +4108,7 @@ class Program_weight_tensor_parameter_342:
 
 class Program_weight_tensor_parameter_343:
     name = "parameter_343"
+    original_name = "batch_norm2d_37.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.40422")
@@ -3776,6 +4120,7 @@ class Program_weight_tensor_parameter_343:
 
 class Program_weight_tensor_parameter_344:
     name = "parameter_344"
+    original_name = "conv2d_37.w_0"
     shape = [256, 1024, 1, 1]
     dtype = "float32"
     min_val = float("-0.165548")
@@ -3787,6 +4132,7 @@ class Program_weight_tensor_parameter_344:
 
 class Program_weight_tensor_parameter_345:
     name = "parameter_345"
+    original_name = "batch_norm2d_36.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.17975")
@@ -3798,6 +4144,7 @@ class Program_weight_tensor_parameter_345:
 
 class Program_weight_tensor_parameter_346:
     name = "parameter_346"
+    original_name = "batch_norm2d_36.w_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.203723")
@@ -3809,6 +4156,7 @@ class Program_weight_tensor_parameter_346:
 
 class Program_weight_tensor_parameter_347:
     name = "parameter_347"
+    original_name = "batch_norm2d_36.w_2"
     shape = [1024]
     dtype = "float32"
     min_val = float("5.8249e-14")
@@ -3820,6 +4168,7 @@ class Program_weight_tensor_parameter_347:
 
 class Program_weight_tensor_parameter_348:
     name = "parameter_348"
+    original_name = "batch_norm2d_36.w_1"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.0804665")
@@ -3831,6 +4180,7 @@ class Program_weight_tensor_parameter_348:
 
 class Program_weight_tensor_parameter_349:
     name = "parameter_349"
+    original_name = "conv2d_36.w_0"
     shape = [1024, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.165972")
@@ -3842,6 +4192,7 @@ class Program_weight_tensor_parameter_349:
 
 class Program_weight_tensor_parameter_350:
     name = "parameter_350"
+    original_name = "batch_norm2d_35.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.211127")
@@ -3853,6 +4204,7 @@ class Program_weight_tensor_parameter_350:
 
 class Program_weight_tensor_parameter_351:
     name = "parameter_351"
+    original_name = "batch_norm2d_35.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.0180287")
@@ -3864,6 +4216,7 @@ class Program_weight_tensor_parameter_351:
 
 class Program_weight_tensor_parameter_352:
     name = "parameter_352"
+    original_name = "batch_norm2d_35.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("3.35643e-06")
@@ -3875,6 +4228,7 @@ class Program_weight_tensor_parameter_352:
 
 class Program_weight_tensor_parameter_353:
     name = "parameter_353"
+    original_name = "batch_norm2d_35.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.121016")
@@ -3886,6 +4240,7 @@ class Program_weight_tensor_parameter_353:
 
 class Program_weight_tensor_parameter_354:
     name = "parameter_354"
+    original_name = "conv2d_35.w_0"
     shape = [256, 256, 3, 3]
     dtype = "float32"
     min_val = float("-0.0969983")
@@ -3897,6 +4252,7 @@ class Program_weight_tensor_parameter_354:
 
 class Program_weight_tensor_parameter_355:
     name = "parameter_355"
+    original_name = "batch_norm2d_34.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.139594")
@@ -3908,6 +4264,7 @@ class Program_weight_tensor_parameter_355:
 
 class Program_weight_tensor_parameter_356:
     name = "parameter_356"
+    original_name = "batch_norm2d_34.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.0831397")
@@ -3919,6 +4276,7 @@ class Program_weight_tensor_parameter_356:
 
 class Program_weight_tensor_parameter_357:
     name = "parameter_357"
+    original_name = "batch_norm2d_34.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("1.24875e-15")
@@ -3930,6 +4288,7 @@ class Program_weight_tensor_parameter_357:
 
 class Program_weight_tensor_parameter_358:
     name = "parameter_358"
+    original_name = "batch_norm2d_34.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.296561")
@@ -3941,6 +4300,7 @@ class Program_weight_tensor_parameter_358:
 
 class Program_weight_tensor_parameter_359:
     name = "parameter_359"
+    original_name = "conv2d_34.w_0"
     shape = [256, 1024, 1, 1]
     dtype = "float32"
     min_val = float("-0.151306")
@@ -3952,6 +4312,7 @@ class Program_weight_tensor_parameter_359:
 
 class Program_weight_tensor_parameter_360:
     name = "parameter_360"
+    original_name = "batch_norm2d_33.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.239385")
@@ -3963,6 +4324,7 @@ class Program_weight_tensor_parameter_360:
 
 class Program_weight_tensor_parameter_361:
     name = "parameter_361"
+    original_name = "batch_norm2d_33.w_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.28073")
@@ -3974,6 +4336,7 @@ class Program_weight_tensor_parameter_361:
 
 class Program_weight_tensor_parameter_362:
     name = "parameter_362"
+    original_name = "batch_norm2d_33.w_2"
     shape = [1024]
     dtype = "float32"
     min_val = float("4.15589e-17")
@@ -3985,6 +4348,7 @@ class Program_weight_tensor_parameter_362:
 
 class Program_weight_tensor_parameter_363:
     name = "parameter_363"
+    original_name = "batch_norm2d_33.w_1"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.020432")
@@ -3996,6 +4360,7 @@ class Program_weight_tensor_parameter_363:
 
 class Program_weight_tensor_parameter_364:
     name = "parameter_364"
+    original_name = "conv2d_33.w_0"
     shape = [1024, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.185406")
@@ -4007,6 +4372,7 @@ class Program_weight_tensor_parameter_364:
 
 class Program_weight_tensor_parameter_365:
     name = "parameter_365"
+    original_name = "batch_norm2d_32.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.134863")
@@ -4018,6 +4384,7 @@ class Program_weight_tensor_parameter_365:
 
 class Program_weight_tensor_parameter_366:
     name = "parameter_366"
+    original_name = "batch_norm2d_32.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.076787")
@@ -4029,6 +4396,7 @@ class Program_weight_tensor_parameter_366:
 
 class Program_weight_tensor_parameter_367:
     name = "parameter_367"
+    original_name = "batch_norm2d_32.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("4.67884e-15")
@@ -4040,6 +4408,7 @@ class Program_weight_tensor_parameter_367:
 
 class Program_weight_tensor_parameter_368:
     name = "parameter_368"
+    original_name = "batch_norm2d_32.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.403367")
@@ -4051,6 +4420,7 @@ class Program_weight_tensor_parameter_368:
 
 class Program_weight_tensor_parameter_369:
     name = "parameter_369"
+    original_name = "conv2d_32.w_0"
     shape = [256, 256, 3, 3]
     dtype = "float32"
     min_val = float("-0.0753493")
@@ -4062,6 +4432,7 @@ class Program_weight_tensor_parameter_369:
 
 class Program_weight_tensor_parameter_370:
     name = "parameter_370"
+    original_name = "batch_norm2d_31.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.147381")
@@ -4073,6 +4444,7 @@ class Program_weight_tensor_parameter_370:
 
 class Program_weight_tensor_parameter_371:
     name = "parameter_371"
+    original_name = "batch_norm2d_31.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.118148")
@@ -4084,6 +4456,7 @@ class Program_weight_tensor_parameter_371:
 
 class Program_weight_tensor_parameter_372:
     name = "parameter_372"
+    original_name = "batch_norm2d_31.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("3.28172e-15")
@@ -4095,6 +4468,7 @@ class Program_weight_tensor_parameter_372:
 
 class Program_weight_tensor_parameter_373:
     name = "parameter_373"
+    original_name = "batch_norm2d_31.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.257075")
@@ -4106,6 +4480,7 @@ class Program_weight_tensor_parameter_373:
 
 class Program_weight_tensor_parameter_374:
     name = "parameter_374"
+    original_name = "conv2d_31.w_0"
     shape = [256, 1024, 1, 1]
     dtype = "float32"
     min_val = float("-0.115686")
@@ -4117,6 +4492,7 @@ class Program_weight_tensor_parameter_374:
 
 class Program_weight_tensor_parameter_375:
     name = "parameter_375"
+    original_name = "batch_norm2d_30.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.151093")
@@ -4128,6 +4504,7 @@ class Program_weight_tensor_parameter_375:
 
 class Program_weight_tensor_parameter_376:
     name = "parameter_376"
+    original_name = "batch_norm2d_30.w_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.316738")
@@ -4139,6 +4516,7 @@ class Program_weight_tensor_parameter_376:
 
 class Program_weight_tensor_parameter_377:
     name = "parameter_377"
+    original_name = "batch_norm2d_30.w_2"
     shape = [1024]
     dtype = "float32"
     min_val = float("2.55025e-18")
@@ -4150,6 +4528,7 @@ class Program_weight_tensor_parameter_377:
 
 class Program_weight_tensor_parameter_378:
     name = "parameter_378"
+    original_name = "batch_norm2d_30.w_1"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.0195094")
@@ -4161,6 +4540,7 @@ class Program_weight_tensor_parameter_378:
 
 class Program_weight_tensor_parameter_379:
     name = "parameter_379"
+    original_name = "conv2d_30.w_0"
     shape = [1024, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.227901")
@@ -4172,6 +4552,7 @@ class Program_weight_tensor_parameter_379:
 
 class Program_weight_tensor_parameter_380:
     name = "parameter_380"
+    original_name = "batch_norm2d_29.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.126924")
@@ -4183,6 +4564,7 @@ class Program_weight_tensor_parameter_380:
 
 class Program_weight_tensor_parameter_381:
     name = "parameter_381"
+    original_name = "batch_norm2d_29.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.0946831")
@@ -4194,6 +4576,7 @@ class Program_weight_tensor_parameter_381:
 
 class Program_weight_tensor_parameter_382:
     name = "parameter_382"
+    original_name = "batch_norm2d_29.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("5.68885e-16")
@@ -4205,6 +4588,7 @@ class Program_weight_tensor_parameter_382:
 
 class Program_weight_tensor_parameter_383:
     name = "parameter_383"
+    original_name = "batch_norm2d_29.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.396474")
@@ -4216,6 +4600,7 @@ class Program_weight_tensor_parameter_383:
 
 class Program_weight_tensor_parameter_384:
     name = "parameter_384"
+    original_name = "conv2d_29.w_0"
     shape = [256, 256, 3, 3]
     dtype = "float32"
     min_val = float("-0.0865259")
@@ -4227,6 +4612,7 @@ class Program_weight_tensor_parameter_384:
 
 class Program_weight_tensor_parameter_385:
     name = "parameter_385"
+    original_name = "batch_norm2d_28.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.168122")
@@ -4238,6 +4624,7 @@ class Program_weight_tensor_parameter_385:
 
 class Program_weight_tensor_parameter_386:
     name = "parameter_386"
+    original_name = "batch_norm2d_28.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.0953706")
@@ -4249,6 +4636,7 @@ class Program_weight_tensor_parameter_386:
 
 class Program_weight_tensor_parameter_387:
     name = "parameter_387"
+    original_name = "batch_norm2d_28.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("1.73366e-15")
@@ -4260,6 +4648,7 @@ class Program_weight_tensor_parameter_387:
 
 class Program_weight_tensor_parameter_388:
     name = "parameter_388"
+    original_name = "batch_norm2d_28.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.167232")
@@ -4271,6 +4660,7 @@ class Program_weight_tensor_parameter_388:
 
 class Program_weight_tensor_parameter_389:
     name = "parameter_389"
+    original_name = "conv2d_28.w_0"
     shape = [256, 1024, 1, 1]
     dtype = "float32"
     min_val = float("-0.13623")
@@ -4282,6 +4672,7 @@ class Program_weight_tensor_parameter_389:
 
 class Program_weight_tensor_parameter_390:
     name = "parameter_390"
+    original_name = "batch_norm2d_27.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.0766335")
@@ -4293,6 +4684,7 @@ class Program_weight_tensor_parameter_390:
 
 class Program_weight_tensor_parameter_391:
     name = "parameter_391"
+    original_name = "batch_norm2d_27.w_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.163621")
@@ -4304,6 +4696,7 @@ class Program_weight_tensor_parameter_391:
 
 class Program_weight_tensor_parameter_392:
     name = "parameter_392"
+    original_name = "batch_norm2d_27.w_2"
     shape = [1024]
     dtype = "float32"
     min_val = float("1.2871e-15")
@@ -4315,6 +4708,7 @@ class Program_weight_tensor_parameter_392:
 
 class Program_weight_tensor_parameter_393:
     name = "parameter_393"
+    original_name = "batch_norm2d_27.w_1"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.250062")
@@ -4326,6 +4720,7 @@ class Program_weight_tensor_parameter_393:
 
 class Program_weight_tensor_parameter_394:
     name = "parameter_394"
+    original_name = "conv2d_27.w_0"
     shape = [1024, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.273612")
@@ -4337,6 +4732,7 @@ class Program_weight_tensor_parameter_394:
 
 class Program_weight_tensor_parameter_395:
     name = "parameter_395"
+    original_name = "batch_norm2d_26.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.0766335")
@@ -4348,6 +4744,7 @@ class Program_weight_tensor_parameter_395:
 
 class Program_weight_tensor_parameter_396:
     name = "parameter_396"
+    original_name = "batch_norm2d_26.w_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.184578")
@@ -4359,6 +4756,7 @@ class Program_weight_tensor_parameter_396:
 
 class Program_weight_tensor_parameter_397:
     name = "parameter_397"
+    original_name = "batch_norm2d_26.w_2"
     shape = [1024]
     dtype = "float32"
     min_val = float("3.82263e-16")
@@ -4370,6 +4768,7 @@ class Program_weight_tensor_parameter_397:
 
 class Program_weight_tensor_parameter_398:
     name = "parameter_398"
+    original_name = "batch_norm2d_26.w_1"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.234461")
@@ -4381,6 +4780,7 @@ class Program_weight_tensor_parameter_398:
 
 class Program_weight_tensor_parameter_399:
     name = "parameter_399"
+    original_name = "conv2d_26.w_0"
     shape = [1024, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.248088")
@@ -4392,6 +4792,7 @@ class Program_weight_tensor_parameter_399:
 
 class Program_weight_tensor_parameter_400:
     name = "parameter_400"
+    original_name = "batch_norm2d_25.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.109783")
@@ -4403,6 +4804,7 @@ class Program_weight_tensor_parameter_400:
 
 class Program_weight_tensor_parameter_401:
     name = "parameter_401"
+    original_name = "batch_norm2d_25.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.197438")
@@ -4414,6 +4816,7 @@ class Program_weight_tensor_parameter_401:
 
 class Program_weight_tensor_parameter_402:
     name = "parameter_402"
+    original_name = "batch_norm2d_25.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("1.2894e-15")
@@ -4425,6 +4828,7 @@ class Program_weight_tensor_parameter_402:
 
 class Program_weight_tensor_parameter_403:
     name = "parameter_403"
+    original_name = "batch_norm2d_25.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.217346")
@@ -4436,6 +4840,7 @@ class Program_weight_tensor_parameter_403:
 
 class Program_weight_tensor_parameter_404:
     name = "parameter_404"
+    original_name = "conv2d_25.w_0"
     shape = [256, 256, 3, 3]
     dtype = "float32"
     min_val = float("-0.201716")
@@ -4447,6 +4852,7 @@ class Program_weight_tensor_parameter_404:
 
 class Program_weight_tensor_parameter_405:
     name = "parameter_405"
+    original_name = "batch_norm2d_24.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.308919")
@@ -4458,6 +4864,7 @@ class Program_weight_tensor_parameter_405:
 
 class Program_weight_tensor_parameter_406:
     name = "parameter_406"
+    original_name = "batch_norm2d_24.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.279714")
@@ -4469,6 +4876,7 @@ class Program_weight_tensor_parameter_406:
 
 class Program_weight_tensor_parameter_407:
     name = "parameter_407"
+    original_name = "batch_norm2d_24.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("8.94475e-16")
@@ -4480,6 +4888,7 @@ class Program_weight_tensor_parameter_407:
 
 class Program_weight_tensor_parameter_408:
     name = "parameter_408"
+    original_name = "batch_norm2d_24.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.338856")
@@ -4491,6 +4900,7 @@ class Program_weight_tensor_parameter_408:
 
 class Program_weight_tensor_parameter_409:
     name = "parameter_409"
+    original_name = "conv2d_24.w_0"
     shape = [256, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.411436")
@@ -4502,6 +4912,7 @@ class Program_weight_tensor_parameter_409:
 
 class Program_weight_tensor_parameter_410:
     name = "parameter_410"
+    original_name = "batch_norm2d_23.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.289555")
@@ -4513,6 +4924,7 @@ class Program_weight_tensor_parameter_410:
 
 class Program_weight_tensor_parameter_411:
     name = "parameter_411"
+    original_name = "batch_norm2d_23.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.284893")
@@ -4524,6 +4936,7 @@ class Program_weight_tensor_parameter_411:
 
 class Program_weight_tensor_parameter_412:
     name = "parameter_412"
+    original_name = "batch_norm2d_23.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("1.90608e-05")
@@ -4535,6 +4948,7 @@ class Program_weight_tensor_parameter_412:
 
 class Program_weight_tensor_parameter_413:
     name = "parameter_413"
+    original_name = "batch_norm2d_23.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.0842377")
@@ -4546,6 +4960,7 @@ class Program_weight_tensor_parameter_413:
 
 class Program_weight_tensor_parameter_414:
     name = "parameter_414"
+    original_name = "conv2d_23.w_0"
     shape = [512, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.256801")
@@ -4557,6 +4972,7 @@ class Program_weight_tensor_parameter_414:
 
 class Program_weight_tensor_parameter_415:
     name = "parameter_415"
+    original_name = "batch_norm2d_22.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.211798")
@@ -4568,6 +4984,7 @@ class Program_weight_tensor_parameter_415:
 
 class Program_weight_tensor_parameter_416:
     name = "parameter_416"
+    original_name = "batch_norm2d_22.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.404399")
@@ -4579,6 +4996,7 @@ class Program_weight_tensor_parameter_416:
 
 class Program_weight_tensor_parameter_417:
     name = "parameter_417"
+    original_name = "batch_norm2d_22.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("8.13148e-16")
@@ -4590,6 +5008,7 @@ class Program_weight_tensor_parameter_417:
 
 class Program_weight_tensor_parameter_418:
     name = "parameter_418"
+    original_name = "batch_norm2d_22.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.240399")
@@ -4601,6 +5020,7 @@ class Program_weight_tensor_parameter_418:
 
 class Program_weight_tensor_parameter_419:
     name = "parameter_419"
+    original_name = "conv2d_22.w_0"
     shape = [128, 128, 3, 3]
     dtype = "float32"
     min_val = float("-0.125893")
@@ -4612,6 +5032,7 @@ class Program_weight_tensor_parameter_419:
 
 class Program_weight_tensor_parameter_420:
     name = "parameter_420"
+    original_name = "batch_norm2d_21.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.199946")
@@ -4623,6 +5044,7 @@ class Program_weight_tensor_parameter_420:
 
 class Program_weight_tensor_parameter_421:
     name = "parameter_421"
+    original_name = "batch_norm2d_21.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.187177")
@@ -4634,6 +5056,7 @@ class Program_weight_tensor_parameter_421:
 
 class Program_weight_tensor_parameter_422:
     name = "parameter_422"
+    original_name = "batch_norm2d_21.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("3.11128e-15")
@@ -4645,6 +5068,7 @@ class Program_weight_tensor_parameter_422:
 
 class Program_weight_tensor_parameter_423:
     name = "parameter_423"
+    original_name = "batch_norm2d_21.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.214568")
@@ -4656,6 +5080,7 @@ class Program_weight_tensor_parameter_423:
 
 class Program_weight_tensor_parameter_424:
     name = "parameter_424"
+    original_name = "conv2d_21.w_0"
     shape = [128, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.210134")
@@ -4667,6 +5092,7 @@ class Program_weight_tensor_parameter_424:
 
 class Program_weight_tensor_parameter_425:
     name = "parameter_425"
+    original_name = "batch_norm2d_20.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.185496")
@@ -4678,6 +5104,7 @@ class Program_weight_tensor_parameter_425:
 
 class Program_weight_tensor_parameter_426:
     name = "parameter_426"
+    original_name = "batch_norm2d_20.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.202235")
@@ -4689,6 +5116,7 @@ class Program_weight_tensor_parameter_426:
 
 class Program_weight_tensor_parameter_427:
     name = "parameter_427"
+    original_name = "batch_norm2d_20.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("1.12061e-05")
@@ -4700,6 +5128,7 @@ class Program_weight_tensor_parameter_427:
 
 class Program_weight_tensor_parameter_428:
     name = "parameter_428"
+    original_name = "batch_norm2d_20.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.100332")
@@ -4711,6 +5140,7 @@ class Program_weight_tensor_parameter_428:
 
 class Program_weight_tensor_parameter_429:
     name = "parameter_429"
+    original_name = "conv2d_20.w_0"
     shape = [512, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.174174")
@@ -4722,6 +5152,7 @@ class Program_weight_tensor_parameter_429:
 
 class Program_weight_tensor_parameter_430:
     name = "parameter_430"
+    original_name = "batch_norm2d_19.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.192543")
@@ -4733,6 +5164,7 @@ class Program_weight_tensor_parameter_430:
 
 class Program_weight_tensor_parameter_431:
     name = "parameter_431"
+    original_name = "batch_norm2d_19.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.343498")
@@ -4744,6 +5176,7 @@ class Program_weight_tensor_parameter_431:
 
 class Program_weight_tensor_parameter_432:
     name = "parameter_432"
+    original_name = "batch_norm2d_19.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("1.91774e-15")
@@ -4755,6 +5188,7 @@ class Program_weight_tensor_parameter_432:
 
 class Program_weight_tensor_parameter_433:
     name = "parameter_433"
+    original_name = "batch_norm2d_19.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.14513")
@@ -4766,6 +5200,7 @@ class Program_weight_tensor_parameter_433:
 
 class Program_weight_tensor_parameter_434:
     name = "parameter_434"
+    original_name = "conv2d_19.w_0"
     shape = [128, 128, 3, 3]
     dtype = "float32"
     min_val = float("-0.13258")
@@ -4777,6 +5212,7 @@ class Program_weight_tensor_parameter_434:
 
 class Program_weight_tensor_parameter_435:
     name = "parameter_435"
+    original_name = "batch_norm2d_18.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.201505")
@@ -4788,6 +5224,7 @@ class Program_weight_tensor_parameter_435:
 
 class Program_weight_tensor_parameter_436:
     name = "parameter_436"
+    original_name = "batch_norm2d_18.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.204134")
@@ -4799,6 +5236,7 @@ class Program_weight_tensor_parameter_436:
 
 class Program_weight_tensor_parameter_437:
     name = "parameter_437"
+    original_name = "batch_norm2d_18.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("3.94535e-15")
@@ -4810,6 +5248,7 @@ class Program_weight_tensor_parameter_437:
 
 class Program_weight_tensor_parameter_438:
     name = "parameter_438"
+    original_name = "batch_norm2d_18.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.183041")
@@ -4821,6 +5260,7 @@ class Program_weight_tensor_parameter_438:
 
 class Program_weight_tensor_parameter_439:
     name = "parameter_439"
+    original_name = "conv2d_18.w_0"
     shape = [128, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.16164")
@@ -4832,6 +5272,7 @@ class Program_weight_tensor_parameter_439:
 
 class Program_weight_tensor_parameter_440:
     name = "parameter_440"
+    original_name = "batch_norm2d_17.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.223548")
@@ -4843,6 +5284,7 @@ class Program_weight_tensor_parameter_440:
 
 class Program_weight_tensor_parameter_441:
     name = "parameter_441"
+    original_name = "batch_norm2d_17.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.274516")
@@ -4854,6 +5296,7 @@ class Program_weight_tensor_parameter_441:
 
 class Program_weight_tensor_parameter_442:
     name = "parameter_442"
+    original_name = "batch_norm2d_17.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("1.49618e-15")
@@ -4865,6 +5308,7 @@ class Program_weight_tensor_parameter_442:
 
 class Program_weight_tensor_parameter_443:
     name = "parameter_443"
+    original_name = "batch_norm2d_17.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.113495")
@@ -4876,6 +5320,7 @@ class Program_weight_tensor_parameter_443:
 
 class Program_weight_tensor_parameter_444:
     name = "parameter_444"
+    original_name = "conv2d_17.w_0"
     shape = [512, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.426105")
@@ -4887,6 +5332,7 @@ class Program_weight_tensor_parameter_444:
 
 class Program_weight_tensor_parameter_445:
     name = "parameter_445"
+    original_name = "batch_norm2d_16.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.246357")
@@ -4898,6 +5344,7 @@ class Program_weight_tensor_parameter_445:
 
 class Program_weight_tensor_parameter_446:
     name = "parameter_446"
+    original_name = "batch_norm2d_16.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.326265")
@@ -4909,6 +5356,7 @@ class Program_weight_tensor_parameter_446:
 
 class Program_weight_tensor_parameter_447:
     name = "parameter_447"
+    original_name = "batch_norm2d_16.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("5.83535e-16")
@@ -4920,6 +5368,7 @@ class Program_weight_tensor_parameter_447:
 
 class Program_weight_tensor_parameter_448:
     name = "parameter_448"
+    original_name = "batch_norm2d_16.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.00014")
@@ -4931,6 +5380,7 @@ class Program_weight_tensor_parameter_448:
 
 class Program_weight_tensor_parameter_449:
     name = "parameter_449"
+    original_name = "conv2d_16.w_0"
     shape = [128, 128, 3, 3]
     dtype = "float32"
     min_val = float("-0.272606")
@@ -4942,6 +5392,7 @@ class Program_weight_tensor_parameter_449:
 
 class Program_weight_tensor_parameter_450:
     name = "parameter_450"
+    original_name = "batch_norm2d_15.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.209578")
@@ -4953,6 +5404,7 @@ class Program_weight_tensor_parameter_450:
 
 class Program_weight_tensor_parameter_451:
     name = "parameter_451"
+    original_name = "batch_norm2d_15.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.165953")
@@ -4964,6 +5416,7 @@ class Program_weight_tensor_parameter_451:
 
 class Program_weight_tensor_parameter_452:
     name = "parameter_452"
+    original_name = "batch_norm2d_15.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("2.13682e-15")
@@ -4975,6 +5428,7 @@ class Program_weight_tensor_parameter_452:
 
 class Program_weight_tensor_parameter_453:
     name = "parameter_453"
+    original_name = "batch_norm2d_15.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.301143")
@@ -4986,6 +5440,7 @@ class Program_weight_tensor_parameter_453:
 
 class Program_weight_tensor_parameter_454:
     name = "parameter_454"
+    original_name = "conv2d_15.w_0"
     shape = [128, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.191976")
@@ -4997,6 +5452,7 @@ class Program_weight_tensor_parameter_454:
 
 class Program_weight_tensor_parameter_455:
     name = "parameter_455"
+    original_name = "batch_norm2d_14.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.143981")
@@ -5008,6 +5464,7 @@ class Program_weight_tensor_parameter_455:
 
 class Program_weight_tensor_parameter_456:
     name = "parameter_456"
+    original_name = "batch_norm2d_14.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.201234")
@@ -5019,6 +5476,7 @@ class Program_weight_tensor_parameter_456:
 
 class Program_weight_tensor_parameter_457:
     name = "parameter_457"
+    original_name = "batch_norm2d_14.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("6.7546e-16")
@@ -5030,6 +5488,7 @@ class Program_weight_tensor_parameter_457:
 
 class Program_weight_tensor_parameter_458:
     name = "parameter_458"
+    original_name = "batch_norm2d_14.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.53912")
@@ -5041,6 +5500,7 @@ class Program_weight_tensor_parameter_458:
 
 class Program_weight_tensor_parameter_459:
     name = "parameter_459"
+    original_name = "conv2d_14.w_0"
     shape = [512, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.541382")
@@ -5052,6 +5512,7 @@ class Program_weight_tensor_parameter_459:
 
 class Program_weight_tensor_parameter_460:
     name = "parameter_460"
+    original_name = "batch_norm2d_13.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.143981")
@@ -5063,6 +5524,7 @@ class Program_weight_tensor_parameter_460:
 
 class Program_weight_tensor_parameter_461:
     name = "parameter_461"
+    original_name = "batch_norm2d_13.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.136515")
@@ -5074,6 +5536,7 @@ class Program_weight_tensor_parameter_461:
 
 class Program_weight_tensor_parameter_462:
     name = "parameter_462"
+    original_name = "batch_norm2d_13.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("3.54976e-16")
@@ -5085,6 +5548,7 @@ class Program_weight_tensor_parameter_462:
 
 class Program_weight_tensor_parameter_463:
     name = "parameter_463"
+    original_name = "batch_norm2d_13.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.366167")
@@ -5096,6 +5560,7 @@ class Program_weight_tensor_parameter_463:
 
 class Program_weight_tensor_parameter_464:
     name = "parameter_464"
+    original_name = "conv2d_13.w_0"
     shape = [512, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.381495")
@@ -5107,6 +5572,7 @@ class Program_weight_tensor_parameter_464:
 
 class Program_weight_tensor_parameter_465:
     name = "parameter_465"
+    original_name = "batch_norm2d_12.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.303538")
@@ -5118,6 +5584,7 @@ class Program_weight_tensor_parameter_465:
 
 class Program_weight_tensor_parameter_466:
     name = "parameter_466"
+    original_name = "batch_norm2d_12.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.253228")
@@ -5129,6 +5596,7 @@ class Program_weight_tensor_parameter_466:
 
 class Program_weight_tensor_parameter_467:
     name = "parameter_467"
+    original_name = "batch_norm2d_12.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("1.10796e-15")
@@ -5140,6 +5608,7 @@ class Program_weight_tensor_parameter_467:
 
 class Program_weight_tensor_parameter_468:
     name = "parameter_468"
+    original_name = "batch_norm2d_12.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.195148")
@@ -5151,6 +5620,7 @@ class Program_weight_tensor_parameter_468:
 
 class Program_weight_tensor_parameter_469:
     name = "parameter_469"
+    original_name = "conv2d_12.w_0"
     shape = [128, 128, 3, 3]
     dtype = "float32"
     min_val = float("-0.127722")
@@ -5162,6 +5632,7 @@ class Program_weight_tensor_parameter_469:
 
 class Program_weight_tensor_parameter_470:
     name = "parameter_470"
+    original_name = "batch_norm2d_11.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.260373")
@@ -5173,6 +5644,7 @@ class Program_weight_tensor_parameter_470:
 
 class Program_weight_tensor_parameter_471:
     name = "parameter_471"
+    original_name = "batch_norm2d_11.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.224567")
@@ -5184,6 +5656,7 @@ class Program_weight_tensor_parameter_471:
 
 class Program_weight_tensor_parameter_472:
     name = "parameter_472"
+    original_name = "batch_norm2d_11.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("1.16186e-15")
@@ -5195,6 +5668,7 @@ class Program_weight_tensor_parameter_472:
 
 class Program_weight_tensor_parameter_473:
     name = "parameter_473"
+    original_name = "batch_norm2d_11.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.355523")
@@ -5206,6 +5680,7 @@ class Program_weight_tensor_parameter_473:
 
 class Program_weight_tensor_parameter_474:
     name = "parameter_474"
+    original_name = "conv2d_11.w_0"
     shape = [128, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.286497")
@@ -5217,6 +5692,7 @@ class Program_weight_tensor_parameter_474:
 
 class Program_weight_tensor_parameter_475:
     name = "parameter_475"
+    original_name = "batch_norm2d_10.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.199411")
@@ -5228,6 +5704,7 @@ class Program_weight_tensor_parameter_475:
 
 class Program_weight_tensor_parameter_476:
     name = "parameter_476"
+    original_name = "batch_norm2d_10.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.300556")
@@ -5239,6 +5716,7 @@ class Program_weight_tensor_parameter_476:
 
 class Program_weight_tensor_parameter_477:
     name = "parameter_477"
+    original_name = "batch_norm2d_10.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("1.19552e-05")
@@ -5250,6 +5728,7 @@ class Program_weight_tensor_parameter_477:
 
 class Program_weight_tensor_parameter_478:
     name = "parameter_478"
+    original_name = "batch_norm2d_10.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.127439")
@@ -5261,6 +5740,7 @@ class Program_weight_tensor_parameter_478:
 
 class Program_weight_tensor_parameter_479:
     name = "parameter_479"
+    original_name = "conv2d_10.w_0"
     shape = [256, 64, 1, 1]
     dtype = "float32"
     min_val = float("-0.208252")
@@ -5272,6 +5752,7 @@ class Program_weight_tensor_parameter_479:
 
 class Program_weight_tensor_parameter_480:
     name = "parameter_480"
+    original_name = "batch_norm2d_9.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -5281,6 +5762,7 @@ class Program_weight_tensor_parameter_480:
 
 class Program_weight_tensor_parameter_481:
     name = "parameter_481"
+    original_name = "batch_norm2d_9.w_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -5290,6 +5772,7 @@ class Program_weight_tensor_parameter_481:
 
 class Program_weight_tensor_parameter_482:
     name = "parameter_482"
+    original_name = "batch_norm2d_9.w_2"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -5299,6 +5782,7 @@ class Program_weight_tensor_parameter_482:
 
 class Program_weight_tensor_parameter_483:
     name = "parameter_483"
+    original_name = "batch_norm2d_9.w_1"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -5308,6 +5792,7 @@ class Program_weight_tensor_parameter_483:
 
 class Program_weight_tensor_parameter_484:
     name = "parameter_484"
+    original_name = "conv2d_9.w_0"
     shape = [64, 64, 3, 3]
     dtype = "float32"
     min_val = float("-0.248986")
@@ -5319,6 +5804,7 @@ class Program_weight_tensor_parameter_484:
 
 class Program_weight_tensor_parameter_485:
     name = "parameter_485"
+    original_name = "batch_norm2d_8.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -5328,6 +5814,7 @@ class Program_weight_tensor_parameter_485:
 
 class Program_weight_tensor_parameter_486:
     name = "parameter_486"
+    original_name = "batch_norm2d_8.w_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -5337,6 +5824,7 @@ class Program_weight_tensor_parameter_486:
 
 class Program_weight_tensor_parameter_487:
     name = "parameter_487"
+    original_name = "batch_norm2d_8.w_2"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -5346,6 +5834,7 @@ class Program_weight_tensor_parameter_487:
 
 class Program_weight_tensor_parameter_488:
     name = "parameter_488"
+    original_name = "batch_norm2d_8.w_1"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -5355,6 +5844,7 @@ class Program_weight_tensor_parameter_488:
 
 class Program_weight_tensor_parameter_489:
     name = "parameter_489"
+    original_name = "conv2d_8.w_0"
     shape = [64, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.185148")
@@ -5366,6 +5856,7 @@ class Program_weight_tensor_parameter_489:
 
 class Program_weight_tensor_parameter_490:
     name = "parameter_490"
+    original_name = "batch_norm2d_7.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.255247")
@@ -5377,6 +5868,7 @@ class Program_weight_tensor_parameter_490:
 
 class Program_weight_tensor_parameter_491:
     name = "parameter_491"
+    original_name = "batch_norm2d_7.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.251342")
@@ -5388,6 +5880,7 @@ class Program_weight_tensor_parameter_491:
 
 class Program_weight_tensor_parameter_492:
     name = "parameter_492"
+    original_name = "batch_norm2d_7.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("2.15888e-10")
@@ -5399,6 +5892,7 @@ class Program_weight_tensor_parameter_492:
 
 class Program_weight_tensor_parameter_493:
     name = "parameter_493"
+    original_name = "batch_norm2d_7.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.111148")
@@ -5410,6 +5904,7 @@ class Program_weight_tensor_parameter_493:
 
 class Program_weight_tensor_parameter_494:
     name = "parameter_494"
+    original_name = "conv2d_7.w_0"
     shape = [256, 64, 1, 1]
     dtype = "float32"
     min_val = float("-0.245267")
@@ -5421,6 +5916,7 @@ class Program_weight_tensor_parameter_494:
 
 class Program_weight_tensor_parameter_495:
     name = "parameter_495"
+    original_name = "batch_norm2d_6.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -5430,6 +5926,7 @@ class Program_weight_tensor_parameter_495:
 
 class Program_weight_tensor_parameter_496:
     name = "parameter_496"
+    original_name = "batch_norm2d_6.w_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -5439,6 +5936,7 @@ class Program_weight_tensor_parameter_496:
 
 class Program_weight_tensor_parameter_497:
     name = "parameter_497"
+    original_name = "batch_norm2d_6.w_2"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -5448,6 +5946,7 @@ class Program_weight_tensor_parameter_497:
 
 class Program_weight_tensor_parameter_498:
     name = "parameter_498"
+    original_name = "batch_norm2d_6.w_1"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -5457,6 +5956,7 @@ class Program_weight_tensor_parameter_498:
 
 class Program_weight_tensor_parameter_499:
     name = "parameter_499"
+    original_name = "conv2d_6.w_0"
     shape = [64, 64, 3, 3]
     dtype = "float32"
     min_val = float("-0.341815")
@@ -5468,6 +5968,7 @@ class Program_weight_tensor_parameter_499:
 
 class Program_weight_tensor_parameter_500:
     name = "parameter_500"
+    original_name = "batch_norm2d_5.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -5477,6 +5978,7 @@ class Program_weight_tensor_parameter_500:
 
 class Program_weight_tensor_parameter_501:
     name = "parameter_501"
+    original_name = "batch_norm2d_5.w_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -5486,6 +5988,7 @@ class Program_weight_tensor_parameter_501:
 
 class Program_weight_tensor_parameter_502:
     name = "parameter_502"
+    original_name = "batch_norm2d_5.w_2"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -5495,6 +5998,7 @@ class Program_weight_tensor_parameter_502:
 
 class Program_weight_tensor_parameter_503:
     name = "parameter_503"
+    original_name = "batch_norm2d_5.w_1"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -5504,6 +6008,7 @@ class Program_weight_tensor_parameter_503:
 
 class Program_weight_tensor_parameter_504:
     name = "parameter_504"
+    original_name = "conv2d_5.w_0"
     shape = [64, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.259632")
@@ -5515,6 +6020,7 @@ class Program_weight_tensor_parameter_504:
 
 class Program_weight_tensor_parameter_505:
     name = "parameter_505"
+    original_name = "batch_norm2d_4.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.174671")
@@ -5526,6 +6032,7 @@ class Program_weight_tensor_parameter_505:
 
 class Program_weight_tensor_parameter_506:
     name = "parameter_506"
+    original_name = "batch_norm2d_4.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.228103")
@@ -5537,6 +6044,7 @@ class Program_weight_tensor_parameter_506:
 
 class Program_weight_tensor_parameter_507:
     name = "parameter_507"
+    original_name = "batch_norm2d_4.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("4.99401e-15")
@@ -5548,6 +6056,7 @@ class Program_weight_tensor_parameter_507:
 
 class Program_weight_tensor_parameter_508:
     name = "parameter_508"
+    original_name = "batch_norm2d_4.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.44709")
@@ -5559,6 +6068,7 @@ class Program_weight_tensor_parameter_508:
 
 class Program_weight_tensor_parameter_509:
     name = "parameter_509"
+    original_name = "conv2d_4.w_0"
     shape = [256, 64, 1, 1]
     dtype = "float32"
     min_val = float("-0.717678")
@@ -5570,6 +6080,7 @@ class Program_weight_tensor_parameter_509:
 
 class Program_weight_tensor_parameter_510:
     name = "parameter_510"
+    original_name = "batch_norm2d_3.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.174671")
@@ -5581,6 +6092,7 @@ class Program_weight_tensor_parameter_510:
 
 class Program_weight_tensor_parameter_511:
     name = "parameter_511"
+    original_name = "batch_norm2d_3.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.425525")
@@ -5592,6 +6104,7 @@ class Program_weight_tensor_parameter_511:
 
 class Program_weight_tensor_parameter_512:
     name = "parameter_512"
+    original_name = "batch_norm2d_3.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("7.51893e-17")
@@ -5603,6 +6116,7 @@ class Program_weight_tensor_parameter_512:
 
 class Program_weight_tensor_parameter_513:
     name = "parameter_513"
+    original_name = "batch_norm2d_3.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.222182")
@@ -5614,6 +6128,7 @@ class Program_weight_tensor_parameter_513:
 
 class Program_weight_tensor_parameter_514:
     name = "parameter_514"
+    original_name = "conv2d_3.w_0"
     shape = [256, 64, 1, 1]
     dtype = "float32"
     min_val = float("-0.325964")
@@ -5625,6 +6140,7 @@ class Program_weight_tensor_parameter_514:
 
 class Program_weight_tensor_parameter_515:
     name = "parameter_515"
+    original_name = "batch_norm2d_2.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -5634,6 +6150,7 @@ class Program_weight_tensor_parameter_515:
 
 class Program_weight_tensor_parameter_516:
     name = "parameter_516"
+    original_name = "batch_norm2d_2.w_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -5643,6 +6160,7 @@ class Program_weight_tensor_parameter_516:
 
 class Program_weight_tensor_parameter_517:
     name = "parameter_517"
+    original_name = "batch_norm2d_2.w_2"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -5652,6 +6170,7 @@ class Program_weight_tensor_parameter_517:
 
 class Program_weight_tensor_parameter_518:
     name = "parameter_518"
+    original_name = "batch_norm2d_2.w_1"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -5661,6 +6180,7 @@ class Program_weight_tensor_parameter_518:
 
 class Program_weight_tensor_parameter_519:
     name = "parameter_519"
+    original_name = "conv2d_2.w_0"
     shape = [64, 64, 3, 3]
     dtype = "float32"
     min_val = float("-0.32494")
@@ -5672,6 +6192,7 @@ class Program_weight_tensor_parameter_519:
 
 class Program_weight_tensor_parameter_520:
     name = "parameter_520"
+    original_name = "batch_norm2d_1.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -5681,6 +6202,7 @@ class Program_weight_tensor_parameter_520:
 
 class Program_weight_tensor_parameter_521:
     name = "parameter_521"
+    original_name = "batch_norm2d_1.w_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -5690,6 +6212,7 @@ class Program_weight_tensor_parameter_521:
 
 class Program_weight_tensor_parameter_522:
     name = "parameter_522"
+    original_name = "batch_norm2d_1.w_2"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -5699,6 +6222,7 @@ class Program_weight_tensor_parameter_522:
 
 class Program_weight_tensor_parameter_523:
     name = "parameter_523"
+    original_name = "batch_norm2d_1.w_1"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -5708,6 +6232,7 @@ class Program_weight_tensor_parameter_523:
 
 class Program_weight_tensor_parameter_524:
     name = "parameter_524"
+    original_name = "conv2d_1.w_0"
     shape = [64, 64, 1, 1]
     dtype = "float32"
     min_val = float("-0.639838")
@@ -5719,6 +6244,7 @@ class Program_weight_tensor_parameter_524:
 
 class Program_weight_tensor_parameter_525:
     name = "parameter_525"
+    original_name = "batch_norm2d_0.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -5728,6 +6254,7 @@ class Program_weight_tensor_parameter_525:
 
 class Program_weight_tensor_parameter_526:
     name = "parameter_526"
+    original_name = "batch_norm2d_0.w_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -5737,6 +6264,7 @@ class Program_weight_tensor_parameter_526:
 
 class Program_weight_tensor_parameter_527:
     name = "parameter_527"
+    original_name = "batch_norm2d_0.w_2"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -5746,6 +6274,7 @@ class Program_weight_tensor_parameter_527:
 
 class Program_weight_tensor_parameter_528:
     name = "parameter_528"
+    original_name = "batch_norm2d_0.w_1"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -5755,6 +6284,7 @@ class Program_weight_tensor_parameter_528:
 
 class Program_weight_tensor_parameter_529:
     name = "parameter_529"
+    original_name = "conv2d_0.w_0"
     shape = [64, 3, 7, 7]
     dtype = "float32"
     min_val = float("-0.680452")

--- a/paddle_samples/PaddleX/FasterRCNN-ResNet50/subgraph_21/input_meta.py
+++ b/paddle_samples/PaddleX/FasterRCNN-ResNet50/subgraph_21/input_meta.py
@@ -1,5 +1,6 @@
 class Program_weight_tensor_data_0:
     name = "data_0"
+    original_name = "var_4506"
     shape = [1, 3, 800, 1322]
     dtype = "float32"
     min_val = float("-2.1179")
@@ -11,6 +12,7 @@ class Program_weight_tensor_data_0:
 
 class Program_weight_tensor_data_1:
     name = "data_1"
+    original_name = "var_4507"
     shape = [1, 2]
     dtype = "float32"
     data = [800.0, 1322.0]
@@ -18,6 +20,7 @@ class Program_weight_tensor_data_1:
 
 class Program_weight_tensor_data_2:
     name = "data_2"
+    original_name = "var_4659"
     shape = [15, 4]
     dtype = "float32"
     data = [

--- a/paddle_samples/PaddleX/FasterRCNN-ResNet50/subgraph_21/weight_meta.py
+++ b/paddle_samples/PaddleX/FasterRCNN-ResNet50/subgraph_21/weight_meta.py
@@ -1,5 +1,6 @@
 class Program_weight_tensor_parameter_0:
     name = "parameter_0"
+    original_name = "linear_1.b_0"
     shape = [16]
     dtype = "float32"
     min_val = float("0")
@@ -9,6 +10,7 @@ class Program_weight_tensor_parameter_0:
 
 class Program_weight_tensor_parameter_1:
     name = "parameter_1"
+    original_name = "linear_1.w_0"
     shape = [2048, 16]
     dtype = "float32"
     min_val = float("-0.0152186")
@@ -20,6 +22,7 @@ class Program_weight_tensor_parameter_1:
 
 class Program_weight_tensor_parameter_2:
     name = "parameter_2"
+    original_name = "linear_0.b_0"
     shape = [5]
     dtype = "float32"
     min_val = float("0")
@@ -29,6 +32,7 @@ class Program_weight_tensor_parameter_2:
 
 class Program_weight_tensor_parameter_3:
     name = "parameter_3"
+    original_name = "linear_0.w_0"
     shape = [2048, 5]
     dtype = "float32"
     min_val = float("-0.0458831")
@@ -40,6 +44,7 @@ class Program_weight_tensor_parameter_3:
 
 class Program_weight_tensor_parameter_4:
     name = "parameter_4"
+    original_name = "batch_norm2d_52.b_0"
     shape = [2048]
     dtype = "float32"
     min_val = float("-0.0152037")
@@ -51,6 +56,7 @@ class Program_weight_tensor_parameter_4:
 
 class Program_weight_tensor_parameter_5:
     name = "parameter_5"
+    original_name = "batch_norm2d_52.w_0"
     shape = [2048]
     dtype = "float32"
     min_val = float("0.0697471")
@@ -62,6 +68,7 @@ class Program_weight_tensor_parameter_5:
 
 class Program_weight_tensor_parameter_6:
     name = "parameter_6"
+    original_name = "batch_norm2d_52.w_2"
     shape = [2048]
     dtype = "float32"
     min_val = float("1.81695e-05")
@@ -73,6 +80,7 @@ class Program_weight_tensor_parameter_6:
 
 class Program_weight_tensor_parameter_7:
     name = "parameter_7"
+    original_name = "batch_norm2d_52.w_1"
     shape = [2048]
     dtype = "float32"
     min_val = float("-0.0612085")
@@ -84,6 +92,7 @@ class Program_weight_tensor_parameter_7:
 
 class Program_weight_tensor_parameter_8:
     name = "parameter_8"
+    original_name = "conv2d_55.w_0"
     shape = [2048, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.375763")
@@ -95,6 +104,7 @@ class Program_weight_tensor_parameter_8:
 
 class Program_weight_tensor_parameter_9:
     name = "parameter_9"
+    original_name = "batch_norm2d_51.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.256723")
@@ -106,6 +116,7 @@ class Program_weight_tensor_parameter_9:
 
 class Program_weight_tensor_parameter_10:
     name = "parameter_10"
+    original_name = "batch_norm2d_51.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("0.14275")
@@ -117,6 +128,7 @@ class Program_weight_tensor_parameter_10:
 
 class Program_weight_tensor_parameter_11:
     name = "parameter_11"
+    original_name = "batch_norm2d_51.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("0.00782721")
@@ -128,6 +140,7 @@ class Program_weight_tensor_parameter_11:
 
 class Program_weight_tensor_parameter_12:
     name = "parameter_12"
+    original_name = "batch_norm2d_51.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.21336")
@@ -139,6 +152,7 @@ class Program_weight_tensor_parameter_12:
 
 class Program_weight_tensor_parameter_13:
     name = "parameter_13"
+    original_name = "conv2d_54.w_0"
     shape = [512, 512, 3, 3]
     dtype = "float32"
     min_val = float("-0.241829")
@@ -150,6 +164,7 @@ class Program_weight_tensor_parameter_13:
 
 class Program_weight_tensor_parameter_14:
     name = "parameter_14"
+    original_name = "batch_norm2d_50.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.374154")
@@ -161,6 +176,7 @@ class Program_weight_tensor_parameter_14:
 
 class Program_weight_tensor_parameter_15:
     name = "parameter_15"
+    original_name = "batch_norm2d_50.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("0.112266")
@@ -172,6 +188,7 @@ class Program_weight_tensor_parameter_15:
 
 class Program_weight_tensor_parameter_16:
     name = "parameter_16"
+    original_name = "batch_norm2d_50.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("0.00368882")
@@ -183,6 +200,7 @@ class Program_weight_tensor_parameter_16:
 
 class Program_weight_tensor_parameter_17:
     name = "parameter_17"
+    original_name = "batch_norm2d_50.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.165498")
@@ -194,6 +212,7 @@ class Program_weight_tensor_parameter_17:
 
 class Program_weight_tensor_parameter_18:
     name = "parameter_18"
+    original_name = "conv2d_53.w_0"
     shape = [512, 2048, 1, 1]
     dtype = "float32"
     min_val = float("-0.254277")
@@ -205,6 +224,7 @@ class Program_weight_tensor_parameter_18:
 
 class Program_weight_tensor_parameter_19:
     name = "parameter_19"
+    original_name = "batch_norm2d_49.b_0"
     shape = [2048]
     dtype = "float32"
     min_val = float("-0.344745")
@@ -216,6 +236,7 @@ class Program_weight_tensor_parameter_19:
 
 class Program_weight_tensor_parameter_20:
     name = "parameter_20"
+    original_name = "batch_norm2d_49.w_0"
     shape = [2048]
     dtype = "float32"
     min_val = float("-0.055626")
@@ -227,6 +248,7 @@ class Program_weight_tensor_parameter_20:
 
 class Program_weight_tensor_parameter_21:
     name = "parameter_21"
+    original_name = "batch_norm2d_49.w_2"
     shape = [2048]
     dtype = "float32"
     min_val = float("0.000374241")
@@ -238,6 +260,7 @@ class Program_weight_tensor_parameter_21:
 
 class Program_weight_tensor_parameter_22:
     name = "parameter_22"
+    original_name = "batch_norm2d_49.w_1"
     shape = [2048]
     dtype = "float32"
     min_val = float("-0.143817")
@@ -249,6 +272,7 @@ class Program_weight_tensor_parameter_22:
 
 class Program_weight_tensor_parameter_23:
     name = "parameter_23"
+    original_name = "conv2d_52.w_0"
     shape = [2048, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.27623")
@@ -260,6 +284,7 @@ class Program_weight_tensor_parameter_23:
 
 class Program_weight_tensor_parameter_24:
     name = "parameter_24"
+    original_name = "batch_norm2d_48.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.281581")
@@ -271,6 +296,7 @@ class Program_weight_tensor_parameter_24:
 
 class Program_weight_tensor_parameter_25:
     name = "parameter_25"
+    original_name = "batch_norm2d_48.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("0.103043")
@@ -282,6 +308,7 @@ class Program_weight_tensor_parameter_25:
 
 class Program_weight_tensor_parameter_26:
     name = "parameter_26"
+    original_name = "batch_norm2d_48.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("0.00667349")
@@ -293,6 +320,7 @@ class Program_weight_tensor_parameter_26:
 
 class Program_weight_tensor_parameter_27:
     name = "parameter_27"
+    original_name = "batch_norm2d_48.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.333379")
@@ -304,6 +332,7 @@ class Program_weight_tensor_parameter_27:
 
 class Program_weight_tensor_parameter_28:
     name = "parameter_28"
+    original_name = "conv2d_51.w_0"
     shape = [512, 512, 3, 3]
     dtype = "float32"
     min_val = float("-0.206161")
@@ -315,6 +344,7 @@ class Program_weight_tensor_parameter_28:
 
 class Program_weight_tensor_parameter_29:
     name = "parameter_29"
+    original_name = "batch_norm2d_47.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.204726")
@@ -326,6 +356,7 @@ class Program_weight_tensor_parameter_29:
 
 class Program_weight_tensor_parameter_30:
     name = "parameter_30"
+    original_name = "batch_norm2d_47.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("0.11019")
@@ -337,6 +368,7 @@ class Program_weight_tensor_parameter_30:
 
 class Program_weight_tensor_parameter_31:
     name = "parameter_31"
+    original_name = "batch_norm2d_47.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("0.0038453")
@@ -348,6 +380,7 @@ class Program_weight_tensor_parameter_31:
 
 class Program_weight_tensor_parameter_32:
     name = "parameter_32"
+    original_name = "batch_norm2d_47.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.156876")
@@ -359,6 +392,7 @@ class Program_weight_tensor_parameter_32:
 
 class Program_weight_tensor_parameter_33:
     name = "parameter_33"
+    original_name = "conv2d_50.w_0"
     shape = [512, 2048, 1, 1]
     dtype = "float32"
     min_val = float("-0.14362")
@@ -370,6 +404,7 @@ class Program_weight_tensor_parameter_33:
 
 class Program_weight_tensor_parameter_34:
     name = "parameter_34"
+    original_name = "batch_norm2d_46.b_0"
     shape = [2048]
     dtype = "float32"
     min_val = float("-0.175901")
@@ -381,6 +416,7 @@ class Program_weight_tensor_parameter_34:
 
 class Program_weight_tensor_parameter_35:
     name = "parameter_35"
+    original_name = "batch_norm2d_46.w_0"
     shape = [2048]
     dtype = "float32"
     min_val = float("0.0445343")
@@ -392,6 +428,7 @@ class Program_weight_tensor_parameter_35:
 
 class Program_weight_tensor_parameter_36:
     name = "parameter_36"
+    original_name = "batch_norm2d_46.w_2"
     shape = [2048]
     dtype = "float32"
     min_val = float("0.00110278")
@@ -403,6 +440,7 @@ class Program_weight_tensor_parameter_36:
 
 class Program_weight_tensor_parameter_37:
     name = "parameter_37"
+    original_name = "batch_norm2d_46.w_1"
     shape = [2048]
     dtype = "float32"
     min_val = float("-0.14942")
@@ -414,6 +452,7 @@ class Program_weight_tensor_parameter_37:
 
 class Program_weight_tensor_parameter_38:
     name = "parameter_38"
+    original_name = "conv2d_49.w_0"
     shape = [2048, 1024, 1, 1]
     dtype = "float32"
     min_val = float("-0.159272")
@@ -425,6 +464,7 @@ class Program_weight_tensor_parameter_38:
 
 class Program_weight_tensor_parameter_39:
     name = "parameter_39"
+    original_name = "batch_norm2d_45.b_0"
     shape = [2048]
     dtype = "float32"
     min_val = float("-0.175901")
@@ -436,6 +476,7 @@ class Program_weight_tensor_parameter_39:
 
 class Program_weight_tensor_parameter_40:
     name = "parameter_40"
+    original_name = "batch_norm2d_45.w_0"
     shape = [2048]
     dtype = "float32"
     min_val = float("-0.0299724")
@@ -447,6 +488,7 @@ class Program_weight_tensor_parameter_40:
 
 class Program_weight_tensor_parameter_41:
     name = "parameter_41"
+    original_name = "batch_norm2d_45.w_2"
     shape = [2048]
     dtype = "float32"
     min_val = float("0.000317003")
@@ -458,6 +500,7 @@ class Program_weight_tensor_parameter_41:
 
 class Program_weight_tensor_parameter_42:
     name = "parameter_42"
+    original_name = "batch_norm2d_45.w_1"
     shape = [2048]
     dtype = "float32"
     min_val = float("-0.119379")
@@ -469,6 +512,7 @@ class Program_weight_tensor_parameter_42:
 
 class Program_weight_tensor_parameter_43:
     name = "parameter_43"
+    original_name = "conv2d_48.w_0"
     shape = [2048, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.225899")
@@ -480,6 +524,7 @@ class Program_weight_tensor_parameter_43:
 
 class Program_weight_tensor_parameter_44:
     name = "parameter_44"
+    original_name = "batch_norm2d_44.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.16638")
@@ -491,6 +536,7 @@ class Program_weight_tensor_parameter_44:
 
 class Program_weight_tensor_parameter_45:
     name = "parameter_45"
+    original_name = "batch_norm2d_44.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("0.122151")
@@ -502,6 +548,7 @@ class Program_weight_tensor_parameter_45:
 
 class Program_weight_tensor_parameter_46:
     name = "parameter_46"
+    original_name = "batch_norm2d_44.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("0.00556548")
@@ -513,6 +560,7 @@ class Program_weight_tensor_parameter_46:
 
 class Program_weight_tensor_parameter_47:
     name = "parameter_47"
+    original_name = "batch_norm2d_44.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.114167")
@@ -524,6 +572,7 @@ class Program_weight_tensor_parameter_47:
 
 class Program_weight_tensor_parameter_48:
     name = "parameter_48"
+    original_name = "conv2d_47.w_0"
     shape = [512, 512, 3, 3]
     dtype = "float32"
     min_val = float("-0.273942")
@@ -535,6 +584,7 @@ class Program_weight_tensor_parameter_48:
 
 class Program_weight_tensor_parameter_49:
     name = "parameter_49"
+    original_name = "batch_norm2d_43.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.323791")
@@ -546,6 +596,7 @@ class Program_weight_tensor_parameter_49:
 
 class Program_weight_tensor_parameter_50:
     name = "parameter_50"
+    original_name = "batch_norm2d_43.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("0.103624")
@@ -557,6 +608,7 @@ class Program_weight_tensor_parameter_50:
 
 class Program_weight_tensor_parameter_51:
     name = "parameter_51"
+    original_name = "batch_norm2d_43.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("0.00626364")
@@ -568,6 +620,7 @@ class Program_weight_tensor_parameter_51:
 
 class Program_weight_tensor_parameter_52:
     name = "parameter_52"
+    original_name = "batch_norm2d_43.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.154384")
@@ -579,6 +632,7 @@ class Program_weight_tensor_parameter_52:
 
 class Program_weight_tensor_parameter_53:
     name = "parameter_53"
+    original_name = "conv2d_46.w_0"
     shape = [512, 1024, 1, 1]
     dtype = "float32"
     min_val = float("-0.21217")
@@ -590,6 +644,7 @@ class Program_weight_tensor_parameter_53:
 
 class Program_weight_tensor_parameter_54:
     name = "parameter_54"
+    original_name = "conv2d_45.b_0"
     shape = [60]
     dtype = "float32"
     min_val = float("0")
@@ -599,6 +654,7 @@ class Program_weight_tensor_parameter_54:
 
 class Program_weight_tensor_parameter_55:
     name = "parameter_55"
+    original_name = "conv2d_45.w_0"
     shape = [60, 1024, 1, 1]
     dtype = "float32"
     min_val = float("-0.166029")
@@ -610,6 +666,7 @@ class Program_weight_tensor_parameter_55:
 
 class Program_weight_tensor_parameter_56:
     name = "parameter_56"
+    original_name = "conv2d_44.b_0"
     shape = [15]
     dtype = "float32"
     min_val = float("0")
@@ -619,6 +676,7 @@ class Program_weight_tensor_parameter_56:
 
 class Program_weight_tensor_parameter_57:
     name = "parameter_57"
+    original_name = "conv2d_44.w_0"
     shape = [15, 1024, 1, 1]
     dtype = "float32"
     min_val = float("-0.34709")
@@ -630,6 +688,7 @@ class Program_weight_tensor_parameter_57:
 
 class Program_weight_tensor_parameter_58:
     name = "parameter_58"
+    original_name = "conv2d_43.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.0238398")
@@ -641,6 +700,7 @@ class Program_weight_tensor_parameter_58:
 
 class Program_weight_tensor_parameter_59:
     name = "parameter_59"
+    original_name = "conv2d_43.w_0"
     shape = [1024, 1024, 3, 3]
     dtype = "float32"
     min_val = float("-0.065505")
@@ -652,6 +712,7 @@ class Program_weight_tensor_parameter_59:
 
 class Program_weight_tensor_parameter_60:
     name = "parameter_60"
+    original_name = "batch_norm2d_42.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.351039")
@@ -663,6 +724,7 @@ class Program_weight_tensor_parameter_60:
 
 class Program_weight_tensor_parameter_61:
     name = "parameter_61"
+    original_name = "batch_norm2d_42.w_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.07047")
@@ -674,6 +736,7 @@ class Program_weight_tensor_parameter_61:
 
 class Program_weight_tensor_parameter_62:
     name = "parameter_62"
+    original_name = "batch_norm2d_42.w_2"
     shape = [1024]
     dtype = "float32"
     min_val = float("7.26301e-05")
@@ -685,6 +748,7 @@ class Program_weight_tensor_parameter_62:
 
 class Program_weight_tensor_parameter_63:
     name = "parameter_63"
+    original_name = "batch_norm2d_42.w_1"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.144298")
@@ -696,6 +760,7 @@ class Program_weight_tensor_parameter_63:
 
 class Program_weight_tensor_parameter_64:
     name = "parameter_64"
+    original_name = "conv2d_42.w_0"
     shape = [1024, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.281403")
@@ -707,6 +772,7 @@ class Program_weight_tensor_parameter_64:
 
 class Program_weight_tensor_parameter_65:
     name = "parameter_65"
+    original_name = "batch_norm2d_41.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.21126")
@@ -718,6 +784,7 @@ class Program_weight_tensor_parameter_65:
 
 class Program_weight_tensor_parameter_66:
     name = "parameter_66"
+    original_name = "batch_norm2d_41.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.117769")
@@ -729,6 +796,7 @@ class Program_weight_tensor_parameter_66:
 
 class Program_weight_tensor_parameter_67:
     name = "parameter_67"
+    original_name = "batch_norm2d_41.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.00341764")
@@ -740,6 +808,7 @@ class Program_weight_tensor_parameter_67:
 
 class Program_weight_tensor_parameter_68:
     name = "parameter_68"
+    original_name = "batch_norm2d_41.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.170117")
@@ -751,6 +820,7 @@ class Program_weight_tensor_parameter_68:
 
 class Program_weight_tensor_parameter_69:
     name = "parameter_69"
+    original_name = "conv2d_41.w_0"
     shape = [256, 256, 3, 3]
     dtype = "float32"
     min_val = float("-0.226498")
@@ -762,6 +832,7 @@ class Program_weight_tensor_parameter_69:
 
 class Program_weight_tensor_parameter_70:
     name = "parameter_70"
+    original_name = "batch_norm2d_40.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.311823")
@@ -773,6 +844,7 @@ class Program_weight_tensor_parameter_70:
 
 class Program_weight_tensor_parameter_71:
     name = "parameter_71"
+    original_name = "batch_norm2d_40.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.0999985")
@@ -784,6 +856,7 @@ class Program_weight_tensor_parameter_71:
 
 class Program_weight_tensor_parameter_72:
     name = "parameter_72"
+    original_name = "batch_norm2d_40.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.00541504")
@@ -795,6 +868,7 @@ class Program_weight_tensor_parameter_72:
 
 class Program_weight_tensor_parameter_73:
     name = "parameter_73"
+    original_name = "batch_norm2d_40.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.217816")
@@ -806,6 +880,7 @@ class Program_weight_tensor_parameter_73:
 
 class Program_weight_tensor_parameter_74:
     name = "parameter_74"
+    original_name = "conv2d_40.w_0"
     shape = [256, 1024, 1, 1]
     dtype = "float32"
     min_val = float("-0.21339")
@@ -817,6 +892,7 @@ class Program_weight_tensor_parameter_74:
 
 class Program_weight_tensor_parameter_75:
     name = "parameter_75"
+    original_name = "batch_norm2d_39.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.257537")
@@ -828,6 +904,7 @@ class Program_weight_tensor_parameter_75:
 
 class Program_weight_tensor_parameter_76:
     name = "parameter_76"
+    original_name = "batch_norm2d_39.w_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.0934878")
@@ -839,6 +916,7 @@ class Program_weight_tensor_parameter_76:
 
 class Program_weight_tensor_parameter_77:
     name = "parameter_77"
+    original_name = "batch_norm2d_39.w_2"
     shape = [1024]
     dtype = "float32"
     min_val = float("3.37513e-05")
@@ -850,6 +928,7 @@ class Program_weight_tensor_parameter_77:
 
 class Program_weight_tensor_parameter_78:
     name = "parameter_78"
+    original_name = "batch_norm2d_39.w_1"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.0803989")
@@ -861,6 +940,7 @@ class Program_weight_tensor_parameter_78:
 
 class Program_weight_tensor_parameter_79:
     name = "parameter_79"
+    original_name = "conv2d_39.w_0"
     shape = [1024, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.264235")
@@ -872,6 +952,7 @@ class Program_weight_tensor_parameter_79:
 
 class Program_weight_tensor_parameter_80:
     name = "parameter_80"
+    original_name = "batch_norm2d_38.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.230815")
@@ -883,6 +964,7 @@ class Program_weight_tensor_parameter_80:
 
 class Program_weight_tensor_parameter_81:
     name = "parameter_81"
+    original_name = "batch_norm2d_38.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.0986752")
@@ -894,6 +976,7 @@ class Program_weight_tensor_parameter_81:
 
 class Program_weight_tensor_parameter_82:
     name = "parameter_82"
+    original_name = "batch_norm2d_38.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.00330181")
@@ -905,6 +988,7 @@ class Program_weight_tensor_parameter_82:
 
 class Program_weight_tensor_parameter_83:
     name = "parameter_83"
+    original_name = "batch_norm2d_38.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.162266")
@@ -916,6 +1000,7 @@ class Program_weight_tensor_parameter_83:
 
 class Program_weight_tensor_parameter_84:
     name = "parameter_84"
+    original_name = "conv2d_38.w_0"
     shape = [256, 256, 3, 3]
     dtype = "float32"
     min_val = float("-0.276541")
@@ -927,6 +1012,7 @@ class Program_weight_tensor_parameter_84:
 
 class Program_weight_tensor_parameter_85:
     name = "parameter_85"
+    original_name = "batch_norm2d_37.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.308882")
@@ -938,6 +1024,7 @@ class Program_weight_tensor_parameter_85:
 
 class Program_weight_tensor_parameter_86:
     name = "parameter_86"
+    original_name = "batch_norm2d_37.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.0917825")
@@ -949,6 +1036,7 @@ class Program_weight_tensor_parameter_86:
 
 class Program_weight_tensor_parameter_87:
     name = "parameter_87"
+    original_name = "batch_norm2d_37.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.00507757")
@@ -960,6 +1048,7 @@ class Program_weight_tensor_parameter_87:
 
 class Program_weight_tensor_parameter_88:
     name = "parameter_88"
+    original_name = "batch_norm2d_37.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.253439")
@@ -971,6 +1060,7 @@ class Program_weight_tensor_parameter_88:
 
 class Program_weight_tensor_parameter_89:
     name = "parameter_89"
+    original_name = "conv2d_37.w_0"
     shape = [256, 1024, 1, 1]
     dtype = "float32"
     min_val = float("-0.290619")
@@ -982,6 +1072,7 @@ class Program_weight_tensor_parameter_89:
 
 class Program_weight_tensor_parameter_90:
     name = "parameter_90"
+    original_name = "batch_norm2d_36.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.277526")
@@ -993,6 +1084,7 @@ class Program_weight_tensor_parameter_90:
 
 class Program_weight_tensor_parameter_91:
     name = "parameter_91"
+    original_name = "batch_norm2d_36.w_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.0669554")
@@ -1004,6 +1096,7 @@ class Program_weight_tensor_parameter_91:
 
 class Program_weight_tensor_parameter_92:
     name = "parameter_92"
+    original_name = "batch_norm2d_36.w_2"
     shape = [1024]
     dtype = "float32"
     min_val = float("3.75323e-05")
@@ -1015,6 +1108,7 @@ class Program_weight_tensor_parameter_92:
 
 class Program_weight_tensor_parameter_93:
     name = "parameter_93"
+    original_name = "batch_norm2d_36.w_1"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.0983159")
@@ -1026,6 +1120,7 @@ class Program_weight_tensor_parameter_93:
 
 class Program_weight_tensor_parameter_94:
     name = "parameter_94"
+    original_name = "conv2d_36.w_0"
     shape = [1024, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.221032")
@@ -1037,6 +1132,7 @@ class Program_weight_tensor_parameter_94:
 
 class Program_weight_tensor_parameter_95:
     name = "parameter_95"
+    original_name = "batch_norm2d_35.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.296914")
@@ -1048,6 +1144,7 @@ class Program_weight_tensor_parameter_95:
 
 class Program_weight_tensor_parameter_96:
     name = "parameter_96"
+    original_name = "batch_norm2d_35.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.10747")
@@ -1059,6 +1156,7 @@ class Program_weight_tensor_parameter_96:
 
 class Program_weight_tensor_parameter_97:
     name = "parameter_97"
+    original_name = "batch_norm2d_35.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.00385775")
@@ -1070,6 +1168,7 @@ class Program_weight_tensor_parameter_97:
 
 class Program_weight_tensor_parameter_98:
     name = "parameter_98"
+    original_name = "batch_norm2d_35.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.169559")
@@ -1081,6 +1180,7 @@ class Program_weight_tensor_parameter_98:
 
 class Program_weight_tensor_parameter_99:
     name = "parameter_99"
+    original_name = "conv2d_35.w_0"
     shape = [256, 256, 3, 3]
     dtype = "float32"
     min_val = float("-0.169058")
@@ -1092,6 +1192,7 @@ class Program_weight_tensor_parameter_99:
 
 class Program_weight_tensor_parameter_100:
     name = "parameter_100"
+    original_name = "batch_norm2d_34.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.213419")
@@ -1103,6 +1204,7 @@ class Program_weight_tensor_parameter_100:
 
 class Program_weight_tensor_parameter_101:
     name = "parameter_101"
+    original_name = "batch_norm2d_34.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.0886459")
@@ -1114,6 +1216,7 @@ class Program_weight_tensor_parameter_101:
 
 class Program_weight_tensor_parameter_102:
     name = "parameter_102"
+    original_name = "batch_norm2d_34.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.00513009")
@@ -1125,6 +1228,7 @@ class Program_weight_tensor_parameter_102:
 
 class Program_weight_tensor_parameter_103:
     name = "parameter_103"
+    original_name = "batch_norm2d_34.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.186176")
@@ -1136,6 +1240,7 @@ class Program_weight_tensor_parameter_103:
 
 class Program_weight_tensor_parameter_104:
     name = "parameter_104"
+    original_name = "conv2d_34.w_0"
     shape = [256, 1024, 1, 1]
     dtype = "float32"
     min_val = float("-0.185408")
@@ -1147,6 +1252,7 @@ class Program_weight_tensor_parameter_104:
 
 class Program_weight_tensor_parameter_105:
     name = "parameter_105"
+    original_name = "batch_norm2d_33.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.250614")
@@ -1158,6 +1264,7 @@ class Program_weight_tensor_parameter_105:
 
 class Program_weight_tensor_parameter_106:
     name = "parameter_106"
+    original_name = "batch_norm2d_33.w_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.0906886")
@@ -1169,6 +1276,7 @@ class Program_weight_tensor_parameter_106:
 
 class Program_weight_tensor_parameter_107:
     name = "parameter_107"
+    original_name = "batch_norm2d_33.w_2"
     shape = [1024]
     dtype = "float32"
     min_val = float("5.60519e-45")
@@ -1180,6 +1288,7 @@ class Program_weight_tensor_parameter_107:
 
 class Program_weight_tensor_parameter_108:
     name = "parameter_108"
+    original_name = "batch_norm2d_33.w_1"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.167302")
@@ -1191,6 +1300,7 @@ class Program_weight_tensor_parameter_108:
 
 class Program_weight_tensor_parameter_109:
     name = "parameter_109"
+    original_name = "conv2d_33.w_0"
     shape = [1024, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.289658")
@@ -1202,6 +1312,7 @@ class Program_weight_tensor_parameter_109:
 
 class Program_weight_tensor_parameter_110:
     name = "parameter_110"
+    original_name = "batch_norm2d_32.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.352177")
@@ -1213,6 +1324,7 @@ class Program_weight_tensor_parameter_110:
 
 class Program_weight_tensor_parameter_111:
     name = "parameter_111"
+    original_name = "batch_norm2d_32.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.109797")
@@ -1224,6 +1336,7 @@ class Program_weight_tensor_parameter_111:
 
 class Program_weight_tensor_parameter_112:
     name = "parameter_112"
+    original_name = "batch_norm2d_32.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.00447485")
@@ -1235,6 +1348,7 @@ class Program_weight_tensor_parameter_112:
 
 class Program_weight_tensor_parameter_113:
     name = "parameter_113"
+    original_name = "batch_norm2d_32.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.273181")
@@ -1246,6 +1360,7 @@ class Program_weight_tensor_parameter_113:
 
 class Program_weight_tensor_parameter_114:
     name = "parameter_114"
+    original_name = "conv2d_32.w_0"
     shape = [256, 256, 3, 3]
     dtype = "float32"
     min_val = float("-0.136752")
@@ -1257,6 +1372,7 @@ class Program_weight_tensor_parameter_114:
 
 class Program_weight_tensor_parameter_115:
     name = "parameter_115"
+    original_name = "batch_norm2d_31.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.244688")
@@ -1268,6 +1384,7 @@ class Program_weight_tensor_parameter_115:
 
 class Program_weight_tensor_parameter_116:
     name = "parameter_116"
+    original_name = "batch_norm2d_31.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.0940401")
@@ -1279,6 +1396,7 @@ class Program_weight_tensor_parameter_116:
 
 class Program_weight_tensor_parameter_117:
     name = "parameter_117"
+    original_name = "batch_norm2d_31.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.00569284")
@@ -1290,6 +1408,7 @@ class Program_weight_tensor_parameter_117:
 
 class Program_weight_tensor_parameter_118:
     name = "parameter_118"
+    original_name = "batch_norm2d_31.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.217011")
@@ -1301,6 +1420,7 @@ class Program_weight_tensor_parameter_118:
 
 class Program_weight_tensor_parameter_119:
     name = "parameter_119"
+    original_name = "conv2d_31.w_0"
     shape = [256, 1024, 1, 1]
     dtype = "float32"
     min_val = float("-0.152117")
@@ -1312,6 +1432,7 @@ class Program_weight_tensor_parameter_119:
 
 class Program_weight_tensor_parameter_120:
     name = "parameter_120"
+    original_name = "batch_norm2d_30.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.286915")
@@ -1323,6 +1444,7 @@ class Program_weight_tensor_parameter_120:
 
 class Program_weight_tensor_parameter_121:
     name = "parameter_121"
+    original_name = "batch_norm2d_30.w_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.0954698")
@@ -1334,6 +1456,7 @@ class Program_weight_tensor_parameter_121:
 
 class Program_weight_tensor_parameter_122:
     name = "parameter_122"
+    original_name = "batch_norm2d_30.w_2"
     shape = [1024]
     dtype = "float32"
     min_val = float("5.60519e-45")
@@ -1345,6 +1468,7 @@ class Program_weight_tensor_parameter_122:
 
 class Program_weight_tensor_parameter_123:
     name = "parameter_123"
+    original_name = "batch_norm2d_30.w_1"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.115951")
@@ -1356,6 +1480,7 @@ class Program_weight_tensor_parameter_123:
 
 class Program_weight_tensor_parameter_124:
     name = "parameter_124"
+    original_name = "conv2d_30.w_0"
     shape = [1024, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.197382")
@@ -1367,6 +1492,7 @@ class Program_weight_tensor_parameter_124:
 
 class Program_weight_tensor_parameter_125:
     name = "parameter_125"
+    original_name = "batch_norm2d_29.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.375463")
@@ -1378,6 +1504,7 @@ class Program_weight_tensor_parameter_125:
 
 class Program_weight_tensor_parameter_126:
     name = "parameter_126"
+    original_name = "batch_norm2d_29.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.112369")
@@ -1389,6 +1516,7 @@ class Program_weight_tensor_parameter_126:
 
 class Program_weight_tensor_parameter_127:
     name = "parameter_127"
+    original_name = "batch_norm2d_29.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.00590638")
@@ -1400,6 +1528,7 @@ class Program_weight_tensor_parameter_127:
 
 class Program_weight_tensor_parameter_128:
     name = "parameter_128"
+    original_name = "batch_norm2d_29.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.703637")
@@ -1411,6 +1540,7 @@ class Program_weight_tensor_parameter_128:
 
 class Program_weight_tensor_parameter_129:
     name = "parameter_129"
+    original_name = "conv2d_29.w_0"
     shape = [256, 256, 3, 3]
     dtype = "float32"
     min_val = float("-0.281035")
@@ -1422,6 +1552,7 @@ class Program_weight_tensor_parameter_129:
 
 class Program_weight_tensor_parameter_130:
     name = "parameter_130"
+    original_name = "batch_norm2d_28.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.206572")
@@ -1433,6 +1564,7 @@ class Program_weight_tensor_parameter_130:
 
 class Program_weight_tensor_parameter_131:
     name = "parameter_131"
+    original_name = "batch_norm2d_28.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.0505699")
@@ -1444,6 +1576,7 @@ class Program_weight_tensor_parameter_131:
 
 class Program_weight_tensor_parameter_132:
     name = "parameter_132"
+    original_name = "batch_norm2d_28.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.00534348")
@@ -1455,6 +1588,7 @@ class Program_weight_tensor_parameter_132:
 
 class Program_weight_tensor_parameter_133:
     name = "parameter_133"
+    original_name = "batch_norm2d_28.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.875068")
@@ -1466,6 +1600,7 @@ class Program_weight_tensor_parameter_133:
 
 class Program_weight_tensor_parameter_134:
     name = "parameter_134"
+    original_name = "conv2d_28.w_0"
     shape = [256, 1024, 1, 1]
     dtype = "float32"
     min_val = float("-0.140779")
@@ -1477,6 +1612,7 @@ class Program_weight_tensor_parameter_134:
 
 class Program_weight_tensor_parameter_135:
     name = "parameter_135"
+    original_name = "batch_norm2d_27.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.129348")
@@ -1488,6 +1624,7 @@ class Program_weight_tensor_parameter_135:
 
 class Program_weight_tensor_parameter_136:
     name = "parameter_136"
+    original_name = "batch_norm2d_27.w_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.0782665")
@@ -1499,6 +1636,7 @@ class Program_weight_tensor_parameter_136:
 
 class Program_weight_tensor_parameter_137:
     name = "parameter_137"
+    original_name = "batch_norm2d_27.w_2"
     shape = [1024]
     dtype = "float32"
     min_val = float("5.60519e-45")
@@ -1510,6 +1648,7 @@ class Program_weight_tensor_parameter_137:
 
 class Program_weight_tensor_parameter_138:
     name = "parameter_138"
+    original_name = "batch_norm2d_27.w_1"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.212248")
@@ -1521,6 +1660,7 @@ class Program_weight_tensor_parameter_138:
 
 class Program_weight_tensor_parameter_139:
     name = "parameter_139"
+    original_name = "conv2d_27.w_0"
     shape = [1024, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.21405")
@@ -1532,6 +1672,7 @@ class Program_weight_tensor_parameter_139:
 
 class Program_weight_tensor_parameter_140:
     name = "parameter_140"
+    original_name = "batch_norm2d_26.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.129348")
@@ -1543,6 +1684,7 @@ class Program_weight_tensor_parameter_140:
 
 class Program_weight_tensor_parameter_141:
     name = "parameter_141"
+    original_name = "batch_norm2d_26.w_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.112535")
@@ -1554,6 +1696,7 @@ class Program_weight_tensor_parameter_141:
 
 class Program_weight_tensor_parameter_142:
     name = "parameter_142"
+    original_name = "batch_norm2d_26.w_2"
     shape = [1024]
     dtype = "float32"
     min_val = float("5.60519e-45")
@@ -1565,6 +1708,7 @@ class Program_weight_tensor_parameter_142:
 
 class Program_weight_tensor_parameter_143:
     name = "parameter_143"
+    original_name = "batch_norm2d_26.w_1"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.27465")
@@ -1576,6 +1720,7 @@ class Program_weight_tensor_parameter_143:
 
 class Program_weight_tensor_parameter_144:
     name = "parameter_144"
+    original_name = "conv2d_26.w_0"
     shape = [1024, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.250574")
@@ -1587,6 +1732,7 @@ class Program_weight_tensor_parameter_144:
 
 class Program_weight_tensor_parameter_145:
     name = "parameter_145"
+    original_name = "batch_norm2d_25.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.169579")
@@ -1598,6 +1744,7 @@ class Program_weight_tensor_parameter_145:
 
 class Program_weight_tensor_parameter_146:
     name = "parameter_146"
+    original_name = "batch_norm2d_25.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.134955")
@@ -1609,6 +1756,7 @@ class Program_weight_tensor_parameter_146:
 
 class Program_weight_tensor_parameter_147:
     name = "parameter_147"
+    original_name = "batch_norm2d_25.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.00830367")
@@ -1620,6 +1768,7 @@ class Program_weight_tensor_parameter_147:
 
 class Program_weight_tensor_parameter_148:
     name = "parameter_148"
+    original_name = "batch_norm2d_25.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.33506")
@@ -1631,6 +1780,7 @@ class Program_weight_tensor_parameter_148:
 
 class Program_weight_tensor_parameter_149:
     name = "parameter_149"
+    original_name = "conv2d_25.w_0"
     shape = [256, 256, 3, 3]
     dtype = "float32"
     min_val = float("-0.149724")
@@ -1642,6 +1792,7 @@ class Program_weight_tensor_parameter_149:
 
 class Program_weight_tensor_parameter_150:
     name = "parameter_150"
+    original_name = "batch_norm2d_24.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.373664")
@@ -1653,6 +1804,7 @@ class Program_weight_tensor_parameter_150:
 
 class Program_weight_tensor_parameter_151:
     name = "parameter_151"
+    original_name = "batch_norm2d_24.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.131751")
@@ -1664,6 +1816,7 @@ class Program_weight_tensor_parameter_151:
 
 class Program_weight_tensor_parameter_152:
     name = "parameter_152"
+    original_name = "batch_norm2d_24.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.00842175")
@@ -1675,6 +1828,7 @@ class Program_weight_tensor_parameter_152:
 
 class Program_weight_tensor_parameter_153:
     name = "parameter_153"
+    original_name = "batch_norm2d_24.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.32061")
@@ -1686,6 +1840,7 @@ class Program_weight_tensor_parameter_153:
 
 class Program_weight_tensor_parameter_154:
     name = "parameter_154"
+    original_name = "conv2d_24.w_0"
     shape = [256, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.288403")
@@ -1697,6 +1852,7 @@ class Program_weight_tensor_parameter_154:
 
 class Program_weight_tensor_parameter_155:
     name = "parameter_155"
+    original_name = "batch_norm2d_23.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.265845")
@@ -1708,6 +1864,7 @@ class Program_weight_tensor_parameter_155:
 
 class Program_weight_tensor_parameter_156:
     name = "parameter_156"
+    original_name = "batch_norm2d_23.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.118565")
@@ -1719,6 +1876,7 @@ class Program_weight_tensor_parameter_156:
 
 class Program_weight_tensor_parameter_157:
     name = "parameter_157"
+    original_name = "batch_norm2d_23.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("6.90692e-05")
@@ -1730,6 +1888,7 @@ class Program_weight_tensor_parameter_157:
 
 class Program_weight_tensor_parameter_158:
     name = "parameter_158"
+    original_name = "batch_norm2d_23.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.1189")
@@ -1741,6 +1900,7 @@ class Program_weight_tensor_parameter_158:
 
 class Program_weight_tensor_parameter_159:
     name = "parameter_159"
+    original_name = "conv2d_23.w_0"
     shape = [512, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.193565")
@@ -1752,6 +1912,7 @@ class Program_weight_tensor_parameter_159:
 
 class Program_weight_tensor_parameter_160:
     name = "parameter_160"
+    original_name = "batch_norm2d_22.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.232901")
@@ -1763,6 +1924,7 @@ class Program_weight_tensor_parameter_160:
 
 class Program_weight_tensor_parameter_161:
     name = "parameter_161"
+    original_name = "batch_norm2d_22.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.118614")
@@ -1774,6 +1936,7 @@ class Program_weight_tensor_parameter_161:
 
 class Program_weight_tensor_parameter_162:
     name = "parameter_162"
+    original_name = "batch_norm2d_22.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.0036914")
@@ -1785,6 +1948,7 @@ class Program_weight_tensor_parameter_162:
 
 class Program_weight_tensor_parameter_163:
     name = "parameter_163"
+    original_name = "batch_norm2d_22.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.2584")
@@ -1796,6 +1960,7 @@ class Program_weight_tensor_parameter_163:
 
 class Program_weight_tensor_parameter_164:
     name = "parameter_164"
+    original_name = "conv2d_22.w_0"
     shape = [128, 128, 3, 3]
     dtype = "float32"
     min_val = float("-0.16922")
@@ -1807,6 +1972,7 @@ class Program_weight_tensor_parameter_164:
 
 class Program_weight_tensor_parameter_165:
     name = "parameter_165"
+    original_name = "batch_norm2d_21.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.217268")
@@ -1818,6 +1984,7 @@ class Program_weight_tensor_parameter_165:
 
 class Program_weight_tensor_parameter_166:
     name = "parameter_166"
+    original_name = "batch_norm2d_21.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.0919655")
@@ -1829,6 +1996,7 @@ class Program_weight_tensor_parameter_166:
 
 class Program_weight_tensor_parameter_167:
     name = "parameter_167"
+    original_name = "batch_norm2d_21.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.00814545")
@@ -1840,6 +2008,7 @@ class Program_weight_tensor_parameter_167:
 
 class Program_weight_tensor_parameter_168:
     name = "parameter_168"
+    original_name = "batch_norm2d_21.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.257612")
@@ -1851,6 +2020,7 @@ class Program_weight_tensor_parameter_168:
 
 class Program_weight_tensor_parameter_169:
     name = "parameter_169"
+    original_name = "conv2d_21.w_0"
     shape = [128, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.166509")
@@ -1862,6 +2032,7 @@ class Program_weight_tensor_parameter_169:
 
 class Program_weight_tensor_parameter_170:
     name = "parameter_170"
+    original_name = "batch_norm2d_20.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.237501")
@@ -1873,6 +2044,7 @@ class Program_weight_tensor_parameter_170:
 
 class Program_weight_tensor_parameter_171:
     name = "parameter_171"
+    original_name = "batch_norm2d_20.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.139383")
@@ -1884,6 +2056,7 @@ class Program_weight_tensor_parameter_171:
 
 class Program_weight_tensor_parameter_172:
     name = "parameter_172"
+    original_name = "batch_norm2d_20.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("5.60519e-45")
@@ -1895,6 +2068,7 @@ class Program_weight_tensor_parameter_172:
 
 class Program_weight_tensor_parameter_173:
     name = "parameter_173"
+    original_name = "batch_norm2d_20.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.117918")
@@ -1906,6 +2080,7 @@ class Program_weight_tensor_parameter_173:
 
 class Program_weight_tensor_parameter_174:
     name = "parameter_174"
+    original_name = "conv2d_20.w_0"
     shape = [512, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.224215")
@@ -1917,6 +2092,7 @@ class Program_weight_tensor_parameter_174:
 
 class Program_weight_tensor_parameter_175:
     name = "parameter_175"
+    original_name = "batch_norm2d_19.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.24293")
@@ -1928,6 +2104,7 @@ class Program_weight_tensor_parameter_175:
 
 class Program_weight_tensor_parameter_176:
     name = "parameter_176"
+    original_name = "batch_norm2d_19.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.105289")
@@ -1939,6 +2116,7 @@ class Program_weight_tensor_parameter_176:
 
 class Program_weight_tensor_parameter_177:
     name = "parameter_177"
+    original_name = "batch_norm2d_19.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.00365003")
@@ -1950,6 +2128,7 @@ class Program_weight_tensor_parameter_177:
 
 class Program_weight_tensor_parameter_178:
     name = "parameter_178"
+    original_name = "batch_norm2d_19.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.254277")
@@ -1961,6 +2140,7 @@ class Program_weight_tensor_parameter_178:
 
 class Program_weight_tensor_parameter_179:
     name = "parameter_179"
+    original_name = "conv2d_19.w_0"
     shape = [128, 128, 3, 3]
     dtype = "float32"
     min_val = float("-0.180498")
@@ -1972,6 +2152,7 @@ class Program_weight_tensor_parameter_179:
 
 class Program_weight_tensor_parameter_180:
     name = "parameter_180"
+    original_name = "batch_norm2d_18.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.193473")
@@ -1983,6 +2164,7 @@ class Program_weight_tensor_parameter_180:
 
 class Program_weight_tensor_parameter_181:
     name = "parameter_181"
+    original_name = "batch_norm2d_18.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.10514")
@@ -1994,6 +2176,7 @@ class Program_weight_tensor_parameter_181:
 
 class Program_weight_tensor_parameter_182:
     name = "parameter_182"
+    original_name = "batch_norm2d_18.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.00566217")
@@ -2005,6 +2188,7 @@ class Program_weight_tensor_parameter_182:
 
 class Program_weight_tensor_parameter_183:
     name = "parameter_183"
+    original_name = "batch_norm2d_18.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.218979")
@@ -2016,6 +2200,7 @@ class Program_weight_tensor_parameter_183:
 
 class Program_weight_tensor_parameter_184:
     name = "parameter_184"
+    original_name = "conv2d_18.w_0"
     shape = [128, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.167322")
@@ -2027,6 +2212,7 @@ class Program_weight_tensor_parameter_184:
 
 class Program_weight_tensor_parameter_185:
     name = "parameter_185"
+    original_name = "batch_norm2d_17.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.246362")
@@ -2038,6 +2224,7 @@ class Program_weight_tensor_parameter_185:
 
 class Program_weight_tensor_parameter_186:
     name = "parameter_186"
+    original_name = "batch_norm2d_17.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.192972")
@@ -2049,6 +2236,7 @@ class Program_weight_tensor_parameter_186:
 
 class Program_weight_tensor_parameter_187:
     name = "parameter_187"
+    original_name = "batch_norm2d_17.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("5.60519e-45")
@@ -2060,6 +2248,7 @@ class Program_weight_tensor_parameter_187:
 
 class Program_weight_tensor_parameter_188:
     name = "parameter_188"
+    original_name = "batch_norm2d_17.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.127251")
@@ -2071,6 +2260,7 @@ class Program_weight_tensor_parameter_188:
 
 class Program_weight_tensor_parameter_189:
     name = "parameter_189"
+    original_name = "conv2d_17.w_0"
     shape = [512, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.326628")
@@ -2082,6 +2272,7 @@ class Program_weight_tensor_parameter_189:
 
 class Program_weight_tensor_parameter_190:
     name = "parameter_190"
+    original_name = "batch_norm2d_16.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.361239")
@@ -2093,6 +2284,7 @@ class Program_weight_tensor_parameter_190:
 
 class Program_weight_tensor_parameter_191:
     name = "parameter_191"
+    original_name = "batch_norm2d_16.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.108821")
@@ -2104,6 +2296,7 @@ class Program_weight_tensor_parameter_191:
 
 class Program_weight_tensor_parameter_192:
     name = "parameter_192"
+    original_name = "batch_norm2d_16.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.00205709")
@@ -2115,6 +2308,7 @@ class Program_weight_tensor_parameter_192:
 
 class Program_weight_tensor_parameter_193:
     name = "parameter_193"
+    original_name = "batch_norm2d_16.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.88215")
@@ -2126,6 +2320,7 @@ class Program_weight_tensor_parameter_193:
 
 class Program_weight_tensor_parameter_194:
     name = "parameter_194"
+    original_name = "conv2d_16.w_0"
     shape = [128, 128, 3, 3]
     dtype = "float32"
     min_val = float("-0.204917")
@@ -2137,6 +2332,7 @@ class Program_weight_tensor_parameter_194:
 
 class Program_weight_tensor_parameter_195:
     name = "parameter_195"
+    original_name = "batch_norm2d_15.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.338997")
@@ -2148,6 +2344,7 @@ class Program_weight_tensor_parameter_195:
 
 class Program_weight_tensor_parameter_196:
     name = "parameter_196"
+    original_name = "batch_norm2d_15.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.0665975")
@@ -2159,6 +2356,7 @@ class Program_weight_tensor_parameter_196:
 
 class Program_weight_tensor_parameter_197:
     name = "parameter_197"
+    original_name = "batch_norm2d_15.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.00275272")
@@ -2170,6 +2368,7 @@ class Program_weight_tensor_parameter_197:
 
 class Program_weight_tensor_parameter_198:
     name = "parameter_198"
+    original_name = "batch_norm2d_15.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.271973")
@@ -2181,6 +2380,7 @@ class Program_weight_tensor_parameter_198:
 
 class Program_weight_tensor_parameter_199:
     name = "parameter_199"
+    original_name = "conv2d_15.w_0"
     shape = [128, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.190376")
@@ -2192,6 +2392,7 @@ class Program_weight_tensor_parameter_199:
 
 class Program_weight_tensor_parameter_200:
     name = "parameter_200"
+    original_name = "batch_norm2d_14.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.174057")
@@ -2203,6 +2404,7 @@ class Program_weight_tensor_parameter_200:
 
 class Program_weight_tensor_parameter_201:
     name = "parameter_201"
+    original_name = "batch_norm2d_14.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.0848256")
@@ -2214,6 +2416,7 @@ class Program_weight_tensor_parameter_201:
 
 class Program_weight_tensor_parameter_202:
     name = "parameter_202"
+    original_name = "batch_norm2d_14.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("5.60519e-45")
@@ -2225,6 +2428,7 @@ class Program_weight_tensor_parameter_202:
 
 class Program_weight_tensor_parameter_203:
     name = "parameter_203"
+    original_name = "batch_norm2d_14.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.533149")
@@ -2236,6 +2440,7 @@ class Program_weight_tensor_parameter_203:
 
 class Program_weight_tensor_parameter_204:
     name = "parameter_204"
+    original_name = "conv2d_14.w_0"
     shape = [512, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.784791")
@@ -2247,6 +2452,7 @@ class Program_weight_tensor_parameter_204:
 
 class Program_weight_tensor_parameter_205:
     name = "parameter_205"
+    original_name = "batch_norm2d_13.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.174057")
@@ -2258,6 +2464,7 @@ class Program_weight_tensor_parameter_205:
 
 class Program_weight_tensor_parameter_206:
     name = "parameter_206"
+    original_name = "batch_norm2d_13.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.110713")
@@ -2269,6 +2476,7 @@ class Program_weight_tensor_parameter_206:
 
 class Program_weight_tensor_parameter_207:
     name = "parameter_207"
+    original_name = "batch_norm2d_13.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("5.60519e-45")
@@ -2280,6 +2488,7 @@ class Program_weight_tensor_parameter_207:
 
 class Program_weight_tensor_parameter_208:
     name = "parameter_208"
+    original_name = "batch_norm2d_13.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.415602")
@@ -2291,6 +2500,7 @@ class Program_weight_tensor_parameter_208:
 
 class Program_weight_tensor_parameter_209:
     name = "parameter_209"
+    original_name = "conv2d_13.w_0"
     shape = [512, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.296448")
@@ -2302,6 +2512,7 @@ class Program_weight_tensor_parameter_209:
 
 class Program_weight_tensor_parameter_210:
     name = "parameter_210"
+    original_name = "batch_norm2d_12.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.074944")
@@ -2313,6 +2524,7 @@ class Program_weight_tensor_parameter_210:
 
 class Program_weight_tensor_parameter_211:
     name = "parameter_211"
+    original_name = "batch_norm2d_12.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.152032")
@@ -2324,6 +2536,7 @@ class Program_weight_tensor_parameter_211:
 
 class Program_weight_tensor_parameter_212:
     name = "parameter_212"
+    original_name = "batch_norm2d_12.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.0115748")
@@ -2335,6 +2548,7 @@ class Program_weight_tensor_parameter_212:
 
 class Program_weight_tensor_parameter_213:
     name = "parameter_213"
+    original_name = "batch_norm2d_12.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.199519")
@@ -2346,6 +2560,7 @@ class Program_weight_tensor_parameter_213:
 
 class Program_weight_tensor_parameter_214:
     name = "parameter_214"
+    original_name = "conv2d_12.w_0"
     shape = [128, 128, 3, 3]
     dtype = "float32"
     min_val = float("-0.139431")
@@ -2357,6 +2572,7 @@ class Program_weight_tensor_parameter_214:
 
 class Program_weight_tensor_parameter_215:
     name = "parameter_215"
+    original_name = "batch_norm2d_11.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.254442")
@@ -2368,6 +2584,7 @@ class Program_weight_tensor_parameter_215:
 
 class Program_weight_tensor_parameter_216:
     name = "parameter_216"
+    original_name = "batch_norm2d_11.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("7.25214e-19")
@@ -2379,6 +2596,7 @@ class Program_weight_tensor_parameter_216:
 
 class Program_weight_tensor_parameter_217:
     name = "parameter_217"
+    original_name = "batch_norm2d_11.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("5.60519e-45")
@@ -2390,6 +2608,7 @@ class Program_weight_tensor_parameter_217:
 
 class Program_weight_tensor_parameter_218:
     name = "parameter_218"
+    original_name = "batch_norm2d_11.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.268614")
@@ -2401,6 +2620,7 @@ class Program_weight_tensor_parameter_218:
 
 class Program_weight_tensor_parameter_219:
     name = "parameter_219"
+    original_name = "conv2d_11.w_0"
     shape = [128, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.225231")
@@ -2412,6 +2632,7 @@ class Program_weight_tensor_parameter_219:
 
 class Program_weight_tensor_parameter_220:
     name = "parameter_220"
+    original_name = "batch_norm2d_10.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.164081")
@@ -2423,6 +2644,7 @@ class Program_weight_tensor_parameter_220:
 
 class Program_weight_tensor_parameter_221:
     name = "parameter_221"
+    original_name = "batch_norm2d_10.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.255304")
@@ -2434,6 +2656,7 @@ class Program_weight_tensor_parameter_221:
 
 class Program_weight_tensor_parameter_222:
     name = "parameter_222"
+    original_name = "batch_norm2d_10.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("7.13135e-05")
@@ -2445,6 +2668,7 @@ class Program_weight_tensor_parameter_222:
 
 class Program_weight_tensor_parameter_223:
     name = "parameter_223"
+    original_name = "batch_norm2d_10.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.134001")
@@ -2456,6 +2680,7 @@ class Program_weight_tensor_parameter_223:
 
 class Program_weight_tensor_parameter_224:
     name = "parameter_224"
+    original_name = "conv2d_10.w_0"
     shape = [256, 64, 1, 1]
     dtype = "float32"
     min_val = float("-0.325341")
@@ -2467,6 +2692,7 @@ class Program_weight_tensor_parameter_224:
 
 class Program_weight_tensor_parameter_225:
     name = "parameter_225"
+    original_name = "batch_norm2d_9.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -2476,6 +2702,7 @@ class Program_weight_tensor_parameter_225:
 
 class Program_weight_tensor_parameter_226:
     name = "parameter_226"
+    original_name = "batch_norm2d_9.w_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -2485,6 +2712,7 @@ class Program_weight_tensor_parameter_226:
 
 class Program_weight_tensor_parameter_227:
     name = "parameter_227"
+    original_name = "batch_norm2d_9.w_2"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -2494,6 +2722,7 @@ class Program_weight_tensor_parameter_227:
 
 class Program_weight_tensor_parameter_228:
     name = "parameter_228"
+    original_name = "batch_norm2d_9.w_1"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -2503,6 +2732,7 @@ class Program_weight_tensor_parameter_228:
 
 class Program_weight_tensor_parameter_229:
     name = "parameter_229"
+    original_name = "conv2d_9.w_0"
     shape = [64, 64, 3, 3]
     dtype = "float32"
     min_val = float("-0.260063")
@@ -2514,6 +2744,7 @@ class Program_weight_tensor_parameter_229:
 
 class Program_weight_tensor_parameter_230:
     name = "parameter_230"
+    original_name = "batch_norm2d_8.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -2523,6 +2754,7 @@ class Program_weight_tensor_parameter_230:
 
 class Program_weight_tensor_parameter_231:
     name = "parameter_231"
+    original_name = "batch_norm2d_8.w_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -2532,6 +2764,7 @@ class Program_weight_tensor_parameter_231:
 
 class Program_weight_tensor_parameter_232:
     name = "parameter_232"
+    original_name = "batch_norm2d_8.w_2"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -2541,6 +2774,7 @@ class Program_weight_tensor_parameter_232:
 
 class Program_weight_tensor_parameter_233:
     name = "parameter_233"
+    original_name = "batch_norm2d_8.w_1"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -2550,6 +2784,7 @@ class Program_weight_tensor_parameter_233:
 
 class Program_weight_tensor_parameter_234:
     name = "parameter_234"
+    original_name = "conv2d_8.w_0"
     shape = [64, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.188987")
@@ -2561,6 +2796,7 @@ class Program_weight_tensor_parameter_234:
 
 class Program_weight_tensor_parameter_235:
     name = "parameter_235"
+    original_name = "batch_norm2d_7.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.177844")
@@ -2572,6 +2808,7 @@ class Program_weight_tensor_parameter_235:
 
 class Program_weight_tensor_parameter_236:
     name = "parameter_236"
+    original_name = "batch_norm2d_7.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.20365")
@@ -2583,6 +2820,7 @@ class Program_weight_tensor_parameter_236:
 
 class Program_weight_tensor_parameter_237:
     name = "parameter_237"
+    original_name = "batch_norm2d_7.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("5.60519e-45")
@@ -2594,6 +2832,7 @@ class Program_weight_tensor_parameter_237:
 
 class Program_weight_tensor_parameter_238:
     name = "parameter_238"
+    original_name = "batch_norm2d_7.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.0838838")
@@ -2605,6 +2844,7 @@ class Program_weight_tensor_parameter_238:
 
 class Program_weight_tensor_parameter_239:
     name = "parameter_239"
+    original_name = "conv2d_7.w_0"
     shape = [256, 64, 1, 1]
     dtype = "float32"
     min_val = float("-0.252014")
@@ -2616,6 +2856,7 @@ class Program_weight_tensor_parameter_239:
 
 class Program_weight_tensor_parameter_240:
     name = "parameter_240"
+    original_name = "batch_norm2d_6.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -2625,6 +2866,7 @@ class Program_weight_tensor_parameter_240:
 
 class Program_weight_tensor_parameter_241:
     name = "parameter_241"
+    original_name = "batch_norm2d_6.w_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -2634,6 +2876,7 @@ class Program_weight_tensor_parameter_241:
 
 class Program_weight_tensor_parameter_242:
     name = "parameter_242"
+    original_name = "batch_norm2d_6.w_2"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -2643,6 +2886,7 @@ class Program_weight_tensor_parameter_242:
 
 class Program_weight_tensor_parameter_243:
     name = "parameter_243"
+    original_name = "batch_norm2d_6.w_1"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -2652,6 +2896,7 @@ class Program_weight_tensor_parameter_243:
 
 class Program_weight_tensor_parameter_244:
     name = "parameter_244"
+    original_name = "conv2d_6.w_0"
     shape = [64, 64, 3, 3]
     dtype = "float32"
     min_val = float("-0.277947")
@@ -2663,6 +2908,7 @@ class Program_weight_tensor_parameter_244:
 
 class Program_weight_tensor_parameter_245:
     name = "parameter_245"
+    original_name = "batch_norm2d_5.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -2672,6 +2918,7 @@ class Program_weight_tensor_parameter_245:
 
 class Program_weight_tensor_parameter_246:
     name = "parameter_246"
+    original_name = "batch_norm2d_5.w_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -2681,6 +2928,7 @@ class Program_weight_tensor_parameter_246:
 
 class Program_weight_tensor_parameter_247:
     name = "parameter_247"
+    original_name = "batch_norm2d_5.w_2"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -2690,6 +2938,7 @@ class Program_weight_tensor_parameter_247:
 
 class Program_weight_tensor_parameter_248:
     name = "parameter_248"
+    original_name = "batch_norm2d_5.w_1"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -2699,6 +2948,7 @@ class Program_weight_tensor_parameter_248:
 
 class Program_weight_tensor_parameter_249:
     name = "parameter_249"
+    original_name = "conv2d_5.w_0"
     shape = [64, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.340337")
@@ -2710,6 +2960,7 @@ class Program_weight_tensor_parameter_249:
 
 class Program_weight_tensor_parameter_250:
     name = "parameter_250"
+    original_name = "batch_norm2d_4.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.21502")
@@ -2721,6 +2972,7 @@ class Program_weight_tensor_parameter_250:
 
 class Program_weight_tensor_parameter_251:
     name = "parameter_251"
+    original_name = "batch_norm2d_4.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.140844")
@@ -2732,6 +2984,7 @@ class Program_weight_tensor_parameter_251:
 
 class Program_weight_tensor_parameter_252:
     name = "parameter_252"
+    original_name = "batch_norm2d_4.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("5.60519e-45")
@@ -2743,6 +2996,7 @@ class Program_weight_tensor_parameter_252:
 
 class Program_weight_tensor_parameter_253:
     name = "parameter_253"
+    original_name = "batch_norm2d_4.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.788895")
@@ -2754,6 +3008,7 @@ class Program_weight_tensor_parameter_253:
 
 class Program_weight_tensor_parameter_254:
     name = "parameter_254"
+    original_name = "conv2d_4.w_0"
     shape = [256, 64, 1, 1]
     dtype = "float32"
     min_val = float("-0.636716")
@@ -2765,6 +3020,7 @@ class Program_weight_tensor_parameter_254:
 
 class Program_weight_tensor_parameter_255:
     name = "parameter_255"
+    original_name = "batch_norm2d_3.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.21502")
@@ -2776,6 +3032,7 @@ class Program_weight_tensor_parameter_255:
 
 class Program_weight_tensor_parameter_256:
     name = "parameter_256"
+    original_name = "batch_norm2d_3.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.351499")
@@ -2787,6 +3044,7 @@ class Program_weight_tensor_parameter_256:
 
 class Program_weight_tensor_parameter_257:
     name = "parameter_257"
+    original_name = "batch_norm2d_3.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("5.60519e-45")
@@ -2798,6 +3056,7 @@ class Program_weight_tensor_parameter_257:
 
 class Program_weight_tensor_parameter_258:
     name = "parameter_258"
+    original_name = "batch_norm2d_3.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.222001")
@@ -2809,6 +3068,7 @@ class Program_weight_tensor_parameter_258:
 
 class Program_weight_tensor_parameter_259:
     name = "parameter_259"
+    original_name = "conv2d_3.w_0"
     shape = [256, 64, 1, 1]
     dtype = "float32"
     min_val = float("-0.416537")
@@ -2820,6 +3080,7 @@ class Program_weight_tensor_parameter_259:
 
 class Program_weight_tensor_parameter_260:
     name = "parameter_260"
+    original_name = "batch_norm2d_2.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -2829,6 +3090,7 @@ class Program_weight_tensor_parameter_260:
 
 class Program_weight_tensor_parameter_261:
     name = "parameter_261"
+    original_name = "batch_norm2d_2.w_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -2838,6 +3100,7 @@ class Program_weight_tensor_parameter_261:
 
 class Program_weight_tensor_parameter_262:
     name = "parameter_262"
+    original_name = "batch_norm2d_2.w_2"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -2847,6 +3110,7 @@ class Program_weight_tensor_parameter_262:
 
 class Program_weight_tensor_parameter_263:
     name = "parameter_263"
+    original_name = "batch_norm2d_2.w_1"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -2856,6 +3120,7 @@ class Program_weight_tensor_parameter_263:
 
 class Program_weight_tensor_parameter_264:
     name = "parameter_264"
+    original_name = "conv2d_2.w_0"
     shape = [64, 64, 3, 3]
     dtype = "float32"
     min_val = float("-0.367672")
@@ -2867,6 +3132,7 @@ class Program_weight_tensor_parameter_264:
 
 class Program_weight_tensor_parameter_265:
     name = "parameter_265"
+    original_name = "batch_norm2d_1.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -2876,6 +3142,7 @@ class Program_weight_tensor_parameter_265:
 
 class Program_weight_tensor_parameter_266:
     name = "parameter_266"
+    original_name = "batch_norm2d_1.w_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -2885,6 +3152,7 @@ class Program_weight_tensor_parameter_266:
 
 class Program_weight_tensor_parameter_267:
     name = "parameter_267"
+    original_name = "batch_norm2d_1.w_2"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -2894,6 +3162,7 @@ class Program_weight_tensor_parameter_267:
 
 class Program_weight_tensor_parameter_268:
     name = "parameter_268"
+    original_name = "batch_norm2d_1.w_1"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -2903,6 +3172,7 @@ class Program_weight_tensor_parameter_268:
 
 class Program_weight_tensor_parameter_269:
     name = "parameter_269"
+    original_name = "conv2d_1.w_0"
     shape = [64, 64, 1, 1]
     dtype = "float32"
     min_val = float("-0.628632")
@@ -2914,6 +3184,7 @@ class Program_weight_tensor_parameter_269:
 
 class Program_weight_tensor_parameter_270:
     name = "parameter_270"
+    original_name = "batch_norm2d_0.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -2923,6 +3194,7 @@ class Program_weight_tensor_parameter_270:
 
 class Program_weight_tensor_parameter_271:
     name = "parameter_271"
+    original_name = "batch_norm2d_0.w_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -2932,6 +3204,7 @@ class Program_weight_tensor_parameter_271:
 
 class Program_weight_tensor_parameter_272:
     name = "parameter_272"
+    original_name = "batch_norm2d_0.w_2"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -2941,6 +3214,7 @@ class Program_weight_tensor_parameter_272:
 
 class Program_weight_tensor_parameter_273:
     name = "parameter_273"
+    original_name = "batch_norm2d_0.w_1"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -2950,6 +3224,7 @@ class Program_weight_tensor_parameter_273:
 
 class Program_weight_tensor_parameter_274:
     name = "parameter_274"
+    original_name = "conv2d_0.w_0"
     shape = [64, 3, 7, 7]
     dtype = "float32"
     min_val = float("-0.593842")

--- a/paddle_samples/PaddleX/FasterRCNN-Swin-Tiny-FPN/subgraph_2/input_meta.py
+++ b/paddle_samples/PaddleX/FasterRCNN-Swin-Tiny-FPN/subgraph_2/input_meta.py
@@ -1,5 +1,6 @@
 class Program_weight_tensor_data_0:
     name = "data_0"
+    original_name = "param_36"
     shape = [169, 3]
     dtype = "float32"
     min_val = float("-7.94399")
@@ -11,6 +12,7 @@ class Program_weight_tensor_data_0:
 
 class Program_weight_tensor_data_1:
     name = "data_1"
+    original_name = "param_37"
     shape = [169, 3]
     dtype = "float32"
     min_val = float("-6.29996")
@@ -22,6 +24,7 @@ class Program_weight_tensor_data_1:
 
 class Program_weight_tensor_data_2:
     name = "data_2"
+    original_name = "param_38"
     shape = [169, 6]
     dtype = "float32"
     min_val = float("-4.81262")
@@ -33,6 +36,7 @@ class Program_weight_tensor_data_2:
 
 class Program_weight_tensor_data_3:
     name = "data_3"
+    original_name = "param_39"
     shape = [169, 6]
     dtype = "float32"
     min_val = float("-6.72356")
@@ -44,6 +48,7 @@ class Program_weight_tensor_data_3:
 
 class Program_weight_tensor_data_4:
     name = "data_4"
+    original_name = "param_40"
     shape = [169, 12]
     dtype = "float32"
     min_val = float("-7.57191")
@@ -55,6 +60,7 @@ class Program_weight_tensor_data_4:
 
 class Program_weight_tensor_data_5:
     name = "data_5"
+    original_name = "param_41"
     shape = [169, 12]
     dtype = "float32"
     min_val = float("-7.92046")
@@ -66,6 +72,7 @@ class Program_weight_tensor_data_5:
 
 class Program_weight_tensor_data_6:
     name = "data_6"
+    original_name = "param_42"
     shape = [169, 12]
     dtype = "float32"
     min_val = float("-8.59273")
@@ -77,6 +84,7 @@ class Program_weight_tensor_data_6:
 
 class Program_weight_tensor_data_7:
     name = "data_7"
+    original_name = "param_43"
     shape = [169, 12]
     dtype = "float32"
     min_val = float("-5.61264")
@@ -88,6 +96,7 @@ class Program_weight_tensor_data_7:
 
 class Program_weight_tensor_data_8:
     name = "data_8"
+    original_name = "param_44"
     shape = [169, 12]
     dtype = "float32"
     min_val = float("-7.91515")
@@ -99,6 +108,7 @@ class Program_weight_tensor_data_8:
 
 class Program_weight_tensor_data_9:
     name = "data_9"
+    original_name = "param_45"
     shape = [169, 12]
     dtype = "float32"
     min_val = float("-9.66441")
@@ -110,6 +120,7 @@ class Program_weight_tensor_data_9:
 
 class Program_weight_tensor_data_10:
     name = "data_10"
+    original_name = "param_46"
     shape = [169, 24]
     dtype = "float32"
     min_val = float("-11.2016")
@@ -121,6 +132,7 @@ class Program_weight_tensor_data_10:
 
 class Program_weight_tensor_data_11:
     name = "data_11"
+    original_name = "param_47"
     shape = [169, 24]
     dtype = "float32"
     min_val = float("-11.466")
@@ -132,6 +144,7 @@ class Program_weight_tensor_data_11:
 
 class Program_weight_tensor_data_12:
     name = "data_12"
+    original_name = "var_4537"
     shape = [2, 3, 992, 736]
     dtype = "float32"
     min_val = float("-2.10078")
@@ -143,6 +156,7 @@ class Program_weight_tensor_data_12:
 
 class Program_weight_tensor_data_13:
     name = "data_13"
+    original_name = "var_4587"
     shape = [49, 49]
     dtype = "int64"
     min_val = 0
@@ -152,6 +166,7 @@ class Program_weight_tensor_data_13:
 
 class Program_weight_tensor_data_14:
     name = "data_14"
+    original_name = "var_4632"
     shape = [49, 49]
     dtype = "int64"
     min_val = 0
@@ -161,6 +176,7 @@ class Program_weight_tensor_data_14:
 
 class Program_weight_tensor_data_15:
     name = "data_15"
+    original_name = "var_4728"
     shape = [49, 49]
     dtype = "int64"
     min_val = 0
@@ -170,6 +186,7 @@ class Program_weight_tensor_data_15:
 
 class Program_weight_tensor_data_16:
     name = "data_16"
+    original_name = "var_4785"
     shape = [49, 49]
     dtype = "int64"
     min_val = 0
@@ -179,6 +196,7 @@ class Program_weight_tensor_data_16:
 
 class Program_weight_tensor_data_17:
     name = "data_17"
+    original_name = "var_4881"
     shape = [49, 49]
     dtype = "int64"
     min_val = 0
@@ -188,6 +206,7 @@ class Program_weight_tensor_data_17:
 
 class Program_weight_tensor_data_18:
     name = "data_18"
+    original_name = "var_4938"
     shape = [49, 49]
     dtype = "int64"
     min_val = 0
@@ -197,6 +216,7 @@ class Program_weight_tensor_data_18:
 
 class Program_weight_tensor_data_19:
     name = "data_19"
+    original_name = "var_5000"
     shape = [49, 49]
     dtype = "int64"
     min_val = 0
@@ -206,6 +226,7 @@ class Program_weight_tensor_data_19:
 
 class Program_weight_tensor_data_20:
     name = "data_20"
+    original_name = "var_5057"
     shape = [49, 49]
     dtype = "int64"
     min_val = 0
@@ -215,6 +236,7 @@ class Program_weight_tensor_data_20:
 
 class Program_weight_tensor_data_21:
     name = "data_21"
+    original_name = "var_5119"
     shape = [49, 49]
     dtype = "int64"
     min_val = 0
@@ -224,6 +246,7 @@ class Program_weight_tensor_data_21:
 
 class Program_weight_tensor_data_22:
     name = "data_22"
+    original_name = "var_5176"
     shape = [49, 49]
     dtype = "int64"
     min_val = 0
@@ -233,6 +256,7 @@ class Program_weight_tensor_data_22:
 
 class Program_weight_tensor_data_23:
     name = "data_23"
+    original_name = "var_5272"
     shape = [49, 49]
     dtype = "int64"
     min_val = 0
@@ -242,6 +266,7 @@ class Program_weight_tensor_data_23:
 
 class Program_weight_tensor_data_24:
     name = "data_24"
+    original_name = "var_5329"
     shape = [49, 49]
     dtype = "int64"
     min_val = 0

--- a/paddle_samples/PaddleX/FasterRCNN-Swin-Tiny-FPN/subgraph_2/weight_meta.py
+++ b/paddle_samples/PaddleX/FasterRCNN-Swin-Tiny-FPN/subgraph_2/weight_meta.py
@@ -1,5 +1,6 @@
 class Program_weight_tensor_parameter_0:
     name = "parameter_0"
+    original_name = "layer_norm_31.b_0"
     shape = [768]
     dtype = "float32"
     min_val = float("-0.168752")
@@ -11,6 +12,7 @@ class Program_weight_tensor_parameter_0:
 
 class Program_weight_tensor_parameter_1:
     name = "parameter_1"
+    original_name = "layer_norm_31.w_0"
     shape = [768]
     dtype = "float32"
     min_val = float("0.560832")
@@ -22,6 +24,7 @@ class Program_weight_tensor_parameter_1:
 
 class Program_weight_tensor_parameter_2:
     name = "parameter_2"
+    original_name = "linear_50.b_0"
     shape = [768]
     dtype = "float32"
     min_val = float("-5.81437")
@@ -33,6 +36,7 @@ class Program_weight_tensor_parameter_2:
 
 class Program_weight_tensor_parameter_3:
     name = "parameter_3"
+    original_name = "linear_50.w_0"
     shape = [3072, 768]
     dtype = "float32"
     min_val = float("-1.44604")
@@ -44,6 +48,7 @@ class Program_weight_tensor_parameter_3:
 
 class Program_weight_tensor_parameter_4:
     name = "parameter_4"
+    original_name = "linear_49.b_0"
     shape = [3072]
     dtype = "float32"
     min_val = float("-1.20901")
@@ -55,6 +60,7 @@ class Program_weight_tensor_parameter_4:
 
 class Program_weight_tensor_parameter_5:
     name = "parameter_5"
+    original_name = "linear_49.w_0"
     shape = [768, 3072]
     dtype = "float32"
     min_val = float("-0.338838")
@@ -66,6 +72,7 @@ class Program_weight_tensor_parameter_5:
 
 class Program_weight_tensor_parameter_6:
     name = "parameter_6"
+    original_name = "layer_norm_27.b_0"
     shape = [768]
     dtype = "float32"
     min_val = float("-1.52521")
@@ -77,6 +84,7 @@ class Program_weight_tensor_parameter_6:
 
 class Program_weight_tensor_parameter_7:
     name = "parameter_7"
+    original_name = "layer_norm_27.w_0"
     shape = [768]
     dtype = "float32"
     min_val = float("0.00322733")
@@ -88,6 +96,7 @@ class Program_weight_tensor_parameter_7:
 
 class Program_weight_tensor_parameter_8:
     name = "parameter_8"
+    original_name = "linear_48.b_0"
     shape = [768]
     dtype = "float32"
     min_val = float("-8.84714")
@@ -99,6 +108,7 @@ class Program_weight_tensor_parameter_8:
 
 class Program_weight_tensor_parameter_9:
     name = "parameter_9"
+    original_name = "linear_48.w_0"
     shape = [768, 768]
     dtype = "float32"
     min_val = float("-0.795604")
@@ -110,6 +120,7 @@ class Program_weight_tensor_parameter_9:
 
 class Program_weight_tensor_parameter_10:
     name = "parameter_10"
+    original_name = "linear_47.b_0"
     shape = [2304]
     dtype = "float32"
     min_val = float("-2.15808")
@@ -121,6 +132,7 @@ class Program_weight_tensor_parameter_10:
 
 class Program_weight_tensor_parameter_11:
     name = "parameter_11"
+    original_name = "linear_47.w_0"
     shape = [768, 2304]
     dtype = "float32"
     min_val = float("-0.382868")
@@ -132,6 +144,7 @@ class Program_weight_tensor_parameter_11:
 
 class Program_weight_tensor_parameter_12:
     name = "parameter_12"
+    original_name = "layer_norm_26.b_0"
     shape = [768]
     dtype = "float32"
     min_val = float("-2.22171")
@@ -143,6 +156,7 @@ class Program_weight_tensor_parameter_12:
 
 class Program_weight_tensor_parameter_13:
     name = "parameter_13"
+    original_name = "layer_norm_26.w_0"
     shape = [768]
     dtype = "float32"
     min_val = float("0.00866107")
@@ -154,6 +168,7 @@ class Program_weight_tensor_parameter_13:
 
 class Program_weight_tensor_parameter_14:
     name = "parameter_14"
+    original_name = "linear_46.b_0"
     shape = [768]
     dtype = "float32"
     min_val = float("-1.74388")
@@ -165,6 +180,7 @@ class Program_weight_tensor_parameter_14:
 
 class Program_weight_tensor_parameter_15:
     name = "parameter_15"
+    original_name = "linear_46.w_0"
     shape = [3072, 768]
     dtype = "float32"
     min_val = float("-1.36221")
@@ -176,6 +192,7 @@ class Program_weight_tensor_parameter_15:
 
 class Program_weight_tensor_parameter_16:
     name = "parameter_16"
+    original_name = "linear_45.b_0"
     shape = [3072]
     dtype = "float32"
     min_val = float("-0.818577")
@@ -187,6 +204,7 @@ class Program_weight_tensor_parameter_16:
 
 class Program_weight_tensor_parameter_17:
     name = "parameter_17"
+    original_name = "linear_45.w_0"
     shape = [768, 3072]
     dtype = "float32"
     min_val = float("-0.373609")
@@ -198,6 +216,7 @@ class Program_weight_tensor_parameter_17:
 
 class Program_weight_tensor_parameter_18:
     name = "parameter_18"
+    original_name = "layer_norm_25.b_0"
     shape = [768]
     dtype = "float32"
     min_val = float("-2.63537")
@@ -209,6 +228,7 @@ class Program_weight_tensor_parameter_18:
 
 class Program_weight_tensor_parameter_19:
     name = "parameter_19"
+    original_name = "layer_norm_25.w_0"
     shape = [768]
     dtype = "float32"
     min_val = float("-0.184595")
@@ -220,6 +240,7 @@ class Program_weight_tensor_parameter_19:
 
 class Program_weight_tensor_parameter_20:
     name = "parameter_20"
+    original_name = "linear_44.b_0"
     shape = [768]
     dtype = "float32"
     min_val = float("-3.71362")
@@ -231,6 +252,7 @@ class Program_weight_tensor_parameter_20:
 
 class Program_weight_tensor_parameter_21:
     name = "parameter_21"
+    original_name = "linear_44.w_0"
     shape = [768, 768]
     dtype = "float32"
     min_val = float("-0.808131")
@@ -242,6 +264,7 @@ class Program_weight_tensor_parameter_21:
 
 class Program_weight_tensor_parameter_22:
     name = "parameter_22"
+    original_name = "linear_43.b_0"
     shape = [2304]
     dtype = "float32"
     min_val = float("-2.11018")
@@ -253,6 +276,7 @@ class Program_weight_tensor_parameter_22:
 
 class Program_weight_tensor_parameter_23:
     name = "parameter_23"
+    original_name = "linear_43.w_0"
     shape = [768, 2304]
     dtype = "float32"
     min_val = float("-0.276141")
@@ -264,6 +288,7 @@ class Program_weight_tensor_parameter_23:
 
 class Program_weight_tensor_parameter_24:
     name = "parameter_24"
+    original_name = "layer_norm_24.b_0"
     shape = [768]
     dtype = "float32"
     min_val = float("-1.36685")
@@ -275,6 +300,7 @@ class Program_weight_tensor_parameter_24:
 
 class Program_weight_tensor_parameter_25:
     name = "parameter_25"
+    original_name = "layer_norm_24.w_0"
     shape = [768]
     dtype = "float32"
     min_val = float("-0.00405681")
@@ -286,6 +312,7 @@ class Program_weight_tensor_parameter_25:
 
 class Program_weight_tensor_parameter_26:
     name = "parameter_26"
+    original_name = "layer_norm_30.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-0.141366")
@@ -297,6 +324,7 @@ class Program_weight_tensor_parameter_26:
 
 class Program_weight_tensor_parameter_27:
     name = "parameter_27"
+    original_name = "layer_norm_30.w_0"
     shape = [384]
     dtype = "float32"
     min_val = float("0.568525")
@@ -308,6 +336,7 @@ class Program_weight_tensor_parameter_27:
 
 class Program_weight_tensor_parameter_28:
     name = "parameter_28"
+    original_name = "linear_42.w_0"
     shape = [1536, 768]
     dtype = "float32"
     min_val = float("-0.710244")
@@ -319,6 +348,7 @@ class Program_weight_tensor_parameter_28:
 
 class Program_weight_tensor_parameter_29:
     name = "parameter_29"
+    original_name = "layer_norm_23.b_0"
     shape = [1536]
     dtype = "float32"
     min_val = float("-0.495965")
@@ -330,6 +360,7 @@ class Program_weight_tensor_parameter_29:
 
 class Program_weight_tensor_parameter_30:
     name = "parameter_30"
+    original_name = "layer_norm_23.w_0"
     shape = [1536]
     dtype = "float32"
     min_val = float("0.04972")
@@ -341,6 +372,7 @@ class Program_weight_tensor_parameter_30:
 
 class Program_weight_tensor_parameter_31:
     name = "parameter_31"
+    original_name = "linear_41.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-0.573887")
@@ -352,6 +384,7 @@ class Program_weight_tensor_parameter_31:
 
 class Program_weight_tensor_parameter_32:
     name = "parameter_32"
+    original_name = "linear_41.w_0"
     shape = [1536, 384]
     dtype = "float32"
     min_val = float("-1.25328")
@@ -363,6 +396,7 @@ class Program_weight_tensor_parameter_32:
 
 class Program_weight_tensor_parameter_33:
     name = "parameter_33"
+    original_name = "linear_40.b_0"
     shape = [1536]
     dtype = "float32"
     min_val = float("-2.81387")
@@ -374,6 +408,7 @@ class Program_weight_tensor_parameter_33:
 
 class Program_weight_tensor_parameter_34:
     name = "parameter_34"
+    original_name = "linear_40.w_0"
     shape = [384, 1536]
     dtype = "float32"
     min_val = float("-0.561875")
@@ -385,6 +420,7 @@ class Program_weight_tensor_parameter_34:
 
 class Program_weight_tensor_parameter_35:
     name = "parameter_35"
+    original_name = "layer_norm_22.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-1.59367")
@@ -396,6 +432,7 @@ class Program_weight_tensor_parameter_35:
 
 class Program_weight_tensor_parameter_36:
     name = "parameter_36"
+    original_name = "layer_norm_22.w_0"
     shape = [384]
     dtype = "float32"
     min_val = float("0.229563")
@@ -407,6 +444,7 @@ class Program_weight_tensor_parameter_36:
 
 class Program_weight_tensor_parameter_37:
     name = "parameter_37"
+    original_name = "linear_39.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-0.65046")
@@ -418,6 +456,7 @@ class Program_weight_tensor_parameter_37:
 
 class Program_weight_tensor_parameter_38:
     name = "parameter_38"
+    original_name = "linear_39.w_0"
     shape = [384, 384]
     dtype = "float32"
     min_val = float("-0.418149")
@@ -429,6 +468,7 @@ class Program_weight_tensor_parameter_38:
 
 class Program_weight_tensor_parameter_39:
     name = "parameter_39"
+    original_name = "linear_38.b_0"
     shape = [1152]
     dtype = "float32"
     min_val = float("-1.4413")
@@ -440,6 +480,7 @@ class Program_weight_tensor_parameter_39:
 
 class Program_weight_tensor_parameter_40:
     name = "parameter_40"
+    original_name = "linear_38.w_0"
     shape = [384, 1152]
     dtype = "float32"
     min_val = float("-0.342837")
@@ -451,6 +492,7 @@ class Program_weight_tensor_parameter_40:
 
 class Program_weight_tensor_parameter_41:
     name = "parameter_41"
+    original_name = "layer_norm_21.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-1.39739")
@@ -462,6 +504,7 @@ class Program_weight_tensor_parameter_41:
 
 class Program_weight_tensor_parameter_42:
     name = "parameter_42"
+    original_name = "layer_norm_21.w_0"
     shape = [384]
     dtype = "float32"
     min_val = float("0.222464")
@@ -473,6 +516,7 @@ class Program_weight_tensor_parameter_42:
 
 class Program_weight_tensor_parameter_43:
     name = "parameter_43"
+    original_name = "linear_37.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-0.583297")
@@ -484,6 +528,7 @@ class Program_weight_tensor_parameter_43:
 
 class Program_weight_tensor_parameter_44:
     name = "parameter_44"
+    original_name = "linear_37.w_0"
     shape = [1536, 384]
     dtype = "float32"
     min_val = float("-2.38054")
@@ -495,6 +540,7 @@ class Program_weight_tensor_parameter_44:
 
 class Program_weight_tensor_parameter_45:
     name = "parameter_45"
+    original_name = "linear_36.b_0"
     shape = [1536]
     dtype = "float32"
     min_val = float("-2.0459")
@@ -506,6 +552,7 @@ class Program_weight_tensor_parameter_45:
 
 class Program_weight_tensor_parameter_46:
     name = "parameter_46"
+    original_name = "linear_36.w_0"
     shape = [384, 1536]
     dtype = "float32"
     min_val = float("-0.431213")
@@ -517,6 +564,7 @@ class Program_weight_tensor_parameter_46:
 
 class Program_weight_tensor_parameter_47:
     name = "parameter_47"
+    original_name = "layer_norm_20.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-1.30487")
@@ -528,6 +576,7 @@ class Program_weight_tensor_parameter_47:
 
 class Program_weight_tensor_parameter_48:
     name = "parameter_48"
+    original_name = "layer_norm_20.w_0"
     shape = [384]
     dtype = "float32"
     min_val = float("0.22641")
@@ -539,6 +588,7 @@ class Program_weight_tensor_parameter_48:
 
 class Program_weight_tensor_parameter_49:
     name = "parameter_49"
+    original_name = "linear_35.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-0.767002")
@@ -550,6 +600,7 @@ class Program_weight_tensor_parameter_49:
 
 class Program_weight_tensor_parameter_50:
     name = "parameter_50"
+    original_name = "linear_35.w_0"
     shape = [384, 384]
     dtype = "float32"
     min_val = float("-0.359323")
@@ -561,6 +612,7 @@ class Program_weight_tensor_parameter_50:
 
 class Program_weight_tensor_parameter_51:
     name = "parameter_51"
+    original_name = "linear_34.b_0"
     shape = [1152]
     dtype = "float32"
     min_val = float("-2.19963")
@@ -572,6 +624,7 @@ class Program_weight_tensor_parameter_51:
 
 class Program_weight_tensor_parameter_52:
     name = "parameter_52"
+    original_name = "linear_34.w_0"
     shape = [384, 1152]
     dtype = "float32"
     min_val = float("-0.334977")
@@ -583,6 +636,7 @@ class Program_weight_tensor_parameter_52:
 
 class Program_weight_tensor_parameter_53:
     name = "parameter_53"
+    original_name = "layer_norm_19.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-1.07046")
@@ -594,6 +648,7 @@ class Program_weight_tensor_parameter_53:
 
 class Program_weight_tensor_parameter_54:
     name = "parameter_54"
+    original_name = "layer_norm_19.w_0"
     shape = [384]
     dtype = "float32"
     min_val = float("0.284299")
@@ -605,6 +660,7 @@ class Program_weight_tensor_parameter_54:
 
 class Program_weight_tensor_parameter_55:
     name = "parameter_55"
+    original_name = "linear_33.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-0.433301")
@@ -616,6 +672,7 @@ class Program_weight_tensor_parameter_55:
 
 class Program_weight_tensor_parameter_56:
     name = "parameter_56"
+    original_name = "linear_33.w_0"
     shape = [1536, 384]
     dtype = "float32"
     min_val = float("-1.82147")
@@ -627,6 +684,7 @@ class Program_weight_tensor_parameter_56:
 
 class Program_weight_tensor_parameter_57:
     name = "parameter_57"
+    original_name = "linear_32.b_0"
     shape = [1536]
     dtype = "float32"
     min_val = float("-1.51168")
@@ -638,6 +696,7 @@ class Program_weight_tensor_parameter_57:
 
 class Program_weight_tensor_parameter_58:
     name = "parameter_58"
+    original_name = "linear_32.w_0"
     shape = [384, 1536]
     dtype = "float32"
     min_val = float("-0.232466")
@@ -649,6 +708,7 @@ class Program_weight_tensor_parameter_58:
 
 class Program_weight_tensor_parameter_59:
     name = "parameter_59"
+    original_name = "layer_norm_18.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-1.15625")
@@ -660,6 +720,7 @@ class Program_weight_tensor_parameter_59:
 
 class Program_weight_tensor_parameter_60:
     name = "parameter_60"
+    original_name = "layer_norm_18.w_0"
     shape = [384]
     dtype = "float32"
     min_val = float("0.272542")
@@ -671,6 +732,7 @@ class Program_weight_tensor_parameter_60:
 
 class Program_weight_tensor_parameter_61:
     name = "parameter_61"
+    original_name = "linear_31.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-0.401789")
@@ -682,6 +744,7 @@ class Program_weight_tensor_parameter_61:
 
 class Program_weight_tensor_parameter_62:
     name = "parameter_62"
+    original_name = "linear_31.w_0"
     shape = [384, 384]
     dtype = "float32"
     min_val = float("-0.293648")
@@ -693,6 +756,7 @@ class Program_weight_tensor_parameter_62:
 
 class Program_weight_tensor_parameter_63:
     name = "parameter_63"
+    original_name = "linear_30.b_0"
     shape = [1152]
     dtype = "float32"
     min_val = float("-1.55252")
@@ -704,6 +768,7 @@ class Program_weight_tensor_parameter_63:
 
 class Program_weight_tensor_parameter_64:
     name = "parameter_64"
+    original_name = "linear_30.w_0"
     shape = [384, 1152]
     dtype = "float32"
     min_val = float("-0.442443")
@@ -715,6 +780,7 @@ class Program_weight_tensor_parameter_64:
 
 class Program_weight_tensor_parameter_65:
     name = "parameter_65"
+    original_name = "layer_norm_17.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-0.937845")
@@ -726,6 +792,7 @@ class Program_weight_tensor_parameter_65:
 
 class Program_weight_tensor_parameter_66:
     name = "parameter_66"
+    original_name = "layer_norm_17.w_0"
     shape = [384]
     dtype = "float32"
     min_val = float("0.312443")
@@ -737,6 +804,7 @@ class Program_weight_tensor_parameter_66:
 
 class Program_weight_tensor_parameter_67:
     name = "parameter_67"
+    original_name = "linear_29.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-0.354627")
@@ -748,6 +816,7 @@ class Program_weight_tensor_parameter_67:
 
 class Program_weight_tensor_parameter_68:
     name = "parameter_68"
+    original_name = "linear_29.w_0"
     shape = [1536, 384]
     dtype = "float32"
     min_val = float("-1.14078")
@@ -759,6 +828,7 @@ class Program_weight_tensor_parameter_68:
 
 class Program_weight_tensor_parameter_69:
     name = "parameter_69"
+    original_name = "linear_28.b_0"
     shape = [1536]
     dtype = "float32"
     min_val = float("-1.08429")
@@ -770,6 +840,7 @@ class Program_weight_tensor_parameter_69:
 
 class Program_weight_tensor_parameter_70:
     name = "parameter_70"
+    original_name = "linear_28.w_0"
     shape = [384, 1536]
     dtype = "float32"
     min_val = float("-0.236862")
@@ -781,6 +852,7 @@ class Program_weight_tensor_parameter_70:
 
 class Program_weight_tensor_parameter_71:
     name = "parameter_71"
+    original_name = "layer_norm_16.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-1.23882")
@@ -792,6 +864,7 @@ class Program_weight_tensor_parameter_71:
 
 class Program_weight_tensor_parameter_72:
     name = "parameter_72"
+    original_name = "layer_norm_16.w_0"
     shape = [384]
     dtype = "float32"
     min_val = float("0.279653")
@@ -803,6 +876,7 @@ class Program_weight_tensor_parameter_72:
 
 class Program_weight_tensor_parameter_73:
     name = "parameter_73"
+    original_name = "linear_27.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-0.644428")
@@ -814,6 +888,7 @@ class Program_weight_tensor_parameter_73:
 
 class Program_weight_tensor_parameter_74:
     name = "parameter_74"
+    original_name = "linear_27.w_0"
     shape = [384, 384]
     dtype = "float32"
     min_val = float("-0.236666")
@@ -825,6 +900,7 @@ class Program_weight_tensor_parameter_74:
 
 class Program_weight_tensor_parameter_75:
     name = "parameter_75"
+    original_name = "linear_26.b_0"
     shape = [1152]
     dtype = "float32"
     min_val = float("-1.56019")
@@ -836,6 +912,7 @@ class Program_weight_tensor_parameter_75:
 
 class Program_weight_tensor_parameter_76:
     name = "parameter_76"
+    original_name = "linear_26.w_0"
     shape = [384, 1152]
     dtype = "float32"
     min_val = float("-0.397211")
@@ -847,6 +924,7 @@ class Program_weight_tensor_parameter_76:
 
 class Program_weight_tensor_parameter_77:
     name = "parameter_77"
+    original_name = "layer_norm_15.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-0.754481")
@@ -858,6 +936,7 @@ class Program_weight_tensor_parameter_77:
 
 class Program_weight_tensor_parameter_78:
     name = "parameter_78"
+    original_name = "layer_norm_15.w_0"
     shape = [384]
     dtype = "float32"
     min_val = float("0.281965")
@@ -869,6 +948,7 @@ class Program_weight_tensor_parameter_78:
 
 class Program_weight_tensor_parameter_79:
     name = "parameter_79"
+    original_name = "linear_25.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-0.384184")
@@ -880,6 +960,7 @@ class Program_weight_tensor_parameter_79:
 
 class Program_weight_tensor_parameter_80:
     name = "parameter_80"
+    original_name = "linear_25.w_0"
     shape = [1536, 384]
     dtype = "float32"
     min_val = float("-0.571151")
@@ -891,6 +972,7 @@ class Program_weight_tensor_parameter_80:
 
 class Program_weight_tensor_parameter_81:
     name = "parameter_81"
+    original_name = "linear_24.b_0"
     shape = [1536]
     dtype = "float32"
     min_val = float("-1.19725")
@@ -902,6 +984,7 @@ class Program_weight_tensor_parameter_81:
 
 class Program_weight_tensor_parameter_82:
     name = "parameter_82"
+    original_name = "linear_24.w_0"
     shape = [384, 1536]
     dtype = "float32"
     min_val = float("-0.263039")
@@ -913,6 +996,7 @@ class Program_weight_tensor_parameter_82:
 
 class Program_weight_tensor_parameter_83:
     name = "parameter_83"
+    original_name = "layer_norm_14.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-1.20586")
@@ -924,6 +1008,7 @@ class Program_weight_tensor_parameter_83:
 
 class Program_weight_tensor_parameter_84:
     name = "parameter_84"
+    original_name = "layer_norm_14.w_0"
     shape = [384]
     dtype = "float32"
     min_val = float("0.293684")
@@ -935,6 +1020,7 @@ class Program_weight_tensor_parameter_84:
 
 class Program_weight_tensor_parameter_85:
     name = "parameter_85"
+    original_name = "linear_23.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-0.406677")
@@ -946,6 +1032,7 @@ class Program_weight_tensor_parameter_85:
 
 class Program_weight_tensor_parameter_86:
     name = "parameter_86"
+    original_name = "linear_23.w_0"
     shape = [384, 384]
     dtype = "float32"
     min_val = float("-0.211905")
@@ -957,6 +1044,7 @@ class Program_weight_tensor_parameter_86:
 
 class Program_weight_tensor_parameter_87:
     name = "parameter_87"
+    original_name = "linear_22.b_0"
     shape = [1152]
     dtype = "float32"
     min_val = float("-1.56963")
@@ -968,6 +1056,7 @@ class Program_weight_tensor_parameter_87:
 
 class Program_weight_tensor_parameter_88:
     name = "parameter_88"
+    original_name = "linear_22.w_0"
     shape = [384, 1152]
     dtype = "float32"
     min_val = float("-0.482257")
@@ -979,6 +1068,7 @@ class Program_weight_tensor_parameter_88:
 
 class Program_weight_tensor_parameter_89:
     name = "parameter_89"
+    original_name = "layer_norm_13.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-0.692796")
@@ -990,6 +1080,7 @@ class Program_weight_tensor_parameter_89:
 
 class Program_weight_tensor_parameter_90:
     name = "parameter_90"
+    original_name = "layer_norm_13.w_0"
     shape = [384]
     dtype = "float32"
     min_val = float("0.258539")
@@ -1001,6 +1092,7 @@ class Program_weight_tensor_parameter_90:
 
 class Program_weight_tensor_parameter_91:
     name = "parameter_91"
+    original_name = "linear_21.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-0.755557")
@@ -1012,6 +1104,7 @@ class Program_weight_tensor_parameter_91:
 
 class Program_weight_tensor_parameter_92:
     name = "parameter_92"
+    original_name = "linear_21.w_0"
     shape = [1536, 384]
     dtype = "float32"
     min_val = float("-0.26178")
@@ -1023,6 +1116,7 @@ class Program_weight_tensor_parameter_92:
 
 class Program_weight_tensor_parameter_93:
     name = "parameter_93"
+    original_name = "linear_20.b_0"
     shape = [1536]
     dtype = "float32"
     min_val = float("-1.29827")
@@ -1034,6 +1128,7 @@ class Program_weight_tensor_parameter_93:
 
 class Program_weight_tensor_parameter_94:
     name = "parameter_94"
+    original_name = "linear_20.w_0"
     shape = [384, 1536]
     dtype = "float32"
     min_val = float("-0.255692")
@@ -1045,6 +1140,7 @@ class Program_weight_tensor_parameter_94:
 
 class Program_weight_tensor_parameter_95:
     name = "parameter_95"
+    original_name = "layer_norm_12.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-1.18388")
@@ -1056,6 +1152,7 @@ class Program_weight_tensor_parameter_95:
 
 class Program_weight_tensor_parameter_96:
     name = "parameter_96"
+    original_name = "layer_norm_12.w_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-0.000973684")
@@ -1067,6 +1164,7 @@ class Program_weight_tensor_parameter_96:
 
 class Program_weight_tensor_parameter_97:
     name = "parameter_97"
+    original_name = "linear_19.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-0.788606")
@@ -1078,6 +1176,7 @@ class Program_weight_tensor_parameter_97:
 
 class Program_weight_tensor_parameter_98:
     name = "parameter_98"
+    original_name = "linear_19.w_0"
     shape = [384, 384]
     dtype = "float32"
     min_val = float("-0.383635")
@@ -1089,6 +1188,7 @@ class Program_weight_tensor_parameter_98:
 
 class Program_weight_tensor_parameter_99:
     name = "parameter_99"
+    original_name = "linear_18.b_0"
     shape = [1152]
     dtype = "float32"
     min_val = float("-1.74415")
@@ -1100,6 +1200,7 @@ class Program_weight_tensor_parameter_99:
 
 class Program_weight_tensor_parameter_100:
     name = "parameter_100"
+    original_name = "linear_18.w_0"
     shape = [384, 1152]
     dtype = "float32"
     min_val = float("-0.328353")
@@ -1111,6 +1212,7 @@ class Program_weight_tensor_parameter_100:
 
 class Program_weight_tensor_parameter_101:
     name = "parameter_101"
+    original_name = "layer_norm_11.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-0.469447")
@@ -1122,6 +1224,7 @@ class Program_weight_tensor_parameter_101:
 
 class Program_weight_tensor_parameter_102:
     name = "parameter_102"
+    original_name = "layer_norm_11.w_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-0.00110878")
@@ -1133,6 +1236,7 @@ class Program_weight_tensor_parameter_102:
 
 class Program_weight_tensor_parameter_103:
     name = "parameter_103"
+    original_name = "layer_norm_29.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.074831")
@@ -1144,6 +1248,7 @@ class Program_weight_tensor_parameter_103:
 
 class Program_weight_tensor_parameter_104:
     name = "parameter_104"
+    original_name = "layer_norm_29.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("0.536004")
@@ -1155,6 +1260,7 @@ class Program_weight_tensor_parameter_104:
 
 class Program_weight_tensor_parameter_105:
     name = "parameter_105"
+    original_name = "linear_17.w_0"
     shape = [768, 384]
     dtype = "float32"
     min_val = float("-0.181326")
@@ -1166,6 +1272,7 @@ class Program_weight_tensor_parameter_105:
 
 class Program_weight_tensor_parameter_106:
     name = "parameter_106"
+    original_name = "layer_norm_10.b_0"
     shape = [768]
     dtype = "float32"
     min_val = float("-0.769858")
@@ -1177,6 +1284,7 @@ class Program_weight_tensor_parameter_106:
 
 class Program_weight_tensor_parameter_107:
     name = "parameter_107"
+    original_name = "layer_norm_10.w_0"
     shape = [768]
     dtype = "float32"
     min_val = float("0.14506")
@@ -1188,6 +1296,7 @@ class Program_weight_tensor_parameter_107:
 
 class Program_weight_tensor_parameter_108:
     name = "parameter_108"
+    original_name = "linear_16.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.531828")
@@ -1199,6 +1308,7 @@ class Program_weight_tensor_parameter_108:
 
 class Program_weight_tensor_parameter_109:
     name = "parameter_109"
+    original_name = "linear_16.w_0"
     shape = [768, 192]
     dtype = "float32"
     min_val = float("-0.331664")
@@ -1210,6 +1320,7 @@ class Program_weight_tensor_parameter_109:
 
 class Program_weight_tensor_parameter_110:
     name = "parameter_110"
+    original_name = "linear_15.b_0"
     shape = [768]
     dtype = "float32"
     min_val = float("-1.22841")
@@ -1221,6 +1332,7 @@ class Program_weight_tensor_parameter_110:
 
 class Program_weight_tensor_parameter_111:
     name = "parameter_111"
+    original_name = "linear_15.w_0"
     shape = [192, 768]
     dtype = "float32"
     min_val = float("-0.337807")
@@ -1232,6 +1344,7 @@ class Program_weight_tensor_parameter_111:
 
 class Program_weight_tensor_parameter_112:
     name = "parameter_112"
+    original_name = "layer_norm_9.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-1.13742")
@@ -1243,6 +1356,7 @@ class Program_weight_tensor_parameter_112:
 
 class Program_weight_tensor_parameter_113:
     name = "parameter_113"
+    original_name = "layer_norm_9.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("0.689568")
@@ -1254,6 +1368,7 @@ class Program_weight_tensor_parameter_113:
 
 class Program_weight_tensor_parameter_114:
     name = "parameter_114"
+    original_name = "linear_14.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.400887")
@@ -1265,6 +1380,7 @@ class Program_weight_tensor_parameter_114:
 
 class Program_weight_tensor_parameter_115:
     name = "parameter_115"
+    original_name = "linear_14.w_0"
     shape = [192, 192]
     dtype = "float32"
     min_val = float("-0.204488")
@@ -1276,6 +1392,7 @@ class Program_weight_tensor_parameter_115:
 
 class Program_weight_tensor_parameter_116:
     name = "parameter_116"
+    original_name = "linear_13.b_0"
     shape = [576]
     dtype = "float32"
     min_val = float("-1.41262")
@@ -1287,6 +1404,7 @@ class Program_weight_tensor_parameter_116:
 
 class Program_weight_tensor_parameter_117:
     name = "parameter_117"
+    original_name = "linear_13.w_0"
     shape = [192, 576]
     dtype = "float32"
     min_val = float("-0.409732")
@@ -1298,6 +1416,7 @@ class Program_weight_tensor_parameter_117:
 
 class Program_weight_tensor_parameter_118:
     name = "parameter_118"
+    original_name = "layer_norm_8.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-1.36883")
@@ -1309,6 +1428,7 @@ class Program_weight_tensor_parameter_118:
 
 class Program_weight_tensor_parameter_119:
     name = "parameter_119"
+    original_name = "layer_norm_8.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("0.300175")
@@ -1320,6 +1440,7 @@ class Program_weight_tensor_parameter_119:
 
 class Program_weight_tensor_parameter_120:
     name = "parameter_120"
+    original_name = "linear_12.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.43221")
@@ -1331,6 +1452,7 @@ class Program_weight_tensor_parameter_120:
 
 class Program_weight_tensor_parameter_121:
     name = "parameter_121"
+    original_name = "linear_12.w_0"
     shape = [768, 192]
     dtype = "float32"
     min_val = float("-0.256229")
@@ -1342,6 +1464,7 @@ class Program_weight_tensor_parameter_121:
 
 class Program_weight_tensor_parameter_122:
     name = "parameter_122"
+    original_name = "linear_11.b_0"
     shape = [768]
     dtype = "float32"
     min_val = float("-1.27322")
@@ -1353,6 +1476,7 @@ class Program_weight_tensor_parameter_122:
 
 class Program_weight_tensor_parameter_123:
     name = "parameter_123"
+    original_name = "linear_11.w_0"
     shape = [192, 768]
     dtype = "float32"
     min_val = float("-0.514693")
@@ -1364,6 +1488,7 @@ class Program_weight_tensor_parameter_123:
 
 class Program_weight_tensor_parameter_124:
     name = "parameter_124"
+    original_name = "layer_norm_7.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.883769")
@@ -1375,6 +1500,7 @@ class Program_weight_tensor_parameter_124:
 
 class Program_weight_tensor_parameter_125:
     name = "parameter_125"
+    original_name = "layer_norm_7.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("0.257292")
@@ -1386,6 +1512,7 @@ class Program_weight_tensor_parameter_125:
 
 class Program_weight_tensor_parameter_126:
     name = "parameter_126"
+    original_name = "linear_10.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.37044")
@@ -1397,6 +1524,7 @@ class Program_weight_tensor_parameter_126:
 
 class Program_weight_tensor_parameter_127:
     name = "parameter_127"
+    original_name = "linear_10.w_0"
     shape = [192, 192]
     dtype = "float32"
     min_val = float("-0.185597")
@@ -1408,6 +1536,7 @@ class Program_weight_tensor_parameter_127:
 
 class Program_weight_tensor_parameter_128:
     name = "parameter_128"
+    original_name = "linear_9.b_0"
     shape = [576]
     dtype = "float32"
     min_val = float("-1.44885")
@@ -1419,6 +1548,7 @@ class Program_weight_tensor_parameter_128:
 
 class Program_weight_tensor_parameter_129:
     name = "parameter_129"
+    original_name = "linear_9.w_0"
     shape = [192, 576]
     dtype = "float32"
     min_val = float("-0.300921")
@@ -1430,6 +1560,7 @@ class Program_weight_tensor_parameter_129:
 
 class Program_weight_tensor_parameter_130:
     name = "parameter_130"
+    original_name = "layer_norm_6.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.790131")
@@ -1441,6 +1572,7 @@ class Program_weight_tensor_parameter_130:
 
 class Program_weight_tensor_parameter_131:
     name = "parameter_131"
+    original_name = "layer_norm_6.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("0.229522")
@@ -1452,6 +1584,7 @@ class Program_weight_tensor_parameter_131:
 
 class Program_weight_tensor_parameter_132:
     name = "parameter_132"
+    original_name = "layer_norm_28.b_0"
     shape = [96]
     dtype = "float32"
     min_val = float("-0.0532949")
@@ -1463,6 +1596,7 @@ class Program_weight_tensor_parameter_132:
 
 class Program_weight_tensor_parameter_133:
     name = "parameter_133"
+    original_name = "layer_norm_28.w_0"
     shape = [96]
     dtype = "float32"
     min_val = float("0.533986")
@@ -1474,6 +1608,7 @@ class Program_weight_tensor_parameter_133:
 
 class Program_weight_tensor_parameter_134:
     name = "parameter_134"
+    original_name = "linear_8.w_0"
     shape = [384, 192]
     dtype = "float32"
     min_val = float("-0.155877")
@@ -1485,6 +1620,7 @@ class Program_weight_tensor_parameter_134:
 
 class Program_weight_tensor_parameter_135:
     name = "parameter_135"
+    original_name = "layer_norm_5.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-0.619866")
@@ -1496,6 +1632,7 @@ class Program_weight_tensor_parameter_135:
 
 class Program_weight_tensor_parameter_136:
     name = "parameter_136"
+    original_name = "layer_norm_5.w_0"
     shape = [384]
     dtype = "float32"
     min_val = float("0.216642")
@@ -1507,6 +1644,7 @@ class Program_weight_tensor_parameter_136:
 
 class Program_weight_tensor_parameter_137:
     name = "parameter_137"
+    original_name = "linear_7.b_0"
     shape = [96]
     dtype = "float32"
     min_val = float("-1.05803")
@@ -1518,6 +1656,7 @@ class Program_weight_tensor_parameter_137:
 
 class Program_weight_tensor_parameter_138:
     name = "parameter_138"
+    original_name = "linear_7.w_0"
     shape = [384, 96]
     dtype = "float32"
     min_val = float("-0.42408")
@@ -1529,6 +1668,7 @@ class Program_weight_tensor_parameter_138:
 
 class Program_weight_tensor_parameter_139:
     name = "parameter_139"
+    original_name = "linear_6.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-1.18076")
@@ -1540,6 +1680,7 @@ class Program_weight_tensor_parameter_139:
 
 class Program_weight_tensor_parameter_140:
     name = "parameter_140"
+    original_name = "linear_6.w_0"
     shape = [96, 384]
     dtype = "float32"
     min_val = float("-0.342763")
@@ -1551,6 +1692,7 @@ class Program_weight_tensor_parameter_140:
 
 class Program_weight_tensor_parameter_141:
     name = "parameter_141"
+    original_name = "layer_norm_4.b_0"
     shape = [96]
     dtype = "float32"
     min_val = float("-0.635538")
@@ -1562,6 +1704,7 @@ class Program_weight_tensor_parameter_141:
 
 class Program_weight_tensor_parameter_142:
     name = "parameter_142"
+    original_name = "layer_norm_4.w_0"
     shape = [96]
     dtype = "float32"
     min_val = float("0.394198")
@@ -1573,6 +1716,7 @@ class Program_weight_tensor_parameter_142:
 
 class Program_weight_tensor_parameter_143:
     name = "parameter_143"
+    original_name = "linear_5.b_0"
     shape = [96]
     dtype = "float32"
     min_val = float("-0.300342")
@@ -1584,6 +1728,7 @@ class Program_weight_tensor_parameter_143:
 
 class Program_weight_tensor_parameter_144:
     name = "parameter_144"
+    original_name = "linear_5.w_0"
     shape = [96, 96]
     dtype = "float32"
     min_val = float("-0.266905")
@@ -1595,6 +1740,7 @@ class Program_weight_tensor_parameter_144:
 
 class Program_weight_tensor_parameter_145:
     name = "parameter_145"
+    original_name = "linear_4.b_0"
     shape = [288]
     dtype = "float32"
     min_val = float("-1.24375")
@@ -1606,6 +1752,7 @@ class Program_weight_tensor_parameter_145:
 
 class Program_weight_tensor_parameter_146:
     name = "parameter_146"
+    original_name = "linear_4.w_0"
     shape = [96, 288]
     dtype = "float32"
     min_val = float("-0.330478")
@@ -1617,6 +1764,7 @@ class Program_weight_tensor_parameter_146:
 
 class Program_weight_tensor_parameter_147:
     name = "parameter_147"
+    original_name = "layer_norm_3.b_0"
     shape = [96]
     dtype = "float32"
     min_val = float("-0.958977")
@@ -1628,6 +1776,7 @@ class Program_weight_tensor_parameter_147:
 
 class Program_weight_tensor_parameter_148:
     name = "parameter_148"
+    original_name = "layer_norm_3.w_0"
     shape = [96]
     dtype = "float32"
     min_val = float("0.257012")
@@ -1639,6 +1788,7 @@ class Program_weight_tensor_parameter_148:
 
 class Program_weight_tensor_parameter_149:
     name = "parameter_149"
+    original_name = "linear_3.b_0"
     shape = [96]
     dtype = "float32"
     min_val = float("-1.42525")
@@ -1650,6 +1800,7 @@ class Program_weight_tensor_parameter_149:
 
 class Program_weight_tensor_parameter_150:
     name = "parameter_150"
+    original_name = "linear_3.w_0"
     shape = [384, 96]
     dtype = "float32"
     min_val = float("-0.340986")
@@ -1661,6 +1812,7 @@ class Program_weight_tensor_parameter_150:
 
 class Program_weight_tensor_parameter_151:
     name = "parameter_151"
+    original_name = "linear_2.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-1.43489")
@@ -1672,6 +1824,7 @@ class Program_weight_tensor_parameter_151:
 
 class Program_weight_tensor_parameter_152:
     name = "parameter_152"
+    original_name = "linear_2.w_0"
     shape = [96, 384]
     dtype = "float32"
     min_val = float("-0.397543")
@@ -1683,6 +1836,7 @@ class Program_weight_tensor_parameter_152:
 
 class Program_weight_tensor_parameter_153:
     name = "parameter_153"
+    original_name = "layer_norm_2.b_0"
     shape = [96]
     dtype = "float32"
     min_val = float("-0.787766")
@@ -1694,6 +1848,7 @@ class Program_weight_tensor_parameter_153:
 
 class Program_weight_tensor_parameter_154:
     name = "parameter_154"
+    original_name = "layer_norm_2.w_0"
     shape = [96]
     dtype = "float32"
     min_val = float("0.437761")
@@ -1705,6 +1860,7 @@ class Program_weight_tensor_parameter_154:
 
 class Program_weight_tensor_parameter_155:
     name = "parameter_155"
+    original_name = "linear_1.b_0"
     shape = [96]
     dtype = "float32"
     min_val = float("-0.455284")
@@ -1716,6 +1872,7 @@ class Program_weight_tensor_parameter_155:
 
 class Program_weight_tensor_parameter_156:
     name = "parameter_156"
+    original_name = "linear_1.w_0"
     shape = [96, 96]
     dtype = "float32"
     min_val = float("-0.272615")
@@ -1727,6 +1884,7 @@ class Program_weight_tensor_parameter_156:
 
 class Program_weight_tensor_parameter_157:
     name = "parameter_157"
+    original_name = "linear_0.b_0"
     shape = [288]
     dtype = "float32"
     min_val = float("-1.33195")
@@ -1738,6 +1896,7 @@ class Program_weight_tensor_parameter_157:
 
 class Program_weight_tensor_parameter_158:
     name = "parameter_158"
+    original_name = "linear_0.w_0"
     shape = [96, 288]
     dtype = "float32"
     min_val = float("-0.544212")
@@ -1749,6 +1908,7 @@ class Program_weight_tensor_parameter_158:
 
 class Program_weight_tensor_parameter_159:
     name = "parameter_159"
+    original_name = "layer_norm_1.b_0"
     shape = [96]
     dtype = "float32"
     min_val = float("-0.588848")
@@ -1760,6 +1920,7 @@ class Program_weight_tensor_parameter_159:
 
 class Program_weight_tensor_parameter_160:
     name = "parameter_160"
+    original_name = "layer_norm_1.w_0"
     shape = [96]
     dtype = "float32"
     min_val = float("-0.000809221")
@@ -1771,6 +1932,7 @@ class Program_weight_tensor_parameter_160:
 
 class Program_weight_tensor_parameter_161:
     name = "parameter_161"
+    original_name = "layer_norm_0.b_0"
     shape = [96]
     dtype = "float32"
     min_val = float("-0.713992")
@@ -1782,6 +1944,7 @@ class Program_weight_tensor_parameter_161:
 
 class Program_weight_tensor_parameter_162:
     name = "parameter_162"
+    original_name = "layer_norm_0.w_0"
     shape = [96]
     dtype = "float32"
     min_val = float("-0.0182045")
@@ -1793,6 +1956,7 @@ class Program_weight_tensor_parameter_162:
 
 class Program_weight_tensor_parameter_163:
     name = "parameter_163"
+    original_name = "conv2d_0.b_0"
     shape = [96]
     dtype = "float32"
     min_val = float("-0.979757")
@@ -1804,6 +1968,7 @@ class Program_weight_tensor_parameter_163:
 
 class Program_weight_tensor_parameter_164:
     name = "parameter_164"
+    original_name = "conv2d_0.w_0"
     shape = [96, 3, 4, 4]
     dtype = "float32"
     min_val = float("-0.239188")

--- a/paddle_samples/PaddleX/Mask-RT-DETR-S/subgraph_14/input_meta.py
+++ b/paddle_samples/PaddleX/Mask-RT-DETR-S/subgraph_14/input_meta.py
@@ -1,5 +1,6 @@
 class Program_weight_tensor_data_0:
     name = "data_0"
+    original_name = "param_48"
     shape = [256, 768]
     dtype = "float32"
     min_val = float("-0.443238")
@@ -11,6 +12,7 @@ class Program_weight_tensor_data_0:
 
 class Program_weight_tensor_data_1:
     name = "data_1"
+    original_name = "param_49"
     shape = [768]
     dtype = "float32"
     min_val = float("-0.256503")
@@ -22,6 +24,7 @@ class Program_weight_tensor_data_1:
 
 class Program_weight_tensor_data_2:
     name = "data_2"
+    original_name = "param_50"
     shape = [256, 768]
     dtype = "float32"
     min_val = float("-0.42865")
@@ -33,6 +36,7 @@ class Program_weight_tensor_data_2:
 
 class Program_weight_tensor_data_3:
     name = "data_3"
+    original_name = "param_51"
     shape = [768]
     dtype = "float32"
     min_val = float("-0.203861")
@@ -44,6 +48,7 @@ class Program_weight_tensor_data_3:
 
 class Program_weight_tensor_data_4:
     name = "data_4"
+    original_name = "param_52"
     shape = [256, 768]
     dtype = "float32"
     min_val = float("-0.457353")
@@ -55,6 +60,7 @@ class Program_weight_tensor_data_4:
 
 class Program_weight_tensor_data_5:
     name = "data_5"
+    original_name = "param_53"
     shape = [768]
     dtype = "float32"
     min_val = float("-0.173776")
@@ -66,6 +72,7 @@ class Program_weight_tensor_data_5:
 
 class Program_weight_tensor_data_6:
     name = "data_6"
+    original_name = "param_54"
     shape = [256, 768]
     dtype = "float32"
     min_val = float("-0.440406")
@@ -77,6 +84,7 @@ class Program_weight_tensor_data_6:
 
 class Program_weight_tensor_data_7:
     name = "data_7"
+    original_name = "param_55"
     shape = [768]
     dtype = "float32"
     min_val = float("-0.132557")
@@ -88,6 +96,7 @@ class Program_weight_tensor_data_7:
 
 class Program_weight_tensor_data_8:
     name = "data_8"
+    original_name = "param_56"
     shape = [256, 768]
     dtype = "float32"
     min_val = float("-0.439901")
@@ -99,6 +108,7 @@ class Program_weight_tensor_data_8:
 
 class Program_weight_tensor_data_9:
     name = "data_9"
+    original_name = "param_57"
     shape = [768]
     dtype = "float32"
     min_val = float("-0.0943525")
@@ -110,6 +120,7 @@ class Program_weight_tensor_data_9:
 
 class Program_weight_tensor_data_10:
     name = "data_10"
+    original_name = "param_58"
     shape = [256, 768]
     dtype = "float32"
     min_val = float("-0.409097")
@@ -121,6 +132,7 @@ class Program_weight_tensor_data_10:
 
 class Program_weight_tensor_data_11:
     name = "data_11"
+    original_name = "param_59"
     shape = [768]
     dtype = "float32"
     min_val = float("-0.0834445")
@@ -132,6 +144,7 @@ class Program_weight_tensor_data_11:
 
 class Program_weight_tensor_data_12:
     name = "data_12"
+    original_name = "args_12"
     shape = []
     dtype = "int64"
     data = [160]
@@ -139,6 +152,7 @@ class Program_weight_tensor_data_12:
 
 class Program_weight_tensor_data_13:
     name = "data_13"
+    original_name = "args_13"
     shape = []
     dtype = "int64"
     data = [160]
@@ -146,6 +160,7 @@ class Program_weight_tensor_data_13:
 
 class Program_weight_tensor_data_14:
     name = "data_14"
+    original_name = "var_15367"
     shape = [1, 256, 80, 80]
     dtype = "float32"
     min_val = float("-0.278465")
@@ -157,6 +172,7 @@ class Program_weight_tensor_data_14:
 
 class Program_weight_tensor_data_15:
     name = "data_15"
+    original_name = "var_15368"
     shape = [1, 256, 40, 40]
     dtype = "float32"
     min_val = float("-0.278465")
@@ -168,6 +184,7 @@ class Program_weight_tensor_data_15:
 
 class Program_weight_tensor_data_16:
     name = "data_16"
+    original_name = "var_15369"
     shape = [1, 256, 20, 20]
     dtype = "float32"
     min_val = float("-0.278465")
@@ -179,6 +196,7 @@ class Program_weight_tensor_data_16:
 
 class Program_weight_tensor_data_17:
     name = "data_17"
+    original_name = "var_15370"
     shape = [1, 128, 160, 160]
     dtype = "float32"
     min_val = float("-8.1605")
@@ -190,8 +208,10 @@ class Program_weight_tensor_data_17:
 
 class Program_weight_tensor_data_18:
     name = "data_18"
+    original_name = "var_15374"
     shape = [1, 3, 640, 640]
     dtype = "float32"
+    min_val = float("0.0")
     max_val = float("1.0")
     mean = float("0.478072")
     std = float("0.264937")
@@ -200,6 +220,7 @@ class Program_weight_tensor_data_18:
 
 class Program_weight_tensor_data_19:
     name = "data_19"
+    original_name = "var_15375"
     shape = [1, 2]
     dtype = "float32"
     data = [640.0, 640.0]
@@ -207,6 +228,7 @@ class Program_weight_tensor_data_19:
 
 class Program_weight_tensor_data_20:
     name = "data_20"
+    original_name = "var_15376"
     shape = [1, 2]
     dtype = "float32"
     data = [0.8, 0.710322]
@@ -214,6 +236,7 @@ class Program_weight_tensor_data_20:
 
 class Program_weight_tensor_data_21:
     name = "data_21"
+    original_name = "var_15404"
     shape = [1, 8400, 4]
     dtype = "float32"
     min_val = float("-4.36945")
@@ -225,6 +248,7 @@ class Program_weight_tensor_data_21:
 
 class Program_weight_tensor_data_22:
     name = "data_22"
+    original_name = "var_15405"
     shape = [1, 8400, 1]
     dtype = "bool"
     min_val = 0

--- a/paddle_samples/PaddleX/Mask-RT-DETR-S/subgraph_14/weight_meta.py
+++ b/paddle_samples/PaddleX/Mask-RT-DETR-S/subgraph_14/weight_meta.py
@@ -1,5 +1,6 @@
 class Program_weight_tensor_parameter_0:
     name = "parameter_0"
+    original_name = "layer_norm_4.b_0_deepcopy_143"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.257077")
@@ -11,6 +12,7 @@ class Program_weight_tensor_parameter_0:
 
 class Program_weight_tensor_parameter_1:
     name = "parameter_1"
+    original_name = "layer_norm_4.w_0_deepcopy_142"
     shape = [256]
     dtype = "float32"
     min_val = float("0.681366")
@@ -22,6 +24,7 @@ class Program_weight_tensor_parameter_1:
 
 class Program_weight_tensor_parameter_2:
     name = "parameter_2"
+    original_name = "linear_9.b_0_deepcopy_141"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.225948")
@@ -33,6 +36,7 @@ class Program_weight_tensor_parameter_2:
 
 class Program_weight_tensor_parameter_3:
     name = "parameter_3"
+    original_name = "linear_9.w_0_deepcopy_140"
     shape = [1024, 256]
     dtype = "float32"
     min_val = float("-0.479769")
@@ -44,6 +48,7 @@ class Program_weight_tensor_parameter_3:
 
 class Program_weight_tensor_parameter_4:
     name = "parameter_4"
+    original_name = "linear_8.b_0_deepcopy_139"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.175478")
@@ -55,6 +60,7 @@ class Program_weight_tensor_parameter_4:
 
 class Program_weight_tensor_parameter_5:
     name = "parameter_5"
+    original_name = "linear_8.w_0_deepcopy_138"
     shape = [256, 1024]
     dtype = "float32"
     min_val = float("-0.394211")
@@ -66,6 +72,7 @@ class Program_weight_tensor_parameter_5:
 
 class Program_weight_tensor_parameter_6:
     name = "parameter_6"
+    original_name = "layer_norm_3.b_0_deepcopy_137"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.148705")
@@ -77,6 +84,7 @@ class Program_weight_tensor_parameter_6:
 
 class Program_weight_tensor_parameter_7:
     name = "parameter_7"
+    original_name = "layer_norm_3.w_0_deepcopy_136"
     shape = [256]
     dtype = "float32"
     min_val = float("0.811608")
@@ -88,6 +96,7 @@ class Program_weight_tensor_parameter_7:
 
 class Program_weight_tensor_parameter_8:
     name = "parameter_8"
+    original_name = "linear_7.b_0_deepcopy_135"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.1688")
@@ -99,6 +108,7 @@ class Program_weight_tensor_parameter_8:
 
 class Program_weight_tensor_parameter_9:
     name = "parameter_9"
+    original_name = "linear_7.w_0_deepcopy_134"
     shape = [256, 256]
     dtype = "float32"
     min_val = float("-0.296662")
@@ -110,6 +120,7 @@ class Program_weight_tensor_parameter_9:
 
 class Program_weight_tensor_parameter_10:
     name = "parameter_10"
+    original_name = "linear_5.b_0_deepcopy_131"
     shape = [96]
     dtype = "float32"
     min_val = float("-0.102205")
@@ -121,6 +132,7 @@ class Program_weight_tensor_parameter_10:
 
 class Program_weight_tensor_parameter_11:
     name = "parameter_11"
+    original_name = "linear_5.w_0_deepcopy_130"
     shape = [256, 96]
     dtype = "float32"
     min_val = float("-0.434342")
@@ -132,6 +144,7 @@ class Program_weight_tensor_parameter_11:
 
 class Program_weight_tensor_parameter_12:
     name = "parameter_12"
+    original_name = "linear_4.b_0_deepcopy_129"
     shape = [192]
     dtype = "float32"
     min_val = float("-4.2661")
@@ -143,6 +156,7 @@ class Program_weight_tensor_parameter_12:
 
 class Program_weight_tensor_parameter_13:
     name = "parameter_13"
+    original_name = "linear_4.w_0_deepcopy_128"
     shape = [256, 192]
     dtype = "float32"
     min_val = float("-0.534478")
@@ -154,6 +168,7 @@ class Program_weight_tensor_parameter_13:
 
 class Program_weight_tensor_parameter_14:
     name = "parameter_14"
+    original_name = "linear_6.b_0_deepcopy_133"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.0804182")
@@ -165,6 +180,7 @@ class Program_weight_tensor_parameter_14:
 
 class Program_weight_tensor_parameter_15:
     name = "parameter_15"
+    original_name = "linear_6.w_0_deepcopy_132"
     shape = [256, 256]
     dtype = "float32"
     min_val = float("-0.274237")
@@ -176,6 +192,7 @@ class Program_weight_tensor_parameter_15:
 
 class Program_weight_tensor_parameter_16:
     name = "parameter_16"
+    original_name = "layer_norm_2.b_0_deepcopy_127"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.166629")
@@ -187,6 +204,7 @@ class Program_weight_tensor_parameter_16:
 
 class Program_weight_tensor_parameter_17:
     name = "parameter_17"
+    original_name = "layer_norm_2.w_0_deepcopy_126"
     shape = [256]
     dtype = "float32"
     min_val = float("0.96747")
@@ -198,6 +216,7 @@ class Program_weight_tensor_parameter_17:
 
 class Program_weight_tensor_parameter_18:
     name = "parameter_18"
+    original_name = "linear_3.b_0_deepcopy_125"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.5991")
@@ -209,6 +228,7 @@ class Program_weight_tensor_parameter_18:
 
 class Program_weight_tensor_parameter_19:
     name = "parameter_19"
+    original_name = "linear_3.w_0_deepcopy_124"
     shape = [256, 256]
     dtype = "float32"
     min_val = float("-0.506166")
@@ -220,6 +240,7 @@ class Program_weight_tensor_parameter_19:
 
 class Program_weight_tensor_parameter_20:
     name = "parameter_20"
+    original_name = "layer_norm_4.b_0_deepcopy_121"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.166846")
@@ -231,6 +252,7 @@ class Program_weight_tensor_parameter_20:
 
 class Program_weight_tensor_parameter_21:
     name = "parameter_21"
+    original_name = "layer_norm_4.w_0_deepcopy_120"
     shape = [256]
     dtype = "float32"
     min_val = float("0.680942")
@@ -242,6 +264,7 @@ class Program_weight_tensor_parameter_21:
 
 class Program_weight_tensor_parameter_22:
     name = "parameter_22"
+    original_name = "linear_9.b_0_deepcopy_119"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.171694")
@@ -253,6 +276,7 @@ class Program_weight_tensor_parameter_22:
 
 class Program_weight_tensor_parameter_23:
     name = "parameter_23"
+    original_name = "linear_9.w_0_deepcopy_118"
     shape = [1024, 256]
     dtype = "float32"
     min_val = float("-0.386215")
@@ -264,6 +288,7 @@ class Program_weight_tensor_parameter_23:
 
 class Program_weight_tensor_parameter_24:
     name = "parameter_24"
+    original_name = "linear_8.b_0_deepcopy_117"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.17664")
@@ -275,6 +300,7 @@ class Program_weight_tensor_parameter_24:
 
 class Program_weight_tensor_parameter_25:
     name = "parameter_25"
+    original_name = "linear_8.w_0_deepcopy_116"
     shape = [256, 1024]
     dtype = "float32"
     min_val = float("-0.372825")
@@ -286,6 +312,7 @@ class Program_weight_tensor_parameter_25:
 
 class Program_weight_tensor_parameter_26:
     name = "parameter_26"
+    original_name = "layer_norm_3.b_0_deepcopy_115"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.125284")
@@ -297,6 +324,7 @@ class Program_weight_tensor_parameter_26:
 
 class Program_weight_tensor_parameter_27:
     name = "parameter_27"
+    original_name = "layer_norm_3.w_0_deepcopy_114"
     shape = [256]
     dtype = "float32"
     min_val = float("0.859133")
@@ -308,6 +336,7 @@ class Program_weight_tensor_parameter_27:
 
 class Program_weight_tensor_parameter_28:
     name = "parameter_28"
+    original_name = "linear_7.b_0_deepcopy_113"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.139522")
@@ -319,6 +348,7 @@ class Program_weight_tensor_parameter_28:
 
 class Program_weight_tensor_parameter_29:
     name = "parameter_29"
+    original_name = "linear_7.w_0_deepcopy_112"
     shape = [256, 256]
     dtype = "float32"
     min_val = float("-0.315115")
@@ -330,6 +360,7 @@ class Program_weight_tensor_parameter_29:
 
 class Program_weight_tensor_parameter_30:
     name = "parameter_30"
+    original_name = "linear_5.b_0_deepcopy_109"
     shape = [96]
     dtype = "float32"
     min_val = float("-0.065347")
@@ -341,6 +372,7 @@ class Program_weight_tensor_parameter_30:
 
 class Program_weight_tensor_parameter_31:
     name = "parameter_31"
+    original_name = "linear_5.w_0_deepcopy_108"
     shape = [256, 96]
     dtype = "float32"
     min_val = float("-0.347224")
@@ -352,6 +384,7 @@ class Program_weight_tensor_parameter_31:
 
 class Program_weight_tensor_parameter_32:
     name = "parameter_32"
+    original_name = "linear_4.b_0_deepcopy_107"
     shape = [192]
     dtype = "float32"
     min_val = float("-4.22649")
@@ -363,6 +396,7 @@ class Program_weight_tensor_parameter_32:
 
 class Program_weight_tensor_parameter_33:
     name = "parameter_33"
+    original_name = "linear_4.w_0_deepcopy_106"
     shape = [256, 192]
     dtype = "float32"
     min_val = float("-0.483596")
@@ -374,6 +408,7 @@ class Program_weight_tensor_parameter_33:
 
 class Program_weight_tensor_parameter_34:
     name = "parameter_34"
+    original_name = "linear_6.b_0_deepcopy_111"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.176126")
@@ -385,6 +420,7 @@ class Program_weight_tensor_parameter_34:
 
 class Program_weight_tensor_parameter_35:
     name = "parameter_35"
+    original_name = "linear_6.w_0_deepcopy_110"
     shape = [256, 256]
     dtype = "float32"
     min_val = float("-0.312742")
@@ -396,6 +432,7 @@ class Program_weight_tensor_parameter_35:
 
 class Program_weight_tensor_parameter_36:
     name = "parameter_36"
+    original_name = "layer_norm_2.b_0_deepcopy_105"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.173981")
@@ -407,6 +444,7 @@ class Program_weight_tensor_parameter_36:
 
 class Program_weight_tensor_parameter_37:
     name = "parameter_37"
+    original_name = "layer_norm_2.w_0_deepcopy_104"
     shape = [256]
     dtype = "float32"
     min_val = float("0.836381")
@@ -418,6 +456,7 @@ class Program_weight_tensor_parameter_37:
 
 class Program_weight_tensor_parameter_38:
     name = "parameter_38"
+    original_name = "linear_3.b_0_deepcopy_103"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.232186")
@@ -429,6 +468,7 @@ class Program_weight_tensor_parameter_38:
 
 class Program_weight_tensor_parameter_39:
     name = "parameter_39"
+    original_name = "linear_3.w_0_deepcopy_102"
     shape = [256, 256]
     dtype = "float32"
     min_val = float("-0.323358")
@@ -440,6 +480,7 @@ class Program_weight_tensor_parameter_39:
 
 class Program_weight_tensor_parameter_40:
     name = "parameter_40"
+    original_name = "layer_norm_4.b_0_deepcopy_99"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.119385")
@@ -451,6 +492,7 @@ class Program_weight_tensor_parameter_40:
 
 class Program_weight_tensor_parameter_41:
     name = "parameter_41"
+    original_name = "layer_norm_4.w_0_deepcopy_98"
     shape = [256]
     dtype = "float32"
     min_val = float("0.703915")
@@ -462,6 +504,7 @@ class Program_weight_tensor_parameter_41:
 
 class Program_weight_tensor_parameter_42:
     name = "parameter_42"
+    original_name = "linear_9.b_0_deepcopy_97"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.112626")
@@ -473,6 +516,7 @@ class Program_weight_tensor_parameter_42:
 
 class Program_weight_tensor_parameter_43:
     name = "parameter_43"
+    original_name = "linear_9.w_0_deepcopy_96"
     shape = [1024, 256]
     dtype = "float32"
     min_val = float("-0.429047")
@@ -484,6 +528,7 @@ class Program_weight_tensor_parameter_43:
 
 class Program_weight_tensor_parameter_44:
     name = "parameter_44"
+    original_name = "linear_8.b_0_deepcopy_95"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.207784")
@@ -495,6 +540,7 @@ class Program_weight_tensor_parameter_44:
 
 class Program_weight_tensor_parameter_45:
     name = "parameter_45"
+    original_name = "linear_8.w_0_deepcopy_94"
     shape = [256, 1024]
     dtype = "float32"
     min_val = float("-0.392619")
@@ -506,6 +552,7 @@ class Program_weight_tensor_parameter_45:
 
 class Program_weight_tensor_parameter_46:
     name = "parameter_46"
+    original_name = "layer_norm_3.b_0_deepcopy_93"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.140992")
@@ -517,6 +564,7 @@ class Program_weight_tensor_parameter_46:
 
 class Program_weight_tensor_parameter_47:
     name = "parameter_47"
+    original_name = "layer_norm_3.w_0_deepcopy_92"
     shape = [256]
     dtype = "float32"
     min_val = float("0.904747")
@@ -528,6 +576,7 @@ class Program_weight_tensor_parameter_47:
 
 class Program_weight_tensor_parameter_48:
     name = "parameter_48"
+    original_name = "linear_7.b_0_deepcopy_91"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.134226")
@@ -539,6 +588,7 @@ class Program_weight_tensor_parameter_48:
 
 class Program_weight_tensor_parameter_49:
     name = "parameter_49"
+    original_name = "linear_7.w_0_deepcopy_90"
     shape = [256, 256]
     dtype = "float32"
     min_val = float("-0.331404")
@@ -550,6 +600,7 @@ class Program_weight_tensor_parameter_49:
 
 class Program_weight_tensor_parameter_50:
     name = "parameter_50"
+    original_name = "linear_5.b_0_deepcopy_87"
     shape = [96]
     dtype = "float32"
     min_val = float("-0.210059")
@@ -561,6 +612,7 @@ class Program_weight_tensor_parameter_50:
 
 class Program_weight_tensor_parameter_51:
     name = "parameter_51"
+    original_name = "linear_5.w_0_deepcopy_86"
     shape = [256, 96]
     dtype = "float32"
     min_val = float("-0.393647")
@@ -572,6 +624,7 @@ class Program_weight_tensor_parameter_51:
 
 class Program_weight_tensor_parameter_52:
     name = "parameter_52"
+    original_name = "linear_4.b_0_deepcopy_85"
     shape = [192]
     dtype = "float32"
     min_val = float("-4.25235")
@@ -583,6 +636,7 @@ class Program_weight_tensor_parameter_52:
 
 class Program_weight_tensor_parameter_53:
     name = "parameter_53"
+    original_name = "linear_4.w_0_deepcopy_84"
     shape = [256, 192]
     dtype = "float32"
     min_val = float("-0.50817")
@@ -594,6 +648,7 @@ class Program_weight_tensor_parameter_53:
 
 class Program_weight_tensor_parameter_54:
     name = "parameter_54"
+    original_name = "linear_6.b_0_deepcopy_89"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.137511")
@@ -605,6 +660,7 @@ class Program_weight_tensor_parameter_54:
 
 class Program_weight_tensor_parameter_55:
     name = "parameter_55"
+    original_name = "linear_6.w_0_deepcopy_88"
     shape = [256, 256]
     dtype = "float32"
     min_val = float("-0.35258")
@@ -616,6 +672,7 @@ class Program_weight_tensor_parameter_55:
 
 class Program_weight_tensor_parameter_56:
     name = "parameter_56"
+    original_name = "layer_norm_2.b_0_deepcopy_83"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.326547")
@@ -627,6 +684,7 @@ class Program_weight_tensor_parameter_56:
 
 class Program_weight_tensor_parameter_57:
     name = "parameter_57"
+    original_name = "layer_norm_2.w_0_deepcopy_82"
     shape = [256]
     dtype = "float32"
     min_val = float("0.733154")
@@ -638,6 +696,7 @@ class Program_weight_tensor_parameter_57:
 
 class Program_weight_tensor_parameter_58:
     name = "parameter_58"
+    original_name = "linear_3.b_0_deepcopy_81"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.180855")
@@ -649,6 +708,7 @@ class Program_weight_tensor_parameter_58:
 
 class Program_weight_tensor_parameter_59:
     name = "parameter_59"
+    original_name = "linear_3.w_0_deepcopy_80"
     shape = [256, 256]
     dtype = "float32"
     min_val = float("-0.264527")
@@ -660,6 +720,7 @@ class Program_weight_tensor_parameter_59:
 
 class Program_weight_tensor_parameter_60:
     name = "parameter_60"
+    original_name = "layer_norm_4.b_0_deepcopy_77"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.146117")
@@ -671,6 +732,7 @@ class Program_weight_tensor_parameter_60:
 
 class Program_weight_tensor_parameter_61:
     name = "parameter_61"
+    original_name = "layer_norm_4.w_0_deepcopy_76"
     shape = [256]
     dtype = "float32"
     min_val = float("0.750467")
@@ -682,6 +744,7 @@ class Program_weight_tensor_parameter_61:
 
 class Program_weight_tensor_parameter_62:
     name = "parameter_62"
+    original_name = "linear_9.b_0_deepcopy_75"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.155623")
@@ -693,6 +756,7 @@ class Program_weight_tensor_parameter_62:
 
 class Program_weight_tensor_parameter_63:
     name = "parameter_63"
+    original_name = "linear_9.w_0_deepcopy_74"
     shape = [1024, 256]
     dtype = "float32"
     min_val = float("-0.420884")
@@ -704,6 +768,7 @@ class Program_weight_tensor_parameter_63:
 
 class Program_weight_tensor_parameter_64:
     name = "parameter_64"
+    original_name = "linear_8.b_0_deepcopy_73"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.199214")
@@ -715,6 +780,7 @@ class Program_weight_tensor_parameter_64:
 
 class Program_weight_tensor_parameter_65:
     name = "parameter_65"
+    original_name = "linear_8.w_0_deepcopy_72"
     shape = [256, 1024]
     dtype = "float32"
     min_val = float("-0.378287")
@@ -726,6 +792,7 @@ class Program_weight_tensor_parameter_65:
 
 class Program_weight_tensor_parameter_66:
     name = "parameter_66"
+    original_name = "layer_norm_3.b_0_deepcopy_71"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.148889")
@@ -737,6 +804,7 @@ class Program_weight_tensor_parameter_66:
 
 class Program_weight_tensor_parameter_67:
     name = "parameter_67"
+    original_name = "layer_norm_3.w_0_deepcopy_70"
     shape = [256]
     dtype = "float32"
     min_val = float("0.884987")
@@ -748,6 +816,7 @@ class Program_weight_tensor_parameter_67:
 
 class Program_weight_tensor_parameter_68:
     name = "parameter_68"
+    original_name = "linear_7.b_0_deepcopy_69"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.129623")
@@ -759,6 +828,7 @@ class Program_weight_tensor_parameter_68:
 
 class Program_weight_tensor_parameter_69:
     name = "parameter_69"
+    original_name = "linear_7.w_0_deepcopy_68"
     shape = [256, 256]
     dtype = "float32"
     min_val = float("-0.375354")
@@ -770,6 +840,7 @@ class Program_weight_tensor_parameter_69:
 
 class Program_weight_tensor_parameter_70:
     name = "parameter_70"
+    original_name = "linear_5.b_0_deepcopy_65"
     shape = [96]
     dtype = "float32"
     min_val = float("-0.176131")
@@ -781,6 +852,7 @@ class Program_weight_tensor_parameter_70:
 
 class Program_weight_tensor_parameter_71:
     name = "parameter_71"
+    original_name = "linear_5.w_0_deepcopy_64"
     shape = [256, 96]
     dtype = "float32"
     min_val = float("-0.510437")
@@ -792,6 +864,7 @@ class Program_weight_tensor_parameter_71:
 
 class Program_weight_tensor_parameter_72:
     name = "parameter_72"
+    original_name = "linear_4.b_0_deepcopy_63"
     shape = [192]
     dtype = "float32"
     min_val = float("-4.40857")
@@ -803,6 +876,7 @@ class Program_weight_tensor_parameter_72:
 
 class Program_weight_tensor_parameter_73:
     name = "parameter_73"
+    original_name = "linear_4.w_0_deepcopy_62"
     shape = [256, 192]
     dtype = "float32"
     min_val = float("-0.538118")
@@ -814,6 +888,7 @@ class Program_weight_tensor_parameter_73:
 
 class Program_weight_tensor_parameter_74:
     name = "parameter_74"
+    original_name = "linear_6.b_0_deepcopy_67"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.164591")
@@ -825,6 +900,7 @@ class Program_weight_tensor_parameter_74:
 
 class Program_weight_tensor_parameter_75:
     name = "parameter_75"
+    original_name = "linear_6.w_0_deepcopy_66"
     shape = [256, 256]
     dtype = "float32"
     min_val = float("-0.341205")
@@ -836,6 +912,7 @@ class Program_weight_tensor_parameter_75:
 
 class Program_weight_tensor_parameter_76:
     name = "parameter_76"
+    original_name = "layer_norm_2.b_0_deepcopy_61"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.222436")
@@ -847,6 +924,7 @@ class Program_weight_tensor_parameter_76:
 
 class Program_weight_tensor_parameter_77:
     name = "parameter_77"
+    original_name = "layer_norm_2.w_0_deepcopy_60"
     shape = [256]
     dtype = "float32"
     min_val = float("0.456384")
@@ -858,6 +936,7 @@ class Program_weight_tensor_parameter_77:
 
 class Program_weight_tensor_parameter_78:
     name = "parameter_78"
+    original_name = "linear_3.b_0_deepcopy_59"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.191942")
@@ -869,6 +948,7 @@ class Program_weight_tensor_parameter_78:
 
 class Program_weight_tensor_parameter_79:
     name = "parameter_79"
+    original_name = "linear_3.w_0_deepcopy_58"
     shape = [256, 256]
     dtype = "float32"
     min_val = float("-0.307978")
@@ -880,6 +960,7 @@ class Program_weight_tensor_parameter_79:
 
 class Program_weight_tensor_parameter_80:
     name = "parameter_80"
+    original_name = "layer_norm_4.b_0_deepcopy_55"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.363568")
@@ -891,6 +972,7 @@ class Program_weight_tensor_parameter_80:
 
 class Program_weight_tensor_parameter_81:
     name = "parameter_81"
+    original_name = "layer_norm_4.w_0_deepcopy_54"
     shape = [256]
     dtype = "float32"
     min_val = float("0.78889")
@@ -902,6 +984,7 @@ class Program_weight_tensor_parameter_81:
 
 class Program_weight_tensor_parameter_82:
     name = "parameter_82"
+    original_name = "linear_9.b_0_deepcopy_53"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.283697")
@@ -913,6 +996,7 @@ class Program_weight_tensor_parameter_82:
 
 class Program_weight_tensor_parameter_83:
     name = "parameter_83"
+    original_name = "linear_9.w_0_deepcopy_52"
     shape = [1024, 256]
     dtype = "float32"
     min_val = float("-0.564167")
@@ -924,6 +1008,7 @@ class Program_weight_tensor_parameter_83:
 
 class Program_weight_tensor_parameter_84:
     name = "parameter_84"
+    original_name = "linear_8.b_0_deepcopy_51"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.37974")
@@ -935,6 +1020,7 @@ class Program_weight_tensor_parameter_84:
 
 class Program_weight_tensor_parameter_85:
     name = "parameter_85"
+    original_name = "linear_8.w_0_deepcopy_50"
     shape = [256, 1024]
     dtype = "float32"
     min_val = float("-0.423296")
@@ -946,6 +1032,7 @@ class Program_weight_tensor_parameter_85:
 
 class Program_weight_tensor_parameter_86:
     name = "parameter_86"
+    original_name = "layer_norm_3.b_0_deepcopy_49"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.136425")
@@ -957,6 +1044,7 @@ class Program_weight_tensor_parameter_86:
 
 class Program_weight_tensor_parameter_87:
     name = "parameter_87"
+    original_name = "layer_norm_3.w_0_deepcopy_48"
     shape = [256]
     dtype = "float32"
     min_val = float("0.859815")
@@ -968,6 +1056,7 @@ class Program_weight_tensor_parameter_87:
 
 class Program_weight_tensor_parameter_88:
     name = "parameter_88"
+    original_name = "linear_7.b_0_deepcopy_47"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.120992")
@@ -979,6 +1068,7 @@ class Program_weight_tensor_parameter_88:
 
 class Program_weight_tensor_parameter_89:
     name = "parameter_89"
+    original_name = "linear_7.w_0_deepcopy_46"
     shape = [256, 256]
     dtype = "float32"
     min_val = float("-0.354922")
@@ -990,6 +1080,7 @@ class Program_weight_tensor_parameter_89:
 
 class Program_weight_tensor_parameter_90:
     name = "parameter_90"
+    original_name = "linear_5.b_0_deepcopy_43"
     shape = [96]
     dtype = "float32"
     min_val = float("-0.112906")
@@ -1001,6 +1092,7 @@ class Program_weight_tensor_parameter_90:
 
 class Program_weight_tensor_parameter_91:
     name = "parameter_91"
+    original_name = "linear_5.w_0_deepcopy_42"
     shape = [256, 96]
     dtype = "float32"
     min_val = float("-0.607715")
@@ -1012,6 +1104,7 @@ class Program_weight_tensor_parameter_91:
 
 class Program_weight_tensor_parameter_92:
     name = "parameter_92"
+    original_name = "linear_4.b_0_deepcopy_41"
     shape = [192]
     dtype = "float32"
     min_val = float("-4.22325")
@@ -1023,6 +1116,7 @@ class Program_weight_tensor_parameter_92:
 
 class Program_weight_tensor_parameter_93:
     name = "parameter_93"
+    original_name = "linear_4.w_0_deepcopy_40"
     shape = [256, 192]
     dtype = "float32"
     min_val = float("-0.621372")
@@ -1034,6 +1128,7 @@ class Program_weight_tensor_parameter_93:
 
 class Program_weight_tensor_parameter_94:
     name = "parameter_94"
+    original_name = "linear_6.b_0_deepcopy_45"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.208167")
@@ -1045,6 +1140,7 @@ class Program_weight_tensor_parameter_94:
 
 class Program_weight_tensor_parameter_95:
     name = "parameter_95"
+    original_name = "linear_6.w_0_deepcopy_44"
     shape = [256, 256]
     dtype = "float32"
     min_val = float("-0.327044")
@@ -1056,6 +1152,7 @@ class Program_weight_tensor_parameter_95:
 
 class Program_weight_tensor_parameter_96:
     name = "parameter_96"
+    original_name = "layer_norm_2.b_0_deepcopy_39"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.298091")
@@ -1067,6 +1164,7 @@ class Program_weight_tensor_parameter_96:
 
 class Program_weight_tensor_parameter_97:
     name = "parameter_97"
+    original_name = "layer_norm_2.w_0_deepcopy_38"
     shape = [256]
     dtype = "float32"
     min_val = float("0.633639")
@@ -1078,6 +1176,7 @@ class Program_weight_tensor_parameter_97:
 
 class Program_weight_tensor_parameter_98:
     name = "parameter_98"
+    original_name = "linear_3.b_0_deepcopy_37"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.269271")
@@ -1089,6 +1188,7 @@ class Program_weight_tensor_parameter_98:
 
 class Program_weight_tensor_parameter_99:
     name = "parameter_99"
+    original_name = "linear_3.w_0_deepcopy_36"
     shape = [256, 256]
     dtype = "float32"
     min_val = float("-0.425386")
@@ -1100,6 +1200,7 @@ class Program_weight_tensor_parameter_99:
 
 class Program_weight_tensor_parameter_100:
     name = "parameter_100"
+    original_name = "layer_norm_4.b_0_deepcopy_33"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.193797")
@@ -1111,6 +1212,7 @@ class Program_weight_tensor_parameter_100:
 
 class Program_weight_tensor_parameter_101:
     name = "parameter_101"
+    original_name = "layer_norm_4.w_0_deepcopy_32"
     shape = [256]
     dtype = "float32"
     min_val = float("0.715448")
@@ -1122,6 +1224,7 @@ class Program_weight_tensor_parameter_101:
 
 class Program_weight_tensor_parameter_102:
     name = "parameter_102"
+    original_name = "linear_9.b_0_deepcopy_31"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.332269")
@@ -1133,6 +1236,7 @@ class Program_weight_tensor_parameter_102:
 
 class Program_weight_tensor_parameter_103:
     name = "parameter_103"
+    original_name = "linear_9.w_0_deepcopy_30"
     shape = [1024, 256]
     dtype = "float32"
     min_val = float("-0.645393")
@@ -1144,6 +1248,7 @@ class Program_weight_tensor_parameter_103:
 
 class Program_weight_tensor_parameter_104:
     name = "parameter_104"
+    original_name = "linear_8.b_0_deepcopy_29"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.297501")
@@ -1155,6 +1260,7 @@ class Program_weight_tensor_parameter_104:
 
 class Program_weight_tensor_parameter_105:
     name = "parameter_105"
+    original_name = "linear_8.w_0_deepcopy_28"
     shape = [256, 1024]
     dtype = "float32"
     min_val = float("-0.439843")
@@ -1166,6 +1272,7 @@ class Program_weight_tensor_parameter_105:
 
 class Program_weight_tensor_parameter_106:
     name = "parameter_106"
+    original_name = "layer_norm_3.b_0_deepcopy_27"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.22177")
@@ -1177,6 +1284,7 @@ class Program_weight_tensor_parameter_106:
 
 class Program_weight_tensor_parameter_107:
     name = "parameter_107"
+    original_name = "layer_norm_3.w_0_deepcopy_26"
     shape = [256]
     dtype = "float32"
     min_val = float("0.870443")
@@ -1188,6 +1296,7 @@ class Program_weight_tensor_parameter_107:
 
 class Program_weight_tensor_parameter_108:
     name = "parameter_108"
+    original_name = "linear_7.b_0_deepcopy_25"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.102303")
@@ -1199,6 +1308,7 @@ class Program_weight_tensor_parameter_108:
 
 class Program_weight_tensor_parameter_109:
     name = "parameter_109"
+    original_name = "linear_7.w_0_deepcopy_24"
     shape = [256, 256]
     dtype = "float32"
     min_val = float("-0.333307")
@@ -1210,6 +1320,7 @@ class Program_weight_tensor_parameter_109:
 
 class Program_weight_tensor_parameter_110:
     name = "parameter_110"
+    original_name = "linear_5.b_0_deepcopy_21"
     shape = [96]
     dtype = "float32"
     min_val = float("-0.240894")
@@ -1221,6 +1332,7 @@ class Program_weight_tensor_parameter_110:
 
 class Program_weight_tensor_parameter_111:
     name = "parameter_111"
+    original_name = "linear_5.w_0_deepcopy_20"
     shape = [256, 96]
     dtype = "float32"
     min_val = float("-0.477188")
@@ -1232,6 +1344,7 @@ class Program_weight_tensor_parameter_111:
 
 class Program_weight_tensor_parameter_112:
     name = "parameter_112"
+    original_name = "linear_4.b_0_deepcopy_19"
     shape = [192]
     dtype = "float32"
     min_val = float("-4.19973")
@@ -1243,6 +1356,7 @@ class Program_weight_tensor_parameter_112:
 
 class Program_weight_tensor_parameter_113:
     name = "parameter_113"
+    original_name = "linear_4.w_0_deepcopy_18"
     shape = [256, 192]
     dtype = "float32"
     min_val = float("-0.626619")
@@ -1254,6 +1368,7 @@ class Program_weight_tensor_parameter_113:
 
 class Program_weight_tensor_parameter_114:
     name = "parameter_114"
+    original_name = "linear_6.b_0_deepcopy_23"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.284102")
@@ -1265,6 +1380,7 @@ class Program_weight_tensor_parameter_114:
 
 class Program_weight_tensor_parameter_115:
     name = "parameter_115"
+    original_name = "linear_6.w_0_deepcopy_22"
     shape = [256, 256]
     dtype = "float32"
     min_val = float("-0.319682")
@@ -1276,6 +1392,7 @@ class Program_weight_tensor_parameter_115:
 
 class Program_weight_tensor_parameter_116:
     name = "parameter_116"
+    original_name = "layer_norm_2.b_0_deepcopy_17"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.231613")
@@ -1287,6 +1404,7 @@ class Program_weight_tensor_parameter_116:
 
 class Program_weight_tensor_parameter_117:
     name = "parameter_117"
+    original_name = "layer_norm_2.w_0_deepcopy_16"
     shape = [256]
     dtype = "float32"
     min_val = float("0.641499")
@@ -1298,6 +1416,7 @@ class Program_weight_tensor_parameter_117:
 
 class Program_weight_tensor_parameter_118:
     name = "parameter_118"
+    original_name = "linear_3.b_0_deepcopy_15"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.345921")
@@ -1309,6 +1428,7 @@ class Program_weight_tensor_parameter_118:
 
 class Program_weight_tensor_parameter_119:
     name = "parameter_119"
+    original_name = "linear_3.w_0_deepcopy_14"
     shape = [256, 256]
     dtype = "float32"
     min_val = float("-0.397349")
@@ -1320,6 +1440,7 @@ class Program_weight_tensor_parameter_119:
 
 class Program_weight_tensor_parameter_120:
     name = "parameter_120"
+    original_name = "linear_11.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.1751")
@@ -1331,6 +1452,7 @@ class Program_weight_tensor_parameter_120:
 
 class Program_weight_tensor_parameter_121:
     name = "parameter_121"
+    original_name = "linear_11.w_0"
     shape = [512, 256]
     dtype = "float32"
     min_val = float("-2.82062")
@@ -1342,6 +1464,7 @@ class Program_weight_tensor_parameter_121:
 
 class Program_weight_tensor_parameter_122:
     name = "parameter_122"
+    original_name = "linear_10.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.497467")
@@ -1353,6 +1476,7 @@ class Program_weight_tensor_parameter_122:
 
 class Program_weight_tensor_parameter_123:
     name = "parameter_123"
+    original_name = "linear_10.w_0"
     shape = [4, 512]
     dtype = "float32"
     min_val = float("-4.98618")
@@ -1364,6 +1488,7 @@ class Program_weight_tensor_parameter_123:
 
 class Program_weight_tensor_parameter_124:
     name = "parameter_124"
+    original_name = "linear_14.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.121052")
@@ -1375,6 +1500,7 @@ class Program_weight_tensor_parameter_124:
 
 class Program_weight_tensor_parameter_125:
     name = "parameter_125"
+    original_name = "linear_14.w_0"
     shape = [256, 128]
     dtype = "float32"
     min_val = float("-1.10794")
@@ -1386,6 +1512,7 @@ class Program_weight_tensor_parameter_125:
 
 class Program_weight_tensor_parameter_126:
     name = "parameter_126"
+    original_name = "linear_13.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.439998")
@@ -1397,6 +1524,7 @@ class Program_weight_tensor_parameter_126:
 
 class Program_weight_tensor_parameter_127:
     name = "parameter_127"
+    original_name = "linear_13.w_0"
     shape = [256, 256]
     dtype = "float32"
     min_val = float("-1.79083")
@@ -1408,6 +1536,7 @@ class Program_weight_tensor_parameter_127:
 
 class Program_weight_tensor_parameter_128:
     name = "parameter_128"
+    original_name = "linear_12.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.591331")
@@ -1419,6 +1548,7 @@ class Program_weight_tensor_parameter_128:
 
 class Program_weight_tensor_parameter_129:
     name = "parameter_129"
+    original_name = "linear_12.w_0"
     shape = [256, 256]
     dtype = "float32"
     min_val = float("-0.442693")
@@ -1430,6 +1560,7 @@ class Program_weight_tensor_parameter_129:
 
 class Program_weight_tensor_parameter_130:
     name = "parameter_130"
+    original_name = "layer_norm_6.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.03312")
@@ -1441,6 +1572,7 @@ class Program_weight_tensor_parameter_130:
 
 class Program_weight_tensor_parameter_131:
     name = "parameter_131"
+    original_name = "layer_norm_6.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.467435")
@@ -1452,6 +1584,7 @@ class Program_weight_tensor_parameter_131:
 
 class Program_weight_tensor_parameter_132:
     name = "parameter_132"
+    original_name = "linear_19.b_0"
     shape = [4]
     dtype = "float32"
     min_val = float("0")
@@ -1461,6 +1594,7 @@ class Program_weight_tensor_parameter_132:
 
 class Program_weight_tensor_parameter_133:
     name = "parameter_133"
+    original_name = "linear_19.w_0"
     shape = [256, 4]
     dtype = "float32"
     min_val = float("-0.627713")
@@ -1472,6 +1606,7 @@ class Program_weight_tensor_parameter_133:
 
 class Program_weight_tensor_parameter_134:
     name = "parameter_134"
+    original_name = "linear_18.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.325887")
@@ -1483,6 +1618,7 @@ class Program_weight_tensor_parameter_134:
 
 class Program_weight_tensor_parameter_135:
     name = "parameter_135"
+    original_name = "linear_18.w_0"
     shape = [256, 256]
     dtype = "float32"
     min_val = float("-4.22838")
@@ -1494,6 +1630,7 @@ class Program_weight_tensor_parameter_135:
 
 class Program_weight_tensor_parameter_136:
     name = "parameter_136"
+    original_name = "linear_17.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.425893")
@@ -1505,6 +1642,7 @@ class Program_weight_tensor_parameter_136:
 
 class Program_weight_tensor_parameter_137:
     name = "parameter_137"
+    original_name = "linear_17.w_0"
     shape = [256, 256]
     dtype = "float32"
     min_val = float("-0.377984")
@@ -1516,6 +1654,7 @@ class Program_weight_tensor_parameter_137:
 
 class Program_weight_tensor_parameter_138:
     name = "parameter_138"
+    original_name = "linear_16.b_0"
     shape = [2]
     dtype = "float32"
     min_val = float("0")
@@ -1525,6 +1664,7 @@ class Program_weight_tensor_parameter_138:
 
 class Program_weight_tensor_parameter_139:
     name = "parameter_139"
+    original_name = "linear_16.w_0"
     shape = [256, 2]
     dtype = "float32"
     min_val = float("-0.0623768")
@@ -1536,6 +1676,7 @@ class Program_weight_tensor_parameter_139:
 
 class Program_weight_tensor_parameter_140:
     name = "parameter_140"
+    original_name = "layer_norm_5.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.959546")
@@ -1547,6 +1688,7 @@ class Program_weight_tensor_parameter_140:
 
 class Program_weight_tensor_parameter_141:
     name = "parameter_141"
+    original_name = "layer_norm_5.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.72901")
@@ -1558,6 +1700,7 @@ class Program_weight_tensor_parameter_141:
 
 class Program_weight_tensor_parameter_142:
     name = "parameter_142"
+    original_name = "linear_15.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.842428")
@@ -1569,6 +1712,7 @@ class Program_weight_tensor_parameter_142:
 
 class Program_weight_tensor_parameter_143:
     name = "parameter_143"
+    original_name = "linear_15.w_0"
     shape = [256, 256]
     dtype = "float32"
     min_val = float("-0.541244")
@@ -1580,6 +1724,7 @@ class Program_weight_tensor_parameter_143:
 
 class Program_weight_tensor_parameter_144:
     name = "parameter_144"
+    original_name = "batch_norm2d_136.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.313387")
@@ -1591,6 +1736,7 @@ class Program_weight_tensor_parameter_144:
 
 class Program_weight_tensor_parameter_145:
     name = "parameter_145"
+    original_name = "batch_norm2d_136.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.784497")
@@ -1602,6 +1748,7 @@ class Program_weight_tensor_parameter_145:
 
 class Program_weight_tensor_parameter_146:
     name = "parameter_146"
+    original_name = "batch_norm2d_136.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("1.77866")
@@ -1613,6 +1760,7 @@ class Program_weight_tensor_parameter_146:
 
 class Program_weight_tensor_parameter_147:
     name = "parameter_147"
+    original_name = "batch_norm2d_136.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.07588")
@@ -1624,6 +1772,7 @@ class Program_weight_tensor_parameter_147:
 
 class Program_weight_tensor_parameter_148:
     name = "parameter_148"
+    original_name = "conv2d_95.w_0"
     shape = [256, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.344515")
@@ -1635,6 +1784,7 @@ class Program_weight_tensor_parameter_148:
 
 class Program_weight_tensor_parameter_149:
     name = "parameter_149"
+    original_name = "batch_norm2d_135.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.243712")
@@ -1646,6 +1796,7 @@ class Program_weight_tensor_parameter_149:
 
 class Program_weight_tensor_parameter_150:
     name = "parameter_150"
+    original_name = "batch_norm2d_135.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.711525")
@@ -1657,6 +1808,7 @@ class Program_weight_tensor_parameter_150:
 
 class Program_weight_tensor_parameter_151:
     name = "parameter_151"
+    original_name = "batch_norm2d_135.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("5.42479")
@@ -1668,6 +1820,7 @@ class Program_weight_tensor_parameter_151:
 
 class Program_weight_tensor_parameter_152:
     name = "parameter_152"
+    original_name = "batch_norm2d_135.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.664479")
@@ -1679,6 +1832,7 @@ class Program_weight_tensor_parameter_152:
 
 class Program_weight_tensor_parameter_153:
     name = "parameter_153"
+    original_name = "conv2d_94.w_0"
     shape = [256, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.458922")
@@ -1690,6 +1844,7 @@ class Program_weight_tensor_parameter_153:
 
 class Program_weight_tensor_parameter_154:
     name = "parameter_154"
+    original_name = "batch_norm2d_134.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.415495")
@@ -1701,6 +1856,7 @@ class Program_weight_tensor_parameter_154:
 
 class Program_weight_tensor_parameter_155:
     name = "parameter_155"
+    original_name = "batch_norm2d_134.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.696872")
@@ -1712,6 +1868,7 @@ class Program_weight_tensor_parameter_155:
 
 class Program_weight_tensor_parameter_156:
     name = "parameter_156"
+    original_name = "batch_norm2d_134.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("2.75006")
@@ -1723,6 +1880,7 @@ class Program_weight_tensor_parameter_156:
 
 class Program_weight_tensor_parameter_157:
     name = "parameter_157"
+    original_name = "batch_norm2d_134.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.951373")
@@ -1734,6 +1892,7 @@ class Program_weight_tensor_parameter_157:
 
 class Program_weight_tensor_parameter_158:
     name = "parameter_158"
+    original_name = "conv2d_93.w_0"
     shape = [256, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.42062")

--- a/paddle_samples/PaddleX/MobileNetV4_conv_medium/subgraph_0/input_meta.py
+++ b/paddle_samples/PaddleX/MobileNetV4_conv_medium/subgraph_0/input_meta.py
@@ -1,5 +1,6 @@
 class Program_weight_tensor_data_0:
     name = "data_0"
+    original_name = "var_359"
     shape = [124, 3, 256, 256]
     dtype = "float32"
     min_val = float("-4.82939")

--- a/paddle_samples/PaddleX/MobileNetV4_conv_medium/subgraph_0/weight_meta.py
+++ b/paddle_samples/PaddleX/MobileNetV4_conv_medium/subgraph_0/weight_meta.py
@@ -1,5 +1,6 @@
 class Program_weight_tensor_parameter_0:
     name = "parameter_0"
+    original_name = "linear_0.b_0"
     shape = [102]
     dtype = "float32"
     min_val = float("-0.0417919")
@@ -11,6 +12,7 @@ class Program_weight_tensor_parameter_0:
 
 class Program_weight_tensor_parameter_1:
     name = "parameter_1"
+    original_name = "linear_0.w_0"
     shape = [1280, 102]
     dtype = "float32"
     min_val = float("-0.213076")
@@ -22,6 +24,7 @@ class Program_weight_tensor_parameter_1:
 
 class Program_weight_tensor_parameter_2:
     name = "parameter_2"
+    original_name = "batch_norm_76.b_0"
     shape = [1280]
     dtype = "float32"
     min_val = float("-2.46676")
@@ -33,6 +36,7 @@ class Program_weight_tensor_parameter_2:
 
 class Program_weight_tensor_parameter_3:
     name = "parameter_3"
+    original_name = "batch_norm_76.w_0"
     shape = [1280]
     dtype = "float32"
     min_val = float("0.673963")
@@ -44,6 +48,7 @@ class Program_weight_tensor_parameter_3:
 
 class Program_weight_tensor_parameter_4:
     name = "parameter_4"
+    original_name = "batch_norm_76.w_2"
     shape = [1280]
     dtype = "float32"
     min_val = float("0.00405725")
@@ -55,6 +60,7 @@ class Program_weight_tensor_parameter_4:
 
 class Program_weight_tensor_parameter_5:
     name = "parameter_5"
+    original_name = "batch_norm_76.w_1"
     shape = [1280]
     dtype = "float32"
     min_val = float("-0.136147")
@@ -66,6 +72,7 @@ class Program_weight_tensor_parameter_5:
 
 class Program_weight_tensor_parameter_6:
     name = "parameter_6"
+    original_name = "conv2d_76.w_0"
     shape = [1280, 960, 1, 1]
     dtype = "float32"
     min_val = float("-0.298345")
@@ -77,6 +84,7 @@ class Program_weight_tensor_parameter_6:
 
 class Program_weight_tensor_parameter_7:
     name = "parameter_7"
+    original_name = "batch_norm_75.b_0"
     shape = [960]
     dtype = "float32"
     min_val = float("-4.1777")
@@ -88,6 +96,7 @@ class Program_weight_tensor_parameter_7:
 
 class Program_weight_tensor_parameter_8:
     name = "parameter_8"
+    original_name = "batch_norm_75.w_0"
     shape = [960]
     dtype = "float32"
     min_val = float("0.202702")
@@ -99,6 +108,7 @@ class Program_weight_tensor_parameter_8:
 
 class Program_weight_tensor_parameter_9:
     name = "parameter_9"
+    original_name = "batch_norm_75.w_2"
     shape = [960]
     dtype = "float32"
     min_val = float("8.72257")
@@ -110,6 +120,7 @@ class Program_weight_tensor_parameter_9:
 
 class Program_weight_tensor_parameter_10:
     name = "parameter_10"
+    original_name = "batch_norm_75.w_1"
     shape = [960]
     dtype = "float32"
     min_val = float("-5.86778")
@@ -121,6 +132,7 @@ class Program_weight_tensor_parameter_10:
 
 class Program_weight_tensor_parameter_11:
     name = "parameter_11"
+    original_name = "conv2d_75.w_0"
     shape = [960, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.338598")
@@ -132,6 +144,7 @@ class Program_weight_tensor_parameter_11:
 
 class Program_weight_tensor_parameter_12:
     name = "parameter_12"
+    original_name = "batch_norm_74.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-2.20433")
@@ -143,6 +156,7 @@ class Program_weight_tensor_parameter_12:
 
 class Program_weight_tensor_parameter_13:
     name = "parameter_13"
+    original_name = "batch_norm_74.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.493937")
@@ -154,6 +168,7 @@ class Program_weight_tensor_parameter_13:
 
 class Program_weight_tensor_parameter_14:
     name = "parameter_14"
+    original_name = "batch_norm_74.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.0175491")
@@ -165,6 +180,7 @@ class Program_weight_tensor_parameter_14:
 
 class Program_weight_tensor_parameter_15:
     name = "parameter_15"
+    original_name = "batch_norm_74.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.106817")
@@ -176,6 +192,7 @@ class Program_weight_tensor_parameter_15:
 
 class Program_weight_tensor_parameter_16:
     name = "parameter_16"
+    original_name = "conv2d_74.w_0"
     shape = [256, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.247811")
@@ -187,6 +204,7 @@ class Program_weight_tensor_parameter_16:
 
 class Program_weight_tensor_parameter_17:
     name = "parameter_17"
+    original_name = "batch_norm_73.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-7.78068")
@@ -198,6 +216,7 @@ class Program_weight_tensor_parameter_17:
 
 class Program_weight_tensor_parameter_18:
     name = "parameter_18"
+    original_name = "batch_norm_73.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("0.272292")
@@ -209,6 +228,7 @@ class Program_weight_tensor_parameter_18:
 
 class Program_weight_tensor_parameter_19:
     name = "parameter_19"
+    original_name = "batch_norm_73.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("6.86002e-19")
@@ -220,6 +240,7 @@ class Program_weight_tensor_parameter_19:
 
 class Program_weight_tensor_parameter_20:
     name = "parameter_20"
+    original_name = "batch_norm_73.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-1.93864")
@@ -231,6 +252,7 @@ class Program_weight_tensor_parameter_20:
 
 class Program_weight_tensor_parameter_21:
     name = "parameter_21"
+    original_name = "conv2d_73.w_0"
     shape = [512, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.32843")
@@ -242,6 +264,7 @@ class Program_weight_tensor_parameter_21:
 
 class Program_weight_tensor_parameter_22:
     name = "parameter_22"
+    original_name = "batch_norm_72.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-3.28179")
@@ -253,6 +276,7 @@ class Program_weight_tensor_parameter_22:
 
 class Program_weight_tensor_parameter_23:
     name = "parameter_23"
+    original_name = "batch_norm_72.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.688927")
@@ -264,6 +288,7 @@ class Program_weight_tensor_parameter_23:
 
 class Program_weight_tensor_parameter_24:
     name = "parameter_24"
+    original_name = "batch_norm_72.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.473166")
@@ -275,6 +300,7 @@ class Program_weight_tensor_parameter_24:
 
 class Program_weight_tensor_parameter_25:
     name = "parameter_25"
+    original_name = "batch_norm_72.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-7.5734")
@@ -286,6 +312,7 @@ class Program_weight_tensor_parameter_25:
 
 class Program_weight_tensor_parameter_26:
     name = "parameter_26"
+    original_name = "conv2d_72.w_0"
     shape = [256, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.434448")
@@ -297,6 +324,7 @@ class Program_weight_tensor_parameter_26:
 
 class Program_weight_tensor_parameter_27:
     name = "parameter_27"
+    original_name = "batch_norm_71.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.12966")
@@ -308,6 +336,7 @@ class Program_weight_tensor_parameter_27:
 
 class Program_weight_tensor_parameter_28:
     name = "parameter_28"
+    original_name = "batch_norm_71.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.692899")
@@ -319,6 +348,7 @@ class Program_weight_tensor_parameter_28:
 
 class Program_weight_tensor_parameter_29:
     name = "parameter_29"
+    original_name = "batch_norm_71.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.00620742")
@@ -330,6 +360,7 @@ class Program_weight_tensor_parameter_29:
 
 class Program_weight_tensor_parameter_30:
     name = "parameter_30"
+    original_name = "batch_norm_71.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.0405889")
@@ -341,6 +372,7 @@ class Program_weight_tensor_parameter_30:
 
 class Program_weight_tensor_parameter_31:
     name = "parameter_31"
+    original_name = "conv2d_71.w_0"
     shape = [256, 1024, 1, 1]
     dtype = "float32"
     min_val = float("-0.41556")
@@ -352,6 +384,7 @@ class Program_weight_tensor_parameter_31:
 
 class Program_weight_tensor_parameter_32:
     name = "parameter_32"
+    original_name = "batch_norm_70.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-4.00836")
@@ -363,6 +396,7 @@ class Program_weight_tensor_parameter_32:
 
 class Program_weight_tensor_parameter_33:
     name = "parameter_33"
+    original_name = "batch_norm_70.w_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("0.0285159")
@@ -374,6 +408,7 @@ class Program_weight_tensor_parameter_33:
 
 class Program_weight_tensor_parameter_34:
     name = "parameter_34"
+    original_name = "batch_norm_70.w_2"
     shape = [1024]
     dtype = "float32"
     min_val = float("1.67876e-42")
@@ -385,6 +420,7 @@ class Program_weight_tensor_parameter_34:
 
 class Program_weight_tensor_parameter_35:
     name = "parameter_35"
+    original_name = "batch_norm_70.w_1"
     shape = [1024]
     dtype = "float32"
     min_val = float("-6.97646")
@@ -396,6 +432,7 @@ class Program_weight_tensor_parameter_35:
 
 class Program_weight_tensor_parameter_36:
     name = "parameter_36"
+    original_name = "conv2d_70.w_0"
     shape = [1024, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.260247")
@@ -407,6 +444,7 @@ class Program_weight_tensor_parameter_36:
 
 class Program_weight_tensor_parameter_37:
     name = "parameter_37"
+    original_name = "batch_norm_69.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.805816")
@@ -418,6 +456,7 @@ class Program_weight_tensor_parameter_37:
 
 class Program_weight_tensor_parameter_38:
     name = "parameter_38"
+    original_name = "batch_norm_69.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.511367")
@@ -429,6 +468,7 @@ class Program_weight_tensor_parameter_38:
 
 class Program_weight_tensor_parameter_39:
     name = "parameter_39"
+    original_name = "batch_norm_69.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.0223441")
@@ -440,6 +480,7 @@ class Program_weight_tensor_parameter_39:
 
 class Program_weight_tensor_parameter_40:
     name = "parameter_40"
+    original_name = "batch_norm_69.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.0598293")
@@ -451,6 +492,7 @@ class Program_weight_tensor_parameter_40:
 
 class Program_weight_tensor_parameter_41:
     name = "parameter_41"
+    original_name = "conv2d_69.w_0"
     shape = [256, 1024, 1, 1]
     dtype = "float32"
     min_val = float("-0.242781")
@@ -462,6 +504,7 @@ class Program_weight_tensor_parameter_41:
 
 class Program_weight_tensor_parameter_42:
     name = "parameter_42"
+    original_name = "batch_norm_68.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-3.94656")
@@ -473,6 +516,7 @@ class Program_weight_tensor_parameter_42:
 
 class Program_weight_tensor_parameter_43:
     name = "parameter_43"
+    original_name = "batch_norm_68.w_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("0.122884")
@@ -484,6 +528,7 @@ class Program_weight_tensor_parameter_43:
 
 class Program_weight_tensor_parameter_44:
     name = "parameter_44"
+    original_name = "batch_norm_68.w_2"
     shape = [1024]
     dtype = "float32"
     min_val = float("9.2492e-28")
@@ -495,6 +540,7 @@ class Program_weight_tensor_parameter_44:
 
 class Program_weight_tensor_parameter_45:
     name = "parameter_45"
+    original_name = "batch_norm_68.w_1"
     shape = [1024]
     dtype = "float32"
     min_val = float("-5.95783")
@@ -506,6 +552,7 @@ class Program_weight_tensor_parameter_45:
 
 class Program_weight_tensor_parameter_46:
     name = "parameter_46"
+    original_name = "conv2d_68.w_0"
     shape = [1024, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.381973")
@@ -517,6 +564,7 @@ class Program_weight_tensor_parameter_46:
 
 class Program_weight_tensor_parameter_47:
     name = "parameter_47"
+    original_name = "batch_norm_67.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.94885")
@@ -528,6 +576,7 @@ class Program_weight_tensor_parameter_47:
 
 class Program_weight_tensor_parameter_48:
     name = "parameter_48"
+    original_name = "batch_norm_67.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.478707")
@@ -539,6 +588,7 @@ class Program_weight_tensor_parameter_48:
 
 class Program_weight_tensor_parameter_49:
     name = "parameter_49"
+    original_name = "batch_norm_67.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.41903")
@@ -550,6 +600,7 @@ class Program_weight_tensor_parameter_49:
 
 class Program_weight_tensor_parameter_50:
     name = "parameter_50"
+    original_name = "batch_norm_67.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-2.57923")
@@ -561,6 +612,7 @@ class Program_weight_tensor_parameter_50:
 
 class Program_weight_tensor_parameter_51:
     name = "parameter_51"
+    original_name = "conv2d_67.w_0"
     shape = [256, 1024, 1, 1]
     dtype = "float32"
     min_val = float("-0.287789")
@@ -572,6 +624,7 @@ class Program_weight_tensor_parameter_51:
 
 class Program_weight_tensor_parameter_52:
     name = "parameter_52"
+    original_name = "batch_norm_66.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-7.23322")
@@ -583,6 +636,7 @@ class Program_weight_tensor_parameter_52:
 
 class Program_weight_tensor_parameter_53:
     name = "parameter_53"
+    original_name = "batch_norm_66.w_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("0.0108447")
@@ -594,6 +648,7 @@ class Program_weight_tensor_parameter_53:
 
 class Program_weight_tensor_parameter_54:
     name = "parameter_54"
+    original_name = "batch_norm_66.w_2"
     shape = [1024]
     dtype = "float32"
     min_val = float("1.11824e-42")
@@ -605,6 +660,7 @@ class Program_weight_tensor_parameter_54:
 
 class Program_weight_tensor_parameter_55:
     name = "parameter_55"
+    original_name = "batch_norm_66.w_1"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.70769")
@@ -616,6 +672,7 @@ class Program_weight_tensor_parameter_55:
 
 class Program_weight_tensor_parameter_56:
     name = "parameter_56"
+    original_name = "conv2d_66.w_0"
     shape = [1024, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.250232")
@@ -627,6 +684,7 @@ class Program_weight_tensor_parameter_56:
 
 class Program_weight_tensor_parameter_57:
     name = "parameter_57"
+    original_name = "batch_norm_65.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-2.86964")
@@ -638,6 +696,7 @@ class Program_weight_tensor_parameter_57:
 
 class Program_weight_tensor_parameter_58:
     name = "parameter_58"
+    original_name = "batch_norm_65.w_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("0.0512698")
@@ -649,6 +708,7 @@ class Program_weight_tensor_parameter_58:
 
 class Program_weight_tensor_parameter_59:
     name = "parameter_59"
+    original_name = "batch_norm_65.w_2"
     shape = [1024]
     dtype = "float32"
     min_val = float("1.62551e-42")
@@ -660,6 +720,7 @@ class Program_weight_tensor_parameter_59:
 
 class Program_weight_tensor_parameter_60:
     name = "parameter_60"
+    original_name = "batch_norm_65.w_1"
     shape = [1024]
     dtype = "float32"
     min_val = float("-1.53838")
@@ -671,6 +732,7 @@ class Program_weight_tensor_parameter_60:
 
 class Program_weight_tensor_parameter_61:
     name = "parameter_61"
+    original_name = "conv2d_65.w_0"
     shape = [1024, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.359075")
@@ -682,6 +744,7 @@ class Program_weight_tensor_parameter_61:
 
 class Program_weight_tensor_parameter_62:
     name = "parameter_62"
+    original_name = "batch_norm_64.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-2.52468")
@@ -693,6 +756,7 @@ class Program_weight_tensor_parameter_62:
 
 class Program_weight_tensor_parameter_63:
     name = "parameter_63"
+    original_name = "batch_norm_64.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.831132")
@@ -704,6 +768,7 @@ class Program_weight_tensor_parameter_63:
 
 class Program_weight_tensor_parameter_64:
     name = "parameter_64"
+    original_name = "batch_norm_64.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.0202336")
@@ -715,6 +780,7 @@ class Program_weight_tensor_parameter_64:
 
 class Program_weight_tensor_parameter_65:
     name = "parameter_65"
+    original_name = "batch_norm_64.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-6.36406")
@@ -726,6 +792,7 @@ class Program_weight_tensor_parameter_65:
 
 class Program_weight_tensor_parameter_66:
     name = "parameter_66"
+    original_name = "conv2d_64.w_0"
     shape = [256, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.435062")
@@ -737,6 +804,7 @@ class Program_weight_tensor_parameter_66:
 
 class Program_weight_tensor_parameter_67:
     name = "parameter_67"
+    original_name = "batch_norm_63.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.42137")
@@ -748,6 +816,7 @@ class Program_weight_tensor_parameter_67:
 
 class Program_weight_tensor_parameter_68:
     name = "parameter_68"
+    original_name = "batch_norm_63.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.215733")
@@ -759,6 +828,7 @@ class Program_weight_tensor_parameter_68:
 
 class Program_weight_tensor_parameter_69:
     name = "parameter_69"
+    original_name = "batch_norm_63.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.23927")
@@ -770,6 +840,7 @@ class Program_weight_tensor_parameter_69:
 
 class Program_weight_tensor_parameter_70:
     name = "parameter_70"
+    original_name = "batch_norm_63.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-2.12745")
@@ -781,6 +852,7 @@ class Program_weight_tensor_parameter_70:
 
 class Program_weight_tensor_parameter_71:
     name = "parameter_71"
+    original_name = "conv2d_63.w_0"
     shape = [256, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.298574")
@@ -792,6 +864,7 @@ class Program_weight_tensor_parameter_71:
 
 class Program_weight_tensor_parameter_72:
     name = "parameter_72"
+    original_name = "batch_norm_62.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-6.13272")
@@ -803,6 +876,7 @@ class Program_weight_tensor_parameter_72:
 
 class Program_weight_tensor_parameter_73:
     name = "parameter_73"
+    original_name = "batch_norm_62.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("0.121069")
@@ -814,6 +888,7 @@ class Program_weight_tensor_parameter_73:
 
 class Program_weight_tensor_parameter_74:
     name = "parameter_74"
+    original_name = "batch_norm_62.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("1.20372e-42")
@@ -825,6 +900,7 @@ class Program_weight_tensor_parameter_74:
 
 class Program_weight_tensor_parameter_75:
     name = "parameter_75"
+    original_name = "batch_norm_62.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.580441")
@@ -836,6 +912,7 @@ class Program_weight_tensor_parameter_75:
 
 class Program_weight_tensor_parameter_76:
     name = "parameter_76"
+    original_name = "conv2d_62.w_0"
     shape = [512, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.229638")
@@ -847,6 +924,7 @@ class Program_weight_tensor_parameter_76:
 
 class Program_weight_tensor_parameter_77:
     name = "parameter_77"
+    original_name = "batch_norm_61.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-2.05501")
@@ -858,6 +936,7 @@ class Program_weight_tensor_parameter_77:
 
 class Program_weight_tensor_parameter_78:
     name = "parameter_78"
+    original_name = "batch_norm_61.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("0.0642323")
@@ -869,6 +948,7 @@ class Program_weight_tensor_parameter_78:
 
 class Program_weight_tensor_parameter_79:
     name = "parameter_79"
+    original_name = "batch_norm_61.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("1.67876e-42")
@@ -880,6 +960,7 @@ class Program_weight_tensor_parameter_79:
 
 class Program_weight_tensor_parameter_80:
     name = "parameter_80"
+    original_name = "batch_norm_61.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-1.54186")
@@ -891,6 +972,7 @@ class Program_weight_tensor_parameter_80:
 
 class Program_weight_tensor_parameter_81:
     name = "parameter_81"
+    original_name = "conv2d_61.w_0"
     shape = [512, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.335409")
@@ -902,6 +984,7 @@ class Program_weight_tensor_parameter_81:
 
 class Program_weight_tensor_parameter_82:
     name = "parameter_82"
+    original_name = "batch_norm_60.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-2.35225")
@@ -913,6 +996,7 @@ class Program_weight_tensor_parameter_82:
 
 class Program_weight_tensor_parameter_83:
     name = "parameter_83"
+    original_name = "batch_norm_60.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.602247")
@@ -924,6 +1008,7 @@ class Program_weight_tensor_parameter_83:
 
 class Program_weight_tensor_parameter_84:
     name = "parameter_84"
+    original_name = "batch_norm_60.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.000353021")
@@ -935,6 +1020,7 @@ class Program_weight_tensor_parameter_84:
 
 class Program_weight_tensor_parameter_85:
     name = "parameter_85"
+    original_name = "batch_norm_60.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.71236")
@@ -946,6 +1032,7 @@ class Program_weight_tensor_parameter_85:
 
 class Program_weight_tensor_parameter_86:
     name = "parameter_86"
+    original_name = "conv2d_60.w_0"
     shape = [256, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.29849")
@@ -957,6 +1044,7 @@ class Program_weight_tensor_parameter_86:
 
 class Program_weight_tensor_parameter_87:
     name = "parameter_87"
+    original_name = "batch_norm_59.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.01026")
@@ -968,6 +1056,7 @@ class Program_weight_tensor_parameter_87:
 
 class Program_weight_tensor_parameter_88:
     name = "parameter_88"
+    original_name = "batch_norm_59.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.0662464")
@@ -979,6 +1068,7 @@ class Program_weight_tensor_parameter_88:
 
 class Program_weight_tensor_parameter_89:
     name = "parameter_89"
+    original_name = "batch_norm_59.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.0148794")
@@ -990,6 +1080,7 @@ class Program_weight_tensor_parameter_89:
 
 class Program_weight_tensor_parameter_90:
     name = "parameter_90"
+    original_name = "batch_norm_59.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.0691899")
@@ -1001,6 +1092,7 @@ class Program_weight_tensor_parameter_90:
 
 class Program_weight_tensor_parameter_91:
     name = "parameter_91"
+    original_name = "conv2d_59.w_0"
     shape = [256, 1024, 1, 1]
     dtype = "float32"
     min_val = float("-0.239188")
@@ -1012,6 +1104,7 @@ class Program_weight_tensor_parameter_91:
 
 class Program_weight_tensor_parameter_92:
     name = "parameter_92"
+    original_name = "batch_norm_58.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-4.21957")
@@ -1023,6 +1116,7 @@ class Program_weight_tensor_parameter_92:
 
 class Program_weight_tensor_parameter_93:
     name = "parameter_93"
+    original_name = "batch_norm_58.w_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("0.113134")
@@ -1034,6 +1128,7 @@ class Program_weight_tensor_parameter_93:
 
 class Program_weight_tensor_parameter_94:
     name = "parameter_94"
+    original_name = "batch_norm_58.w_2"
     shape = [1024]
     dtype = "float32"
     min_val = float("1.67876e-42")
@@ -1045,6 +1140,7 @@ class Program_weight_tensor_parameter_94:
 
 class Program_weight_tensor_parameter_95:
     name = "parameter_95"
+    original_name = "batch_norm_58.w_1"
     shape = [1024]
     dtype = "float32"
     min_val = float("-1.18621")
@@ -1056,6 +1152,7 @@ class Program_weight_tensor_parameter_95:
 
 class Program_weight_tensor_parameter_96:
     name = "parameter_96"
+    original_name = "conv2d_58.w_0"
     shape = [1024, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.211522")
@@ -1067,6 +1164,7 @@ class Program_weight_tensor_parameter_96:
 
 class Program_weight_tensor_parameter_97:
     name = "parameter_97"
+    original_name = "batch_norm_57.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.98935")
@@ -1078,6 +1176,7 @@ class Program_weight_tensor_parameter_97:
 
 class Program_weight_tensor_parameter_98:
     name = "parameter_98"
+    original_name = "batch_norm_57.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.630948")
@@ -1089,6 +1188,7 @@ class Program_weight_tensor_parameter_98:
 
 class Program_weight_tensor_parameter_99:
     name = "parameter_99"
+    original_name = "batch_norm_57.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.00020621")
@@ -1100,6 +1200,7 @@ class Program_weight_tensor_parameter_99:
 
 class Program_weight_tensor_parameter_100:
     name = "parameter_100"
+    original_name = "batch_norm_57.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.20382")
@@ -1111,6 +1212,7 @@ class Program_weight_tensor_parameter_100:
 
 class Program_weight_tensor_parameter_101:
     name = "parameter_101"
+    original_name = "conv2d_57.w_0"
     shape = [256, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.277028")
@@ -1122,6 +1224,7 @@ class Program_weight_tensor_parameter_101:
 
 class Program_weight_tensor_parameter_102:
     name = "parameter_102"
+    original_name = "batch_norm_56.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.929524")
@@ -1133,6 +1236,7 @@ class Program_weight_tensor_parameter_102:
 
 class Program_weight_tensor_parameter_103:
     name = "parameter_103"
+    original_name = "batch_norm_56.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.0415774")
@@ -1144,6 +1248,7 @@ class Program_weight_tensor_parameter_103:
 
 class Program_weight_tensor_parameter_104:
     name = "parameter_104"
+    original_name = "batch_norm_56.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.0576867")
@@ -1155,6 +1260,7 @@ class Program_weight_tensor_parameter_104:
 
 class Program_weight_tensor_parameter_105:
     name = "parameter_105"
+    original_name = "batch_norm_56.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.143846")
@@ -1166,6 +1272,7 @@ class Program_weight_tensor_parameter_105:
 
 class Program_weight_tensor_parameter_106:
     name = "parameter_106"
+    original_name = "conv2d_56.w_0"
     shape = [256, 1024, 1, 1]
     dtype = "float32"
     min_val = float("-0.245266")
@@ -1177,6 +1284,7 @@ class Program_weight_tensor_parameter_106:
 
 class Program_weight_tensor_parameter_107:
     name = "parameter_107"
+    original_name = "batch_norm_55.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-5.64332")
@@ -1188,6 +1296,7 @@ class Program_weight_tensor_parameter_107:
 
 class Program_weight_tensor_parameter_108:
     name = "parameter_108"
+    original_name = "batch_norm_55.w_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("0.193728")
@@ -1199,6 +1308,7 @@ class Program_weight_tensor_parameter_108:
 
 class Program_weight_tensor_parameter_109:
     name = "parameter_109"
+    original_name = "batch_norm_55.w_2"
     shape = [1024]
     dtype = "float32"
     min_val = float("1.67876e-42")
@@ -1210,6 +1320,7 @@ class Program_weight_tensor_parameter_109:
 
 class Program_weight_tensor_parameter_110:
     name = "parameter_110"
+    original_name = "batch_norm_55.w_1"
     shape = [1024]
     dtype = "float32"
     min_val = float("-3.80816")
@@ -1221,6 +1332,7 @@ class Program_weight_tensor_parameter_110:
 
 class Program_weight_tensor_parameter_111:
     name = "parameter_111"
+    original_name = "conv2d_55.w_0"
     shape = [1024, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.253615")
@@ -1232,6 +1344,7 @@ class Program_weight_tensor_parameter_111:
 
 class Program_weight_tensor_parameter_112:
     name = "parameter_112"
+    original_name = "batch_norm_54.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.55063")
@@ -1243,6 +1356,7 @@ class Program_weight_tensor_parameter_112:
 
 class Program_weight_tensor_parameter_113:
     name = "parameter_113"
+    original_name = "batch_norm_54.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.0993726")
@@ -1254,6 +1368,7 @@ class Program_weight_tensor_parameter_113:
 
 class Program_weight_tensor_parameter_114:
     name = "parameter_114"
+    original_name = "batch_norm_54.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.548538")
@@ -1265,6 +1380,7 @@ class Program_weight_tensor_parameter_114:
 
 class Program_weight_tensor_parameter_115:
     name = "parameter_115"
+    original_name = "batch_norm_54.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-4.41659")
@@ -1276,6 +1392,7 @@ class Program_weight_tensor_parameter_115:
 
 class Program_weight_tensor_parameter_116:
     name = "parameter_116"
+    original_name = "conv2d_54.w_0"
     shape = [256, 1024, 1, 1]
     dtype = "float32"
     min_val = float("-0.305451")
@@ -1287,6 +1404,7 @@ class Program_weight_tensor_parameter_116:
 
 class Program_weight_tensor_parameter_117:
     name = "parameter_117"
+    original_name = "batch_norm_53.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-6.82879")
@@ -1298,6 +1416,7 @@ class Program_weight_tensor_parameter_117:
 
 class Program_weight_tensor_parameter_118:
     name = "parameter_118"
+    original_name = "batch_norm_53.w_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("0.0338038")
@@ -1309,6 +1428,7 @@ class Program_weight_tensor_parameter_118:
 
 class Program_weight_tensor_parameter_119:
     name = "parameter_119"
+    original_name = "batch_norm_53.w_2"
     shape = [1024]
     dtype = "float32"
     min_val = float("1.13645e-42")
@@ -1320,6 +1440,7 @@ class Program_weight_tensor_parameter_119:
 
 class Program_weight_tensor_parameter_120:
     name = "parameter_120"
+    original_name = "batch_norm_53.w_1"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.677955")
@@ -1331,6 +1452,7 @@ class Program_weight_tensor_parameter_120:
 
 class Program_weight_tensor_parameter_121:
     name = "parameter_121"
+    original_name = "conv2d_53.w_0"
     shape = [1024, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.22885")
@@ -1342,6 +1464,7 @@ class Program_weight_tensor_parameter_121:
 
 class Program_weight_tensor_parameter_122:
     name = "parameter_122"
+    original_name = "batch_norm_52.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-1.86404")
@@ -1353,6 +1476,7 @@ class Program_weight_tensor_parameter_122:
 
 class Program_weight_tensor_parameter_123:
     name = "parameter_123"
+    original_name = "batch_norm_52.w_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("0.0668295")
@@ -1364,6 +1488,7 @@ class Program_weight_tensor_parameter_123:
 
 class Program_weight_tensor_parameter_124:
     name = "parameter_124"
+    original_name = "batch_norm_52.w_2"
     shape = [1024]
     dtype = "float32"
     min_val = float("1.65073e-42")
@@ -1375,6 +1500,7 @@ class Program_weight_tensor_parameter_124:
 
 class Program_weight_tensor_parameter_125:
     name = "parameter_125"
+    original_name = "batch_norm_52.w_1"
     shape = [1024]
     dtype = "float32"
     min_val = float("-1.47914")
@@ -1386,6 +1512,7 @@ class Program_weight_tensor_parameter_125:
 
 class Program_weight_tensor_parameter_126:
     name = "parameter_126"
+    original_name = "conv2d_52.w_0"
     shape = [1024, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.310368")
@@ -1397,6 +1524,7 @@ class Program_weight_tensor_parameter_126:
 
 class Program_weight_tensor_parameter_127:
     name = "parameter_127"
+    original_name = "batch_norm_51.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-2.93209")
@@ -1408,6 +1536,7 @@ class Program_weight_tensor_parameter_127:
 
 class Program_weight_tensor_parameter_128:
     name = "parameter_128"
+    original_name = "batch_norm_51.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.753114")
@@ -1419,6 +1548,7 @@ class Program_weight_tensor_parameter_128:
 
 class Program_weight_tensor_parameter_129:
     name = "parameter_129"
+    original_name = "batch_norm_51.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("2.31732e-05")
@@ -1430,6 +1560,7 @@ class Program_weight_tensor_parameter_129:
 
 class Program_weight_tensor_parameter_130:
     name = "parameter_130"
+    original_name = "batch_norm_51.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.804192")
@@ -1441,6 +1572,7 @@ class Program_weight_tensor_parameter_130:
 
 class Program_weight_tensor_parameter_131:
     name = "parameter_131"
+    original_name = "conv2d_51.w_0"
     shape = [256, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.322569")
@@ -1452,6 +1584,7 @@ class Program_weight_tensor_parameter_131:
 
 class Program_weight_tensor_parameter_132:
     name = "parameter_132"
+    original_name = "batch_norm_50.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.06337")
@@ -1463,6 +1596,7 @@ class Program_weight_tensor_parameter_132:
 
 class Program_weight_tensor_parameter_133:
     name = "parameter_133"
+    original_name = "batch_norm_50.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.0448606")
@@ -1474,6 +1608,7 @@ class Program_weight_tensor_parameter_133:
 
 class Program_weight_tensor_parameter_134:
     name = "parameter_134"
+    original_name = "batch_norm_50.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.452495")
@@ -1485,6 +1620,7 @@ class Program_weight_tensor_parameter_134:
 
 class Program_weight_tensor_parameter_135:
     name = "parameter_135"
+    original_name = "batch_norm_50.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-2.34625")
@@ -1496,6 +1632,7 @@ class Program_weight_tensor_parameter_135:
 
 class Program_weight_tensor_parameter_136:
     name = "parameter_136"
+    original_name = "conv2d_50.w_0"
     shape = [256, 1024, 1, 1]
     dtype = "float32"
     min_val = float("-0.265746")
@@ -1507,6 +1644,7 @@ class Program_weight_tensor_parameter_136:
 
 class Program_weight_tensor_parameter_137:
     name = "parameter_137"
+    original_name = "batch_norm_49.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-10.3864")
@@ -1518,6 +1656,7 @@ class Program_weight_tensor_parameter_137:
 
 class Program_weight_tensor_parameter_138:
     name = "parameter_138"
+    original_name = "batch_norm_49.w_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("0.171525")
@@ -1529,6 +1668,7 @@ class Program_weight_tensor_parameter_138:
 
 class Program_weight_tensor_parameter_139:
     name = "parameter_139"
+    original_name = "batch_norm_49.w_2"
     shape = [1024]
     dtype = "float32"
     min_val = float("1.15887e-42")
@@ -1540,6 +1680,7 @@ class Program_weight_tensor_parameter_139:
 
 class Program_weight_tensor_parameter_140:
     name = "parameter_140"
+    original_name = "batch_norm_49.w_1"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.60269")
@@ -1551,6 +1692,7 @@ class Program_weight_tensor_parameter_140:
 
 class Program_weight_tensor_parameter_141:
     name = "parameter_141"
+    original_name = "conv2d_49.w_0"
     shape = [1024, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.220196")
@@ -1562,6 +1704,7 @@ class Program_weight_tensor_parameter_141:
 
 class Program_weight_tensor_parameter_142:
     name = "parameter_142"
+    original_name = "batch_norm_48.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-1.87647")
@@ -1573,6 +1716,7 @@ class Program_weight_tensor_parameter_142:
 
 class Program_weight_tensor_parameter_143:
     name = "parameter_143"
+    original_name = "batch_norm_48.w_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("0.11464")
@@ -1584,6 +1728,7 @@ class Program_weight_tensor_parameter_143:
 
 class Program_weight_tensor_parameter_144:
     name = "parameter_144"
+    original_name = "batch_norm_48.w_2"
     shape = [1024]
     dtype = "float32"
     min_val = float("1.66054e-42")
@@ -1595,6 +1740,7 @@ class Program_weight_tensor_parameter_144:
 
 class Program_weight_tensor_parameter_145:
     name = "parameter_145"
+    original_name = "batch_norm_48.w_1"
     shape = [1024]
     dtype = "float32"
     min_val = float("-1.87606")
@@ -1606,6 +1752,7 @@ class Program_weight_tensor_parameter_145:
 
 class Program_weight_tensor_parameter_146:
     name = "parameter_146"
+    original_name = "conv2d_48.w_0"
     shape = [1024, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.403756")
@@ -1617,6 +1764,7 @@ class Program_weight_tensor_parameter_146:
 
 class Program_weight_tensor_parameter_147:
     name = "parameter_147"
+    original_name = "batch_norm_47.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-2.88305")
@@ -1628,6 +1776,7 @@ class Program_weight_tensor_parameter_147:
 
 class Program_weight_tensor_parameter_148:
     name = "parameter_148"
+    original_name = "batch_norm_47.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.652199")
@@ -1639,6 +1788,7 @@ class Program_weight_tensor_parameter_148:
 
 class Program_weight_tensor_parameter_149:
     name = "parameter_149"
+    original_name = "batch_norm_47.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("5.27836e-05")
@@ -1650,6 +1800,7 @@ class Program_weight_tensor_parameter_149:
 
 class Program_weight_tensor_parameter_150:
     name = "parameter_150"
+    original_name = "batch_norm_47.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.36315")
@@ -1661,6 +1812,7 @@ class Program_weight_tensor_parameter_150:
 
 class Program_weight_tensor_parameter_151:
     name = "parameter_151"
+    original_name = "conv2d_47.w_0"
     shape = [256, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.314152")
@@ -1672,6 +1824,7 @@ class Program_weight_tensor_parameter_151:
 
 class Program_weight_tensor_parameter_152:
     name = "parameter_152"
+    original_name = "batch_norm_46.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.09378")
@@ -1683,6 +1836,7 @@ class Program_weight_tensor_parameter_152:
 
 class Program_weight_tensor_parameter_153:
     name = "parameter_153"
+    original_name = "batch_norm_46.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.0516584")
@@ -1694,6 +1848,7 @@ class Program_weight_tensor_parameter_153:
 
 class Program_weight_tensor_parameter_154:
     name = "parameter_154"
+    original_name = "batch_norm_46.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.451342")
@@ -1705,6 +1860,7 @@ class Program_weight_tensor_parameter_154:
 
 class Program_weight_tensor_parameter_155:
     name = "parameter_155"
+    original_name = "batch_norm_46.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-3.08851")
@@ -1716,6 +1872,7 @@ class Program_weight_tensor_parameter_155:
 
 class Program_weight_tensor_parameter_156:
     name = "parameter_156"
+    original_name = "conv2d_46.w_0"
     shape = [256, 1024, 1, 1]
     dtype = "float32"
     min_val = float("-0.277856")
@@ -1727,6 +1884,7 @@ class Program_weight_tensor_parameter_156:
 
 class Program_weight_tensor_parameter_157:
     name = "parameter_157"
+    original_name = "batch_norm_45.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-6.42365")
@@ -1738,6 +1896,7 @@ class Program_weight_tensor_parameter_157:
 
 class Program_weight_tensor_parameter_158:
     name = "parameter_158"
+    original_name = "batch_norm_45.w_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("0.0558595")
@@ -1749,6 +1908,7 @@ class Program_weight_tensor_parameter_158:
 
 class Program_weight_tensor_parameter_159:
     name = "parameter_159"
+    original_name = "batch_norm_45.w_2"
     shape = [1024]
     dtype = "float32"
     min_val = float("1.27098e-42")
@@ -1760,6 +1920,7 @@ class Program_weight_tensor_parameter_159:
 
 class Program_weight_tensor_parameter_160:
     name = "parameter_160"
+    original_name = "batch_norm_45.w_1"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.715336")
@@ -1771,6 +1932,7 @@ class Program_weight_tensor_parameter_160:
 
 class Program_weight_tensor_parameter_161:
     name = "parameter_161"
+    original_name = "conv2d_45.w_0"
     shape = [1024, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.227747")
@@ -1782,6 +1944,7 @@ class Program_weight_tensor_parameter_161:
 
 class Program_weight_tensor_parameter_162:
     name = "parameter_162"
+    original_name = "batch_norm_44.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-1.93005")
@@ -1793,6 +1956,7 @@ class Program_weight_tensor_parameter_162:
 
 class Program_weight_tensor_parameter_163:
     name = "parameter_163"
+    original_name = "batch_norm_44.w_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("0.139966")
@@ -1804,6 +1968,7 @@ class Program_weight_tensor_parameter_163:
 
 class Program_weight_tensor_parameter_164:
     name = "parameter_164"
+    original_name = "batch_norm_44.w_2"
     shape = [1024]
     dtype = "float32"
     min_val = float("1.64092e-42")
@@ -1815,6 +1980,7 @@ class Program_weight_tensor_parameter_164:
 
 class Program_weight_tensor_parameter_165:
     name = "parameter_165"
+    original_name = "batch_norm_44.w_1"
     shape = [1024]
     dtype = "float32"
     min_val = float("-1.72552")
@@ -1826,6 +1992,7 @@ class Program_weight_tensor_parameter_165:
 
 class Program_weight_tensor_parameter_166:
     name = "parameter_166"
+    original_name = "conv2d_44.w_0"
     shape = [1024, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.402738")
@@ -1837,6 +2004,7 @@ class Program_weight_tensor_parameter_166:
 
 class Program_weight_tensor_parameter_167:
     name = "parameter_167"
+    original_name = "batch_norm_43.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-2.35042")
@@ -1848,6 +2016,7 @@ class Program_weight_tensor_parameter_167:
 
 class Program_weight_tensor_parameter_168:
     name = "parameter_168"
+    original_name = "batch_norm_43.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.651124")
@@ -1859,6 +2028,7 @@ class Program_weight_tensor_parameter_168:
 
 class Program_weight_tensor_parameter_169:
     name = "parameter_169"
+    original_name = "batch_norm_43.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("6.24325e-05")
@@ -1870,6 +2040,7 @@ class Program_weight_tensor_parameter_169:
 
 class Program_weight_tensor_parameter_170:
     name = "parameter_170"
+    original_name = "batch_norm_43.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-2.53589")
@@ -1881,6 +2052,7 @@ class Program_weight_tensor_parameter_170:
 
 class Program_weight_tensor_parameter_171:
     name = "parameter_171"
+    original_name = "conv2d_43.w_0"
     shape = [256, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.335805")
@@ -1892,6 +2064,7 @@ class Program_weight_tensor_parameter_171:
 
 class Program_weight_tensor_parameter_172:
     name = "parameter_172"
+    original_name = "batch_norm_42.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-2.73899")
@@ -1903,6 +2076,7 @@ class Program_weight_tensor_parameter_172:
 
 class Program_weight_tensor_parameter_173:
     name = "parameter_173"
+    original_name = "batch_norm_42.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.010269")
@@ -1914,6 +2088,7 @@ class Program_weight_tensor_parameter_173:
 
 class Program_weight_tensor_parameter_174:
     name = "parameter_174"
+    original_name = "batch_norm_42.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("1.17807")
@@ -1925,6 +2100,7 @@ class Program_weight_tensor_parameter_174:
 
 class Program_weight_tensor_parameter_175:
     name = "parameter_175"
+    original_name = "batch_norm_42.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-6.38332")
@@ -1936,6 +2112,7 @@ class Program_weight_tensor_parameter_175:
 
 class Program_weight_tensor_parameter_176:
     name = "parameter_176"
+    original_name = "conv2d_42.w_0"
     shape = [256, 960, 1, 1]
     dtype = "float32"
     min_val = float("-0.481481")
@@ -1947,6 +2124,7 @@ class Program_weight_tensor_parameter_176:
 
 class Program_weight_tensor_parameter_177:
     name = "parameter_177"
+    original_name = "batch_norm_41.b_0"
     shape = [960]
     dtype = "float32"
     min_val = float("-4.24342")
@@ -1958,6 +2136,7 @@ class Program_weight_tensor_parameter_177:
 
 class Program_weight_tensor_parameter_178:
     name = "parameter_178"
+    original_name = "batch_norm_41.w_0"
     shape = [960]
     dtype = "float32"
     min_val = float("0.305971")
@@ -1969,6 +2148,7 @@ class Program_weight_tensor_parameter_178:
 
 class Program_weight_tensor_parameter_179:
     name = "parameter_179"
+    original_name = "batch_norm_41.w_2"
     shape = [960]
     dtype = "float32"
     min_val = float("1.67876e-42")
@@ -1980,6 +2160,7 @@ class Program_weight_tensor_parameter_179:
 
 class Program_weight_tensor_parameter_180:
     name = "parameter_180"
+    original_name = "batch_norm_41.w_1"
     shape = [960]
     dtype = "float32"
     min_val = float("-0.78732")
@@ -1991,6 +2172,7 @@ class Program_weight_tensor_parameter_180:
 
 class Program_weight_tensor_parameter_181:
     name = "parameter_181"
+    original_name = "conv2d_41.w_0"
     shape = [960, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.191921")
@@ -2002,6 +2184,7 @@ class Program_weight_tensor_parameter_181:
 
 class Program_weight_tensor_parameter_182:
     name = "parameter_182"
+    original_name = "batch_norm_40.b_0"
     shape = [960]
     dtype = "float32"
     min_val = float("-1.62349")
@@ -2013,6 +2196,7 @@ class Program_weight_tensor_parameter_182:
 
 class Program_weight_tensor_parameter_183:
     name = "parameter_183"
+    original_name = "batch_norm_40.w_0"
     shape = [960]
     dtype = "float32"
     min_val = float("0.435477")
@@ -2024,6 +2208,7 @@ class Program_weight_tensor_parameter_183:
 
 class Program_weight_tensor_parameter_184:
     name = "parameter_184"
+    original_name = "batch_norm_40.w_2"
     shape = [960]
     dtype = "float32"
     min_val = float("1.70678e-42")
@@ -2035,6 +2220,7 @@ class Program_weight_tensor_parameter_184:
 
 class Program_weight_tensor_parameter_185:
     name = "parameter_185"
+    original_name = "batch_norm_40.w_1"
     shape = [960]
     dtype = "float32"
     min_val = float("-1.14483")
@@ -2046,6 +2232,7 @@ class Program_weight_tensor_parameter_185:
 
 class Program_weight_tensor_parameter_186:
     name = "parameter_186"
+    original_name = "conv2d_40.w_0"
     shape = [960, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.492031")
@@ -2057,6 +2244,7 @@ class Program_weight_tensor_parameter_186:
 
 class Program_weight_tensor_parameter_187:
     name = "parameter_187"
+    original_name = "batch_norm_39.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-2.50468")
@@ -2068,6 +2256,7 @@ class Program_weight_tensor_parameter_187:
 
 class Program_weight_tensor_parameter_188:
     name = "parameter_188"
+    original_name = "batch_norm_39.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.576109")
@@ -2079,6 +2268,7 @@ class Program_weight_tensor_parameter_188:
 
 class Program_weight_tensor_parameter_189:
     name = "parameter_189"
+    original_name = "batch_norm_39.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.0299641")
@@ -2090,6 +2280,7 @@ class Program_weight_tensor_parameter_189:
 
 class Program_weight_tensor_parameter_190:
     name = "parameter_190"
+    original_name = "batch_norm_39.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-9.2325")
@@ -2101,6 +2292,7 @@ class Program_weight_tensor_parameter_190:
 
 class Program_weight_tensor_parameter_191:
     name = "parameter_191"
+    original_name = "conv2d_39.w_0"
     shape = [160, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.388109")
@@ -2112,6 +2304,7 @@ class Program_weight_tensor_parameter_191:
 
 class Program_weight_tensor_parameter_192:
     name = "parameter_192"
+    original_name = "batch_norm_38.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-4.34")
@@ -2123,6 +2316,7 @@ class Program_weight_tensor_parameter_192:
 
 class Program_weight_tensor_parameter_193:
     name = "parameter_193"
+    original_name = "batch_norm_38.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.410675")
@@ -2134,6 +2328,7 @@ class Program_weight_tensor_parameter_193:
 
 class Program_weight_tensor_parameter_194:
     name = "parameter_194"
+    original_name = "batch_norm_38.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.0644587")
@@ -2145,6 +2340,7 @@ class Program_weight_tensor_parameter_194:
 
 class Program_weight_tensor_parameter_195:
     name = "parameter_195"
+    original_name = "batch_norm_38.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.220693")
@@ -2156,6 +2352,7 @@ class Program_weight_tensor_parameter_195:
 
 class Program_weight_tensor_parameter_196:
     name = "parameter_196"
+    original_name = "conv2d_38.w_0"
     shape = [160, 640, 1, 1]
     dtype = "float32"
     min_val = float("-0.252572")
@@ -2167,6 +2364,7 @@ class Program_weight_tensor_parameter_196:
 
 class Program_weight_tensor_parameter_197:
     name = "parameter_197"
+    original_name = "batch_norm_37.b_0"
     shape = [640]
     dtype = "float32"
     min_val = float("-4.09296")
@@ -2178,6 +2376,7 @@ class Program_weight_tensor_parameter_197:
 
 class Program_weight_tensor_parameter_198:
     name = "parameter_198"
+    original_name = "batch_norm_37.w_0"
     shape = [640]
     dtype = "float32"
     min_val = float("0.177202")
@@ -2189,6 +2388,7 @@ class Program_weight_tensor_parameter_198:
 
 class Program_weight_tensor_parameter_199:
     name = "parameter_199"
+    original_name = "batch_norm_37.w_2"
     shape = [640]
     dtype = "float32"
     min_val = float("1.67876e-42")
@@ -2200,6 +2400,7 @@ class Program_weight_tensor_parameter_199:
 
 class Program_weight_tensor_parameter_200:
     name = "parameter_200"
+    original_name = "batch_norm_37.w_1"
     shape = [640]
     dtype = "float32"
     min_val = float("-1.06598")
@@ -2211,6 +2412,7 @@ class Program_weight_tensor_parameter_200:
 
 class Program_weight_tensor_parameter_201:
     name = "parameter_201"
+    original_name = "conv2d_37.w_0"
     shape = [640, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.283321")
@@ -2222,6 +2424,7 @@ class Program_weight_tensor_parameter_201:
 
 class Program_weight_tensor_parameter_202:
     name = "parameter_202"
+    original_name = "batch_norm_36.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-2.62977")
@@ -2233,6 +2436,7 @@ class Program_weight_tensor_parameter_202:
 
 class Program_weight_tensor_parameter_203:
     name = "parameter_203"
+    original_name = "batch_norm_36.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.159914")
@@ -2244,6 +2448,7 @@ class Program_weight_tensor_parameter_203:
 
 class Program_weight_tensor_parameter_204:
     name = "parameter_204"
+    original_name = "batch_norm_36.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.00548876")
@@ -2255,6 +2460,7 @@ class Program_weight_tensor_parameter_204:
 
 class Program_weight_tensor_parameter_205:
     name = "parameter_205"
+    original_name = "batch_norm_36.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-5.49342")
@@ -2266,6 +2472,7 @@ class Program_weight_tensor_parameter_205:
 
 class Program_weight_tensor_parameter_206:
     name = "parameter_206"
+    original_name = "conv2d_36.w_0"
     shape = [160, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.309248")
@@ -2277,6 +2484,7 @@ class Program_weight_tensor_parameter_206:
 
 class Program_weight_tensor_parameter_207:
     name = "parameter_207"
+    original_name = "batch_norm_35.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-2.57798")
@@ -2288,6 +2496,7 @@ class Program_weight_tensor_parameter_207:
 
 class Program_weight_tensor_parameter_208:
     name = "parameter_208"
+    original_name = "batch_norm_35.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.201047")
@@ -2299,6 +2508,7 @@ class Program_weight_tensor_parameter_208:
 
 class Program_weight_tensor_parameter_209:
     name = "parameter_209"
+    original_name = "batch_norm_35.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.0222785")
@@ -2310,6 +2520,7 @@ class Program_weight_tensor_parameter_209:
 
 class Program_weight_tensor_parameter_210:
     name = "parameter_210"
+    original_name = "batch_norm_35.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.202729")
@@ -2321,6 +2532,7 @@ class Program_weight_tensor_parameter_210:
 
 class Program_weight_tensor_parameter_211:
     name = "parameter_211"
+    original_name = "conv2d_35.w_0"
     shape = [160, 320, 1, 1]
     dtype = "float32"
     min_val = float("-0.299088")
@@ -2332,6 +2544,7 @@ class Program_weight_tensor_parameter_211:
 
 class Program_weight_tensor_parameter_212:
     name = "parameter_212"
+    original_name = "batch_norm_34.b_0"
     shape = [320]
     dtype = "float32"
     min_val = float("-4.08498")
@@ -2343,6 +2556,7 @@ class Program_weight_tensor_parameter_212:
 
 class Program_weight_tensor_parameter_213:
     name = "parameter_213"
+    original_name = "batch_norm_34.w_0"
     shape = [320]
     dtype = "float32"
     min_val = float("0.45528")
@@ -2354,6 +2568,7 @@ class Program_weight_tensor_parameter_213:
 
 class Program_weight_tensor_parameter_214:
     name = "parameter_214"
+    original_name = "batch_norm_34.w_2"
     shape = [320]
     dtype = "float32"
     min_val = float("6.20489e-31")
@@ -2365,6 +2580,7 @@ class Program_weight_tensor_parameter_214:
 
 class Program_weight_tensor_parameter_215:
     name = "parameter_215"
+    original_name = "batch_norm_34.w_1"
     shape = [320]
     dtype = "float32"
     min_val = float("-5.22954")
@@ -2376,6 +2592,7 @@ class Program_weight_tensor_parameter_215:
 
 class Program_weight_tensor_parameter_216:
     name = "parameter_216"
+    original_name = "conv2d_34.w_0"
     shape = [320, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.380312")
@@ -2387,6 +2604,7 @@ class Program_weight_tensor_parameter_216:
 
 class Program_weight_tensor_parameter_217:
     name = "parameter_217"
+    original_name = "batch_norm_33.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-3.47002")
@@ -2398,6 +2616,7 @@ class Program_weight_tensor_parameter_217:
 
 class Program_weight_tensor_parameter_218:
     name = "parameter_218"
+    original_name = "batch_norm_33.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.0848781")
@@ -2409,6 +2628,7 @@ class Program_weight_tensor_parameter_218:
 
 class Program_weight_tensor_parameter_219:
     name = "parameter_219"
+    original_name = "batch_norm_33.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.0392376")
@@ -2420,6 +2640,7 @@ class Program_weight_tensor_parameter_219:
 
 class Program_weight_tensor_parameter_220:
     name = "parameter_220"
+    original_name = "batch_norm_33.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.277031")
@@ -2431,6 +2652,7 @@ class Program_weight_tensor_parameter_220:
 
 class Program_weight_tensor_parameter_221:
     name = "parameter_221"
+    original_name = "conv2d_33.w_0"
     shape = [160, 640, 1, 1]
     dtype = "float32"
     min_val = float("-0.387852")
@@ -2442,6 +2664,7 @@ class Program_weight_tensor_parameter_221:
 
 class Program_weight_tensor_parameter_222:
     name = "parameter_222"
+    original_name = "batch_norm_32.b_0"
     shape = [640]
     dtype = "float32"
     min_val = float("-8.20421")
@@ -2453,6 +2676,7 @@ class Program_weight_tensor_parameter_222:
 
 class Program_weight_tensor_parameter_223:
     name = "parameter_223"
+    original_name = "batch_norm_32.w_0"
     shape = [640]
     dtype = "float32"
     min_val = float("0.0720156")
@@ -2464,6 +2688,7 @@ class Program_weight_tensor_parameter_223:
 
 class Program_weight_tensor_parameter_224:
     name = "parameter_224"
+    original_name = "batch_norm_32.w_2"
     shape = [640]
     dtype = "float32"
     min_val = float("1.67876e-42")
@@ -2475,6 +2700,7 @@ class Program_weight_tensor_parameter_224:
 
 class Program_weight_tensor_parameter_225:
     name = "parameter_225"
+    original_name = "batch_norm_32.w_1"
     shape = [640]
     dtype = "float32"
     min_val = float("-1.08412")
@@ -2486,6 +2712,7 @@ class Program_weight_tensor_parameter_225:
 
 class Program_weight_tensor_parameter_226:
     name = "parameter_226"
+    original_name = "conv2d_32.w_0"
     shape = [640, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.435185")
@@ -2497,6 +2724,7 @@ class Program_weight_tensor_parameter_226:
 
 class Program_weight_tensor_parameter_227:
     name = "parameter_227"
+    original_name = "batch_norm_31.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-2.01333")
@@ -2508,6 +2736,7 @@ class Program_weight_tensor_parameter_227:
 
 class Program_weight_tensor_parameter_228:
     name = "parameter_228"
+    original_name = "batch_norm_31.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.529682")
@@ -2519,6 +2748,7 @@ class Program_weight_tensor_parameter_228:
 
 class Program_weight_tensor_parameter_229:
     name = "parameter_229"
+    original_name = "batch_norm_31.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.00133031")
@@ -2530,6 +2760,7 @@ class Program_weight_tensor_parameter_229:
 
 class Program_weight_tensor_parameter_230:
     name = "parameter_230"
+    original_name = "batch_norm_31.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.976939")
@@ -2541,6 +2772,7 @@ class Program_weight_tensor_parameter_230:
 
 class Program_weight_tensor_parameter_231:
     name = "parameter_231"
+    original_name = "conv2d_31.w_0"
     shape = [160, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.373896")
@@ -2552,6 +2784,7 @@ class Program_weight_tensor_parameter_231:
 
 class Program_weight_tensor_parameter_232:
     name = "parameter_232"
+    original_name = "batch_norm_30.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-4.38401")
@@ -2563,6 +2796,7 @@ class Program_weight_tensor_parameter_232:
 
 class Program_weight_tensor_parameter_233:
     name = "parameter_233"
+    original_name = "batch_norm_30.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.0730612")
@@ -2574,6 +2808,7 @@ class Program_weight_tensor_parameter_233:
 
 class Program_weight_tensor_parameter_234:
     name = "parameter_234"
+    original_name = "batch_norm_30.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.171028")
@@ -2585,6 +2820,7 @@ class Program_weight_tensor_parameter_234:
 
 class Program_weight_tensor_parameter_235:
     name = "parameter_235"
+    original_name = "batch_norm_30.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-2.27293")
@@ -2596,6 +2832,7 @@ class Program_weight_tensor_parameter_235:
 
 class Program_weight_tensor_parameter_236:
     name = "parameter_236"
+    original_name = "conv2d_30.w_0"
     shape = [160, 640, 1, 1]
     dtype = "float32"
     min_val = float("-0.382332")
@@ -2607,6 +2844,7 @@ class Program_weight_tensor_parameter_236:
 
 class Program_weight_tensor_parameter_237:
     name = "parameter_237"
+    original_name = "batch_norm_29.b_0"
     shape = [640]
     dtype = "float32"
     min_val = float("-15.3634")
@@ -2618,6 +2856,7 @@ class Program_weight_tensor_parameter_237:
 
 class Program_weight_tensor_parameter_238:
     name = "parameter_238"
+    original_name = "batch_norm_29.w_0"
     shape = [640]
     dtype = "float32"
     min_val = float("0.00447807")
@@ -2629,6 +2868,7 @@ class Program_weight_tensor_parameter_238:
 
 class Program_weight_tensor_parameter_239:
     name = "parameter_239"
+    original_name = "batch_norm_29.w_2"
     shape = [640]
     dtype = "float32"
     min_val = float("1.24575e-42")
@@ -2640,6 +2880,7 @@ class Program_weight_tensor_parameter_239:
 
 class Program_weight_tensor_parameter_240:
     name = "parameter_240"
+    original_name = "batch_norm_29.w_1"
     shape = [640]
     dtype = "float32"
     min_val = float("-0.409731")
@@ -2651,6 +2892,7 @@ class Program_weight_tensor_parameter_240:
 
 class Program_weight_tensor_parameter_241:
     name = "parameter_241"
+    original_name = "conv2d_29.w_0"
     shape = [640, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.20192")
@@ -2662,6 +2904,7 @@ class Program_weight_tensor_parameter_241:
 
 class Program_weight_tensor_parameter_242:
     name = "parameter_242"
+    original_name = "batch_norm_28.b_0"
     shape = [640]
     dtype = "float32"
     min_val = float("-1.77156")
@@ -2673,6 +2916,7 @@ class Program_weight_tensor_parameter_242:
 
 class Program_weight_tensor_parameter_243:
     name = "parameter_243"
+    original_name = "batch_norm_28.w_0"
     shape = [640]
     dtype = "float32"
     min_val = float("0.0628849")
@@ -2684,6 +2928,7 @@ class Program_weight_tensor_parameter_243:
 
 class Program_weight_tensor_parameter_244:
     name = "parameter_244"
+    original_name = "batch_norm_28.w_2"
     shape = [640]
     dtype = "float32"
     min_val = float("1.65633e-42")
@@ -2695,6 +2940,7 @@ class Program_weight_tensor_parameter_244:
 
 class Program_weight_tensor_parameter_245:
     name = "parameter_245"
+    original_name = "batch_norm_28.w_1"
     shape = [640]
     dtype = "float32"
     min_val = float("-1.09645")
@@ -2706,6 +2952,7 @@ class Program_weight_tensor_parameter_245:
 
 class Program_weight_tensor_parameter_246:
     name = "parameter_246"
+    original_name = "conv2d_28.w_0"
     shape = [640, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.380529")
@@ -2717,6 +2964,7 @@ class Program_weight_tensor_parameter_246:
 
 class Program_weight_tensor_parameter_247:
     name = "parameter_247"
+    original_name = "batch_norm_27.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-2.54662")
@@ -2728,6 +2976,7 @@ class Program_weight_tensor_parameter_247:
 
 class Program_weight_tensor_parameter_248:
     name = "parameter_248"
+    original_name = "batch_norm_27.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.123873")
@@ -2739,6 +2988,7 @@ class Program_weight_tensor_parameter_248:
 
 class Program_weight_tensor_parameter_249:
     name = "parameter_249"
+    original_name = "batch_norm_27.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.000398601")
@@ -2750,6 +3000,7 @@ class Program_weight_tensor_parameter_249:
 
 class Program_weight_tensor_parameter_250:
     name = "parameter_250"
+    original_name = "batch_norm_27.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.899844")
@@ -2761,6 +3012,7 @@ class Program_weight_tensor_parameter_250:
 
 class Program_weight_tensor_parameter_251:
     name = "parameter_251"
+    original_name = "conv2d_27.w_0"
     shape = [160, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.354645")
@@ -2772,6 +3024,7 @@ class Program_weight_tensor_parameter_251:
 
 class Program_weight_tensor_parameter_252:
     name = "parameter_252"
+    original_name = "batch_norm_26.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-3.15722")
@@ -2783,6 +3036,7 @@ class Program_weight_tensor_parameter_252:
 
 class Program_weight_tensor_parameter_253:
     name = "parameter_253"
+    original_name = "batch_norm_26.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.154135")
@@ -2794,6 +3048,7 @@ class Program_weight_tensor_parameter_253:
 
 class Program_weight_tensor_parameter_254:
     name = "parameter_254"
+    original_name = "batch_norm_26.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.135937")
@@ -2805,6 +3060,7 @@ class Program_weight_tensor_parameter_254:
 
 class Program_weight_tensor_parameter_255:
     name = "parameter_255"
+    original_name = "batch_norm_26.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-1.0209")
@@ -2816,6 +3072,7 @@ class Program_weight_tensor_parameter_255:
 
 class Program_weight_tensor_parameter_256:
     name = "parameter_256"
+    original_name = "conv2d_26.w_0"
     shape = [160, 640, 1, 1]
     dtype = "float32"
     min_val = float("-0.346731")
@@ -2827,6 +3084,7 @@ class Program_weight_tensor_parameter_256:
 
 class Program_weight_tensor_parameter_257:
     name = "parameter_257"
+    original_name = "batch_norm_25.b_0"
     shape = [640]
     dtype = "float32"
     min_val = float("-18.1626")
@@ -2838,6 +3096,7 @@ class Program_weight_tensor_parameter_257:
 
 class Program_weight_tensor_parameter_258:
     name = "parameter_258"
+    original_name = "batch_norm_25.w_0"
     shape = [640]
     dtype = "float32"
     min_val = float("0.0181023")
@@ -2849,6 +3108,7 @@ class Program_weight_tensor_parameter_258:
 
 class Program_weight_tensor_parameter_259:
     name = "parameter_259"
+    original_name = "batch_norm_25.w_2"
     shape = [640]
     dtype = "float32"
     min_val = float("1.28079e-42")
@@ -2860,6 +3120,7 @@ class Program_weight_tensor_parameter_259:
 
 class Program_weight_tensor_parameter_260:
     name = "parameter_260"
+    original_name = "batch_norm_25.w_1"
     shape = [640]
     dtype = "float32"
     min_val = float("-0.740359")
@@ -2871,6 +3132,7 @@ class Program_weight_tensor_parameter_260:
 
 class Program_weight_tensor_parameter_261:
     name = "parameter_261"
+    original_name = "conv2d_25.w_0"
     shape = [640, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.199563")
@@ -2882,6 +3144,7 @@ class Program_weight_tensor_parameter_261:
 
 class Program_weight_tensor_parameter_262:
     name = "parameter_262"
+    original_name = "batch_norm_24.b_0"
     shape = [640]
     dtype = "float32"
     min_val = float("-1.68141")
@@ -2893,6 +3156,7 @@ class Program_weight_tensor_parameter_262:
 
 class Program_weight_tensor_parameter_263:
     name = "parameter_263"
+    original_name = "batch_norm_24.w_0"
     shape = [640]
     dtype = "float32"
     min_val = float("0.134278")
@@ -2904,6 +3168,7 @@ class Program_weight_tensor_parameter_263:
 
 class Program_weight_tensor_parameter_264:
     name = "parameter_264"
+    original_name = "batch_norm_24.w_2"
     shape = [640]
     dtype = "float32"
     min_val = float("1.67876e-42")
@@ -2915,6 +3180,7 @@ class Program_weight_tensor_parameter_264:
 
 class Program_weight_tensor_parameter_265:
     name = "parameter_265"
+    original_name = "batch_norm_24.w_1"
     shape = [640]
     dtype = "float32"
     min_val = float("-1.2269")
@@ -2926,6 +3192,7 @@ class Program_weight_tensor_parameter_265:
 
 class Program_weight_tensor_parameter_266:
     name = "parameter_266"
+    original_name = "conv2d_24.w_0"
     shape = [640, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.44214")
@@ -2937,6 +3204,7 @@ class Program_weight_tensor_parameter_266:
 
 class Program_weight_tensor_parameter_267:
     name = "parameter_267"
+    original_name = "batch_norm_23.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-2.02969")
@@ -2948,6 +3216,7 @@ class Program_weight_tensor_parameter_267:
 
 class Program_weight_tensor_parameter_268:
     name = "parameter_268"
+    original_name = "batch_norm_23.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.388072")
@@ -2959,6 +3228,7 @@ class Program_weight_tensor_parameter_268:
 
 class Program_weight_tensor_parameter_269:
     name = "parameter_269"
+    original_name = "batch_norm_23.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.000119877")
@@ -2970,6 +3240,7 @@ class Program_weight_tensor_parameter_269:
 
 class Program_weight_tensor_parameter_270:
     name = "parameter_270"
+    original_name = "batch_norm_23.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.609156")
@@ -2981,6 +3252,7 @@ class Program_weight_tensor_parameter_270:
 
 class Program_weight_tensor_parameter_271:
     name = "parameter_271"
+    original_name = "conv2d_23.w_0"
     shape = [160, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.368288")
@@ -2992,6 +3264,7 @@ class Program_weight_tensor_parameter_271:
 
 class Program_weight_tensor_parameter_272:
     name = "parameter_272"
+    original_name = "batch_norm_22.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-2.5937")
@@ -3003,6 +3276,7 @@ class Program_weight_tensor_parameter_272:
 
 class Program_weight_tensor_parameter_273:
     name = "parameter_273"
+    original_name = "batch_norm_22.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.0225828")
@@ -3014,6 +3288,7 @@ class Program_weight_tensor_parameter_273:
 
 class Program_weight_tensor_parameter_274:
     name = "parameter_274"
+    original_name = "batch_norm_22.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.145788")
@@ -3025,6 +3300,7 @@ class Program_weight_tensor_parameter_274:
 
 class Program_weight_tensor_parameter_275:
     name = "parameter_275"
+    original_name = "batch_norm_22.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-1.23906")
@@ -3036,6 +3312,7 @@ class Program_weight_tensor_parameter_275:
 
 class Program_weight_tensor_parameter_276:
     name = "parameter_276"
+    original_name = "conv2d_22.w_0"
     shape = [160, 640, 1, 1]
     dtype = "float32"
     min_val = float("-0.349966")
@@ -3047,6 +3324,7 @@ class Program_weight_tensor_parameter_276:
 
 class Program_weight_tensor_parameter_277:
     name = "parameter_277"
+    original_name = "batch_norm_21.b_0"
     shape = [640]
     dtype = "float32"
     min_val = float("-7.54167")
@@ -3058,6 +3336,7 @@ class Program_weight_tensor_parameter_277:
 
 class Program_weight_tensor_parameter_278:
     name = "parameter_278"
+    original_name = "batch_norm_21.w_0"
     shape = [640]
     dtype = "float32"
     min_val = float("0.0366009")
@@ -3069,6 +3348,7 @@ class Program_weight_tensor_parameter_278:
 
 class Program_weight_tensor_parameter_279:
     name = "parameter_279"
+    original_name = "batch_norm_21.w_2"
     shape = [640]
     dtype = "float32"
     min_val = float("1.24015e-42")
@@ -3080,6 +3360,7 @@ class Program_weight_tensor_parameter_279:
 
 class Program_weight_tensor_parameter_280:
     name = "parameter_280"
+    original_name = "batch_norm_21.w_1"
     shape = [640]
     dtype = "float32"
     min_val = float("-0.731562")
@@ -3091,6 +3372,7 @@ class Program_weight_tensor_parameter_280:
 
 class Program_weight_tensor_parameter_281:
     name = "parameter_281"
+    original_name = "conv2d_21.w_0"
     shape = [640, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.355503")
@@ -3102,6 +3384,7 @@ class Program_weight_tensor_parameter_281:
 
 class Program_weight_tensor_parameter_282:
     name = "parameter_282"
+    original_name = "batch_norm_20.b_0"
     shape = [640]
     dtype = "float32"
     min_val = float("-1.97155")
@@ -3113,6 +3396,7 @@ class Program_weight_tensor_parameter_282:
 
 class Program_weight_tensor_parameter_283:
     name = "parameter_283"
+    original_name = "batch_norm_20.w_0"
     shape = [640]
     dtype = "float32"
     min_val = float("0.0153546")
@@ -3124,6 +3408,7 @@ class Program_weight_tensor_parameter_283:
 
 class Program_weight_tensor_parameter_284:
     name = "parameter_284"
+    original_name = "batch_norm_20.w_2"
     shape = [640]
     dtype = "float32"
     min_val = float("1.67876e-42")
@@ -3135,6 +3420,7 @@ class Program_weight_tensor_parameter_284:
 
 class Program_weight_tensor_parameter_285:
     name = "parameter_285"
+    original_name = "batch_norm_20.w_1"
     shape = [640]
     dtype = "float32"
     min_val = float("-1.40045")
@@ -3146,6 +3432,7 @@ class Program_weight_tensor_parameter_285:
 
 class Program_weight_tensor_parameter_286:
     name = "parameter_286"
+    original_name = "conv2d_20.w_0"
     shape = [640, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.460659")
@@ -3157,6 +3444,7 @@ class Program_weight_tensor_parameter_286:
 
 class Program_weight_tensor_parameter_287:
     name = "parameter_287"
+    original_name = "batch_norm_19.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-2.42683")
@@ -3168,6 +3456,7 @@ class Program_weight_tensor_parameter_287:
 
 class Program_weight_tensor_parameter_288:
     name = "parameter_288"
+    original_name = "batch_norm_19.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.250069")
@@ -3179,6 +3468,7 @@ class Program_weight_tensor_parameter_288:
 
 class Program_weight_tensor_parameter_289:
     name = "parameter_289"
+    original_name = "batch_norm_19.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("4.96099e-05")
@@ -3190,6 +3480,7 @@ class Program_weight_tensor_parameter_289:
 
 class Program_weight_tensor_parameter_290:
     name = "parameter_290"
+    original_name = "batch_norm_19.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.689616")
@@ -3201,6 +3492,7 @@ class Program_weight_tensor_parameter_290:
 
 class Program_weight_tensor_parameter_291:
     name = "parameter_291"
+    original_name = "conv2d_19.w_0"
     shape = [160, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.324593")
@@ -3212,6 +3504,7 @@ class Program_weight_tensor_parameter_291:
 
 class Program_weight_tensor_parameter_292:
     name = "parameter_292"
+    original_name = "batch_norm_18.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-2.29284")
@@ -3223,6 +3516,7 @@ class Program_weight_tensor_parameter_292:
 
 class Program_weight_tensor_parameter_293:
     name = "parameter_293"
+    original_name = "batch_norm_18.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.118593")
@@ -3234,6 +3528,7 @@ class Program_weight_tensor_parameter_293:
 
 class Program_weight_tensor_parameter_294:
     name = "parameter_294"
+    original_name = "batch_norm_18.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.148362")
@@ -3245,6 +3540,7 @@ class Program_weight_tensor_parameter_294:
 
 class Program_weight_tensor_parameter_295:
     name = "parameter_295"
+    original_name = "batch_norm_18.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-1.74502")
@@ -3256,6 +3552,7 @@ class Program_weight_tensor_parameter_295:
 
 class Program_weight_tensor_parameter_296:
     name = "parameter_296"
+    original_name = "conv2d_18.w_0"
     shape = [160, 640, 1, 1]
     dtype = "float32"
     min_val = float("-0.285577")
@@ -3267,6 +3564,7 @@ class Program_weight_tensor_parameter_296:
 
 class Program_weight_tensor_parameter_297:
     name = "parameter_297"
+    original_name = "batch_norm_17.b_0"
     shape = [640]
     dtype = "float32"
     min_val = float("-10.1072")
@@ -3278,6 +3576,7 @@ class Program_weight_tensor_parameter_297:
 
 class Program_weight_tensor_parameter_298:
     name = "parameter_298"
+    original_name = "batch_norm_17.w_0"
     shape = [640]
     dtype = "float32"
     min_val = float("0.143022")
@@ -3289,6 +3588,7 @@ class Program_weight_tensor_parameter_298:
 
 class Program_weight_tensor_parameter_299:
     name = "parameter_299"
+    original_name = "batch_norm_17.w_2"
     shape = [640]
     dtype = "float32"
     min_val = float("1.24996e-42")
@@ -3300,6 +3600,7 @@ class Program_weight_tensor_parameter_299:
 
 class Program_weight_tensor_parameter_300:
     name = "parameter_300"
+    original_name = "batch_norm_17.w_1"
     shape = [640]
     dtype = "float32"
     min_val = float("-0.482993")
@@ -3311,6 +3612,7 @@ class Program_weight_tensor_parameter_300:
 
 class Program_weight_tensor_parameter_301:
     name = "parameter_301"
+    original_name = "conv2d_17.w_0"
     shape = [640, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.235092")
@@ -3322,6 +3624,7 @@ class Program_weight_tensor_parameter_301:
 
 class Program_weight_tensor_parameter_302:
     name = "parameter_302"
+    original_name = "batch_norm_16.b_0"
     shape = [640]
     dtype = "float32"
     min_val = float("-2.23127")
@@ -3333,6 +3636,7 @@ class Program_weight_tensor_parameter_302:
 
 class Program_weight_tensor_parameter_303:
     name = "parameter_303"
+    original_name = "batch_norm_16.w_0"
     shape = [640]
     dtype = "float32"
     min_val = float("-0.0383393")
@@ -3344,6 +3648,7 @@ class Program_weight_tensor_parameter_303:
 
 class Program_weight_tensor_parameter_304:
     name = "parameter_304"
+    original_name = "batch_norm_16.w_2"
     shape = [640]
     dtype = "float32"
     min_val = float("1.66614e-42")
@@ -3355,6 +3660,7 @@ class Program_weight_tensor_parameter_304:
 
 class Program_weight_tensor_parameter_305:
     name = "parameter_305"
+    original_name = "batch_norm_16.w_1"
     shape = [640]
     dtype = "float32"
     min_val = float("-1.26517")
@@ -3366,6 +3672,7 @@ class Program_weight_tensor_parameter_305:
 
 class Program_weight_tensor_parameter_306:
     name = "parameter_306"
+    original_name = "conv2d_16.w_0"
     shape = [640, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.338378")
@@ -3377,6 +3684,7 @@ class Program_weight_tensor_parameter_306:
 
 class Program_weight_tensor_parameter_307:
     name = "parameter_307"
+    original_name = "batch_norm_15.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-2.02857")
@@ -3388,6 +3696,7 @@ class Program_weight_tensor_parameter_307:
 
 class Program_weight_tensor_parameter_308:
     name = "parameter_308"
+    original_name = "batch_norm_15.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.680062")
@@ -3399,6 +3708,7 @@ class Program_weight_tensor_parameter_308:
 
 class Program_weight_tensor_parameter_309:
     name = "parameter_309"
+    original_name = "batch_norm_15.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("3.3703e-05")
@@ -3410,6 +3720,7 @@ class Program_weight_tensor_parameter_309:
 
 class Program_weight_tensor_parameter_310:
     name = "parameter_310"
+    original_name = "batch_norm_15.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.549658")
@@ -3421,6 +3732,7 @@ class Program_weight_tensor_parameter_310:
 
 class Program_weight_tensor_parameter_311:
     name = "parameter_311"
+    original_name = "conv2d_15.w_0"
     shape = [160, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.314294")
@@ -3432,6 +3744,7 @@ class Program_weight_tensor_parameter_311:
 
 class Program_weight_tensor_parameter_312:
     name = "parameter_312"
+    original_name = "batch_norm_14.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-4.37019")
@@ -3443,6 +3756,7 @@ class Program_weight_tensor_parameter_312:
 
 class Program_weight_tensor_parameter_313:
     name = "parameter_313"
+    original_name = "batch_norm_14.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.0515668")
@@ -3454,6 +3768,7 @@ class Program_weight_tensor_parameter_313:
 
 class Program_weight_tensor_parameter_314:
     name = "parameter_314"
+    original_name = "batch_norm_14.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.521728")
@@ -3465,6 +3780,7 @@ class Program_weight_tensor_parameter_314:
 
 class Program_weight_tensor_parameter_315:
     name = "parameter_315"
+    original_name = "batch_norm_14.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-3.24998")
@@ -3476,6 +3792,7 @@ class Program_weight_tensor_parameter_315:
 
 class Program_weight_tensor_parameter_316:
     name = "parameter_316"
+    original_name = "conv2d_14.w_0"
     shape = [160, 480, 1, 1]
     dtype = "float32"
     min_val = float("-0.379788")
@@ -3487,6 +3804,7 @@ class Program_weight_tensor_parameter_316:
 
 class Program_weight_tensor_parameter_317:
     name = "parameter_317"
+    original_name = "batch_norm_13.b_0"
     shape = [480]
     dtype = "float32"
     min_val = float("-3.61694")
@@ -3498,6 +3816,7 @@ class Program_weight_tensor_parameter_317:
 
 class Program_weight_tensor_parameter_318:
     name = "parameter_318"
+    original_name = "batch_norm_13.w_0"
     shape = [480]
     dtype = "float32"
     min_val = float("0.427867")
@@ -3509,6 +3828,7 @@ class Program_weight_tensor_parameter_318:
 
 class Program_weight_tensor_parameter_319:
     name = "parameter_319"
+    original_name = "batch_norm_13.w_2"
     shape = [480]
     dtype = "float32"
     min_val = float("1.36767e-42")
@@ -3520,6 +3840,7 @@ class Program_weight_tensor_parameter_319:
 
 class Program_weight_tensor_parameter_320:
     name = "parameter_320"
+    original_name = "batch_norm_13.w_1"
     shape = [480]
     dtype = "float32"
     min_val = float("-1.16914")
@@ -3531,6 +3852,7 @@ class Program_weight_tensor_parameter_320:
 
 class Program_weight_tensor_parameter_321:
     name = "parameter_321"
+    original_name = "conv2d_13.w_0"
     shape = [480, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.196789")
@@ -3542,6 +3864,7 @@ class Program_weight_tensor_parameter_321:
 
 class Program_weight_tensor_parameter_322:
     name = "parameter_322"
+    original_name = "batch_norm_12.b_0"
     shape = [480]
     dtype = "float32"
     min_val = float("-1.56259")
@@ -3553,6 +3876,7 @@ class Program_weight_tensor_parameter_322:
 
 class Program_weight_tensor_parameter_323:
     name = "parameter_323"
+    original_name = "batch_norm_12.w_0"
     shape = [480]
     dtype = "float32"
     min_val = float("0.172465")
@@ -3564,6 +3888,7 @@ class Program_weight_tensor_parameter_323:
 
 class Program_weight_tensor_parameter_324:
     name = "parameter_324"
+    original_name = "batch_norm_12.w_2"
     shape = [480]
     dtype = "float32"
     min_val = float("1.67876e-42")
@@ -3575,6 +3900,7 @@ class Program_weight_tensor_parameter_324:
 
 class Program_weight_tensor_parameter_325:
     name = "parameter_325"
+    original_name = "batch_norm_12.w_1"
     shape = [480]
     dtype = "float32"
     min_val = float("-1.05546")
@@ -3586,6 +3912,7 @@ class Program_weight_tensor_parameter_325:
 
 class Program_weight_tensor_parameter_326:
     name = "parameter_326"
+    original_name = "conv2d_12.w_0"
     shape = [480, 80, 1, 1]
     dtype = "float32"
     min_val = float("-0.474654")
@@ -3597,6 +3924,7 @@ class Program_weight_tensor_parameter_326:
 
 class Program_weight_tensor_parameter_327:
     name = "parameter_327"
+    original_name = "batch_norm_11.b_0"
     shape = [80]
     dtype = "float32"
     min_val = float("-1.92372")
@@ -3608,6 +3936,7 @@ class Program_weight_tensor_parameter_327:
 
 class Program_weight_tensor_parameter_328:
     name = "parameter_328"
+    original_name = "batch_norm_11.w_0"
     shape = [80]
     dtype = "float32"
     min_val = float("0.482362")
@@ -3619,6 +3948,7 @@ class Program_weight_tensor_parameter_328:
 
 class Program_weight_tensor_parameter_329:
     name = "parameter_329"
+    original_name = "batch_norm_11.w_2"
     shape = [80]
     dtype = "float32"
     min_val = float("0.0323412")
@@ -3630,6 +3960,7 @@ class Program_weight_tensor_parameter_329:
 
 class Program_weight_tensor_parameter_330:
     name = "parameter_330"
+    original_name = "batch_norm_11.w_1"
     shape = [80]
     dtype = "float32"
     min_val = float("-0.702961")
@@ -3641,6 +3972,7 @@ class Program_weight_tensor_parameter_330:
 
 class Program_weight_tensor_parameter_331:
     name = "parameter_331"
+    original_name = "conv2d_11.w_0"
     shape = [80, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.257872")
@@ -3652,6 +3984,7 @@ class Program_weight_tensor_parameter_331:
 
 class Program_weight_tensor_parameter_332:
     name = "parameter_332"
+    original_name = "batch_norm_10.b_0"
     shape = [80]
     dtype = "float32"
     min_val = float("-2.6901")
@@ -3663,6 +3996,7 @@ class Program_weight_tensor_parameter_332:
 
 class Program_weight_tensor_parameter_333:
     name = "parameter_333"
+    original_name = "batch_norm_10.w_0"
     shape = [80]
     dtype = "float32"
     min_val = float("-0.124356")
@@ -3674,6 +4008,7 @@ class Program_weight_tensor_parameter_333:
 
 class Program_weight_tensor_parameter_334:
     name = "parameter_334"
+    original_name = "batch_norm_10.w_2"
     shape = [80]
     dtype = "float32"
     min_val = float("0.0772324")
@@ -3685,6 +4020,7 @@ class Program_weight_tensor_parameter_334:
 
 class Program_weight_tensor_parameter_335:
     name = "parameter_335"
+    original_name = "batch_norm_10.w_1"
     shape = [80]
     dtype = "float32"
     min_val = float("-0.722866")
@@ -3696,6 +4032,7 @@ class Program_weight_tensor_parameter_335:
 
 class Program_weight_tensor_parameter_336:
     name = "parameter_336"
+    original_name = "conv2d_10.w_0"
     shape = [80, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.253241")
@@ -3707,6 +4044,7 @@ class Program_weight_tensor_parameter_336:
 
 class Program_weight_tensor_parameter_337:
     name = "parameter_337"
+    original_name = "batch_norm_9.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-4.85783")
@@ -3718,6 +4056,7 @@ class Program_weight_tensor_parameter_337:
 
 class Program_weight_tensor_parameter_338:
     name = "parameter_338"
+    original_name = "batch_norm_9.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.34939")
@@ -3729,6 +4068,7 @@ class Program_weight_tensor_parameter_338:
 
 class Program_weight_tensor_parameter_339:
     name = "parameter_339"
+    original_name = "batch_norm_9.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.000161736")
@@ -3740,6 +4080,7 @@ class Program_weight_tensor_parameter_339:
 
 class Program_weight_tensor_parameter_340:
     name = "parameter_340"
+    original_name = "batch_norm_9.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.734053")
@@ -3751,6 +4092,7 @@ class Program_weight_tensor_parameter_340:
 
 class Program_weight_tensor_parameter_341:
     name = "parameter_341"
+    original_name = "conv2d_9.w_0"
     shape = [160, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.217529")
@@ -3762,6 +4104,7 @@ class Program_weight_tensor_parameter_341:
 
 class Program_weight_tensor_parameter_342:
     name = "parameter_342"
+    original_name = "batch_norm_8.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-1.24806")
@@ -3773,6 +4116,7 @@ class Program_weight_tensor_parameter_342:
 
 class Program_weight_tensor_parameter_343:
     name = "parameter_343"
+    original_name = "batch_norm_8.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.316254")
@@ -3784,6 +4128,7 @@ class Program_weight_tensor_parameter_343:
 
 class Program_weight_tensor_parameter_344:
     name = "parameter_344"
+    original_name = "batch_norm_8.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.0989657")
@@ -3795,6 +4140,7 @@ class Program_weight_tensor_parameter_344:
 
 class Program_weight_tensor_parameter_345:
     name = "parameter_345"
+    original_name = "batch_norm_8.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.82059")
@@ -3806,6 +4152,7 @@ class Program_weight_tensor_parameter_345:
 
 class Program_weight_tensor_parameter_346:
     name = "parameter_346"
+    original_name = "conv2d_8.w_0"
     shape = [160, 80, 1, 1]
     dtype = "float32"
     min_val = float("-0.334067")
@@ -3817,6 +4164,7 @@ class Program_weight_tensor_parameter_346:
 
 class Program_weight_tensor_parameter_347:
     name = "parameter_347"
+    original_name = "batch_norm_7.b_0"
     shape = [80]
     dtype = "float32"
     min_val = float("-2.96819")
@@ -3828,6 +4176,7 @@ class Program_weight_tensor_parameter_347:
 
 class Program_weight_tensor_parameter_348:
     name = "parameter_348"
+    original_name = "batch_norm_7.w_0"
     shape = [80]
     dtype = "float32"
     min_val = float("-0.068095")
@@ -3839,6 +4188,7 @@ class Program_weight_tensor_parameter_348:
 
 class Program_weight_tensor_parameter_349:
     name = "parameter_349"
+    original_name = "batch_norm_7.w_2"
     shape = [80]
     dtype = "float32"
     min_val = float("0.00603855")
@@ -3850,6 +4200,7 @@ class Program_weight_tensor_parameter_349:
 
 class Program_weight_tensor_parameter_350:
     name = "parameter_350"
+    original_name = "batch_norm_7.w_1"
     shape = [80]
     dtype = "float32"
     min_val = float("-0.400424")
@@ -3861,6 +4212,7 @@ class Program_weight_tensor_parameter_350:
 
 class Program_weight_tensor_parameter_351:
     name = "parameter_351"
+    original_name = "conv2d_7.w_0"
     shape = [80, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.272232")
@@ -3872,6 +4224,7 @@ class Program_weight_tensor_parameter_351:
 
 class Program_weight_tensor_parameter_352:
     name = "parameter_352"
+    original_name = "batch_norm_6.b_0"
     shape = [80]
     dtype = "float32"
     min_val = float("-1.77743")
@@ -3883,6 +4236,7 @@ class Program_weight_tensor_parameter_352:
 
 class Program_weight_tensor_parameter_353:
     name = "parameter_353"
+    original_name = "batch_norm_6.w_0"
     shape = [80]
     dtype = "float32"
     min_val = float("0.46935")
@@ -3894,6 +4248,7 @@ class Program_weight_tensor_parameter_353:
 
 class Program_weight_tensor_parameter_354:
     name = "parameter_354"
+    original_name = "batch_norm_6.w_2"
     shape = [80]
     dtype = "float32"
     min_val = float("0.127531")
@@ -3905,6 +4260,7 @@ class Program_weight_tensor_parameter_354:
 
 class Program_weight_tensor_parameter_355:
     name = "parameter_355"
+    original_name = "batch_norm_6.w_1"
     shape = [80]
     dtype = "float32"
     min_val = float("-1.89619")
@@ -3916,6 +4272,7 @@ class Program_weight_tensor_parameter_355:
 
 class Program_weight_tensor_parameter_356:
     name = "parameter_356"
+    original_name = "conv2d_6.w_0"
     shape = [80, 192, 1, 1]
     dtype = "float32"
     min_val = float("-0.321269")
@@ -3927,6 +4284,7 @@ class Program_weight_tensor_parameter_356:
 
 class Program_weight_tensor_parameter_357:
     name = "parameter_357"
+    original_name = "batch_norm_5.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-1.04199")
@@ -3938,6 +4296,7 @@ class Program_weight_tensor_parameter_357:
 
 class Program_weight_tensor_parameter_358:
     name = "parameter_358"
+    original_name = "batch_norm_5.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("0.428364")
@@ -3949,6 +4308,7 @@ class Program_weight_tensor_parameter_358:
 
 class Program_weight_tensor_parameter_359:
     name = "parameter_359"
+    original_name = "batch_norm_5.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("0.00124346")
@@ -3960,6 +4320,7 @@ class Program_weight_tensor_parameter_359:
 
 class Program_weight_tensor_parameter_360:
     name = "parameter_360"
+    original_name = "batch_norm_5.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-1.17843")
@@ -3971,6 +4332,7 @@ class Program_weight_tensor_parameter_360:
 
 class Program_weight_tensor_parameter_361:
     name = "parameter_361"
+    original_name = "conv2d_5.w_0"
     shape = [192, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.208177")
@@ -3982,6 +4344,7 @@ class Program_weight_tensor_parameter_361:
 
 class Program_weight_tensor_parameter_362:
     name = "parameter_362"
+    original_name = "batch_norm_4.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-1.25766")
@@ -3993,6 +4356,7 @@ class Program_weight_tensor_parameter_362:
 
 class Program_weight_tensor_parameter_363:
     name = "parameter_363"
+    original_name = "batch_norm_4.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("0.636521")
@@ -4004,6 +4368,7 @@ class Program_weight_tensor_parameter_363:
 
 class Program_weight_tensor_parameter_364:
     name = "parameter_364"
+    original_name = "batch_norm_4.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("0.0399959")
@@ -4015,6 +4380,7 @@ class Program_weight_tensor_parameter_364:
 
 class Program_weight_tensor_parameter_365:
     name = "parameter_365"
+    original_name = "batch_norm_4.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.716985")
@@ -4026,6 +4392,7 @@ class Program_weight_tensor_parameter_365:
 
 class Program_weight_tensor_parameter_366:
     name = "parameter_366"
+    original_name = "conv2d_4.w_0"
     shape = [192, 48, 1, 1]
     dtype = "float32"
     min_val = float("-0.598131")
@@ -4037,6 +4404,7 @@ class Program_weight_tensor_parameter_366:
 
 class Program_weight_tensor_parameter_367:
     name = "parameter_367"
+    original_name = "batch_norm_3.b_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -4046,6 +4414,7 @@ class Program_weight_tensor_parameter_367:
 
 class Program_weight_tensor_parameter_368:
     name = "parameter_368"
+    original_name = "batch_norm_3.w_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -4055,6 +4424,7 @@ class Program_weight_tensor_parameter_368:
 
 class Program_weight_tensor_parameter_369:
     name = "parameter_369"
+    original_name = "batch_norm_3.w_2"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -4064,6 +4434,7 @@ class Program_weight_tensor_parameter_369:
 
 class Program_weight_tensor_parameter_370:
     name = "parameter_370"
+    original_name = "batch_norm_3.w_1"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -4073,6 +4444,7 @@ class Program_weight_tensor_parameter_370:
 
 class Program_weight_tensor_parameter_371:
     name = "parameter_371"
+    original_name = "conv2d_3.w_0"
     shape = [48, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.328685")
@@ -4084,6 +4456,7 @@ class Program_weight_tensor_parameter_371:
 
 class Program_weight_tensor_parameter_372:
     name = "parameter_372"
+    original_name = "batch_norm_2.b_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -4093,6 +4466,7 @@ class Program_weight_tensor_parameter_372:
 
 class Program_weight_tensor_parameter_373:
     name = "parameter_373"
+    original_name = "batch_norm_2.w_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -4102,6 +4476,7 @@ class Program_weight_tensor_parameter_373:
 
 class Program_weight_tensor_parameter_374:
     name = "parameter_374"
+    original_name = "batch_norm_2.w_2"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -4111,6 +4486,7 @@ class Program_weight_tensor_parameter_374:
 
 class Program_weight_tensor_parameter_375:
     name = "parameter_375"
+    original_name = "batch_norm_2.w_1"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -4120,6 +4496,7 @@ class Program_weight_tensor_parameter_375:
 
 class Program_weight_tensor_parameter_376:
     name = "parameter_376"
+    original_name = "conv2d_2.w_0"
     shape = [48, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.313397")
@@ -4131,6 +4508,7 @@ class Program_weight_tensor_parameter_376:
 
 class Program_weight_tensor_parameter_377:
     name = "parameter_377"
+    original_name = "batch_norm_1.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-6.13005")
@@ -4142,6 +4520,7 @@ class Program_weight_tensor_parameter_377:
 
 class Program_weight_tensor_parameter_378:
     name = "parameter_378"
+    original_name = "batch_norm_1.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.519146")
@@ -4153,6 +4532,7 @@ class Program_weight_tensor_parameter_378:
 
 class Program_weight_tensor_parameter_379:
     name = "parameter_379"
+    original_name = "batch_norm_1.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.536347")
@@ -4164,6 +4544,7 @@ class Program_weight_tensor_parameter_379:
 
 class Program_weight_tensor_parameter_380:
     name = "parameter_380"
+    original_name = "batch_norm_1.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-3.64792")
@@ -4175,6 +4556,7 @@ class Program_weight_tensor_parameter_380:
 
 class Program_weight_tensor_parameter_381:
     name = "parameter_381"
+    original_name = "conv2d_1.w_0"
     shape = [128, 32, 3, 3]
     dtype = "float32"
     min_val = float("-0.488146")
@@ -4186,6 +4568,7 @@ class Program_weight_tensor_parameter_381:
 
 class Program_weight_tensor_parameter_382:
     name = "parameter_382"
+    original_name = "batch_norm_0.b_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -4195,6 +4578,7 @@ class Program_weight_tensor_parameter_382:
 
 class Program_weight_tensor_parameter_383:
     name = "parameter_383"
+    original_name = "batch_norm_0.w_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -4204,6 +4588,7 @@ class Program_weight_tensor_parameter_383:
 
 class Program_weight_tensor_parameter_384:
     name = "parameter_384"
+    original_name = "batch_norm_0.w_2"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -4213,6 +4598,7 @@ class Program_weight_tensor_parameter_384:
 
 class Program_weight_tensor_parameter_385:
     name = "parameter_385"
+    original_name = "batch_norm_0.w_1"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -4222,6 +4608,7 @@ class Program_weight_tensor_parameter_385:
 
 class Program_weight_tensor_parameter_386:
     name = "parameter_386"
+    original_name = "conv2d_0.w_0"
     shape = [32, 3, 3, 3]
     dtype = "float32"
     min_val = float("-0.15224")

--- a/paddle_samples/PaddleX/MobileNetV4_hybrid_large/subgraph_2/input_meta.py
+++ b/paddle_samples/PaddleX/MobileNetV4_hybrid_large/subgraph_2/input_meta.py
@@ -1,5 +1,6 @@
 class Program_weight_tensor_data_0:
     name = "data_0"
+    original_name = "param_0"
     shape = [96]
     dtype = "float32"
     min_val = float("-1.5956")
@@ -11,6 +12,7 @@ class Program_weight_tensor_data_0:
 
 class Program_weight_tensor_data_1:
     name = "data_1"
+    original_name = "param_1"
     shape = [96]
     dtype = "float32"
     min_val = float("-8.38982")
@@ -22,6 +24,7 @@ class Program_weight_tensor_data_1:
 
 class Program_weight_tensor_data_2:
     name = "data_2"
+    original_name = "param_10"
     shape = [192]
     dtype = "float32"
     min_val = float("-1.35857")
@@ -33,6 +36,7 @@ class Program_weight_tensor_data_2:
 
 class Program_weight_tensor_data_3:
     name = "data_3"
+    original_name = "param_11"
     shape = [192]
     dtype = "float32"
     min_val = float("-4.03801")
@@ -44,6 +48,7 @@ class Program_weight_tensor_data_3:
 
 class Program_weight_tensor_data_4:
     name = "data_4"
+    original_name = "param_12"
     shape = [192]
     dtype = "float32"
     min_val = float("-1.66111")
@@ -55,6 +60,7 @@ class Program_weight_tensor_data_4:
 
 class Program_weight_tensor_data_5:
     name = "data_5"
+    original_name = "param_13"
     shape = [192]
     dtype = "float32"
     min_val = float("-6.20082")
@@ -66,6 +72,7 @@ class Program_weight_tensor_data_5:
 
 class Program_weight_tensor_data_6:
     name = "data_6"
+    original_name = "param_14"
     shape = [192]
     dtype = "float32"
     min_val = float("-3.21386")
@@ -77,6 +84,7 @@ class Program_weight_tensor_data_6:
 
 class Program_weight_tensor_data_7:
     name = "data_7"
+    original_name = "param_15"
     shape = [192]
     dtype = "float32"
     min_val = float("-13.4928")
@@ -88,6 +96,7 @@ class Program_weight_tensor_data_7:
 
 class Program_weight_tensor_data_8:
     name = "data_8"
+    original_name = "param_16"
     shape = [192]
     dtype = "float32"
     min_val = float("-7.43462")
@@ -99,6 +108,7 @@ class Program_weight_tensor_data_8:
 
 class Program_weight_tensor_data_9:
     name = "data_9"
+    original_name = "param_17"
     shape = [512]
     dtype = "float32"
     min_val = float("-3.21152")
@@ -110,6 +120,7 @@ class Program_weight_tensor_data_9:
 
 class Program_weight_tensor_data_10:
     name = "data_10"
+    original_name = "param_18"
     shape = [512]
     dtype = "float32"
     min_val = float("-1.62979")
@@ -121,6 +132,7 @@ class Program_weight_tensor_data_10:
 
 class Program_weight_tensor_data_11:
     name = "data_11"
+    original_name = "param_19"
     shape = [512]
     dtype = "float32"
     min_val = float("-1.64878")
@@ -132,6 +144,7 @@ class Program_weight_tensor_data_11:
 
 class Program_weight_tensor_data_12:
     name = "data_12"
+    original_name = "param_2"
     shape = [192]
     dtype = "float32"
     min_val = float("-2.06332")
@@ -143,6 +156,7 @@ class Program_weight_tensor_data_12:
 
 class Program_weight_tensor_data_13:
     name = "data_13"
+    original_name = "param_20"
     shape = [512]
     dtype = "float32"
     min_val = float("-1.35291")
@@ -154,6 +168,7 @@ class Program_weight_tensor_data_13:
 
 class Program_weight_tensor_data_14:
     name = "data_14"
+    original_name = "param_21"
     shape = [512]
     dtype = "float32"
     min_val = float("-1.59504")
@@ -165,6 +180,7 @@ class Program_weight_tensor_data_14:
 
 class Program_weight_tensor_data_15:
     name = "data_15"
+    original_name = "param_22"
     shape = [512]
     dtype = "float32"
     min_val = float("-1.50642")
@@ -176,6 +192,7 @@ class Program_weight_tensor_data_15:
 
 class Program_weight_tensor_data_16:
     name = "data_16"
+    original_name = "param_23"
     shape = [512]
     dtype = "float32"
     min_val = float("-1.34455")
@@ -187,6 +204,7 @@ class Program_weight_tensor_data_16:
 
 class Program_weight_tensor_data_17:
     name = "data_17"
+    original_name = "param_24"
     shape = [512]
     dtype = "float32"
     min_val = float("-1.27155")
@@ -198,6 +216,7 @@ class Program_weight_tensor_data_17:
 
 class Program_weight_tensor_data_18:
     name = "data_18"
+    original_name = "param_25"
     shape = [512]
     dtype = "float32"
     min_val = float("-1.02089")
@@ -209,6 +228,7 @@ class Program_weight_tensor_data_18:
 
 class Program_weight_tensor_data_19:
     name = "data_19"
+    original_name = "param_26"
     shape = [512]
     dtype = "float32"
     min_val = float("-1.72642")
@@ -220,6 +240,7 @@ class Program_weight_tensor_data_19:
 
 class Program_weight_tensor_data_20:
     name = "data_20"
+    original_name = "param_27"
     shape = [512]
     dtype = "float32"
     min_val = float("-4.88923")
@@ -231,6 +252,7 @@ class Program_weight_tensor_data_20:
 
 class Program_weight_tensor_data_21:
     name = "data_21"
+    original_name = "param_28"
     shape = [512]
     dtype = "float32"
     min_val = float("-1.29465")
@@ -242,6 +264,7 @@ class Program_weight_tensor_data_21:
 
 class Program_weight_tensor_data_22:
     name = "data_22"
+    original_name = "param_29"
     shape = [512]
     dtype = "float32"
     min_val = float("-5.48204")
@@ -253,6 +276,7 @@ class Program_weight_tensor_data_22:
 
 class Program_weight_tensor_data_23:
     name = "data_23"
+    original_name = "param_3"
     shape = [192]
     dtype = "float32"
     min_val = float("-1.24935")
@@ -264,6 +288,7 @@ class Program_weight_tensor_data_23:
 
 class Program_weight_tensor_data_24:
     name = "data_24"
+    original_name = "param_30"
     shape = [512]
     dtype = "float32"
     min_val = float("-2.1995")
@@ -275,6 +300,7 @@ class Program_weight_tensor_data_24:
 
 class Program_weight_tensor_data_25:
     name = "data_25"
+    original_name = "param_31"
     shape = [512]
     dtype = "float32"
     min_val = float("-9.28786")
@@ -286,6 +312,7 @@ class Program_weight_tensor_data_25:
 
 class Program_weight_tensor_data_26:
     name = "data_26"
+    original_name = "param_32"
     shape = [512]
     dtype = "float32"
     min_val = float("-1.40352")
@@ -297,6 +324,7 @@ class Program_weight_tensor_data_26:
 
 class Program_weight_tensor_data_27:
     name = "data_27"
+    original_name = "param_33"
     shape = [512]
     dtype = "float32"
     min_val = float("-10.7566")
@@ -308,6 +336,7 @@ class Program_weight_tensor_data_27:
 
 class Program_weight_tensor_data_28:
     name = "data_28"
+    original_name = "param_34"
     shape = [512]
     dtype = "float32"
     min_val = float("-3.58612")
@@ -319,6 +348,7 @@ class Program_weight_tensor_data_28:
 
 class Program_weight_tensor_data_29:
     name = "data_29"
+    original_name = "param_4"
     shape = [192]
     dtype = "float32"
     min_val = float("-1.53518")
@@ -330,6 +360,7 @@ class Program_weight_tensor_data_29:
 
 class Program_weight_tensor_data_30:
     name = "data_30"
+    original_name = "param_5"
     shape = [192]
     dtype = "float32"
     min_val = float("-1.36551")
@@ -341,6 +372,7 @@ class Program_weight_tensor_data_30:
 
 class Program_weight_tensor_data_31:
     name = "data_31"
+    original_name = "param_6"
     shape = [192]
     dtype = "float32"
     min_val = float("-1.35657")
@@ -352,6 +384,7 @@ class Program_weight_tensor_data_31:
 
 class Program_weight_tensor_data_32:
     name = "data_32"
+    original_name = "param_7"
     shape = [192]
     dtype = "float32"
     min_val = float("-1.27522")
@@ -363,6 +396,7 @@ class Program_weight_tensor_data_32:
 
 class Program_weight_tensor_data_33:
     name = "data_33"
+    original_name = "param_8"
     shape = [192]
     dtype = "float32"
     min_val = float("-1.5561")
@@ -374,6 +408,7 @@ class Program_weight_tensor_data_33:
 
 class Program_weight_tensor_data_34:
     name = "data_34"
+    original_name = "param_9"
     shape = [192]
     dtype = "float32"
     min_val = float("-3.48307")
@@ -385,6 +420,7 @@ class Program_weight_tensor_data_34:
 
 class Program_weight_tensor_data_35:
     name = "data_35"
+    original_name = "var_0"
     shape = [32, 3, 384, 384]
     dtype = "float32"
     min_val = float("-4.59204")

--- a/paddle_samples/PaddleX/MobileNetV4_hybrid_large/subgraph_2/weight_meta.py
+++ b/paddle_samples/PaddleX/MobileNetV4_hybrid_large/subgraph_2/weight_meta.py
@@ -1,5 +1,6 @@
 class Program_weight_tensor_parameter_0:
     name = "parameter_0"
+    original_name = "linear_0.b_0"
     shape = [102]
     dtype = "float32"
     data = None
@@ -7,6 +8,7 @@ class Program_weight_tensor_parameter_0:
 
 class Program_weight_tensor_parameter_1:
     name = "parameter_1"
+    original_name = "linear_0.w_0"
     shape = [1280, 102]
     dtype = "float32"
     min_val = float("-0.065889")
@@ -18,6 +20,7 @@ class Program_weight_tensor_parameter_1:
 
 class Program_weight_tensor_parameter_2:
     name = "parameter_2"
+    original_name = "batch_norm_120.b_0"
     shape = [1280]
     dtype = "float32"
     min_val = float("0.0562052")
@@ -29,6 +32,7 @@ class Program_weight_tensor_parameter_2:
 
 class Program_weight_tensor_parameter_3:
     name = "parameter_3"
+    original_name = "batch_norm_120.w_0"
     shape = [1280]
     dtype = "float32"
     min_val = float("0.665716")
@@ -40,6 +44,7 @@ class Program_weight_tensor_parameter_3:
 
 class Program_weight_tensor_parameter_4:
     name = "parameter_4"
+    original_name = "batch_norm_120.w_2"
     shape = [1280]
     dtype = "float32"
     min_val = float("0.000648785")
@@ -51,6 +56,7 @@ class Program_weight_tensor_parameter_4:
 
 class Program_weight_tensor_parameter_5:
     name = "parameter_5"
+    original_name = "batch_norm_120.w_1"
     shape = [1280]
     dtype = "float32"
     min_val = float("-0.035632")
@@ -62,6 +68,7 @@ class Program_weight_tensor_parameter_5:
 
 class Program_weight_tensor_parameter_6:
     name = "parameter_6"
+    original_name = "conv2d_144.w_0"
     shape = [1280, 960, 1, 1]
     dtype = "float32"
     min_val = float("-0.212087")
@@ -73,6 +80,7 @@ class Program_weight_tensor_parameter_6:
 
 class Program_weight_tensor_parameter_7:
     name = "parameter_7"
+    original_name = "batch_norm_119.b_0"
     shape = [960]
     dtype = "float32"
     min_val = float("-6.08268")
@@ -84,6 +92,7 @@ class Program_weight_tensor_parameter_7:
 
 class Program_weight_tensor_parameter_8:
     name = "parameter_8"
+    original_name = "batch_norm_119.w_0"
     shape = [960]
     dtype = "float32"
     min_val = float("0.161293")
@@ -95,6 +104,7 @@ class Program_weight_tensor_parameter_8:
 
 class Program_weight_tensor_parameter_9:
     name = "parameter_9"
+    original_name = "batch_norm_119.w_2"
     shape = [960]
     dtype = "float32"
     min_val = float("6.53884")
@@ -106,6 +116,7 @@ class Program_weight_tensor_parameter_9:
 
 class Program_weight_tensor_parameter_10:
     name = "parameter_10"
+    original_name = "batch_norm_119.w_1"
     shape = [960]
     dtype = "float32"
     min_val = float("-5.59455")
@@ -117,6 +128,7 @@ class Program_weight_tensor_parameter_10:
 
 class Program_weight_tensor_parameter_11:
     name = "parameter_11"
+    original_name = "conv2d_143.w_0"
     shape = [960, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.267254")
@@ -128,6 +140,7 @@ class Program_weight_tensor_parameter_11:
 
 class Program_weight_tensor_parameter_12:
     name = "parameter_12"
+    original_name = "batch_norm_118.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.849359")
@@ -139,6 +152,7 @@ class Program_weight_tensor_parameter_12:
 
 class Program_weight_tensor_parameter_13:
     name = "parameter_13"
+    original_name = "batch_norm_118.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-3.73374")
@@ -150,6 +164,7 @@ class Program_weight_tensor_parameter_13:
 
 class Program_weight_tensor_parameter_14:
     name = "parameter_14"
+    original_name = "batch_norm_118.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("0.000509833")
@@ -161,6 +176,7 @@ class Program_weight_tensor_parameter_14:
 
 class Program_weight_tensor_parameter_15:
     name = "parameter_15"
+    original_name = "batch_norm_118.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-1.04036")
@@ -172,6 +188,7 @@ class Program_weight_tensor_parameter_15:
 
 class Program_weight_tensor_parameter_16:
     name = "parameter_16"
+    original_name = "conv2d_142.w_0"
     shape = [512, 2048, 1, 1]
     dtype = "float32"
     min_val = float("-0.355404")
@@ -183,6 +200,7 @@ class Program_weight_tensor_parameter_16:
 
 class Program_weight_tensor_parameter_17:
     name = "parameter_17"
+    original_name = "batch_norm_117.b_0"
     shape = [2048]
     dtype = "float32"
     min_val = float("-11.3215")
@@ -194,6 +212,7 @@ class Program_weight_tensor_parameter_17:
 
 class Program_weight_tensor_parameter_18:
     name = "parameter_18"
+    original_name = "batch_norm_117.w_0"
     shape = [2048]
     dtype = "float32"
     min_val = float("-0.429331")
@@ -205,6 +224,7 @@ class Program_weight_tensor_parameter_18:
 
 class Program_weight_tensor_parameter_19:
     name = "parameter_19"
+    original_name = "batch_norm_117.w_2"
     shape = [2048]
     dtype = "float32"
     min_val = float("0.00137084")
@@ -216,6 +236,7 @@ class Program_weight_tensor_parameter_19:
 
 class Program_weight_tensor_parameter_20:
     name = "parameter_20"
+    original_name = "batch_norm_117.w_1"
     shape = [2048]
     dtype = "float32"
     min_val = float("-1.11476")
@@ -227,6 +248,7 @@ class Program_weight_tensor_parameter_20:
 
 class Program_weight_tensor_parameter_21:
     name = "parameter_21"
+    original_name = "conv2d_141.w_0"
     shape = [2048, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.456615")
@@ -238,6 +260,7 @@ class Program_weight_tensor_parameter_21:
 
 class Program_weight_tensor_parameter_22:
     name = "parameter_22"
+    original_name = "batch_norm_116.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-2.19633")
@@ -249,6 +272,7 @@ class Program_weight_tensor_parameter_22:
 
 class Program_weight_tensor_parameter_23:
     name = "parameter_23"
+    original_name = "batch_norm_116.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("0.36293")
@@ -260,6 +284,7 @@ class Program_weight_tensor_parameter_23:
 
 class Program_weight_tensor_parameter_24:
     name = "parameter_24"
+    original_name = "batch_norm_116.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("0.0029126")
@@ -271,6 +296,7 @@ class Program_weight_tensor_parameter_24:
 
 class Program_weight_tensor_parameter_25:
     name = "parameter_25"
+    original_name = "batch_norm_116.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-3.68297")
@@ -282,6 +308,7 @@ class Program_weight_tensor_parameter_25:
 
 class Program_weight_tensor_parameter_26:
     name = "parameter_26"
+    original_name = "conv2d_140.w_0"
     shape = [512, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.241631")
@@ -293,6 +320,7 @@ class Program_weight_tensor_parameter_26:
 
 class Program_weight_tensor_parameter_27:
     name = "parameter_27"
+    original_name = "conv2d_139.w_0"
     shape = [512, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.16762")
@@ -304,6 +332,7 @@ class Program_weight_tensor_parameter_27:
 
 class Program_weight_tensor_parameter_28:
     name = "parameter_28"
+    original_name = "conv2d_138.w_0"
     shape = [64, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.174267")
@@ -315,6 +344,7 @@ class Program_weight_tensor_parameter_28:
 
 class Program_weight_tensor_parameter_29:
     name = "parameter_29"
+    original_name = "conv2d_137.w_0"
     shape = [64, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.337007")
@@ -326,6 +356,7 @@ class Program_weight_tensor_parameter_29:
 
 class Program_weight_tensor_parameter_30:
     name = "parameter_30"
+    original_name = "conv2d_136.w_0"
     shape = [512, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.257836")
@@ -337,6 +368,7 @@ class Program_weight_tensor_parameter_30:
 
 class Program_weight_tensor_parameter_31:
     name = "parameter_31"
+    original_name = "batch_norm_115.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-3.46741")
@@ -348,6 +380,7 @@ class Program_weight_tensor_parameter_31:
 
 class Program_weight_tensor_parameter_32:
     name = "parameter_32"
+    original_name = "batch_norm_115.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.608943")
@@ -359,6 +392,7 @@ class Program_weight_tensor_parameter_32:
 
 class Program_weight_tensor_parameter_33:
     name = "parameter_33"
+    original_name = "batch_norm_115.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("0.40362")
@@ -370,6 +404,7 @@ class Program_weight_tensor_parameter_33:
 
 class Program_weight_tensor_parameter_34:
     name = "parameter_34"
+    original_name = "batch_norm_115.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-13.319")
@@ -381,6 +416,7 @@ class Program_weight_tensor_parameter_34:
 
 class Program_weight_tensor_parameter_35:
     name = "parameter_35"
+    original_name = "batch_norm_114.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-1.24337")
@@ -392,6 +428,7 @@ class Program_weight_tensor_parameter_35:
 
 class Program_weight_tensor_parameter_36:
     name = "parameter_36"
+    original_name = "batch_norm_114.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-1.25156")
@@ -403,6 +440,7 @@ class Program_weight_tensor_parameter_36:
 
 class Program_weight_tensor_parameter_37:
     name = "parameter_37"
+    original_name = "batch_norm_114.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("0.000528468")
@@ -414,6 +452,7 @@ class Program_weight_tensor_parameter_37:
 
 class Program_weight_tensor_parameter_38:
     name = "parameter_38"
+    original_name = "batch_norm_114.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.769018")
@@ -425,6 +464,7 @@ class Program_weight_tensor_parameter_38:
 
 class Program_weight_tensor_parameter_39:
     name = "parameter_39"
+    original_name = "conv2d_135.w_0"
     shape = [512, 2048, 1, 1]
     dtype = "float32"
     min_val = float("-0.224832")
@@ -436,6 +476,7 @@ class Program_weight_tensor_parameter_39:
 
 class Program_weight_tensor_parameter_40:
     name = "parameter_40"
+    original_name = "batch_norm_113.b_0"
     shape = [2048]
     dtype = "float32"
     min_val = float("-6.15627")
@@ -447,6 +488,7 @@ class Program_weight_tensor_parameter_40:
 
 class Program_weight_tensor_parameter_41:
     name = "parameter_41"
+    original_name = "batch_norm_113.w_0"
     shape = [2048]
     dtype = "float32"
     min_val = float("-0.951391")
@@ -458,6 +500,7 @@ class Program_weight_tensor_parameter_41:
 
 class Program_weight_tensor_parameter_42:
     name = "parameter_42"
+    original_name = "batch_norm_113.w_2"
     shape = [2048]
     dtype = "float32"
     min_val = float("5.11224e-05")
@@ -469,6 +512,7 @@ class Program_weight_tensor_parameter_42:
 
 class Program_weight_tensor_parameter_43:
     name = "parameter_43"
+    original_name = "batch_norm_113.w_1"
     shape = [2048]
     dtype = "float32"
     min_val = float("-1.15548")
@@ -480,6 +524,7 @@ class Program_weight_tensor_parameter_43:
 
 class Program_weight_tensor_parameter_44:
     name = "parameter_44"
+    original_name = "conv2d_134.w_0"
     shape = [2048, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.552767")
@@ -491,6 +536,7 @@ class Program_weight_tensor_parameter_44:
 
 class Program_weight_tensor_parameter_45:
     name = "parameter_45"
+    original_name = "batch_norm_112.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-2.24819")
@@ -502,6 +548,7 @@ class Program_weight_tensor_parameter_45:
 
 class Program_weight_tensor_parameter_46:
     name = "parameter_46"
+    original_name = "batch_norm_112.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("0.257119")
@@ -513,6 +560,7 @@ class Program_weight_tensor_parameter_46:
 
 class Program_weight_tensor_parameter_47:
     name = "parameter_47"
+    original_name = "batch_norm_112.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("0.00173841")
@@ -524,6 +572,7 @@ class Program_weight_tensor_parameter_47:
 
 class Program_weight_tensor_parameter_48:
     name = "parameter_48"
+    original_name = "batch_norm_112.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-1.88672")
@@ -535,6 +584,7 @@ class Program_weight_tensor_parameter_48:
 
 class Program_weight_tensor_parameter_49:
     name = "parameter_49"
+    original_name = "conv2d_133.w_0"
     shape = [512, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.235658")
@@ -546,6 +596,7 @@ class Program_weight_tensor_parameter_49:
 
 class Program_weight_tensor_parameter_50:
     name = "parameter_50"
+    original_name = "conv2d_132.w_0"
     shape = [512, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.221559")
@@ -557,6 +608,7 @@ class Program_weight_tensor_parameter_50:
 
 class Program_weight_tensor_parameter_51:
     name = "parameter_51"
+    original_name = "conv2d_131.w_0"
     shape = [64, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.200632")
@@ -568,6 +620,7 @@ class Program_weight_tensor_parameter_51:
 
 class Program_weight_tensor_parameter_52:
     name = "parameter_52"
+    original_name = "conv2d_130.w_0"
     shape = [64, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.147475")
@@ -579,6 +632,7 @@ class Program_weight_tensor_parameter_52:
 
 class Program_weight_tensor_parameter_53:
     name = "parameter_53"
+    original_name = "conv2d_129.w_0"
     shape = [512, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.199359")
@@ -590,6 +644,7 @@ class Program_weight_tensor_parameter_53:
 
 class Program_weight_tensor_parameter_54:
     name = "parameter_54"
+    original_name = "batch_norm_111.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-2.31547")
@@ -601,6 +656,7 @@ class Program_weight_tensor_parameter_54:
 
 class Program_weight_tensor_parameter_55:
     name = "parameter_55"
+    original_name = "batch_norm_111.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-1.59614")
@@ -612,6 +668,7 @@ class Program_weight_tensor_parameter_55:
 
 class Program_weight_tensor_parameter_56:
     name = "parameter_56"
+    original_name = "batch_norm_111.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("0.164188")
@@ -623,6 +680,7 @@ class Program_weight_tensor_parameter_56:
 
 class Program_weight_tensor_parameter_57:
     name = "parameter_57"
+    original_name = "batch_norm_111.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-11.3783")
@@ -634,6 +692,7 @@ class Program_weight_tensor_parameter_57:
 
 class Program_weight_tensor_parameter_58:
     name = "parameter_58"
+    original_name = "batch_norm_110.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-1.41345")
@@ -645,6 +704,7 @@ class Program_weight_tensor_parameter_58:
 
 class Program_weight_tensor_parameter_59:
     name = "parameter_59"
+    original_name = "batch_norm_110.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-1.33805")
@@ -656,6 +716,7 @@ class Program_weight_tensor_parameter_59:
 
 class Program_weight_tensor_parameter_60:
     name = "parameter_60"
+    original_name = "batch_norm_110.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("0.000219974")
@@ -667,6 +728,7 @@ class Program_weight_tensor_parameter_60:
 
 class Program_weight_tensor_parameter_61:
     name = "parameter_61"
+    original_name = "batch_norm_110.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.608706")
@@ -678,6 +740,7 @@ class Program_weight_tensor_parameter_61:
 
 class Program_weight_tensor_parameter_62:
     name = "parameter_62"
+    original_name = "conv2d_128.w_0"
     shape = [512, 2048, 1, 1]
     dtype = "float32"
     min_val = float("-0.28105")
@@ -689,6 +752,7 @@ class Program_weight_tensor_parameter_62:
 
 class Program_weight_tensor_parameter_63:
     name = "parameter_63"
+    original_name = "batch_norm_109.b_0"
     shape = [2048]
     dtype = "float32"
     min_val = float("-5.66011")
@@ -700,6 +764,7 @@ class Program_weight_tensor_parameter_63:
 
 class Program_weight_tensor_parameter_64:
     name = "parameter_64"
+    original_name = "batch_norm_109.w_0"
     shape = [2048]
     dtype = "float32"
     min_val = float("-0.65397")
@@ -711,6 +776,7 @@ class Program_weight_tensor_parameter_64:
 
 class Program_weight_tensor_parameter_65:
     name = "parameter_65"
+    original_name = "batch_norm_109.w_2"
     shape = [2048]
     dtype = "float32"
     min_val = float("2.5734e-05")
@@ -722,6 +788,7 @@ class Program_weight_tensor_parameter_65:
 
 class Program_weight_tensor_parameter_66:
     name = "parameter_66"
+    original_name = "batch_norm_109.w_1"
     shape = [2048]
     dtype = "float32"
     min_val = float("-1.57089")
@@ -733,6 +800,7 @@ class Program_weight_tensor_parameter_66:
 
 class Program_weight_tensor_parameter_67:
     name = "parameter_67"
+    original_name = "conv2d_127.w_0"
     shape = [2048, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.398897")
@@ -744,6 +812,7 @@ class Program_weight_tensor_parameter_67:
 
 class Program_weight_tensor_parameter_68:
     name = "parameter_68"
+    original_name = "batch_norm_108.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-2.75018")
@@ -755,6 +824,7 @@ class Program_weight_tensor_parameter_68:
 
 class Program_weight_tensor_parameter_69:
     name = "parameter_69"
+    original_name = "batch_norm_108.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.426174")
@@ -766,6 +836,7 @@ class Program_weight_tensor_parameter_69:
 
 class Program_weight_tensor_parameter_70:
     name = "parameter_70"
+    original_name = "batch_norm_108.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("0.000127549")
@@ -777,6 +848,7 @@ class Program_weight_tensor_parameter_70:
 
 class Program_weight_tensor_parameter_71:
     name = "parameter_71"
+    original_name = "batch_norm_108.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-1.9238")
@@ -788,6 +860,7 @@ class Program_weight_tensor_parameter_71:
 
 class Program_weight_tensor_parameter_72:
     name = "parameter_72"
+    original_name = "conv2d_126.w_0"
     shape = [512, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.260347")
@@ -799,6 +872,7 @@ class Program_weight_tensor_parameter_72:
 
 class Program_weight_tensor_parameter_73:
     name = "parameter_73"
+    original_name = "conv2d_125.w_0"
     shape = [512, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.178261")
@@ -810,6 +884,7 @@ class Program_weight_tensor_parameter_73:
 
 class Program_weight_tensor_parameter_74:
     name = "parameter_74"
+    original_name = "conv2d_124.w_0"
     shape = [64, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.155641")
@@ -821,6 +896,7 @@ class Program_weight_tensor_parameter_74:
 
 class Program_weight_tensor_parameter_75:
     name = "parameter_75"
+    original_name = "conv2d_123.w_0"
     shape = [64, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.381657")
@@ -832,6 +908,7 @@ class Program_weight_tensor_parameter_75:
 
 class Program_weight_tensor_parameter_76:
     name = "parameter_76"
+    original_name = "conv2d_122.w_0"
     shape = [512, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.225203")
@@ -843,6 +920,7 @@ class Program_weight_tensor_parameter_76:
 
 class Program_weight_tensor_parameter_77:
     name = "parameter_77"
+    original_name = "batch_norm_107.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-1.28187")
@@ -854,6 +932,7 @@ class Program_weight_tensor_parameter_77:
 
 class Program_weight_tensor_parameter_78:
     name = "parameter_78"
+    original_name = "batch_norm_107.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.953441")
@@ -865,6 +944,7 @@ class Program_weight_tensor_parameter_78:
 
 class Program_weight_tensor_parameter_79:
     name = "parameter_79"
+    original_name = "batch_norm_107.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("0.0123261")
@@ -876,6 +956,7 @@ class Program_weight_tensor_parameter_79:
 
 class Program_weight_tensor_parameter_80:
     name = "parameter_80"
+    original_name = "batch_norm_107.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-7.40231")
@@ -887,6 +968,7 @@ class Program_weight_tensor_parameter_80:
 
 class Program_weight_tensor_parameter_81:
     name = "parameter_81"
+    original_name = "batch_norm_106.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-1.64569")
@@ -898,6 +980,7 @@ class Program_weight_tensor_parameter_81:
 
 class Program_weight_tensor_parameter_82:
     name = "parameter_82"
+    original_name = "batch_norm_106.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-1.24173")
@@ -909,6 +992,7 @@ class Program_weight_tensor_parameter_82:
 
 class Program_weight_tensor_parameter_83:
     name = "parameter_83"
+    original_name = "batch_norm_106.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("0.00284707")
@@ -920,6 +1004,7 @@ class Program_weight_tensor_parameter_83:
 
 class Program_weight_tensor_parameter_84:
     name = "parameter_84"
+    original_name = "batch_norm_106.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.972609")
@@ -931,6 +1016,7 @@ class Program_weight_tensor_parameter_84:
 
 class Program_weight_tensor_parameter_85:
     name = "parameter_85"
+    original_name = "conv2d_121.w_0"
     shape = [512, 2048, 1, 1]
     dtype = "float32"
     min_val = float("-0.34553")
@@ -942,6 +1028,7 @@ class Program_weight_tensor_parameter_85:
 
 class Program_weight_tensor_parameter_86:
     name = "parameter_86"
+    original_name = "batch_norm_105.b_0"
     shape = [2048]
     dtype = "float32"
     min_val = float("-5.75779")
@@ -953,6 +1040,7 @@ class Program_weight_tensor_parameter_86:
 
 class Program_weight_tensor_parameter_87:
     name = "parameter_87"
+    original_name = "batch_norm_105.w_0"
     shape = [2048]
     dtype = "float32"
     min_val = float("-0.000205009")
@@ -964,6 +1052,7 @@ class Program_weight_tensor_parameter_87:
 
 class Program_weight_tensor_parameter_88:
     name = "parameter_88"
+    original_name = "batch_norm_105.w_2"
     shape = [2048]
     dtype = "float32"
     min_val = float("4.17349e-05")
@@ -975,6 +1064,7 @@ class Program_weight_tensor_parameter_88:
 
 class Program_weight_tensor_parameter_89:
     name = "parameter_89"
+    original_name = "batch_norm_105.w_1"
     shape = [2048]
     dtype = "float32"
     min_val = float("-1.23492")
@@ -986,6 +1076,7 @@ class Program_weight_tensor_parameter_89:
 
 class Program_weight_tensor_parameter_90:
     name = "parameter_90"
+    original_name = "conv2d_120.w_0"
     shape = [2048, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.281572")
@@ -997,6 +1088,7 @@ class Program_weight_tensor_parameter_90:
 
 class Program_weight_tensor_parameter_91:
     name = "parameter_91"
+    original_name = "batch_norm_104.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-2.3994")
@@ -1008,6 +1100,7 @@ class Program_weight_tensor_parameter_91:
 
 class Program_weight_tensor_parameter_92:
     name = "parameter_92"
+    original_name = "batch_norm_104.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.978339")
@@ -1019,6 +1112,7 @@ class Program_weight_tensor_parameter_92:
 
 class Program_weight_tensor_parameter_93:
     name = "parameter_93"
+    original_name = "batch_norm_104.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("0.00012489")
@@ -1030,6 +1124,7 @@ class Program_weight_tensor_parameter_93:
 
 class Program_weight_tensor_parameter_94:
     name = "parameter_94"
+    original_name = "batch_norm_104.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-1.23637")
@@ -1041,6 +1136,7 @@ class Program_weight_tensor_parameter_94:
 
 class Program_weight_tensor_parameter_95:
     name = "parameter_95"
+    original_name = "conv2d_119.w_0"
     shape = [512, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.266579")
@@ -1052,6 +1148,7 @@ class Program_weight_tensor_parameter_95:
 
 class Program_weight_tensor_parameter_96:
     name = "parameter_96"
+    original_name = "conv2d_118.w_0"
     shape = [512, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.16664")
@@ -1063,6 +1160,7 @@ class Program_weight_tensor_parameter_96:
 
 class Program_weight_tensor_parameter_97:
     name = "parameter_97"
+    original_name = "conv2d_117.w_0"
     shape = [64, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.143172")
@@ -1074,6 +1172,7 @@ class Program_weight_tensor_parameter_97:
 
 class Program_weight_tensor_parameter_98:
     name = "parameter_98"
+    original_name = "conv2d_116.w_0"
     shape = [64, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.202909")
@@ -1085,6 +1184,7 @@ class Program_weight_tensor_parameter_98:
 
 class Program_weight_tensor_parameter_99:
     name = "parameter_99"
+    original_name = "conv2d_115.w_0"
     shape = [512, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.185941")
@@ -1096,6 +1196,7 @@ class Program_weight_tensor_parameter_99:
 
 class Program_weight_tensor_parameter_100:
     name = "parameter_100"
+    original_name = "batch_norm_103.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-1.00586")
@@ -1107,6 +1208,7 @@ class Program_weight_tensor_parameter_100:
 
 class Program_weight_tensor_parameter_101:
     name = "parameter_101"
+    original_name = "batch_norm_103.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.792165")
@@ -1118,6 +1220,7 @@ class Program_weight_tensor_parameter_101:
 
 class Program_weight_tensor_parameter_102:
     name = "parameter_102"
+    original_name = "batch_norm_103.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("0.0119626")
@@ -1129,6 +1232,7 @@ class Program_weight_tensor_parameter_102:
 
 class Program_weight_tensor_parameter_103:
     name = "parameter_103"
+    original_name = "batch_norm_103.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-6.11962")
@@ -1140,6 +1244,7 @@ class Program_weight_tensor_parameter_103:
 
 class Program_weight_tensor_parameter_104:
     name = "parameter_104"
+    original_name = "batch_norm_102.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-1.10446")
@@ -1151,6 +1256,7 @@ class Program_weight_tensor_parameter_104:
 
 class Program_weight_tensor_parameter_105:
     name = "parameter_105"
+    original_name = "batch_norm_102.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-1.88866")
@@ -1162,6 +1268,7 @@ class Program_weight_tensor_parameter_105:
 
 class Program_weight_tensor_parameter_106:
     name = "parameter_106"
+    original_name = "batch_norm_102.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("0.0145462")
@@ -1173,6 +1280,7 @@ class Program_weight_tensor_parameter_106:
 
 class Program_weight_tensor_parameter_107:
     name = "parameter_107"
+    original_name = "batch_norm_102.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-2.80373")
@@ -1184,6 +1292,7 @@ class Program_weight_tensor_parameter_107:
 
 class Program_weight_tensor_parameter_108:
     name = "parameter_108"
+    original_name = "conv2d_114.w_0"
     shape = [512, 2048, 1, 1]
     dtype = "float32"
     min_val = float("-0.354645")
@@ -1195,6 +1304,7 @@ class Program_weight_tensor_parameter_108:
 
 class Program_weight_tensor_parameter_109:
     name = "parameter_109"
+    original_name = "batch_norm_101.b_0"
     shape = [2048]
     dtype = "float32"
     min_val = float("-5.45242")
@@ -1206,6 +1316,7 @@ class Program_weight_tensor_parameter_109:
 
 class Program_weight_tensor_parameter_110:
     name = "parameter_110"
+    original_name = "batch_norm_101.w_0"
     shape = [2048]
     dtype = "float32"
     min_val = float("-1.16283")
@@ -1217,6 +1328,7 @@ class Program_weight_tensor_parameter_110:
 
 class Program_weight_tensor_parameter_111:
     name = "parameter_111"
+    original_name = "batch_norm_101.w_2"
     shape = [2048]
     dtype = "float32"
     min_val = float("3.79752e-42")
@@ -1228,6 +1340,7 @@ class Program_weight_tensor_parameter_111:
 
 class Program_weight_tensor_parameter_112:
     name = "parameter_112"
+    original_name = "batch_norm_101.w_1"
     shape = [2048]
     dtype = "float32"
     min_val = float("-0.810335")
@@ -1239,6 +1352,7 @@ class Program_weight_tensor_parameter_112:
 
 class Program_weight_tensor_parameter_113:
     name = "parameter_113"
+    original_name = "conv2d_113.w_0"
     shape = [2048, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.41054")
@@ -1250,6 +1364,7 @@ class Program_weight_tensor_parameter_113:
 
 class Program_weight_tensor_parameter_114:
     name = "parameter_114"
+    original_name = "batch_norm_100.b_0"
     shape = [2048]
     dtype = "float32"
     min_val = float("-3.5502")
@@ -1261,6 +1376,7 @@ class Program_weight_tensor_parameter_114:
 
 class Program_weight_tensor_parameter_115:
     name = "parameter_115"
+    original_name = "batch_norm_100.w_0"
     shape = [2048]
     dtype = "float32"
     min_val = float("-1.09995")
@@ -1272,6 +1388,7 @@ class Program_weight_tensor_parameter_115:
 
 class Program_weight_tensor_parameter_116:
     name = "parameter_116"
+    original_name = "batch_norm_100.w_2"
     shape = [2048]
     dtype = "float32"
     min_val = float("4.23472e-42")
@@ -1283,6 +1400,7 @@ class Program_weight_tensor_parameter_116:
 
 class Program_weight_tensor_parameter_117:
     name = "parameter_117"
+    original_name = "batch_norm_100.w_1"
     shape = [2048]
     dtype = "float32"
     min_val = float("-1.11133")
@@ -1294,6 +1412,7 @@ class Program_weight_tensor_parameter_117:
 
 class Program_weight_tensor_parameter_118:
     name = "parameter_118"
+    original_name = "conv2d_112.w_0"
     shape = [2048, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.29383")
@@ -1305,6 +1424,7 @@ class Program_weight_tensor_parameter_118:
 
 class Program_weight_tensor_parameter_119:
     name = "parameter_119"
+    original_name = "batch_norm_99.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-1.88395")
@@ -1316,6 +1436,7 @@ class Program_weight_tensor_parameter_119:
 
 class Program_weight_tensor_parameter_120:
     name = "parameter_120"
+    original_name = "batch_norm_99.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("0.510868")
@@ -1327,6 +1448,7 @@ class Program_weight_tensor_parameter_120:
 
 class Program_weight_tensor_parameter_121:
     name = "parameter_121"
+    original_name = "batch_norm_99.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("1.94033e-05")
@@ -1338,6 +1460,7 @@ class Program_weight_tensor_parameter_121:
 
 class Program_weight_tensor_parameter_122:
     name = "parameter_122"
+    original_name = "batch_norm_99.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.904918")
@@ -1349,6 +1472,7 @@ class Program_weight_tensor_parameter_122:
 
 class Program_weight_tensor_parameter_123:
     name = "parameter_123"
+    original_name = "conv2d_111.w_0"
     shape = [512, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.376935")
@@ -1360,6 +1484,7 @@ class Program_weight_tensor_parameter_123:
 
 class Program_weight_tensor_parameter_124:
     name = "parameter_124"
+    original_name = "batch_norm_98.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.972038")
@@ -1371,6 +1496,7 @@ class Program_weight_tensor_parameter_124:
 
 class Program_weight_tensor_parameter_125:
     name = "parameter_125"
+    original_name = "batch_norm_98.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-1.53518")
@@ -1382,6 +1508,7 @@ class Program_weight_tensor_parameter_125:
 
 class Program_weight_tensor_parameter_126:
     name = "parameter_126"
+    original_name = "batch_norm_98.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("0.0216367")
@@ -1393,6 +1520,7 @@ class Program_weight_tensor_parameter_126:
 
 class Program_weight_tensor_parameter_127:
     name = "parameter_127"
+    original_name = "batch_norm_98.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-3.38118")
@@ -1404,6 +1532,7 @@ class Program_weight_tensor_parameter_127:
 
 class Program_weight_tensor_parameter_128:
     name = "parameter_128"
+    original_name = "conv2d_110.w_0"
     shape = [512, 2048, 1, 1]
     dtype = "float32"
     min_val = float("-0.257744")
@@ -1415,6 +1544,7 @@ class Program_weight_tensor_parameter_128:
 
 class Program_weight_tensor_parameter_129:
     name = "parameter_129"
+    original_name = "batch_norm_97.b_0"
     shape = [2048]
     dtype = "float32"
     min_val = float("-4.89085")
@@ -1426,6 +1556,7 @@ class Program_weight_tensor_parameter_129:
 
 class Program_weight_tensor_parameter_130:
     name = "parameter_130"
+    original_name = "batch_norm_97.w_0"
     shape = [2048]
     dtype = "float32"
     min_val = float("-1.33656")
@@ -1437,6 +1568,7 @@ class Program_weight_tensor_parameter_130:
 
 class Program_weight_tensor_parameter_131:
     name = "parameter_131"
+    original_name = "batch_norm_97.w_2"
     shape = [2048]
     dtype = "float32"
     min_val = float("3.93905e-42")
@@ -1448,6 +1580,7 @@ class Program_weight_tensor_parameter_131:
 
 class Program_weight_tensor_parameter_132:
     name = "parameter_132"
+    original_name = "batch_norm_97.w_1"
     shape = [2048]
     dtype = "float32"
     min_val = float("-0.447193")
@@ -1459,6 +1592,7 @@ class Program_weight_tensor_parameter_132:
 
 class Program_weight_tensor_parameter_133:
     name = "parameter_133"
+    original_name = "conv2d_109.w_0"
     shape = [2048, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.187784")
@@ -1470,6 +1604,7 @@ class Program_weight_tensor_parameter_133:
 
 class Program_weight_tensor_parameter_134:
     name = "parameter_134"
+    original_name = "batch_norm_96.b_0"
     shape = [2048]
     dtype = "float32"
     min_val = float("-3.57796")
@@ -1481,6 +1616,7 @@ class Program_weight_tensor_parameter_134:
 
 class Program_weight_tensor_parameter_135:
     name = "parameter_135"
+    original_name = "batch_norm_96.w_0"
     shape = [2048]
     dtype = "float32"
     min_val = float("-0.479898")
@@ -1492,6 +1628,7 @@ class Program_weight_tensor_parameter_135:
 
 class Program_weight_tensor_parameter_136:
     name = "parameter_136"
+    original_name = "batch_norm_96.w_2"
     shape = [2048]
     dtype = "float32"
     min_val = float("3.42898e-42")
@@ -1503,6 +1640,7 @@ class Program_weight_tensor_parameter_136:
 
 class Program_weight_tensor_parameter_137:
     name = "parameter_137"
+    original_name = "batch_norm_96.w_1"
     shape = [2048]
     dtype = "float32"
     min_val = float("-1.09173")
@@ -1514,6 +1652,7 @@ class Program_weight_tensor_parameter_137:
 
 class Program_weight_tensor_parameter_138:
     name = "parameter_138"
+    original_name = "conv2d_108.w_0"
     shape = [2048, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.252524")
@@ -1525,6 +1664,7 @@ class Program_weight_tensor_parameter_138:
 
 class Program_weight_tensor_parameter_139:
     name = "parameter_139"
+    original_name = "batch_norm_95.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-2.19671")
@@ -1536,6 +1676,7 @@ class Program_weight_tensor_parameter_139:
 
 class Program_weight_tensor_parameter_140:
     name = "parameter_140"
+    original_name = "batch_norm_95.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-1.49578")
@@ -1547,6 +1688,7 @@ class Program_weight_tensor_parameter_140:
 
 class Program_weight_tensor_parameter_141:
     name = "parameter_141"
+    original_name = "batch_norm_95.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("1.70503e-05")
@@ -1558,6 +1700,7 @@ class Program_weight_tensor_parameter_141:
 
 class Program_weight_tensor_parameter_142:
     name = "parameter_142"
+    original_name = "batch_norm_95.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-1.44825")
@@ -1569,6 +1712,7 @@ class Program_weight_tensor_parameter_142:
 
 class Program_weight_tensor_parameter_143:
     name = "parameter_143"
+    original_name = "conv2d_107.w_0"
     shape = [512, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.318353")
@@ -1580,6 +1724,7 @@ class Program_weight_tensor_parameter_143:
 
 class Program_weight_tensor_parameter_144:
     name = "parameter_144"
+    original_name = "batch_norm_94.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-1.32415")
@@ -1591,6 +1736,7 @@ class Program_weight_tensor_parameter_144:
 
 class Program_weight_tensor_parameter_145:
     name = "parameter_145"
+    original_name = "batch_norm_94.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-1.35853")
@@ -1602,6 +1748,7 @@ class Program_weight_tensor_parameter_145:
 
 class Program_weight_tensor_parameter_146:
     name = "parameter_146"
+    original_name = "batch_norm_94.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("0.00386669")
@@ -1613,6 +1760,7 @@ class Program_weight_tensor_parameter_146:
 
 class Program_weight_tensor_parameter_147:
     name = "parameter_147"
+    original_name = "batch_norm_94.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-1.07725")
@@ -1624,6 +1772,7 @@ class Program_weight_tensor_parameter_147:
 
 class Program_weight_tensor_parameter_148:
     name = "parameter_148"
+    original_name = "conv2d_106.w_0"
     shape = [512, 2048, 1, 1]
     dtype = "float32"
     min_val = float("-0.241646")
@@ -1635,6 +1784,7 @@ class Program_weight_tensor_parameter_148:
 
 class Program_weight_tensor_parameter_149:
     name = "parameter_149"
+    original_name = "batch_norm_93.b_0"
     shape = [2048]
     dtype = "float32"
     min_val = float("-5.36556")
@@ -1646,6 +1796,7 @@ class Program_weight_tensor_parameter_149:
 
 class Program_weight_tensor_parameter_150:
     name = "parameter_150"
+    original_name = "batch_norm_93.w_0"
     shape = [2048]
     dtype = "float32"
     min_val = float("0.604939")
@@ -1657,6 +1808,7 @@ class Program_weight_tensor_parameter_150:
 
 class Program_weight_tensor_parameter_151:
     name = "parameter_151"
+    original_name = "batch_norm_93.w_2"
     shape = [2048]
     dtype = "float32"
     min_val = float("0.383445")
@@ -1668,6 +1820,7 @@ class Program_weight_tensor_parameter_151:
 
 class Program_weight_tensor_parameter_152:
     name = "parameter_152"
+    original_name = "batch_norm_93.w_1"
     shape = [2048]
     dtype = "float32"
     min_val = float("-1.15736")
@@ -1679,6 +1832,7 @@ class Program_weight_tensor_parameter_152:
 
 class Program_weight_tensor_parameter_153:
     name = "parameter_153"
+    original_name = "conv2d_105.w_0"
     shape = [2048, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.177446")
@@ -1690,6 +1844,7 @@ class Program_weight_tensor_parameter_153:
 
 class Program_weight_tensor_parameter_154:
     name = "parameter_154"
+    original_name = "batch_norm_92.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-2.35007")
@@ -1701,6 +1856,7 @@ class Program_weight_tensor_parameter_154:
 
 class Program_weight_tensor_parameter_155:
     name = "parameter_155"
+    original_name = "batch_norm_92.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-1.14736")
@@ -1712,6 +1868,7 @@ class Program_weight_tensor_parameter_155:
 
 class Program_weight_tensor_parameter_156:
     name = "parameter_156"
+    original_name = "batch_norm_92.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("1.86812e-05")
@@ -1723,6 +1880,7 @@ class Program_weight_tensor_parameter_156:
 
 class Program_weight_tensor_parameter_157:
     name = "parameter_157"
+    original_name = "batch_norm_92.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.862557")
@@ -1734,6 +1892,7 @@ class Program_weight_tensor_parameter_157:
 
 class Program_weight_tensor_parameter_158:
     name = "parameter_158"
+    original_name = "conv2d_104.w_0"
     shape = [512, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.309683")
@@ -1745,6 +1904,7 @@ class Program_weight_tensor_parameter_158:
 
 class Program_weight_tensor_parameter_159:
     name = "parameter_159"
+    original_name = "batch_norm_91.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-1.08297")
@@ -1756,6 +1916,7 @@ class Program_weight_tensor_parameter_159:
 
 class Program_weight_tensor_parameter_160:
     name = "parameter_160"
+    original_name = "batch_norm_91.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-1.5433")
@@ -1767,6 +1928,7 @@ class Program_weight_tensor_parameter_160:
 
 class Program_weight_tensor_parameter_161:
     name = "parameter_161"
+    original_name = "batch_norm_91.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("0.0052472")
@@ -1778,6 +1940,7 @@ class Program_weight_tensor_parameter_161:
 
 class Program_weight_tensor_parameter_162:
     name = "parameter_162"
+    original_name = "batch_norm_91.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-1.03703")
@@ -1789,6 +1952,7 @@ class Program_weight_tensor_parameter_162:
 
 class Program_weight_tensor_parameter_163:
     name = "parameter_163"
+    original_name = "conv2d_103.w_0"
     shape = [512, 2048, 1, 1]
     dtype = "float32"
     min_val = float("-0.212466")
@@ -1800,6 +1964,7 @@ class Program_weight_tensor_parameter_163:
 
 class Program_weight_tensor_parameter_164:
     name = "parameter_164"
+    original_name = "batch_norm_90.b_0"
     shape = [2048]
     dtype = "float32"
     min_val = float("-5.32047")
@@ -1811,6 +1976,7 @@ class Program_weight_tensor_parameter_164:
 
 class Program_weight_tensor_parameter_165:
     name = "parameter_165"
+    original_name = "batch_norm_90.w_0"
     shape = [2048]
     dtype = "float32"
     min_val = float("0.650442")
@@ -1822,6 +1988,7 @@ class Program_weight_tensor_parameter_165:
 
 class Program_weight_tensor_parameter_166:
     name = "parameter_166"
+    original_name = "batch_norm_90.w_2"
     shape = [2048]
     dtype = "float32"
     min_val = float("0.372743")
@@ -1833,6 +2000,7 @@ class Program_weight_tensor_parameter_166:
 
 class Program_weight_tensor_parameter_167:
     name = "parameter_167"
+    original_name = "batch_norm_90.w_1"
     shape = [2048]
     dtype = "float32"
     min_val = float("-1.14271")
@@ -1844,6 +2012,7 @@ class Program_weight_tensor_parameter_167:
 
 class Program_weight_tensor_parameter_168:
     name = "parameter_168"
+    original_name = "conv2d_102.w_0"
     shape = [2048, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.149967")
@@ -1855,6 +2024,7 @@ class Program_weight_tensor_parameter_168:
 
 class Program_weight_tensor_parameter_169:
     name = "parameter_169"
+    original_name = "batch_norm_89.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-2.45385")
@@ -1866,6 +2036,7 @@ class Program_weight_tensor_parameter_169:
 
 class Program_weight_tensor_parameter_170:
     name = "parameter_170"
+    original_name = "batch_norm_89.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.929382")
@@ -1877,6 +2048,7 @@ class Program_weight_tensor_parameter_170:
 
 class Program_weight_tensor_parameter_171:
     name = "parameter_171"
+    original_name = "batch_norm_89.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("1.99478e-05")
@@ -1888,6 +2060,7 @@ class Program_weight_tensor_parameter_171:
 
 class Program_weight_tensor_parameter_172:
     name = "parameter_172"
+    original_name = "batch_norm_89.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-1.69118")
@@ -1899,6 +2072,7 @@ class Program_weight_tensor_parameter_172:
 
 class Program_weight_tensor_parameter_173:
     name = "parameter_173"
+    original_name = "conv2d_101.w_0"
     shape = [512, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.328097")
@@ -1910,6 +2084,7 @@ class Program_weight_tensor_parameter_173:
 
 class Program_weight_tensor_parameter_174:
     name = "parameter_174"
+    original_name = "batch_norm_88.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-1.22385")
@@ -1921,6 +2096,7 @@ class Program_weight_tensor_parameter_174:
 
 class Program_weight_tensor_parameter_175:
     name = "parameter_175"
+    original_name = "batch_norm_88.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-1.55662")
@@ -1932,6 +2108,7 @@ class Program_weight_tensor_parameter_175:
 
 class Program_weight_tensor_parameter_176:
     name = "parameter_176"
+    original_name = "batch_norm_88.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("0.0648687")
@@ -1943,6 +2120,7 @@ class Program_weight_tensor_parameter_176:
 
 class Program_weight_tensor_parameter_177:
     name = "parameter_177"
+    original_name = "batch_norm_88.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-3.5949")
@@ -1954,6 +2132,7 @@ class Program_weight_tensor_parameter_177:
 
 class Program_weight_tensor_parameter_178:
     name = "parameter_178"
+    original_name = "conv2d_100.w_0"
     shape = [512, 2048, 1, 1]
     dtype = "float32"
     min_val = float("-0.307212")
@@ -1965,6 +2144,7 @@ class Program_weight_tensor_parameter_178:
 
 class Program_weight_tensor_parameter_179:
     name = "parameter_179"
+    original_name = "batch_norm_87.b_0"
     shape = [2048]
     dtype = "float32"
     min_val = float("-4.8164")
@@ -1976,6 +2156,7 @@ class Program_weight_tensor_parameter_179:
 
 class Program_weight_tensor_parameter_180:
     name = "parameter_180"
+    original_name = "batch_norm_87.w_0"
     shape = [2048]
     dtype = "float32"
     min_val = float("-1.32886")
@@ -1987,6 +2168,7 @@ class Program_weight_tensor_parameter_180:
 
 class Program_weight_tensor_parameter_181:
     name = "parameter_181"
+    original_name = "batch_norm_87.w_2"
     shape = [2048]
     dtype = "float32"
     min_val = float("2.66116e-39")
@@ -1998,6 +2180,7 @@ class Program_weight_tensor_parameter_181:
 
 class Program_weight_tensor_parameter_182:
     name = "parameter_182"
+    original_name = "batch_norm_87.w_1"
     shape = [2048]
     dtype = "float32"
     min_val = float("-0.528327")
@@ -2009,6 +2192,7 @@ class Program_weight_tensor_parameter_182:
 
 class Program_weight_tensor_parameter_183:
     name = "parameter_183"
+    original_name = "conv2d_99.w_0"
     shape = [2048, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.186496")
@@ -2020,6 +2204,7 @@ class Program_weight_tensor_parameter_183:
 
 class Program_weight_tensor_parameter_184:
     name = "parameter_184"
+    original_name = "batch_norm_86.b_0"
     shape = [2048]
     dtype = "float32"
     min_val = float("-3.84194")
@@ -2031,6 +2216,7 @@ class Program_weight_tensor_parameter_184:
 
 class Program_weight_tensor_parameter_185:
     name = "parameter_185"
+    original_name = "batch_norm_86.w_0"
     shape = [2048]
     dtype = "float32"
     min_val = float("-0.51325")
@@ -2042,6 +2228,7 @@ class Program_weight_tensor_parameter_185:
 
 class Program_weight_tensor_parameter_186:
     name = "parameter_186"
+    original_name = "batch_norm_86.w_2"
     shape = [2048]
     dtype = "float32"
     min_val = float("6.00162e-31")
@@ -2053,6 +2240,7 @@ class Program_weight_tensor_parameter_186:
 
 class Program_weight_tensor_parameter_187:
     name = "parameter_187"
+    original_name = "batch_norm_86.w_1"
     shape = [2048]
     dtype = "float32"
     min_val = float("-1.03211")
@@ -2064,6 +2252,7 @@ class Program_weight_tensor_parameter_187:
 
 class Program_weight_tensor_parameter_188:
     name = "parameter_188"
+    original_name = "conv2d_98.w_0"
     shape = [2048, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.27775")
@@ -2075,6 +2264,7 @@ class Program_weight_tensor_parameter_188:
 
 class Program_weight_tensor_parameter_189:
     name = "parameter_189"
+    original_name = "batch_norm_85.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-2.31808")
@@ -2086,6 +2276,7 @@ class Program_weight_tensor_parameter_189:
 
 class Program_weight_tensor_parameter_190:
     name = "parameter_190"
+    original_name = "batch_norm_85.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("0.233779")
@@ -2097,6 +2288,7 @@ class Program_weight_tensor_parameter_190:
 
 class Program_weight_tensor_parameter_191:
     name = "parameter_191"
+    original_name = "batch_norm_85.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("1.29332e-05")
@@ -2108,6 +2300,7 @@ class Program_weight_tensor_parameter_191:
 
 class Program_weight_tensor_parameter_192:
     name = "parameter_192"
+    original_name = "batch_norm_85.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-1.12978")
@@ -2119,6 +2312,7 @@ class Program_weight_tensor_parameter_192:
 
 class Program_weight_tensor_parameter_193:
     name = "parameter_193"
+    original_name = "conv2d_97.w_0"
     shape = [512, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.28328")
@@ -2130,6 +2324,7 @@ class Program_weight_tensor_parameter_193:
 
 class Program_weight_tensor_parameter_194:
     name = "parameter_194"
+    original_name = "batch_norm_84.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-1.38798")
@@ -2141,6 +2336,7 @@ class Program_weight_tensor_parameter_194:
 
 class Program_weight_tensor_parameter_195:
     name = "parameter_195"
+    original_name = "batch_norm_84.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-1.42474")
@@ -2152,6 +2348,7 @@ class Program_weight_tensor_parameter_195:
 
 class Program_weight_tensor_parameter_196:
     name = "parameter_196"
+    original_name = "batch_norm_84.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("0.00389445")
@@ -2163,6 +2360,7 @@ class Program_weight_tensor_parameter_196:
 
 class Program_weight_tensor_parameter_197:
     name = "parameter_197"
+    original_name = "batch_norm_84.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.733924")
@@ -2174,6 +2372,7 @@ class Program_weight_tensor_parameter_197:
 
 class Program_weight_tensor_parameter_198:
     name = "parameter_198"
+    original_name = "conv2d_96.w_0"
     shape = [512, 2048, 1, 1]
     dtype = "float32"
     min_val = float("-0.344032")
@@ -2185,6 +2384,7 @@ class Program_weight_tensor_parameter_198:
 
 class Program_weight_tensor_parameter_199:
     name = "parameter_199"
+    original_name = "batch_norm_83.b_0"
     shape = [2048]
     dtype = "float32"
     min_val = float("-4.87113")
@@ -2196,6 +2396,7 @@ class Program_weight_tensor_parameter_199:
 
 class Program_weight_tensor_parameter_200:
     name = "parameter_200"
+    original_name = "batch_norm_83.w_0"
     shape = [2048]
     dtype = "float32"
     min_val = float("0.657237")
@@ -2207,6 +2408,7 @@ class Program_weight_tensor_parameter_200:
 
 class Program_weight_tensor_parameter_201:
     name = "parameter_201"
+    original_name = "batch_norm_83.w_2"
     shape = [2048]
     dtype = "float32"
     min_val = float("0.346546")
@@ -2218,6 +2420,7 @@ class Program_weight_tensor_parameter_201:
 
 class Program_weight_tensor_parameter_202:
     name = "parameter_202"
+    original_name = "batch_norm_83.w_1"
     shape = [2048]
     dtype = "float32"
     min_val = float("-1.13568")
@@ -2229,6 +2432,7 @@ class Program_weight_tensor_parameter_202:
 
 class Program_weight_tensor_parameter_203:
     name = "parameter_203"
+    original_name = "conv2d_95.w_0"
     shape = [2048, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.17938")
@@ -2240,6 +2444,7 @@ class Program_weight_tensor_parameter_203:
 
 class Program_weight_tensor_parameter_204:
     name = "parameter_204"
+    original_name = "batch_norm_82.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-2.2647")
@@ -2251,6 +2456,7 @@ class Program_weight_tensor_parameter_204:
 
 class Program_weight_tensor_parameter_205:
     name = "parameter_205"
+    original_name = "batch_norm_82.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("0.0536416")
@@ -2262,6 +2468,7 @@ class Program_weight_tensor_parameter_205:
 
 class Program_weight_tensor_parameter_206:
     name = "parameter_206"
+    original_name = "batch_norm_82.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("1.78835e-05")
@@ -2273,6 +2480,7 @@ class Program_weight_tensor_parameter_206:
 
 class Program_weight_tensor_parameter_207:
     name = "parameter_207"
+    original_name = "batch_norm_82.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-1.01859")
@@ -2284,6 +2492,7 @@ class Program_weight_tensor_parameter_207:
 
 class Program_weight_tensor_parameter_208:
     name = "parameter_208"
+    original_name = "conv2d_94.w_0"
     shape = [512, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.308866")
@@ -2295,6 +2504,7 @@ class Program_weight_tensor_parameter_208:
 
 class Program_weight_tensor_parameter_209:
     name = "parameter_209"
+    original_name = "batch_norm_81.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-1.11172")
@@ -2306,6 +2516,7 @@ class Program_weight_tensor_parameter_209:
 
 class Program_weight_tensor_parameter_210:
     name = "parameter_210"
+    original_name = "batch_norm_81.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-1.07665")
@@ -2317,6 +2528,7 @@ class Program_weight_tensor_parameter_210:
 
 class Program_weight_tensor_parameter_211:
     name = "parameter_211"
+    original_name = "batch_norm_81.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("0.0911171")
@@ -2328,6 +2540,7 @@ class Program_weight_tensor_parameter_211:
 
 class Program_weight_tensor_parameter_212:
     name = "parameter_212"
+    original_name = "batch_norm_81.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-2.91887")
@@ -2339,6 +2552,7 @@ class Program_weight_tensor_parameter_212:
 
 class Program_weight_tensor_parameter_213:
     name = "parameter_213"
+    original_name = "conv2d_93.w_0"
     shape = [512, 2048, 1, 1]
     dtype = "float32"
     min_val = float("-0.214884")
@@ -2350,6 +2564,7 @@ class Program_weight_tensor_parameter_213:
 
 class Program_weight_tensor_parameter_214:
     name = "parameter_214"
+    original_name = "batch_norm_80.b_0"
     shape = [2048]
     dtype = "float32"
     min_val = float("-7.43499")
@@ -2361,6 +2576,7 @@ class Program_weight_tensor_parameter_214:
 
 class Program_weight_tensor_parameter_215:
     name = "parameter_215"
+    original_name = "batch_norm_80.w_0"
     shape = [2048]
     dtype = "float32"
     min_val = float("-1.10144")
@@ -2372,6 +2588,7 @@ class Program_weight_tensor_parameter_215:
 
 class Program_weight_tensor_parameter_216:
     name = "parameter_216"
+    original_name = "batch_norm_80.w_2"
     shape = [2048]
     dtype = "float32"
     min_val = float("1.36425e-27")
@@ -2383,6 +2600,7 @@ class Program_weight_tensor_parameter_216:
 
 class Program_weight_tensor_parameter_217:
     name = "parameter_217"
+    original_name = "batch_norm_80.w_1"
     shape = [2048]
     dtype = "float32"
     min_val = float("-0.590005")
@@ -2394,6 +2612,7 @@ class Program_weight_tensor_parameter_217:
 
 class Program_weight_tensor_parameter_218:
     name = "parameter_218"
+    original_name = "conv2d_92.w_0"
     shape = [2048, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.229883")
@@ -2405,6 +2624,7 @@ class Program_weight_tensor_parameter_218:
 
 class Program_weight_tensor_parameter_219:
     name = "parameter_219"
+    original_name = "batch_norm_79.b_0"
     shape = [2048]
     dtype = "float32"
     min_val = float("-3.49967")
@@ -2416,6 +2636,7 @@ class Program_weight_tensor_parameter_219:
 
 class Program_weight_tensor_parameter_220:
     name = "parameter_220"
+    original_name = "batch_norm_79.w_0"
     shape = [2048]
     dtype = "float32"
     min_val = float("-1.91531")
@@ -2427,6 +2648,7 @@ class Program_weight_tensor_parameter_220:
 
 class Program_weight_tensor_parameter_221:
     name = "parameter_221"
+    original_name = "batch_norm_79.w_2"
     shape = [2048]
     dtype = "float32"
     min_val = float("1.0472e-24")
@@ -2438,6 +2660,7 @@ class Program_weight_tensor_parameter_221:
 
 class Program_weight_tensor_parameter_222:
     name = "parameter_222"
+    original_name = "batch_norm_79.w_1"
     shape = [2048]
     dtype = "float32"
     min_val = float("-1.56828")
@@ -2449,6 +2672,7 @@ class Program_weight_tensor_parameter_222:
 
 class Program_weight_tensor_parameter_223:
     name = "parameter_223"
+    original_name = "conv2d_91.w_0"
     shape = [2048, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.267181")
@@ -2460,6 +2684,7 @@ class Program_weight_tensor_parameter_223:
 
 class Program_weight_tensor_parameter_224:
     name = "parameter_224"
+    original_name = "batch_norm_78.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-2.49939")
@@ -2471,6 +2696,7 @@ class Program_weight_tensor_parameter_224:
 
 class Program_weight_tensor_parameter_225:
     name = "parameter_225"
+    original_name = "batch_norm_78.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("0.320904")
@@ -2482,6 +2708,7 @@ class Program_weight_tensor_parameter_225:
 
 class Program_weight_tensor_parameter_226:
     name = "parameter_226"
+    original_name = "batch_norm_78.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("9.89151e-06")
@@ -2493,6 +2720,7 @@ class Program_weight_tensor_parameter_226:
 
 class Program_weight_tensor_parameter_227:
     name = "parameter_227"
+    original_name = "batch_norm_78.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-1.16382")
@@ -2504,6 +2732,7 @@ class Program_weight_tensor_parameter_227:
 
 class Program_weight_tensor_parameter_228:
     name = "parameter_228"
+    original_name = "conv2d_90.w_0"
     shape = [512, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.260933")
@@ -2515,6 +2744,7 @@ class Program_weight_tensor_parameter_228:
 
 class Program_weight_tensor_parameter_229:
     name = "parameter_229"
+    original_name = "batch_norm_77.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-1.35136")
@@ -2526,6 +2756,7 @@ class Program_weight_tensor_parameter_229:
 
 class Program_weight_tensor_parameter_230:
     name = "parameter_230"
+    original_name = "batch_norm_77.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-1.12935")
@@ -2537,6 +2768,7 @@ class Program_weight_tensor_parameter_230:
 
 class Program_weight_tensor_parameter_231:
     name = "parameter_231"
+    original_name = "batch_norm_77.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("0.0154554")
@@ -2548,6 +2780,7 @@ class Program_weight_tensor_parameter_231:
 
 class Program_weight_tensor_parameter_232:
     name = "parameter_232"
+    original_name = "batch_norm_77.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-1.82193")
@@ -2559,6 +2792,7 @@ class Program_weight_tensor_parameter_232:
 
 class Program_weight_tensor_parameter_233:
     name = "parameter_233"
+    original_name = "conv2d_89.w_0"
     shape = [512, 2048, 1, 1]
     dtype = "float32"
     min_val = float("-0.428029")
@@ -2570,6 +2804,7 @@ class Program_weight_tensor_parameter_233:
 
 class Program_weight_tensor_parameter_234:
     name = "parameter_234"
+    original_name = "batch_norm_76.b_0"
     shape = [2048]
     dtype = "float32"
     min_val = float("-4.82478")
@@ -2581,6 +2816,7 @@ class Program_weight_tensor_parameter_234:
 
 class Program_weight_tensor_parameter_235:
     name = "parameter_235"
+    original_name = "batch_norm_76.w_0"
     shape = [2048]
     dtype = "float32"
     min_val = float("-1.32987")
@@ -2592,6 +2828,7 @@ class Program_weight_tensor_parameter_235:
 
 class Program_weight_tensor_parameter_236:
     name = "parameter_236"
+    original_name = "batch_norm_76.w_2"
     shape = [2048]
     dtype = "float32"
     min_val = float("9.34609e-38")
@@ -2603,6 +2840,7 @@ class Program_weight_tensor_parameter_236:
 
 class Program_weight_tensor_parameter_237:
     name = "parameter_237"
+    original_name = "batch_norm_76.w_1"
     shape = [2048]
     dtype = "float32"
     min_val = float("-0.57879")
@@ -2614,6 +2852,7 @@ class Program_weight_tensor_parameter_237:
 
 class Program_weight_tensor_parameter_238:
     name = "parameter_238"
+    original_name = "conv2d_88.w_0"
     shape = [2048, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.208862")
@@ -2625,6 +2864,7 @@ class Program_weight_tensor_parameter_238:
 
 class Program_weight_tensor_parameter_239:
     name = "parameter_239"
+    original_name = "batch_norm_75.b_0"
     shape = [2048]
     dtype = "float32"
     min_val = float("-3.22218")
@@ -2636,6 +2876,7 @@ class Program_weight_tensor_parameter_239:
 
 class Program_weight_tensor_parameter_240:
     name = "parameter_240"
+    original_name = "batch_norm_75.w_0"
     shape = [2048]
     dtype = "float32"
     min_val = float("-0.430903")
@@ -2647,6 +2888,7 @@ class Program_weight_tensor_parameter_240:
 
 class Program_weight_tensor_parameter_241:
     name = "parameter_241"
+    original_name = "batch_norm_75.w_2"
     shape = [2048]
     dtype = "float32"
     min_val = float("3.35759e-32")
@@ -2658,6 +2900,7 @@ class Program_weight_tensor_parameter_241:
 
 class Program_weight_tensor_parameter_242:
     name = "parameter_242"
+    original_name = "batch_norm_75.w_1"
     shape = [2048]
     dtype = "float32"
     min_val = float("-1.16719")
@@ -2669,6 +2912,7 @@ class Program_weight_tensor_parameter_242:
 
 class Program_weight_tensor_parameter_243:
     name = "parameter_243"
+    original_name = "conv2d_87.w_0"
     shape = [2048, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.305926")
@@ -2680,6 +2924,7 @@ class Program_weight_tensor_parameter_243:
 
 class Program_weight_tensor_parameter_244:
     name = "parameter_244"
+    original_name = "batch_norm_74.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-2.00683")
@@ -2691,6 +2936,7 @@ class Program_weight_tensor_parameter_244:
 
 class Program_weight_tensor_parameter_245:
     name = "parameter_245"
+    original_name = "batch_norm_74.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("0.34583")
@@ -2702,6 +2948,7 @@ class Program_weight_tensor_parameter_245:
 
 class Program_weight_tensor_parameter_246:
     name = "parameter_246"
+    original_name = "batch_norm_74.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("8.76092e-06")
@@ -2713,6 +2960,7 @@ class Program_weight_tensor_parameter_246:
 
 class Program_weight_tensor_parameter_247:
     name = "parameter_247"
+    original_name = "batch_norm_74.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.590218")
@@ -2724,6 +2972,7 @@ class Program_weight_tensor_parameter_247:
 
 class Program_weight_tensor_parameter_248:
     name = "parameter_248"
+    original_name = "conv2d_86.w_0"
     shape = [512, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.262784")
@@ -2735,6 +2984,7 @@ class Program_weight_tensor_parameter_248:
 
 class Program_weight_tensor_parameter_249:
     name = "parameter_249"
+    original_name = "batch_norm_73.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-1.2279")
@@ -2746,6 +2996,7 @@ class Program_weight_tensor_parameter_249:
 
 class Program_weight_tensor_parameter_250:
     name = "parameter_250"
+    original_name = "batch_norm_73.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-1.01114")
@@ -2757,6 +3008,7 @@ class Program_weight_tensor_parameter_250:
 
 class Program_weight_tensor_parameter_251:
     name = "parameter_251"
+    original_name = "batch_norm_73.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("0.0113409")
@@ -2768,6 +3020,7 @@ class Program_weight_tensor_parameter_251:
 
 class Program_weight_tensor_parameter_252:
     name = "parameter_252"
+    original_name = "batch_norm_73.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-1.48026")
@@ -2779,6 +3032,7 @@ class Program_weight_tensor_parameter_252:
 
 class Program_weight_tensor_parameter_253:
     name = "parameter_253"
+    original_name = "conv2d_85.w_0"
     shape = [512, 2048, 1, 1]
     dtype = "float32"
     min_val = float("-0.403289")
@@ -2790,6 +3044,7 @@ class Program_weight_tensor_parameter_253:
 
 class Program_weight_tensor_parameter_254:
     name = "parameter_254"
+    original_name = "batch_norm_72.b_0"
     shape = [2048]
     dtype = "float32"
     min_val = float("-8.14895")
@@ -2801,6 +3056,7 @@ class Program_weight_tensor_parameter_254:
 
 class Program_weight_tensor_parameter_255:
     name = "parameter_255"
+    original_name = "batch_norm_72.w_0"
     shape = [2048]
     dtype = "float32"
     min_val = float("-1.06542")
@@ -2812,6 +3068,7 @@ class Program_weight_tensor_parameter_255:
 
 class Program_weight_tensor_parameter_256:
     name = "parameter_256"
+    original_name = "batch_norm_72.w_2"
     shape = [2048]
     dtype = "float32"
     min_val = float("5.57808e-38")
@@ -2823,6 +3080,7 @@ class Program_weight_tensor_parameter_256:
 
 class Program_weight_tensor_parameter_257:
     name = "parameter_257"
+    original_name = "batch_norm_72.w_1"
     shape = [2048]
     dtype = "float32"
     min_val = float("-0.42384")
@@ -2834,6 +3092,7 @@ class Program_weight_tensor_parameter_257:
 
 class Program_weight_tensor_parameter_258:
     name = "parameter_258"
+    original_name = "conv2d_84.w_0"
     shape = [2048, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.214026")
@@ -2845,6 +3104,7 @@ class Program_weight_tensor_parameter_258:
 
 class Program_weight_tensor_parameter_259:
     name = "parameter_259"
+    original_name = "batch_norm_71.b_0"
     shape = [2048]
     dtype = "float32"
     min_val = float("-3.70938")
@@ -2856,6 +3116,7 @@ class Program_weight_tensor_parameter_259:
 
 class Program_weight_tensor_parameter_260:
     name = "parameter_260"
+    original_name = "batch_norm_71.w_0"
     shape = [2048]
     dtype = "float32"
     min_val = float("-0.852026")
@@ -2867,6 +3128,7 @@ class Program_weight_tensor_parameter_260:
 
 class Program_weight_tensor_parameter_261:
     name = "parameter_261"
+    original_name = "batch_norm_71.w_2"
     shape = [2048]
     dtype = "float32"
     min_val = float("2.33463e-39")
@@ -2878,6 +3140,7 @@ class Program_weight_tensor_parameter_261:
 
 class Program_weight_tensor_parameter_262:
     name = "parameter_262"
+    original_name = "batch_norm_71.w_1"
     shape = [2048]
     dtype = "float32"
     min_val = float("-1.23515")
@@ -2889,6 +3152,7 @@ class Program_weight_tensor_parameter_262:
 
 class Program_weight_tensor_parameter_263:
     name = "parameter_263"
+    original_name = "conv2d_83.w_0"
     shape = [2048, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.321721")
@@ -2900,6 +3164,7 @@ class Program_weight_tensor_parameter_263:
 
 class Program_weight_tensor_parameter_264:
     name = "parameter_264"
+    original_name = "batch_norm_70.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-2.13011")
@@ -2911,6 +3176,7 @@ class Program_weight_tensor_parameter_264:
 
 class Program_weight_tensor_parameter_265:
     name = "parameter_265"
+    original_name = "batch_norm_70.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.45509")
@@ -2922,6 +3188,7 @@ class Program_weight_tensor_parameter_265:
 
 class Program_weight_tensor_parameter_266:
     name = "parameter_266"
+    original_name = "batch_norm_70.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("5.00538e-06")
@@ -2933,6 +3200,7 @@ class Program_weight_tensor_parameter_266:
 
 class Program_weight_tensor_parameter_267:
     name = "parameter_267"
+    original_name = "batch_norm_70.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-1.13656")
@@ -2944,6 +3212,7 @@ class Program_weight_tensor_parameter_267:
 
 class Program_weight_tensor_parameter_268:
     name = "parameter_268"
+    original_name = "conv2d_82.w_0"
     shape = [512, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.223072")
@@ -2955,6 +3224,7 @@ class Program_weight_tensor_parameter_268:
 
 class Program_weight_tensor_parameter_269:
     name = "parameter_269"
+    original_name = "batch_norm_69.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-3.1881")
@@ -2966,6 +3236,7 @@ class Program_weight_tensor_parameter_269:
 
 class Program_weight_tensor_parameter_270:
     name = "parameter_270"
+    original_name = "batch_norm_69.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("0.214372")
@@ -2977,6 +3248,7 @@ class Program_weight_tensor_parameter_270:
 
 class Program_weight_tensor_parameter_271:
     name = "parameter_271"
+    original_name = "batch_norm_69.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("0.170041")
@@ -2988,6 +3260,7 @@ class Program_weight_tensor_parameter_271:
 
 class Program_weight_tensor_parameter_272:
     name = "parameter_272"
+    original_name = "batch_norm_69.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-3.5625")
@@ -2999,6 +3272,7 @@ class Program_weight_tensor_parameter_272:
 
 class Program_weight_tensor_parameter_273:
     name = "parameter_273"
+    original_name = "conv2d_81.w_0"
     shape = [512, 768, 1, 1]
     dtype = "float32"
     min_val = float("-0.350117")
@@ -3010,6 +3284,7 @@ class Program_weight_tensor_parameter_273:
 
 class Program_weight_tensor_parameter_274:
     name = "parameter_274"
+    original_name = "batch_norm_68.b_0"
     shape = [768]
     dtype = "float32"
     min_val = float("-6.34958")
@@ -3021,6 +3296,7 @@ class Program_weight_tensor_parameter_274:
 
 class Program_weight_tensor_parameter_275:
     name = "parameter_275"
+    original_name = "batch_norm_68.w_0"
     shape = [768]
     dtype = "float32"
     min_val = float("0.401824")
@@ -3032,6 +3308,7 @@ class Program_weight_tensor_parameter_275:
 
 class Program_weight_tensor_parameter_276:
     name = "parameter_276"
+    original_name = "batch_norm_68.w_2"
     shape = [768]
     dtype = "float32"
     min_val = float("1.03055e-05")
@@ -3043,6 +3320,7 @@ class Program_weight_tensor_parameter_276:
 
 class Program_weight_tensor_parameter_277:
     name = "parameter_277"
+    original_name = "batch_norm_68.w_1"
     shape = [768]
     dtype = "float32"
     min_val = float("-1.26647")
@@ -3054,6 +3332,7 @@ class Program_weight_tensor_parameter_277:
 
 class Program_weight_tensor_parameter_278:
     name = "parameter_278"
+    original_name = "conv2d_80.w_0"
     shape = [768, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.0890396")
@@ -3065,6 +3344,7 @@ class Program_weight_tensor_parameter_278:
 
 class Program_weight_tensor_parameter_279:
     name = "parameter_279"
+    original_name = "batch_norm_67.b_0"
     shape = [768]
     dtype = "float32"
     min_val = float("-2.73745")
@@ -3076,6 +3356,7 @@ class Program_weight_tensor_parameter_279:
 
 class Program_weight_tensor_parameter_280:
     name = "parameter_280"
+    original_name = "batch_norm_67.w_0"
     shape = [768]
     dtype = "float32"
     min_val = float("0.0314033")
@@ -3087,6 +3368,7 @@ class Program_weight_tensor_parameter_280:
 
 class Program_weight_tensor_parameter_281:
     name = "parameter_281"
+    original_name = "batch_norm_67.w_2"
     shape = [768]
     dtype = "float32"
     min_val = float("0.0575145")
@@ -3098,6 +3380,7 @@ class Program_weight_tensor_parameter_281:
 
 class Program_weight_tensor_parameter_282:
     name = "parameter_282"
+    original_name = "batch_norm_67.w_1"
     shape = [768]
     dtype = "float32"
     min_val = float("-0.722909")
@@ -3109,6 +3392,7 @@ class Program_weight_tensor_parameter_282:
 
 class Program_weight_tensor_parameter_283:
     name = "parameter_283"
+    original_name = "conv2d_79.w_0"
     shape = [768, 192, 1, 1]
     dtype = "float32"
     min_val = float("-0.33539")
@@ -3120,6 +3404,7 @@ class Program_weight_tensor_parameter_283:
 
 class Program_weight_tensor_parameter_284:
     name = "parameter_284"
+    original_name = "batch_norm_66.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-2.35774")
@@ -3131,6 +3416,7 @@ class Program_weight_tensor_parameter_284:
 
 class Program_weight_tensor_parameter_285:
     name = "parameter_285"
+    original_name = "batch_norm_66.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("0.301363")
@@ -3142,6 +3428,7 @@ class Program_weight_tensor_parameter_285:
 
 class Program_weight_tensor_parameter_286:
     name = "parameter_286"
+    original_name = "batch_norm_66.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("0.00946652")
@@ -3153,6 +3440,7 @@ class Program_weight_tensor_parameter_286:
 
 class Program_weight_tensor_parameter_287:
     name = "parameter_287"
+    original_name = "batch_norm_66.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-8.04579")
@@ -3164,6 +3452,7 @@ class Program_weight_tensor_parameter_287:
 
 class Program_weight_tensor_parameter_288:
     name = "parameter_288"
+    original_name = "conv2d_78.w_0"
     shape = [192, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.246235")
@@ -3175,6 +3464,7 @@ class Program_weight_tensor_parameter_288:
 
 class Program_weight_tensor_parameter_289:
     name = "parameter_289"
+    original_name = "batch_norm_65.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-2.35838")
@@ -3186,6 +3476,7 @@ class Program_weight_tensor_parameter_289:
 
 class Program_weight_tensor_parameter_290:
     name = "parameter_290"
+    original_name = "batch_norm_65.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-1.62524")
@@ -3197,6 +3488,7 @@ class Program_weight_tensor_parameter_290:
 
 class Program_weight_tensor_parameter_291:
     name = "parameter_291"
+    original_name = "batch_norm_65.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("0.000225161")
@@ -3208,6 +3500,7 @@ class Program_weight_tensor_parameter_291:
 
 class Program_weight_tensor_parameter_292:
     name = "parameter_292"
+    original_name = "batch_norm_65.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.38717")
@@ -3219,6 +3512,7 @@ class Program_weight_tensor_parameter_292:
 
 class Program_weight_tensor_parameter_293:
     name = "parameter_293"
+    original_name = "conv2d_77.w_0"
     shape = [192, 768, 1, 1]
     dtype = "float32"
     min_val = float("-0.225215")
@@ -3230,6 +3524,7 @@ class Program_weight_tensor_parameter_293:
 
 class Program_weight_tensor_parameter_294:
     name = "parameter_294"
+    original_name = "batch_norm_64.b_0"
     shape = [768]
     dtype = "float32"
     min_val = float("-5.53468")
@@ -3241,6 +3536,7 @@ class Program_weight_tensor_parameter_294:
 
 class Program_weight_tensor_parameter_295:
     name = "parameter_295"
+    original_name = "batch_norm_64.w_0"
     shape = [768]
     dtype = "float32"
     min_val = float("0.514771")
@@ -3252,6 +3548,7 @@ class Program_weight_tensor_parameter_295:
 
 class Program_weight_tensor_parameter_296:
     name = "parameter_296"
+    original_name = "batch_norm_64.w_2"
     shape = [768]
     dtype = "float32"
     min_val = float("0.0858132")
@@ -3263,6 +3560,7 @@ class Program_weight_tensor_parameter_296:
 
 class Program_weight_tensor_parameter_297:
     name = "parameter_297"
+    original_name = "batch_norm_64.w_1"
     shape = [768]
     dtype = "float32"
     min_val = float("-0.715485")
@@ -3274,6 +3572,7 @@ class Program_weight_tensor_parameter_297:
 
 class Program_weight_tensor_parameter_298:
     name = "parameter_298"
+    original_name = "conv2d_76.w_0"
     shape = [768, 192, 1, 1]
     dtype = "float32"
     min_val = float("-0.309673")
@@ -3285,6 +3584,7 @@ class Program_weight_tensor_parameter_298:
 
 class Program_weight_tensor_parameter_299:
     name = "parameter_299"
+    original_name = "batch_norm_63.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-2.49596")
@@ -3296,6 +3596,7 @@ class Program_weight_tensor_parameter_299:
 
 class Program_weight_tensor_parameter_300:
     name = "parameter_300"
+    original_name = "batch_norm_63.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.881961")
@@ -3307,6 +3608,7 @@ class Program_weight_tensor_parameter_300:
 
 class Program_weight_tensor_parameter_301:
     name = "parameter_301"
+    original_name = "batch_norm_63.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("0.00187438")
@@ -3318,6 +3620,7 @@ class Program_weight_tensor_parameter_301:
 
 class Program_weight_tensor_parameter_302:
     name = "parameter_302"
+    original_name = "batch_norm_63.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.872741")
@@ -3329,6 +3632,7 @@ class Program_weight_tensor_parameter_302:
 
 class Program_weight_tensor_parameter_303:
     name = "parameter_303"
+    original_name = "conv2d_75.w_0"
     shape = [192, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.20228")
@@ -3340,6 +3644,7 @@ class Program_weight_tensor_parameter_303:
 
 class Program_weight_tensor_parameter_304:
     name = "parameter_304"
+    original_name = "conv2d_74.w_0"
     shape = [192, 384, 1, 1]
     dtype = "float32"
     min_val = float("-0.201897")
@@ -3351,6 +3656,7 @@ class Program_weight_tensor_parameter_304:
 
 class Program_weight_tensor_parameter_305:
     name = "parameter_305"
+    original_name = "conv2d_73.w_0"
     shape = [48, 192, 1, 1]
     dtype = "float32"
     min_val = float("-0.197092")
@@ -3362,6 +3668,7 @@ class Program_weight_tensor_parameter_305:
 
 class Program_weight_tensor_parameter_306:
     name = "parameter_306"
+    original_name = "batch_norm_62.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-2.11287")
@@ -3373,6 +3680,7 @@ class Program_weight_tensor_parameter_306:
 
 class Program_weight_tensor_parameter_307:
     name = "parameter_307"
+    original_name = "batch_norm_62.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-3.89838")
@@ -3384,6 +3692,7 @@ class Program_weight_tensor_parameter_307:
 
 class Program_weight_tensor_parameter_308:
     name = "parameter_308"
+    original_name = "batch_norm_62.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("5.2087e-09")
@@ -3395,6 +3704,7 @@ class Program_weight_tensor_parameter_308:
 
 class Program_weight_tensor_parameter_309:
     name = "parameter_309"
+    original_name = "batch_norm_62.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.552931")
@@ -3406,6 +3716,7 @@ class Program_weight_tensor_parameter_309:
 
 class Program_weight_tensor_parameter_310:
     name = "parameter_310"
+    original_name = "conv2d_71.w_0"
     shape = [192, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.111641")
@@ -3417,6 +3728,7 @@ class Program_weight_tensor_parameter_310:
 
 class Program_weight_tensor_parameter_311:
     name = "parameter_311"
+    original_name = "conv2d_72.w_0"
     shape = [48, 192, 1, 1]
     dtype = "float32"
     min_val = float("-0.221604")
@@ -3428,6 +3740,7 @@ class Program_weight_tensor_parameter_311:
 
 class Program_weight_tensor_parameter_312:
     name = "parameter_312"
+    original_name = "batch_norm_61.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-1.4648")
@@ -3439,6 +3752,7 @@ class Program_weight_tensor_parameter_312:
 
 class Program_weight_tensor_parameter_313:
     name = "parameter_313"
+    original_name = "batch_norm_61.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-1.96411")
@@ -3450,6 +3764,7 @@ class Program_weight_tensor_parameter_313:
 
 class Program_weight_tensor_parameter_314:
     name = "parameter_314"
+    original_name = "batch_norm_61.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("5.18671e-08")
@@ -3461,6 +3776,7 @@ class Program_weight_tensor_parameter_314:
 
 class Program_weight_tensor_parameter_315:
     name = "parameter_315"
+    original_name = "batch_norm_61.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.212521")
@@ -3472,6 +3788,7 @@ class Program_weight_tensor_parameter_315:
 
 class Program_weight_tensor_parameter_316:
     name = "parameter_316"
+    original_name = "conv2d_70.w_0"
     shape = [192, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.125076")
@@ -3483,6 +3800,7 @@ class Program_weight_tensor_parameter_316:
 
 class Program_weight_tensor_parameter_317:
     name = "parameter_317"
+    original_name = "conv2d_69.w_0"
     shape = [384, 192, 1, 1]
     dtype = "float32"
     min_val = float("-0.302599")
@@ -3494,6 +3812,7 @@ class Program_weight_tensor_parameter_317:
 
 class Program_weight_tensor_parameter_318:
     name = "parameter_318"
+    original_name = "batch_norm_60.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-1.80765")
@@ -3505,6 +3824,7 @@ class Program_weight_tensor_parameter_318:
 
 class Program_weight_tensor_parameter_319:
     name = "parameter_319"
+    original_name = "batch_norm_60.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.131579")
@@ -3516,6 +3836,7 @@ class Program_weight_tensor_parameter_319:
 
 class Program_weight_tensor_parameter_320:
     name = "parameter_320"
+    original_name = "batch_norm_60.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("0.655616")
@@ -3527,6 +3848,7 @@ class Program_weight_tensor_parameter_320:
 
 class Program_weight_tensor_parameter_321:
     name = "parameter_321"
+    original_name = "batch_norm_60.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-5.92387")
@@ -3538,6 +3860,7 @@ class Program_weight_tensor_parameter_321:
 
 class Program_weight_tensor_parameter_322:
     name = "parameter_322"
+    original_name = "batch_norm_59.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-3.41143")
@@ -3549,6 +3872,7 @@ class Program_weight_tensor_parameter_322:
 
 class Program_weight_tensor_parameter_323:
     name = "parameter_323"
+    original_name = "batch_norm_59.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.845173")
@@ -3560,6 +3884,7 @@ class Program_weight_tensor_parameter_323:
 
 class Program_weight_tensor_parameter_324:
     name = "parameter_324"
+    original_name = "batch_norm_59.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("0.0103314")
@@ -3571,6 +3896,7 @@ class Program_weight_tensor_parameter_324:
 
 class Program_weight_tensor_parameter_325:
     name = "parameter_325"
+    original_name = "batch_norm_59.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-1.04591")
@@ -3582,6 +3908,7 @@ class Program_weight_tensor_parameter_325:
 
 class Program_weight_tensor_parameter_326:
     name = "parameter_326"
+    original_name = "conv2d_68.w_0"
     shape = [192, 768, 1, 1]
     dtype = "float32"
     min_val = float("-0.226069")
@@ -3593,6 +3920,7 @@ class Program_weight_tensor_parameter_326:
 
 class Program_weight_tensor_parameter_327:
     name = "parameter_327"
+    original_name = "batch_norm_58.b_0"
     shape = [768]
     dtype = "float32"
     min_val = float("-5.16451")
@@ -3604,6 +3932,7 @@ class Program_weight_tensor_parameter_327:
 
 class Program_weight_tensor_parameter_328:
     name = "parameter_328"
+    original_name = "batch_norm_58.w_0"
     shape = [768]
     dtype = "float32"
     min_val = float("-1.07177")
@@ -3615,6 +3944,7 @@ class Program_weight_tensor_parameter_328:
 
 class Program_weight_tensor_parameter_329:
     name = "parameter_329"
+    original_name = "batch_norm_58.w_2"
     shape = [768]
     dtype = "float32"
     min_val = float("4.00491e-42")
@@ -3626,6 +3956,7 @@ class Program_weight_tensor_parameter_329:
 
 class Program_weight_tensor_parameter_330:
     name = "parameter_330"
+    original_name = "batch_norm_58.w_1"
     shape = [768]
     dtype = "float32"
     min_val = float("-0.312892")
@@ -3637,6 +3968,7 @@ class Program_weight_tensor_parameter_330:
 
 class Program_weight_tensor_parameter_331:
     name = "parameter_331"
+    original_name = "conv2d_67.w_0"
     shape = [768, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.199594")
@@ -3648,6 +3980,7 @@ class Program_weight_tensor_parameter_331:
 
 class Program_weight_tensor_parameter_332:
     name = "parameter_332"
+    original_name = "batch_norm_57.b_0"
     shape = [768]
     dtype = "float32"
     min_val = float("-3.98696")
@@ -3659,6 +3992,7 @@ class Program_weight_tensor_parameter_332:
 
 class Program_weight_tensor_parameter_333:
     name = "parameter_333"
+    original_name = "batch_norm_57.w_0"
     shape = [768]
     dtype = "float32"
     min_val = float("-0.000202027")
@@ -3670,6 +4004,7 @@ class Program_weight_tensor_parameter_333:
 
 class Program_weight_tensor_parameter_334:
     name = "parameter_334"
+    original_name = "batch_norm_57.w_2"
     shape = [768]
     dtype = "float32"
     min_val = float("6.80569e-40")
@@ -3681,6 +4016,7 @@ class Program_weight_tensor_parameter_334:
 
 class Program_weight_tensor_parameter_335:
     name = "parameter_335"
+    original_name = "batch_norm_57.w_1"
     shape = [768]
     dtype = "float32"
     min_val = float("-0.58256")
@@ -3692,6 +4028,7 @@ class Program_weight_tensor_parameter_335:
 
 class Program_weight_tensor_parameter_336:
     name = "parameter_336"
+    original_name = "conv2d_66.w_0"
     shape = [768, 192, 1, 1]
     dtype = "float32"
     min_val = float("-0.271419")
@@ -3703,6 +4040,7 @@ class Program_weight_tensor_parameter_336:
 
 class Program_weight_tensor_parameter_337:
     name = "parameter_337"
+    original_name = "batch_norm_56.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-1.91299")
@@ -3714,6 +4052,7 @@ class Program_weight_tensor_parameter_337:
 
 class Program_weight_tensor_parameter_338:
     name = "parameter_338"
+    original_name = "batch_norm_56.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.186835")
@@ -3725,6 +4064,7 @@ class Program_weight_tensor_parameter_338:
 
 class Program_weight_tensor_parameter_339:
     name = "parameter_339"
+    original_name = "batch_norm_56.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("0.00589249")
@@ -3736,6 +4076,7 @@ class Program_weight_tensor_parameter_339:
 
 class Program_weight_tensor_parameter_340:
     name = "parameter_340"
+    original_name = "batch_norm_56.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-3.22894")
@@ -3747,6 +4088,7 @@ class Program_weight_tensor_parameter_340:
 
 class Program_weight_tensor_parameter_341:
     name = "parameter_341"
+    original_name = "conv2d_65.w_0"
     shape = [192, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.385144")
@@ -3758,6 +4100,7 @@ class Program_weight_tensor_parameter_341:
 
 class Program_weight_tensor_parameter_342:
     name = "parameter_342"
+    original_name = "conv2d_64.w_0"
     shape = [192, 384, 1, 1]
     dtype = "float32"
     min_val = float("-0.230138")
@@ -3769,6 +4112,7 @@ class Program_weight_tensor_parameter_342:
 
 class Program_weight_tensor_parameter_343:
     name = "parameter_343"
+    original_name = "conv2d_63.w_0"
     shape = [48, 192, 1, 1]
     dtype = "float32"
     min_val = float("-0.165305")
@@ -3780,6 +4124,7 @@ class Program_weight_tensor_parameter_343:
 
 class Program_weight_tensor_parameter_344:
     name = "parameter_344"
+    original_name = "batch_norm_55.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-1.20047")
@@ -3791,6 +4136,7 @@ class Program_weight_tensor_parameter_344:
 
 class Program_weight_tensor_parameter_345:
     name = "parameter_345"
+    original_name = "batch_norm_55.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-4.55088")
@@ -3802,6 +4148,7 @@ class Program_weight_tensor_parameter_345:
 
 class Program_weight_tensor_parameter_346:
     name = "parameter_346"
+    original_name = "batch_norm_55.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("2.77677e-09")
@@ -3813,6 +4160,7 @@ class Program_weight_tensor_parameter_346:
 
 class Program_weight_tensor_parameter_347:
     name = "parameter_347"
+    original_name = "batch_norm_55.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.876815")
@@ -3824,6 +4172,7 @@ class Program_weight_tensor_parameter_347:
 
 class Program_weight_tensor_parameter_348:
     name = "parameter_348"
+    original_name = "conv2d_61.w_0"
     shape = [192, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.124832")
@@ -3835,6 +4184,7 @@ class Program_weight_tensor_parameter_348:
 
 class Program_weight_tensor_parameter_349:
     name = "parameter_349"
+    original_name = "conv2d_62.w_0"
     shape = [48, 192, 1, 1]
     dtype = "float32"
     min_val = float("-0.163045")
@@ -3846,6 +4196,7 @@ class Program_weight_tensor_parameter_349:
 
 class Program_weight_tensor_parameter_350:
     name = "parameter_350"
+    original_name = "batch_norm_54.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-2.03582")
@@ -3857,6 +4208,7 @@ class Program_weight_tensor_parameter_350:
 
 class Program_weight_tensor_parameter_351:
     name = "parameter_351"
+    original_name = "batch_norm_54.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-1.71626")
@@ -3868,6 +4220,7 @@ class Program_weight_tensor_parameter_351:
 
 class Program_weight_tensor_parameter_352:
     name = "parameter_352"
+    original_name = "batch_norm_54.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("7.37284e-09")
@@ -3879,6 +4232,7 @@ class Program_weight_tensor_parameter_352:
 
 class Program_weight_tensor_parameter_353:
     name = "parameter_353"
+    original_name = "batch_norm_54.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.149349")
@@ -3890,6 +4244,7 @@ class Program_weight_tensor_parameter_353:
 
 class Program_weight_tensor_parameter_354:
     name = "parameter_354"
+    original_name = "conv2d_60.w_0"
     shape = [192, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.114809")
@@ -3901,6 +4256,7 @@ class Program_weight_tensor_parameter_354:
 
 class Program_weight_tensor_parameter_355:
     name = "parameter_355"
+    original_name = "conv2d_59.w_0"
     shape = [384, 192, 1, 1]
     dtype = "float32"
     min_val = float("-0.225892")
@@ -3912,6 +4268,7 @@ class Program_weight_tensor_parameter_355:
 
 class Program_weight_tensor_parameter_356:
     name = "parameter_356"
+    original_name = "batch_norm_53.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-5.97408")
@@ -3923,6 +4280,7 @@ class Program_weight_tensor_parameter_356:
 
 class Program_weight_tensor_parameter_357:
     name = "parameter_357"
+    original_name = "batch_norm_53.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.121788")
@@ -3934,6 +4292,7 @@ class Program_weight_tensor_parameter_357:
 
 class Program_weight_tensor_parameter_358:
     name = "parameter_358"
+    original_name = "batch_norm_53.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("0.455424")
@@ -3945,6 +4304,7 @@ class Program_weight_tensor_parameter_358:
 
 class Program_weight_tensor_parameter_359:
     name = "parameter_359"
+    original_name = "batch_norm_53.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-4.93422")
@@ -3956,6 +4316,7 @@ class Program_weight_tensor_parameter_359:
 
 class Program_weight_tensor_parameter_360:
     name = "parameter_360"
+    original_name = "batch_norm_52.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-1.07078")
@@ -3967,6 +4328,7 @@ class Program_weight_tensor_parameter_360:
 
 class Program_weight_tensor_parameter_361:
     name = "parameter_361"
+    original_name = "batch_norm_52.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.765347")
@@ -3978,6 +4340,7 @@ class Program_weight_tensor_parameter_361:
 
 class Program_weight_tensor_parameter_362:
     name = "parameter_362"
+    original_name = "batch_norm_52.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("0.00293378")
@@ -3989,6 +4352,7 @@ class Program_weight_tensor_parameter_362:
 
 class Program_weight_tensor_parameter_363:
     name = "parameter_363"
+    original_name = "batch_norm_52.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-1.08796")
@@ -4000,6 +4364,7 @@ class Program_weight_tensor_parameter_363:
 
 class Program_weight_tensor_parameter_364:
     name = "parameter_364"
+    original_name = "conv2d_58.w_0"
     shape = [192, 768, 1, 1]
     dtype = "float32"
     min_val = float("-0.198897")
@@ -4011,6 +4376,7 @@ class Program_weight_tensor_parameter_364:
 
 class Program_weight_tensor_parameter_365:
     name = "parameter_365"
+    original_name = "batch_norm_51.b_0"
     shape = [768]
     dtype = "float32"
     min_val = float("-5.52259")
@@ -4022,6 +4388,7 @@ class Program_weight_tensor_parameter_365:
 
 class Program_weight_tensor_parameter_366:
     name = "parameter_366"
+    original_name = "batch_norm_51.w_0"
     shape = [768]
     dtype = "float32"
     min_val = float("-1.78422")
@@ -4033,6 +4400,7 @@ class Program_weight_tensor_parameter_366:
 
 class Program_weight_tensor_parameter_367:
     name = "parameter_367"
+    original_name = "batch_norm_51.w_2"
     shape = [768]
     dtype = "float32"
     min_val = float("3.60554e-42")
@@ -4044,6 +4412,7 @@ class Program_weight_tensor_parameter_367:
 
 class Program_weight_tensor_parameter_368:
     name = "parameter_368"
+    original_name = "batch_norm_51.w_1"
     shape = [768]
     dtype = "float32"
     min_val = float("-0.458037")
@@ -4055,6 +4424,7 @@ class Program_weight_tensor_parameter_368:
 
 class Program_weight_tensor_parameter_369:
     name = "parameter_369"
+    original_name = "conv2d_57.w_0"
     shape = [768, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.252926")
@@ -4066,6 +4436,7 @@ class Program_weight_tensor_parameter_369:
 
 class Program_weight_tensor_parameter_370:
     name = "parameter_370"
+    original_name = "batch_norm_50.b_0"
     shape = [768]
     dtype = "float32"
     min_val = float("-2.94668")
@@ -4077,6 +4448,7 @@ class Program_weight_tensor_parameter_370:
 
 class Program_weight_tensor_parameter_371:
     name = "parameter_371"
+    original_name = "batch_norm_50.w_0"
     shape = [768]
     dtype = "float32"
     min_val = float("-0.239404")
@@ -4088,6 +4460,7 @@ class Program_weight_tensor_parameter_371:
 
 class Program_weight_tensor_parameter_372:
     name = "parameter_372"
+    original_name = "batch_norm_50.w_2"
     shape = [768]
     dtype = "float32"
     min_val = float("4.04695e-42")
@@ -4099,6 +4472,7 @@ class Program_weight_tensor_parameter_372:
 
 class Program_weight_tensor_parameter_373:
     name = "parameter_373"
+    original_name = "batch_norm_50.w_1"
     shape = [768]
     dtype = "float32"
     min_val = float("-0.655032")
@@ -4110,6 +4484,7 @@ class Program_weight_tensor_parameter_373:
 
 class Program_weight_tensor_parameter_374:
     name = "parameter_374"
+    original_name = "conv2d_56.w_0"
     shape = [768, 192, 1, 1]
     dtype = "float32"
     min_val = float("-0.4445")
@@ -4121,6 +4496,7 @@ class Program_weight_tensor_parameter_374:
 
 class Program_weight_tensor_parameter_375:
     name = "parameter_375"
+    original_name = "batch_norm_49.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-2.16851")
@@ -4132,6 +4508,7 @@ class Program_weight_tensor_parameter_375:
 
 class Program_weight_tensor_parameter_376:
     name = "parameter_376"
+    original_name = "batch_norm_49.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.281975")
@@ -4143,6 +4520,7 @@ class Program_weight_tensor_parameter_376:
 
 class Program_weight_tensor_parameter_377:
     name = "parameter_377"
+    original_name = "batch_norm_49.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("0.00382864")
@@ -4154,6 +4532,7 @@ class Program_weight_tensor_parameter_377:
 
 class Program_weight_tensor_parameter_378:
     name = "parameter_378"
+    original_name = "batch_norm_49.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-1.2214")
@@ -4165,6 +4544,7 @@ class Program_weight_tensor_parameter_378:
 
 class Program_weight_tensor_parameter_379:
     name = "parameter_379"
+    original_name = "conv2d_55.w_0"
     shape = [192, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.301503")
@@ -4176,6 +4556,7 @@ class Program_weight_tensor_parameter_379:
 
 class Program_weight_tensor_parameter_380:
     name = "parameter_380"
+    original_name = "conv2d_54.w_0"
     shape = [192, 384, 1, 1]
     dtype = "float32"
     min_val = float("-0.221441")
@@ -4187,6 +4568,7 @@ class Program_weight_tensor_parameter_380:
 
 class Program_weight_tensor_parameter_381:
     name = "parameter_381"
+    original_name = "conv2d_53.w_0"
     shape = [48, 192, 1, 1]
     dtype = "float32"
     min_val = float("-0.207064")
@@ -4198,6 +4580,7 @@ class Program_weight_tensor_parameter_381:
 
 class Program_weight_tensor_parameter_382:
     name = "parameter_382"
+    original_name = "batch_norm_48.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-1.99476")
@@ -4209,6 +4592,7 @@ class Program_weight_tensor_parameter_382:
 
 class Program_weight_tensor_parameter_383:
     name = "parameter_383"
+    original_name = "batch_norm_48.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-1.62969")
@@ -4220,6 +4604,7 @@ class Program_weight_tensor_parameter_383:
 
 class Program_weight_tensor_parameter_384:
     name = "parameter_384"
+    original_name = "batch_norm_48.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("1.42726e-09")
@@ -4231,6 +4616,7 @@ class Program_weight_tensor_parameter_384:
 
 class Program_weight_tensor_parameter_385:
     name = "parameter_385"
+    original_name = "batch_norm_48.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.687938")
@@ -4242,6 +4628,7 @@ class Program_weight_tensor_parameter_385:
 
 class Program_weight_tensor_parameter_386:
     name = "parameter_386"
+    original_name = "conv2d_51.w_0"
     shape = [192, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.104207")
@@ -4253,6 +4640,7 @@ class Program_weight_tensor_parameter_386:
 
 class Program_weight_tensor_parameter_387:
     name = "parameter_387"
+    original_name = "conv2d_52.w_0"
     shape = [48, 192, 1, 1]
     dtype = "float32"
     min_val = float("-0.148975")
@@ -4264,6 +4652,7 @@ class Program_weight_tensor_parameter_387:
 
 class Program_weight_tensor_parameter_388:
     name = "parameter_388"
+    original_name = "batch_norm_47.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-2.4102")
@@ -4275,6 +4664,7 @@ class Program_weight_tensor_parameter_388:
 
 class Program_weight_tensor_parameter_389:
     name = "parameter_389"
+    original_name = "batch_norm_47.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-1.11984")
@@ -4286,6 +4676,7 @@ class Program_weight_tensor_parameter_389:
 
 class Program_weight_tensor_parameter_390:
     name = "parameter_390"
+    original_name = "batch_norm_47.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("6.40798e-09")
@@ -4297,6 +4688,7 @@ class Program_weight_tensor_parameter_390:
 
 class Program_weight_tensor_parameter_391:
     name = "parameter_391"
+    original_name = "batch_norm_47.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-1.3378")
@@ -4308,6 +4700,7 @@ class Program_weight_tensor_parameter_391:
 
 class Program_weight_tensor_parameter_392:
     name = "parameter_392"
+    original_name = "conv2d_50.w_0"
     shape = [192, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.126057")
@@ -4319,6 +4712,7 @@ class Program_weight_tensor_parameter_392:
 
 class Program_weight_tensor_parameter_393:
     name = "parameter_393"
+    original_name = "conv2d_49.w_0"
     shape = [384, 192, 1, 1]
     dtype = "float32"
     min_val = float("-0.166398")
@@ -4330,6 +4724,7 @@ class Program_weight_tensor_parameter_393:
 
 class Program_weight_tensor_parameter_394:
     name = "parameter_394"
+    original_name = "batch_norm_46.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-4.1685")
@@ -4341,6 +4736,7 @@ class Program_weight_tensor_parameter_394:
 
 class Program_weight_tensor_parameter_395:
     name = "parameter_395"
+    original_name = "batch_norm_46.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-1.60508")
@@ -4352,6 +4748,7 @@ class Program_weight_tensor_parameter_395:
 
 class Program_weight_tensor_parameter_396:
     name = "parameter_396"
+    original_name = "batch_norm_46.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("0.222156")
@@ -4363,6 +4760,7 @@ class Program_weight_tensor_parameter_396:
 
 class Program_weight_tensor_parameter_397:
     name = "parameter_397"
+    original_name = "batch_norm_46.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-4.31357")
@@ -4374,6 +4772,7 @@ class Program_weight_tensor_parameter_397:
 
 class Program_weight_tensor_parameter_398:
     name = "parameter_398"
+    original_name = "batch_norm_45.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.729192")
@@ -4385,6 +4784,7 @@ class Program_weight_tensor_parameter_398:
 
 class Program_weight_tensor_parameter_399:
     name = "parameter_399"
+    original_name = "batch_norm_45.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.792123")
@@ -4396,6 +4796,7 @@ class Program_weight_tensor_parameter_399:
 
 class Program_weight_tensor_parameter_400:
     name = "parameter_400"
+    original_name = "batch_norm_45.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("0.0015329")
@@ -4407,6 +4808,7 @@ class Program_weight_tensor_parameter_400:
 
 class Program_weight_tensor_parameter_401:
     name = "parameter_401"
+    original_name = "batch_norm_45.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.886204")
@@ -4418,6 +4820,7 @@ class Program_weight_tensor_parameter_401:
 
 class Program_weight_tensor_parameter_402:
     name = "parameter_402"
+    original_name = "conv2d_48.w_0"
     shape = [192, 768, 1, 1]
     dtype = "float32"
     min_val = float("-0.206761")
@@ -4429,6 +4832,7 @@ class Program_weight_tensor_parameter_402:
 
 class Program_weight_tensor_parameter_403:
     name = "parameter_403"
+    original_name = "batch_norm_44.b_0"
     shape = [768]
     dtype = "float32"
     min_val = float("-7.21567")
@@ -4440,6 +4844,7 @@ class Program_weight_tensor_parameter_403:
 
 class Program_weight_tensor_parameter_404:
     name = "parameter_404"
+    original_name = "batch_norm_44.w_0"
     shape = [768]
     dtype = "float32"
     min_val = float("-2.56895")
@@ -4451,6 +4856,7 @@ class Program_weight_tensor_parameter_404:
 
 class Program_weight_tensor_parameter_405:
     name = "parameter_405"
+    original_name = "batch_norm_44.w_2"
     shape = [768]
     dtype = "float32"
     min_val = float("3.84516e-42")
@@ -4462,6 +4868,7 @@ class Program_weight_tensor_parameter_405:
 
 class Program_weight_tensor_parameter_406:
     name = "parameter_406"
+    original_name = "batch_norm_44.w_1"
     shape = [768]
     dtype = "float32"
     min_val = float("-0.320142")
@@ -4473,6 +4880,7 @@ class Program_weight_tensor_parameter_406:
 
 class Program_weight_tensor_parameter_407:
     name = "parameter_407"
+    original_name = "conv2d_47.w_0"
     shape = [768, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.199375")
@@ -4484,6 +4892,7 @@ class Program_weight_tensor_parameter_407:
 
 class Program_weight_tensor_parameter_408:
     name = "parameter_408"
+    original_name = "batch_norm_43.b_0"
     shape = [768]
     dtype = "float32"
     min_val = float("-4.12156")
@@ -4495,6 +4904,7 @@ class Program_weight_tensor_parameter_408:
 
 class Program_weight_tensor_parameter_409:
     name = "parameter_409"
+    original_name = "batch_norm_43.w_0"
     shape = [768]
     dtype = "float32"
     min_val = float("-0.192663")
@@ -4506,6 +4916,7 @@ class Program_weight_tensor_parameter_409:
 
 class Program_weight_tensor_parameter_410:
     name = "parameter_410"
+    original_name = "batch_norm_43.w_2"
     shape = [768]
     dtype = "float32"
     min_val = float("2.39012e-40")
@@ -4517,6 +4928,7 @@ class Program_weight_tensor_parameter_410:
 
 class Program_weight_tensor_parameter_411:
     name = "parameter_411"
+    original_name = "batch_norm_43.w_1"
     shape = [768]
     dtype = "float32"
     min_val = float("-0.818304")
@@ -4528,6 +4940,7 @@ class Program_weight_tensor_parameter_411:
 
 class Program_weight_tensor_parameter_412:
     name = "parameter_412"
+    original_name = "conv2d_46.w_0"
     shape = [768, 192, 1, 1]
     dtype = "float32"
     min_val = float("-0.26379")
@@ -4539,6 +4952,7 @@ class Program_weight_tensor_parameter_412:
 
 class Program_weight_tensor_parameter_413:
     name = "parameter_413"
+    original_name = "batch_norm_42.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-1.96736")
@@ -4550,6 +4964,7 @@ class Program_weight_tensor_parameter_413:
 
 class Program_weight_tensor_parameter_414:
     name = "parameter_414"
+    original_name = "batch_norm_42.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.198112")
@@ -4561,6 +4976,7 @@ class Program_weight_tensor_parameter_414:
 
 class Program_weight_tensor_parameter_415:
     name = "parameter_415"
+    original_name = "batch_norm_42.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("0.000900268")
@@ -4572,6 +4988,7 @@ class Program_weight_tensor_parameter_415:
 
 class Program_weight_tensor_parameter_416:
     name = "parameter_416"
+    original_name = "batch_norm_42.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-1.47097")
@@ -4583,6 +5000,7 @@ class Program_weight_tensor_parameter_416:
 
 class Program_weight_tensor_parameter_417:
     name = "parameter_417"
+    original_name = "conv2d_45.w_0"
     shape = [192, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.262765")
@@ -4594,6 +5012,7 @@ class Program_weight_tensor_parameter_417:
 
 class Program_weight_tensor_parameter_418:
     name = "parameter_418"
+    original_name = "conv2d_44.w_0"
     shape = [192, 384, 1, 1]
     dtype = "float32"
     min_val = float("-0.217608")
@@ -4605,6 +5024,7 @@ class Program_weight_tensor_parameter_418:
 
 class Program_weight_tensor_parameter_419:
     name = "parameter_419"
+    original_name = "conv2d_43.w_0"
     shape = [48, 192, 1, 1]
     dtype = "float32"
     min_val = float("-0.185753")
@@ -4616,6 +5036,7 @@ class Program_weight_tensor_parameter_419:
 
 class Program_weight_tensor_parameter_420:
     name = "parameter_420"
+    original_name = "batch_norm_41.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-2.11004")
@@ -4627,6 +5048,7 @@ class Program_weight_tensor_parameter_420:
 
 class Program_weight_tensor_parameter_421:
     name = "parameter_421"
+    original_name = "batch_norm_41.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-1.64939")
@@ -4638,6 +5060,7 @@ class Program_weight_tensor_parameter_421:
 
 class Program_weight_tensor_parameter_422:
     name = "parameter_422"
+    original_name = "batch_norm_41.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("4.35614e-10")
@@ -4649,6 +5072,7 @@ class Program_weight_tensor_parameter_422:
 
 class Program_weight_tensor_parameter_423:
     name = "parameter_423"
+    original_name = "batch_norm_41.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.672881")
@@ -4660,6 +5084,7 @@ class Program_weight_tensor_parameter_423:
 
 class Program_weight_tensor_parameter_424:
     name = "parameter_424"
+    original_name = "conv2d_41.w_0"
     shape = [192, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.0888342")
@@ -4671,6 +5096,7 @@ class Program_weight_tensor_parameter_424:
 
 class Program_weight_tensor_parameter_425:
     name = "parameter_425"
+    original_name = "conv2d_42.w_0"
     shape = [48, 192, 1, 1]
     dtype = "float32"
     min_val = float("-0.14017")
@@ -4682,6 +5108,7 @@ class Program_weight_tensor_parameter_425:
 
 class Program_weight_tensor_parameter_426:
     name = "parameter_426"
+    original_name = "batch_norm_40.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-1.962")
@@ -4693,6 +5120,7 @@ class Program_weight_tensor_parameter_426:
 
 class Program_weight_tensor_parameter_427:
     name = "parameter_427"
+    original_name = "batch_norm_40.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-1.38744")
@@ -4704,6 +5132,7 @@ class Program_weight_tensor_parameter_427:
 
 class Program_weight_tensor_parameter_428:
     name = "parameter_428"
+    original_name = "batch_norm_40.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("9.94667e-09")
@@ -4715,6 +5144,7 @@ class Program_weight_tensor_parameter_428:
 
 class Program_weight_tensor_parameter_429:
     name = "parameter_429"
+    original_name = "batch_norm_40.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.561504")
@@ -4726,6 +5156,7 @@ class Program_weight_tensor_parameter_429:
 
 class Program_weight_tensor_parameter_430:
     name = "parameter_430"
+    original_name = "conv2d_40.w_0"
     shape = [192, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.0798203")
@@ -4737,6 +5168,7 @@ class Program_weight_tensor_parameter_430:
 
 class Program_weight_tensor_parameter_431:
     name = "parameter_431"
+    original_name = "conv2d_39.w_0"
     shape = [384, 192, 1, 1]
     dtype = "float32"
     min_val = float("-0.180301")
@@ -4748,6 +5180,7 @@ class Program_weight_tensor_parameter_431:
 
 class Program_weight_tensor_parameter_432:
     name = "parameter_432"
+    original_name = "batch_norm_39.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-5.96476")
@@ -4759,6 +5192,7 @@ class Program_weight_tensor_parameter_432:
 
 class Program_weight_tensor_parameter_433:
     name = "parameter_433"
+    original_name = "batch_norm_39.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-1.52028")
@@ -4770,6 +5204,7 @@ class Program_weight_tensor_parameter_433:
 
 class Program_weight_tensor_parameter_434:
     name = "parameter_434"
+    original_name = "batch_norm_39.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("0.0158846")
@@ -4781,6 +5216,7 @@ class Program_weight_tensor_parameter_434:
 
 class Program_weight_tensor_parameter_435:
     name = "parameter_435"
+    original_name = "batch_norm_39.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-4.07267")
@@ -4792,6 +5228,7 @@ class Program_weight_tensor_parameter_435:
 
 class Program_weight_tensor_parameter_436:
     name = "parameter_436"
+    original_name = "batch_norm_38.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.662139")
@@ -4803,6 +5240,7 @@ class Program_weight_tensor_parameter_436:
 
 class Program_weight_tensor_parameter_437:
     name = "parameter_437"
+    original_name = "batch_norm_38.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.984663")
@@ -4814,6 +5252,7 @@ class Program_weight_tensor_parameter_437:
 
 class Program_weight_tensor_parameter_438:
     name = "parameter_438"
+    original_name = "batch_norm_38.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("0.0137633")
@@ -4825,6 +5264,7 @@ class Program_weight_tensor_parameter_438:
 
 class Program_weight_tensor_parameter_439:
     name = "parameter_439"
+    original_name = "batch_norm_38.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-1.80303")
@@ -4836,6 +5276,7 @@ class Program_weight_tensor_parameter_439:
 
 class Program_weight_tensor_parameter_440:
     name = "parameter_440"
+    original_name = "conv2d_38.w_0"
     shape = [192, 768, 1, 1]
     dtype = "float32"
     min_val = float("-0.242233")
@@ -4847,6 +5288,7 @@ class Program_weight_tensor_parameter_440:
 
 class Program_weight_tensor_parameter_441:
     name = "parameter_441"
+    original_name = "batch_norm_37.b_0"
     shape = [768]
     dtype = "float32"
     min_val = float("-9.67566")
@@ -4858,6 +5300,7 @@ class Program_weight_tensor_parameter_441:
 
 class Program_weight_tensor_parameter_442:
     name = "parameter_442"
+    original_name = "batch_norm_37.w_0"
     shape = [768]
     dtype = "float32"
     min_val = float("-1.71499")
@@ -4869,6 +5312,7 @@ class Program_weight_tensor_parameter_442:
 
 class Program_weight_tensor_parameter_443:
     name = "parameter_443"
+    original_name = "batch_norm_37.w_2"
     shape = [768]
     dtype = "float32"
     min_val = float("5.26148e-40")
@@ -4880,6 +5324,7 @@ class Program_weight_tensor_parameter_443:
 
 class Program_weight_tensor_parameter_444:
     name = "parameter_444"
+    original_name = "batch_norm_37.w_1"
     shape = [768]
     dtype = "float32"
     min_val = float("-0.504895")
@@ -4891,6 +5336,7 @@ class Program_weight_tensor_parameter_444:
 
 class Program_weight_tensor_parameter_445:
     name = "parameter_445"
+    original_name = "conv2d_37.w_0"
     shape = [768, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.203165")
@@ -4902,6 +5348,7 @@ class Program_weight_tensor_parameter_445:
 
 class Program_weight_tensor_parameter_446:
     name = "parameter_446"
+    original_name = "batch_norm_36.b_0"
     shape = [768]
     dtype = "float32"
     min_val = float("-4.5699")
@@ -4913,6 +5360,7 @@ class Program_weight_tensor_parameter_446:
 
 class Program_weight_tensor_parameter_447:
     name = "parameter_447"
+    original_name = "batch_norm_36.w_0"
     shape = [768]
     dtype = "float32"
     min_val = float("-0.00690702")
@@ -4924,6 +5372,7 @@ class Program_weight_tensor_parameter_447:
 
 class Program_weight_tensor_parameter_448:
     name = "parameter_448"
+    original_name = "batch_norm_36.w_2"
     shape = [768]
     dtype = "float32"
     min_val = float("3.10625e-37")
@@ -4935,6 +5384,7 @@ class Program_weight_tensor_parameter_448:
 
 class Program_weight_tensor_parameter_449:
     name = "parameter_449"
+    original_name = "batch_norm_36.w_1"
     shape = [768]
     dtype = "float32"
     min_val = float("-0.718647")
@@ -4946,6 +5396,7 @@ class Program_weight_tensor_parameter_449:
 
 class Program_weight_tensor_parameter_450:
     name = "parameter_450"
+    original_name = "conv2d_36.w_0"
     shape = [768, 192, 1, 1]
     dtype = "float32"
     min_val = float("-0.248763")
@@ -4957,6 +5408,7 @@ class Program_weight_tensor_parameter_450:
 
 class Program_weight_tensor_parameter_451:
     name = "parameter_451"
+    original_name = "batch_norm_35.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-2.03071")
@@ -4968,6 +5420,7 @@ class Program_weight_tensor_parameter_451:
 
 class Program_weight_tensor_parameter_452:
     name = "parameter_452"
+    original_name = "batch_norm_35.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.947577")
@@ -4979,6 +5432,7 @@ class Program_weight_tensor_parameter_452:
 
 class Program_weight_tensor_parameter_453:
     name = "parameter_453"
+    original_name = "batch_norm_35.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("7.3107e-05")
@@ -4990,6 +5444,7 @@ class Program_weight_tensor_parameter_453:
 
 class Program_weight_tensor_parameter_454:
     name = "parameter_454"
+    original_name = "batch_norm_35.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-1.45338")
@@ -5001,6 +5456,7 @@ class Program_weight_tensor_parameter_454:
 
 class Program_weight_tensor_parameter_455:
     name = "parameter_455"
+    original_name = "conv2d_35.w_0"
     shape = [192, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.262698")
@@ -5012,6 +5468,7 @@ class Program_weight_tensor_parameter_455:
 
 class Program_weight_tensor_parameter_456:
     name = "parameter_456"
+    original_name = "batch_norm_34.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-1.23846")
@@ -5023,6 +5480,7 @@ class Program_weight_tensor_parameter_456:
 
 class Program_weight_tensor_parameter_457:
     name = "parameter_457"
+    original_name = "batch_norm_34.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-1.06741")
@@ -5034,6 +5492,7 @@ class Program_weight_tensor_parameter_457:
 
 class Program_weight_tensor_parameter_458:
     name = "parameter_458"
+    original_name = "batch_norm_34.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("0.0241936")
@@ -5045,6 +5504,7 @@ class Program_weight_tensor_parameter_458:
 
 class Program_weight_tensor_parameter_459:
     name = "parameter_459"
+    original_name = "batch_norm_34.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-2.46215")
@@ -5056,6 +5516,7 @@ class Program_weight_tensor_parameter_459:
 
 class Program_weight_tensor_parameter_460:
     name = "parameter_460"
+    original_name = "conv2d_34.w_0"
     shape = [192, 768, 1, 1]
     dtype = "float32"
     min_val = float("-0.2028")
@@ -5067,6 +5528,7 @@ class Program_weight_tensor_parameter_460:
 
 class Program_weight_tensor_parameter_461:
     name = "parameter_461"
+    original_name = "batch_norm_33.b_0"
     shape = [768]
     dtype = "float32"
     min_val = float("-8.46985")
@@ -5078,6 +5540,7 @@ class Program_weight_tensor_parameter_461:
 
 class Program_weight_tensor_parameter_462:
     name = "parameter_462"
+    original_name = "batch_norm_33.w_0"
     shape = [768]
     dtype = "float32"
     min_val = float("-1.8182")
@@ -5089,6 +5552,7 @@ class Program_weight_tensor_parameter_462:
 
 class Program_weight_tensor_parameter_463:
     name = "parameter_463"
+    original_name = "batch_norm_33.w_2"
     shape = [768]
     dtype = "float32"
     min_val = float("9.01175e-42")
@@ -5100,6 +5564,7 @@ class Program_weight_tensor_parameter_463:
 
 class Program_weight_tensor_parameter_464:
     name = "parameter_464"
+    original_name = "batch_norm_33.w_1"
     shape = [768]
     dtype = "float32"
     min_val = float("-0.503014")
@@ -5111,6 +5576,7 @@ class Program_weight_tensor_parameter_464:
 
 class Program_weight_tensor_parameter_465:
     name = "parameter_465"
+    original_name = "conv2d_33.w_0"
     shape = [768, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.190212")
@@ -5122,6 +5588,7 @@ class Program_weight_tensor_parameter_465:
 
 class Program_weight_tensor_parameter_466:
     name = "parameter_466"
+    original_name = "batch_norm_32.b_0"
     shape = [768]
     dtype = "float32"
     min_val = float("-4.00712")
@@ -5133,6 +5600,7 @@ class Program_weight_tensor_parameter_466:
 
 class Program_weight_tensor_parameter_467:
     name = "parameter_467"
+    original_name = "batch_norm_32.w_0"
     shape = [768]
     dtype = "float32"
     min_val = float("-0.452688")
@@ -5144,6 +5612,7 @@ class Program_weight_tensor_parameter_467:
 
 class Program_weight_tensor_parameter_468:
     name = "parameter_468"
+    original_name = "batch_norm_32.w_2"
     shape = [768]
     dtype = "float32"
     min_val = float("1.08099e-35")
@@ -5155,6 +5624,7 @@ class Program_weight_tensor_parameter_468:
 
 class Program_weight_tensor_parameter_469:
     name = "parameter_469"
+    original_name = "batch_norm_32.w_1"
     shape = [768]
     dtype = "float32"
     min_val = float("-0.660947")
@@ -5166,6 +5636,7 @@ class Program_weight_tensor_parameter_469:
 
 class Program_weight_tensor_parameter_470:
     name = "parameter_470"
+    original_name = "conv2d_32.w_0"
     shape = [768, 192, 1, 1]
     dtype = "float32"
     min_val = float("-0.251756")
@@ -5177,6 +5648,7 @@ class Program_weight_tensor_parameter_470:
 
 class Program_weight_tensor_parameter_471:
     name = "parameter_471"
+    original_name = "batch_norm_31.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-1.91871")
@@ -5188,6 +5660,7 @@ class Program_weight_tensor_parameter_471:
 
 class Program_weight_tensor_parameter_472:
     name = "parameter_472"
+    original_name = "batch_norm_31.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.114291")
@@ -5199,6 +5672,7 @@ class Program_weight_tensor_parameter_472:
 
 class Program_weight_tensor_parameter_473:
     name = "parameter_473"
+    original_name = "batch_norm_31.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("4.34141e-05")
@@ -5210,6 +5684,7 @@ class Program_weight_tensor_parameter_473:
 
 class Program_weight_tensor_parameter_474:
     name = "parameter_474"
+    original_name = "batch_norm_31.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-1.1883")
@@ -5221,6 +5696,7 @@ class Program_weight_tensor_parameter_474:
 
 class Program_weight_tensor_parameter_475:
     name = "parameter_475"
+    original_name = "conv2d_31.w_0"
     shape = [192, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.312329")
@@ -5232,6 +5708,7 @@ class Program_weight_tensor_parameter_475:
 
 class Program_weight_tensor_parameter_476:
     name = "parameter_476"
+    original_name = "batch_norm_30.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-1.40998")
@@ -5243,6 +5720,7 @@ class Program_weight_tensor_parameter_476:
 
 class Program_weight_tensor_parameter_477:
     name = "parameter_477"
+    original_name = "batch_norm_30.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.861196")
@@ -5254,6 +5732,7 @@ class Program_weight_tensor_parameter_477:
 
 class Program_weight_tensor_parameter_478:
     name = "parameter_478"
+    original_name = "batch_norm_30.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("0.00726262")
@@ -5265,6 +5744,7 @@ class Program_weight_tensor_parameter_478:
 
 class Program_weight_tensor_parameter_479:
     name = "parameter_479"
+    original_name = "batch_norm_30.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.808877")
@@ -5276,6 +5756,7 @@ class Program_weight_tensor_parameter_479:
 
 class Program_weight_tensor_parameter_480:
     name = "parameter_480"
+    original_name = "conv2d_30.w_0"
     shape = [192, 768, 1, 1]
     dtype = "float32"
     min_val = float("-0.198508")
@@ -5287,6 +5768,7 @@ class Program_weight_tensor_parameter_480:
 
 class Program_weight_tensor_parameter_481:
     name = "parameter_481"
+    original_name = "batch_norm_29.b_0"
     shape = [768]
     dtype = "float32"
     min_val = float("-12.3023")
@@ -5298,6 +5780,7 @@ class Program_weight_tensor_parameter_481:
 
 class Program_weight_tensor_parameter_482:
     name = "parameter_482"
+    original_name = "batch_norm_29.w_0"
     shape = [768]
     dtype = "float32"
     min_val = float("-0.615485")
@@ -5309,6 +5792,7 @@ class Program_weight_tensor_parameter_482:
 
 class Program_weight_tensor_parameter_483:
     name = "parameter_483"
+    original_name = "batch_norm_29.w_2"
     shape = [768]
     dtype = "float32"
     min_val = float("2.05638e-23")
@@ -5320,6 +5804,7 @@ class Program_weight_tensor_parameter_483:
 
 class Program_weight_tensor_parameter_484:
     name = "parameter_484"
+    original_name = "batch_norm_29.w_1"
     shape = [768]
     dtype = "float32"
     min_val = float("-0.709903")
@@ -5331,6 +5816,7 @@ class Program_weight_tensor_parameter_484:
 
 class Program_weight_tensor_parameter_485:
     name = "parameter_485"
+    original_name = "conv2d_29.w_0"
     shape = [768, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.218379")
@@ -5342,6 +5828,7 @@ class Program_weight_tensor_parameter_485:
 
 class Program_weight_tensor_parameter_486:
     name = "parameter_486"
+    original_name = "batch_norm_28.b_0"
     shape = [768]
     dtype = "float32"
     min_val = float("-5.33435")
@@ -5353,6 +5840,7 @@ class Program_weight_tensor_parameter_486:
 
 class Program_weight_tensor_parameter_487:
     name = "parameter_487"
+    original_name = "batch_norm_28.w_0"
     shape = [768]
     dtype = "float32"
     min_val = float("-0.323363")
@@ -5364,6 +5852,7 @@ class Program_weight_tensor_parameter_487:
 
 class Program_weight_tensor_parameter_488:
     name = "parameter_488"
+    original_name = "batch_norm_28.w_2"
     shape = [768]
     dtype = "float32"
     min_val = float("4.28585e-19")
@@ -5375,6 +5864,7 @@ class Program_weight_tensor_parameter_488:
 
 class Program_weight_tensor_parameter_489:
     name = "parameter_489"
+    original_name = "batch_norm_28.w_1"
     shape = [768]
     dtype = "float32"
     min_val = float("-0.538035")
@@ -5386,6 +5876,7 @@ class Program_weight_tensor_parameter_489:
 
 class Program_weight_tensor_parameter_490:
     name = "parameter_490"
+    original_name = "conv2d_28.w_0"
     shape = [768, 192, 1, 1]
     dtype = "float32"
     min_val = float("-0.213552")
@@ -5397,6 +5888,7 @@ class Program_weight_tensor_parameter_490:
 
 class Program_weight_tensor_parameter_491:
     name = "parameter_491"
+    original_name = "batch_norm_27.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-2.41073")
@@ -5408,6 +5900,7 @@ class Program_weight_tensor_parameter_491:
 
 class Program_weight_tensor_parameter_492:
     name = "parameter_492"
+    original_name = "batch_norm_27.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.464419")
@@ -5419,6 +5912,7 @@ class Program_weight_tensor_parameter_492:
 
 class Program_weight_tensor_parameter_493:
     name = "parameter_493"
+    original_name = "batch_norm_27.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("4.86169e-06")
@@ -5430,6 +5924,7 @@ class Program_weight_tensor_parameter_493:
 
 class Program_weight_tensor_parameter_494:
     name = "parameter_494"
+    original_name = "batch_norm_27.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.274127")
@@ -5441,6 +5936,7 @@ class Program_weight_tensor_parameter_494:
 
 class Program_weight_tensor_parameter_495:
     name = "parameter_495"
+    original_name = "conv2d_27.w_0"
     shape = [192, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.180185")
@@ -5452,6 +5948,7 @@ class Program_weight_tensor_parameter_495:
 
 class Program_weight_tensor_parameter_496:
     name = "parameter_496"
+    original_name = "batch_norm_26.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-1.17953")
@@ -5463,6 +5960,7 @@ class Program_weight_tensor_parameter_496:
 
 class Program_weight_tensor_parameter_497:
     name = "parameter_497"
+    original_name = "batch_norm_26.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.524242")
@@ -5474,6 +5972,7 @@ class Program_weight_tensor_parameter_497:
 
 class Program_weight_tensor_parameter_498:
     name = "parameter_498"
+    original_name = "batch_norm_26.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("0.00471967")
@@ -5485,6 +5984,7 @@ class Program_weight_tensor_parameter_498:
 
 class Program_weight_tensor_parameter_499:
     name = "parameter_499"
+    original_name = "batch_norm_26.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-1.49538")
@@ -5496,6 +5996,7 @@ class Program_weight_tensor_parameter_499:
 
 class Program_weight_tensor_parameter_500:
     name = "parameter_500"
+    original_name = "conv2d_26.w_0"
     shape = [192, 768, 1, 1]
     dtype = "float32"
     min_val = float("-0.154027")
@@ -5507,6 +6008,7 @@ class Program_weight_tensor_parameter_500:
 
 class Program_weight_tensor_parameter_501:
     name = "parameter_501"
+    original_name = "batch_norm_25.b_0"
     shape = [768]
     dtype = "float32"
     min_val = float("-6.38483")
@@ -5518,6 +6020,7 @@ class Program_weight_tensor_parameter_501:
 
 class Program_weight_tensor_parameter_502:
     name = "parameter_502"
+    original_name = "batch_norm_25.w_0"
     shape = [768]
     dtype = "float32"
     min_val = float("8.4025e-21")
@@ -5529,6 +6032,7 @@ class Program_weight_tensor_parameter_502:
 
 class Program_weight_tensor_parameter_503:
     name = "parameter_503"
+    original_name = "batch_norm_25.w_2"
     shape = [768]
     dtype = "float32"
     min_val = float("2.57707e-31")
@@ -5540,6 +6044,7 @@ class Program_weight_tensor_parameter_503:
 
 class Program_weight_tensor_parameter_504:
     name = "parameter_504"
+    original_name = "batch_norm_25.w_1"
     shape = [768]
     dtype = "float32"
     min_val = float("-0.304079")
@@ -5551,6 +6056,7 @@ class Program_weight_tensor_parameter_504:
 
 class Program_weight_tensor_parameter_505:
     name = "parameter_505"
+    original_name = "conv2d_25.w_0"
     shape = [768, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.224494")
@@ -5562,6 +6068,7 @@ class Program_weight_tensor_parameter_505:
 
 class Program_weight_tensor_parameter_506:
     name = "parameter_506"
+    original_name = "batch_norm_24.b_0"
     shape = [768]
     dtype = "float32"
     min_val = float("-2.73652")
@@ -5573,6 +6080,7 @@ class Program_weight_tensor_parameter_506:
 
 class Program_weight_tensor_parameter_507:
     name = "parameter_507"
+    original_name = "batch_norm_24.w_0"
     shape = [768]
     dtype = "float32"
     min_val = float("0.0212944")
@@ -5584,6 +6092,7 @@ class Program_weight_tensor_parameter_507:
 
 class Program_weight_tensor_parameter_508:
     name = "parameter_508"
+    original_name = "batch_norm_24.w_2"
     shape = [768]
     dtype = "float32"
     min_val = float("1.73959e-26")
@@ -5595,6 +6104,7 @@ class Program_weight_tensor_parameter_508:
 
 class Program_weight_tensor_parameter_509:
     name = "parameter_509"
+    original_name = "batch_norm_24.w_1"
     shape = [768]
     dtype = "float32"
     min_val = float("-0.75666")
@@ -5606,6 +6116,7 @@ class Program_weight_tensor_parameter_509:
 
 class Program_weight_tensor_parameter_510:
     name = "parameter_510"
+    original_name = "conv2d_24.w_0"
     shape = [768, 192, 1, 1]
     dtype = "float32"
     min_val = float("-0.250588")
@@ -5617,6 +6128,7 @@ class Program_weight_tensor_parameter_510:
 
 class Program_weight_tensor_parameter_511:
     name = "parameter_511"
+    original_name = "batch_norm_23.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-2.1984")
@@ -5628,6 +6140,7 @@ class Program_weight_tensor_parameter_511:
 
 class Program_weight_tensor_parameter_512:
     name = "parameter_512"
+    original_name = "batch_norm_23.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.186452")
@@ -5639,6 +6152,7 @@ class Program_weight_tensor_parameter_512:
 
 class Program_weight_tensor_parameter_513:
     name = "parameter_513"
+    original_name = "batch_norm_23.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("1.33354e-06")
@@ -5650,6 +6164,7 @@ class Program_weight_tensor_parameter_513:
 
 class Program_weight_tensor_parameter_514:
     name = "parameter_514"
+    original_name = "batch_norm_23.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.445254")
@@ -5661,6 +6176,7 @@ class Program_weight_tensor_parameter_514:
 
 class Program_weight_tensor_parameter_515:
     name = "parameter_515"
+    original_name = "conv2d_23.w_0"
     shape = [192, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.197857")
@@ -5672,6 +6188,7 @@ class Program_weight_tensor_parameter_515:
 
 class Program_weight_tensor_parameter_516:
     name = "parameter_516"
+    original_name = "batch_norm_22.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-1.45437")
@@ -5683,6 +6200,7 @@ class Program_weight_tensor_parameter_516:
 
 class Program_weight_tensor_parameter_517:
     name = "parameter_517"
+    original_name = "batch_norm_22.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.069742")
@@ -5694,6 +6212,7 @@ class Program_weight_tensor_parameter_517:
 
 class Program_weight_tensor_parameter_518:
     name = "parameter_518"
+    original_name = "batch_norm_22.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("0.00200234")
@@ -5705,6 +6224,7 @@ class Program_weight_tensor_parameter_518:
 
 class Program_weight_tensor_parameter_519:
     name = "parameter_519"
+    original_name = "batch_norm_22.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-1.23076")
@@ -5716,6 +6236,7 @@ class Program_weight_tensor_parameter_519:
 
 class Program_weight_tensor_parameter_520:
     name = "parameter_520"
+    original_name = "conv2d_22.w_0"
     shape = [192, 768, 1, 1]
     dtype = "float32"
     min_val = float("-0.21233")
@@ -5727,6 +6248,7 @@ class Program_weight_tensor_parameter_520:
 
 class Program_weight_tensor_parameter_521:
     name = "parameter_521"
+    original_name = "batch_norm_21.b_0"
     shape = [768]
     dtype = "float32"
     min_val = float("-5.74278")
@@ -5738,6 +6260,7 @@ class Program_weight_tensor_parameter_521:
 
 class Program_weight_tensor_parameter_522:
     name = "parameter_522"
+    original_name = "batch_norm_21.w_0"
     shape = [768]
     dtype = "float32"
     min_val = float("-1.22135")
@@ -5749,6 +6272,7 @@ class Program_weight_tensor_parameter_522:
 
 class Program_weight_tensor_parameter_523:
     name = "parameter_523"
+    original_name = "batch_norm_21.w_2"
     shape = [768]
     dtype = "float32"
     min_val = float("4.72979e-40")
@@ -5760,6 +6284,7 @@ class Program_weight_tensor_parameter_523:
 
 class Program_weight_tensor_parameter_524:
     name = "parameter_524"
+    original_name = "batch_norm_21.w_1"
     shape = [768]
     dtype = "float32"
     min_val = float("-0.26883")
@@ -5771,6 +6296,7 @@ class Program_weight_tensor_parameter_524:
 
 class Program_weight_tensor_parameter_525:
     name = "parameter_525"
+    original_name = "conv2d_21.w_0"
     shape = [768, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.224953")
@@ -5782,6 +6308,7 @@ class Program_weight_tensor_parameter_525:
 
 class Program_weight_tensor_parameter_526:
     name = "parameter_526"
+    original_name = "batch_norm_20.b_0"
     shape = [768]
     dtype = "float32"
     min_val = float("-3.72558")
@@ -5793,6 +6320,7 @@ class Program_weight_tensor_parameter_526:
 
 class Program_weight_tensor_parameter_527:
     name = "parameter_527"
+    original_name = "batch_norm_20.w_0"
     shape = [768]
     dtype = "float32"
     min_val = float("2.39861e-07")
@@ -5804,6 +6332,7 @@ class Program_weight_tensor_parameter_527:
 
 class Program_weight_tensor_parameter_528:
     name = "parameter_528"
+    original_name = "batch_norm_20.w_2"
     shape = [768]
     dtype = "float32"
     min_val = float("2.00392e-36")
@@ -5815,6 +6344,7 @@ class Program_weight_tensor_parameter_528:
 
 class Program_weight_tensor_parameter_529:
     name = "parameter_529"
+    original_name = "batch_norm_20.w_1"
     shape = [768]
     dtype = "float32"
     min_val = float("-0.753805")
@@ -5826,6 +6356,7 @@ class Program_weight_tensor_parameter_529:
 
 class Program_weight_tensor_parameter_530:
     name = "parameter_530"
+    original_name = "conv2d_20.w_0"
     shape = [768, 192, 1, 1]
     dtype = "float32"
     min_val = float("-0.266654")
@@ -5837,6 +6368,7 @@ class Program_weight_tensor_parameter_530:
 
 class Program_weight_tensor_parameter_531:
     name = "parameter_531"
+    original_name = "batch_norm_19.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-2.23648")
@@ -5848,6 +6380,7 @@ class Program_weight_tensor_parameter_531:
 
 class Program_weight_tensor_parameter_532:
     name = "parameter_532"
+    original_name = "batch_norm_19.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-2.94777")
@@ -5859,6 +6392,7 @@ class Program_weight_tensor_parameter_532:
 
 class Program_weight_tensor_parameter_533:
     name = "parameter_533"
+    original_name = "batch_norm_19.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("1.96535e-06")
@@ -5870,6 +6404,7 @@ class Program_weight_tensor_parameter_533:
 
 class Program_weight_tensor_parameter_534:
     name = "parameter_534"
+    original_name = "batch_norm_19.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.285962")
@@ -5881,6 +6416,7 @@ class Program_weight_tensor_parameter_534:
 
 class Program_weight_tensor_parameter_535:
     name = "parameter_535"
+    original_name = "conv2d_19.w_0"
     shape = [192, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.166394")
@@ -5892,6 +6428,7 @@ class Program_weight_tensor_parameter_535:
 
 class Program_weight_tensor_parameter_536:
     name = "parameter_536"
+    original_name = "batch_norm_18.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-1.62227")
@@ -5903,6 +6440,7 @@ class Program_weight_tensor_parameter_536:
 
 class Program_weight_tensor_parameter_537:
     name = "parameter_537"
+    original_name = "batch_norm_18.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.0937897")
@@ -5914,6 +6452,7 @@ class Program_weight_tensor_parameter_537:
 
 class Program_weight_tensor_parameter_538:
     name = "parameter_538"
+    original_name = "batch_norm_18.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("0.00293501")
@@ -5925,6 +6464,7 @@ class Program_weight_tensor_parameter_538:
 
 class Program_weight_tensor_parameter_539:
     name = "parameter_539"
+    original_name = "batch_norm_18.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-1.32038")
@@ -5936,6 +6476,7 @@ class Program_weight_tensor_parameter_539:
 
 class Program_weight_tensor_parameter_540:
     name = "parameter_540"
+    original_name = "conv2d_18.w_0"
     shape = [192, 768, 1, 1]
     dtype = "float32"
     min_val = float("-0.246051")
@@ -5947,6 +6488,7 @@ class Program_weight_tensor_parameter_540:
 
 class Program_weight_tensor_parameter_541:
     name = "parameter_541"
+    original_name = "batch_norm_17.b_0"
     shape = [768]
     dtype = "float32"
     min_val = float("-5.06271")
@@ -5958,6 +6500,7 @@ class Program_weight_tensor_parameter_541:
 
 class Program_weight_tensor_parameter_542:
     name = "parameter_542"
+    original_name = "batch_norm_17.w_0"
     shape = [768]
     dtype = "float32"
     min_val = float("-2.28004e-09")
@@ -5969,6 +6512,7 @@ class Program_weight_tensor_parameter_542:
 
 class Program_weight_tensor_parameter_543:
     name = "parameter_543"
+    original_name = "batch_norm_17.w_2"
     shape = [768]
     dtype = "float32"
     min_val = float("1.57568e-21")
@@ -5980,6 +6524,7 @@ class Program_weight_tensor_parameter_543:
 
 class Program_weight_tensor_parameter_544:
     name = "parameter_544"
+    original_name = "batch_norm_17.w_1"
     shape = [768]
     dtype = "float32"
     min_val = float("-0.277739")
@@ -5991,6 +6536,7 @@ class Program_weight_tensor_parameter_544:
 
 class Program_weight_tensor_parameter_545:
     name = "parameter_545"
+    original_name = "conv2d_17.w_0"
     shape = [768, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.196284")
@@ -6002,6 +6548,7 @@ class Program_weight_tensor_parameter_545:
 
 class Program_weight_tensor_parameter_546:
     name = "parameter_546"
+    original_name = "batch_norm_16.b_0"
     shape = [768]
     dtype = "float32"
     min_val = float("-4.16903")
@@ -6013,6 +6560,7 @@ class Program_weight_tensor_parameter_546:
 
 class Program_weight_tensor_parameter_547:
     name = "parameter_547"
+    original_name = "batch_norm_16.w_0"
     shape = [768]
     dtype = "float32"
     min_val = float("0.00810076")
@@ -6024,6 +6572,7 @@ class Program_weight_tensor_parameter_547:
 
 class Program_weight_tensor_parameter_548:
     name = "parameter_548"
+    original_name = "batch_norm_16.w_2"
     shape = [768]
     dtype = "float32"
     min_val = float("2.11139e-11")
@@ -6035,6 +6584,7 @@ class Program_weight_tensor_parameter_548:
 
 class Program_weight_tensor_parameter_549:
     name = "parameter_549"
+    original_name = "batch_norm_16.w_1"
     shape = [768]
     dtype = "float32"
     min_val = float("-0.598776")
@@ -6046,6 +6596,7 @@ class Program_weight_tensor_parameter_549:
 
 class Program_weight_tensor_parameter_550:
     name = "parameter_550"
+    original_name = "conv2d_16.w_0"
     shape = [768, 192, 1, 1]
     dtype = "float32"
     min_val = float("-0.386548")
@@ -6057,6 +6608,7 @@ class Program_weight_tensor_parameter_550:
 
 class Program_weight_tensor_parameter_551:
     name = "parameter_551"
+    original_name = "batch_norm_15.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-1.8453")
@@ -6068,6 +6620,7 @@ class Program_weight_tensor_parameter_551:
 
 class Program_weight_tensor_parameter_552:
     name = "parameter_552"
+    original_name = "batch_norm_15.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("0.111661")
@@ -6079,6 +6632,7 @@ class Program_weight_tensor_parameter_552:
 
 class Program_weight_tensor_parameter_553:
     name = "parameter_553"
+    original_name = "batch_norm_15.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("1.07736e-06")
@@ -6090,6 +6644,7 @@ class Program_weight_tensor_parameter_553:
 
 class Program_weight_tensor_parameter_554:
     name = "parameter_554"
+    original_name = "batch_norm_15.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.578086")
@@ -6101,6 +6656,7 @@ class Program_weight_tensor_parameter_554:
 
 class Program_weight_tensor_parameter_555:
     name = "parameter_555"
+    original_name = "conv2d_15.w_0"
     shape = [192, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.186904")
@@ -6112,6 +6668,7 @@ class Program_weight_tensor_parameter_555:
 
 class Program_weight_tensor_parameter_556:
     name = "parameter_556"
+    original_name = "batch_norm_14.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-1.74803")
@@ -6123,6 +6680,7 @@ class Program_weight_tensor_parameter_556:
 
 class Program_weight_tensor_parameter_557:
     name = "parameter_557"
+    original_name = "batch_norm_14.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("0.106976")
@@ -6134,6 +6692,7 @@ class Program_weight_tensor_parameter_557:
 
 class Program_weight_tensor_parameter_558:
     name = "parameter_558"
+    original_name = "batch_norm_14.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("0.0270541")
@@ -6145,6 +6704,7 @@ class Program_weight_tensor_parameter_558:
 
 class Program_weight_tensor_parameter_559:
     name = "parameter_559"
+    original_name = "batch_norm_14.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-2.10191")
@@ -6156,6 +6716,7 @@ class Program_weight_tensor_parameter_559:
 
 class Program_weight_tensor_parameter_560:
     name = "parameter_560"
+    original_name = "conv2d_14.w_0"
     shape = [192, 384, 1, 1]
     dtype = "float32"
     min_val = float("-0.379486")
@@ -6167,6 +6728,7 @@ class Program_weight_tensor_parameter_560:
 
 class Program_weight_tensor_parameter_561:
     name = "parameter_561"
+    original_name = "batch_norm_13.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-1.0197")
@@ -6178,6 +6740,7 @@ class Program_weight_tensor_parameter_561:
 
 class Program_weight_tensor_parameter_562:
     name = "parameter_562"
+    original_name = "batch_norm_13.w_0"
     shape = [384]
     dtype = "float32"
     min_val = float("0.302034")
@@ -6189,6 +6752,7 @@ class Program_weight_tensor_parameter_562:
 
 class Program_weight_tensor_parameter_563:
     name = "parameter_563"
+    original_name = "batch_norm_13.w_2"
     shape = [384]
     dtype = "float32"
     min_val = float("1.28114e-05")
@@ -6200,6 +6764,7 @@ class Program_weight_tensor_parameter_563:
 
 class Program_weight_tensor_parameter_564:
     name = "parameter_564"
+    original_name = "batch_norm_13.w_1"
     shape = [384]
     dtype = "float32"
     min_val = float("-0.509257")
@@ -6211,6 +6776,7 @@ class Program_weight_tensor_parameter_564:
 
 class Program_weight_tensor_parameter_565:
     name = "parameter_565"
+    original_name = "conv2d_13.w_0"
     shape = [384, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.0725179")
@@ -6222,6 +6788,7 @@ class Program_weight_tensor_parameter_565:
 
 class Program_weight_tensor_parameter_566:
     name = "parameter_566"
+    original_name = "batch_norm_12.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-1.85117")
@@ -6233,6 +6800,7 @@ class Program_weight_tensor_parameter_566:
 
 class Program_weight_tensor_parameter_567:
     name = "parameter_567"
+    original_name = "batch_norm_12.w_0"
     shape = [384]
     dtype = "float32"
     min_val = float("0.0520767")
@@ -6244,6 +6812,7 @@ class Program_weight_tensor_parameter_567:
 
 class Program_weight_tensor_parameter_568:
     name = "parameter_568"
+    original_name = "batch_norm_12.w_2"
     shape = [384]
     dtype = "float32"
     min_val = float("0.0498212")
@@ -6255,6 +6824,7 @@ class Program_weight_tensor_parameter_568:
 
 class Program_weight_tensor_parameter_569:
     name = "parameter_569"
+    original_name = "batch_norm_12.w_1"
     shape = [384]
     dtype = "float32"
     min_val = float("-0.338351")
@@ -6266,6 +6836,7 @@ class Program_weight_tensor_parameter_569:
 
 class Program_weight_tensor_parameter_570:
     name = "parameter_570"
+    original_name = "conv2d_12.w_0"
     shape = [384, 96, 1, 1]
     dtype = "float32"
     min_val = float("-0.297999")
@@ -6277,6 +6848,7 @@ class Program_weight_tensor_parameter_570:
 
 class Program_weight_tensor_parameter_571:
     name = "parameter_571"
+    original_name = "batch_norm_11.b_0"
     shape = [96]
     dtype = "float32"
     min_val = float("-1.60052")
@@ -6288,6 +6860,7 @@ class Program_weight_tensor_parameter_571:
 
 class Program_weight_tensor_parameter_572:
     name = "parameter_572"
+    original_name = "batch_norm_11.w_0"
     shape = [96]
     dtype = "float32"
     min_val = float("0.554954")
@@ -6299,6 +6872,7 @@ class Program_weight_tensor_parameter_572:
 
 class Program_weight_tensor_parameter_573:
     name = "parameter_573"
+    original_name = "batch_norm_11.w_2"
     shape = [96]
     dtype = "float32"
     min_val = float("0.000419531")
@@ -6310,6 +6884,7 @@ class Program_weight_tensor_parameter_573:
 
 class Program_weight_tensor_parameter_574:
     name = "parameter_574"
+    original_name = "batch_norm_11.w_1"
     shape = [96]
     dtype = "float32"
     min_val = float("-0.819657")
@@ -6321,6 +6896,7 @@ class Program_weight_tensor_parameter_574:
 
 class Program_weight_tensor_parameter_575:
     name = "parameter_575"
+    original_name = "conv2d_11.w_0"
     shape = [96, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.192034")
@@ -6332,6 +6908,7 @@ class Program_weight_tensor_parameter_575:
 
 class Program_weight_tensor_parameter_576:
     name = "parameter_576"
+    original_name = "batch_norm_10.b_0"
     shape = [96]
     dtype = "float32"
     min_val = float("-1.51506")
@@ -6343,6 +6920,7 @@ class Program_weight_tensor_parameter_576:
 
 class Program_weight_tensor_parameter_577:
     name = "parameter_577"
+    original_name = "batch_norm_10.w_0"
     shape = [96]
     dtype = "float32"
     min_val = float("8.6875e-05")
@@ -6354,6 +6932,7 @@ class Program_weight_tensor_parameter_577:
 
 class Program_weight_tensor_parameter_578:
     name = "parameter_578"
+    original_name = "batch_norm_10.w_2"
     shape = [96]
     dtype = "float32"
     min_val = float("0.0155241")
@@ -6365,6 +6944,7 @@ class Program_weight_tensor_parameter_578:
 
 class Program_weight_tensor_parameter_579:
     name = "parameter_579"
+    original_name = "batch_norm_10.w_1"
     shape = [96]
     dtype = "float32"
     min_val = float("-0.554652")
@@ -6376,6 +6956,7 @@ class Program_weight_tensor_parameter_579:
 
 class Program_weight_tensor_parameter_580:
     name = "parameter_580"
+    original_name = "conv2d_10.w_0"
     shape = [96, 384, 1, 1]
     dtype = "float32"
     min_val = float("-0.175801")
@@ -6387,6 +6968,7 @@ class Program_weight_tensor_parameter_580:
 
 class Program_weight_tensor_parameter_581:
     name = "parameter_581"
+    original_name = "batch_norm_9.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-7.0978")
@@ -6398,6 +6980,7 @@ class Program_weight_tensor_parameter_581:
 
 class Program_weight_tensor_parameter_582:
     name = "parameter_582"
+    original_name = "batch_norm_9.w_0"
     shape = [384]
     dtype = "float32"
     min_val = float("0.234015")
@@ -6409,6 +6992,7 @@ class Program_weight_tensor_parameter_582:
 
 class Program_weight_tensor_parameter_583:
     name = "parameter_583"
+    original_name = "batch_norm_9.w_2"
     shape = [384]
     dtype = "float32"
     min_val = float("5.75968e-06")
@@ -6420,6 +7004,7 @@ class Program_weight_tensor_parameter_583:
 
 class Program_weight_tensor_parameter_584:
     name = "parameter_584"
+    original_name = "batch_norm_9.w_1"
     shape = [384]
     dtype = "float32"
     min_val = float("-0.449491")
@@ -6431,6 +7016,7 @@ class Program_weight_tensor_parameter_584:
 
 class Program_weight_tensor_parameter_585:
     name = "parameter_585"
+    original_name = "conv2d_9.w_0"
     shape = [384, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.14065")
@@ -6442,6 +7028,7 @@ class Program_weight_tensor_parameter_585:
 
 class Program_weight_tensor_parameter_586:
     name = "parameter_586"
+    original_name = "batch_norm_8.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-3.26119")
@@ -6453,6 +7040,7 @@ class Program_weight_tensor_parameter_586:
 
 class Program_weight_tensor_parameter_587:
     name = "parameter_587"
+    original_name = "batch_norm_8.w_0"
     shape = [384]
     dtype = "float32"
     min_val = float("0.0964367")
@@ -6464,6 +7052,7 @@ class Program_weight_tensor_parameter_587:
 
 class Program_weight_tensor_parameter_588:
     name = "parameter_588"
+    original_name = "batch_norm_8.w_2"
     shape = [384]
     dtype = "float32"
     min_val = float("0.0378627")
@@ -6475,6 +7064,7 @@ class Program_weight_tensor_parameter_588:
 
 class Program_weight_tensor_parameter_589:
     name = "parameter_589"
+    original_name = "batch_norm_8.w_1"
     shape = [384]
     dtype = "float32"
     min_val = float("-0.548559")
@@ -6486,6 +7076,7 @@ class Program_weight_tensor_parameter_589:
 
 class Program_weight_tensor_parameter_590:
     name = "parameter_590"
+    original_name = "conv2d_8.w_0"
     shape = [384, 96, 1, 1]
     dtype = "float32"
     min_val = float("-0.333667")
@@ -6497,6 +7088,7 @@ class Program_weight_tensor_parameter_590:
 
 class Program_weight_tensor_parameter_591:
     name = "parameter_591"
+    original_name = "batch_norm_7.b_0"
     shape = [96]
     dtype = "float32"
     min_val = float("-1.67643")
@@ -6508,6 +7100,7 @@ class Program_weight_tensor_parameter_591:
 
 class Program_weight_tensor_parameter_592:
     name = "parameter_592"
+    original_name = "batch_norm_7.w_0"
     shape = [96]
     dtype = "float32"
     min_val = float("0.171086")
@@ -6519,6 +7112,7 @@ class Program_weight_tensor_parameter_592:
 
 class Program_weight_tensor_parameter_593:
     name = "parameter_593"
+    original_name = "batch_norm_7.w_2"
     shape = [96]
     dtype = "float32"
     min_val = float("3.0391e-05")
@@ -6530,6 +7124,7 @@ class Program_weight_tensor_parameter_593:
 
 class Program_weight_tensor_parameter_594:
     name = "parameter_594"
+    original_name = "batch_norm_7.w_1"
     shape = [96]
     dtype = "float32"
     min_val = float("-0.30829")
@@ -6541,6 +7136,7 @@ class Program_weight_tensor_parameter_594:
 
 class Program_weight_tensor_parameter_595:
     name = "parameter_595"
+    original_name = "conv2d_7.w_0"
     shape = [96, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.189422")
@@ -6552,6 +7148,7 @@ class Program_weight_tensor_parameter_595:
 
 class Program_weight_tensor_parameter_596:
     name = "parameter_596"
+    original_name = "batch_norm_6.b_0"
     shape = [96]
     dtype = "float32"
     min_val = float("-2.70767")
@@ -6563,6 +7160,7 @@ class Program_weight_tensor_parameter_596:
 
 class Program_weight_tensor_parameter_597:
     name = "parameter_597"
+    original_name = "batch_norm_6.w_0"
     shape = [96]
     dtype = "float32"
     min_val = float("0.269359")
@@ -6574,6 +7172,7 @@ class Program_weight_tensor_parameter_597:
 
 class Program_weight_tensor_parameter_598:
     name = "parameter_598"
+    original_name = "batch_norm_6.w_2"
     shape = [96]
     dtype = "float32"
     min_val = float("0.0315658")
@@ -6585,6 +7184,7 @@ class Program_weight_tensor_parameter_598:
 
 class Program_weight_tensor_parameter_599:
     name = "parameter_599"
+    original_name = "batch_norm_6.w_1"
     shape = [96]
     dtype = "float32"
     min_val = float("-1.96478")
@@ -6596,6 +7196,7 @@ class Program_weight_tensor_parameter_599:
 
 class Program_weight_tensor_parameter_600:
     name = "parameter_600"
+    original_name = "conv2d_6.w_0"
     shape = [96, 192, 1, 1]
     dtype = "float32"
     min_val = float("-0.276721")
@@ -6607,6 +7208,7 @@ class Program_weight_tensor_parameter_600:
 
 class Program_weight_tensor_parameter_601:
     name = "parameter_601"
+    original_name = "batch_norm_5.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-4.65804")
@@ -6618,6 +7220,7 @@ class Program_weight_tensor_parameter_601:
 
 class Program_weight_tensor_parameter_602:
     name = "parameter_602"
+    original_name = "batch_norm_5.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("0.420985")
@@ -6629,6 +7232,7 @@ class Program_weight_tensor_parameter_602:
 
 class Program_weight_tensor_parameter_603:
     name = "parameter_603"
+    original_name = "batch_norm_5.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("2.59706e-05")
@@ -6640,6 +7244,7 @@ class Program_weight_tensor_parameter_603:
 
 class Program_weight_tensor_parameter_604:
     name = "parameter_604"
+    original_name = "batch_norm_5.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-1.11177")
@@ -6651,6 +7256,7 @@ class Program_weight_tensor_parameter_604:
 
 class Program_weight_tensor_parameter_605:
     name = "parameter_605"
+    original_name = "conv2d_5.w_0"
     shape = [192, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.124449")
@@ -6662,6 +7268,7 @@ class Program_weight_tensor_parameter_605:
 
 class Program_weight_tensor_parameter_606:
     name = "parameter_606"
+    original_name = "batch_norm_4.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-3.19989")
@@ -6673,6 +7280,7 @@ class Program_weight_tensor_parameter_606:
 
 class Program_weight_tensor_parameter_607:
     name = "parameter_607"
+    original_name = "batch_norm_4.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("0.134405")
@@ -6684,6 +7292,7 @@ class Program_weight_tensor_parameter_607:
 
 class Program_weight_tensor_parameter_608:
     name = "parameter_608"
+    original_name = "batch_norm_4.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("0.00566533")
@@ -6695,6 +7304,7 @@ class Program_weight_tensor_parameter_608:
 
 class Program_weight_tensor_parameter_609:
     name = "parameter_609"
+    original_name = "batch_norm_4.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.253176")
@@ -6706,6 +7316,7 @@ class Program_weight_tensor_parameter_609:
 
 class Program_weight_tensor_parameter_610:
     name = "parameter_610"
+    original_name = "conv2d_4.w_0"
     shape = [192, 48, 1, 1]
     dtype = "float32"
     min_val = float("-0.78241")
@@ -6717,6 +7328,7 @@ class Program_weight_tensor_parameter_610:
 
 class Program_weight_tensor_parameter_611:
     name = "parameter_611"
+    original_name = "batch_norm_3.b_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -6726,6 +7338,7 @@ class Program_weight_tensor_parameter_611:
 
 class Program_weight_tensor_parameter_612:
     name = "parameter_612"
+    original_name = "batch_norm_3.w_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -6735,6 +7348,7 @@ class Program_weight_tensor_parameter_612:
 
 class Program_weight_tensor_parameter_613:
     name = "parameter_613"
+    original_name = "batch_norm_3.w_2"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -6744,6 +7358,7 @@ class Program_weight_tensor_parameter_613:
 
 class Program_weight_tensor_parameter_614:
     name = "parameter_614"
+    original_name = "batch_norm_3.w_1"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -6753,6 +7368,7 @@ class Program_weight_tensor_parameter_614:
 
 class Program_weight_tensor_parameter_615:
     name = "parameter_615"
+    original_name = "conv2d_3.w_0"
     shape = [48, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.135296")
@@ -6764,6 +7380,7 @@ class Program_weight_tensor_parameter_615:
 
 class Program_weight_tensor_parameter_616:
     name = "parameter_616"
+    original_name = "batch_norm_2.b_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -6773,6 +7390,7 @@ class Program_weight_tensor_parameter_616:
 
 class Program_weight_tensor_parameter_617:
     name = "parameter_617"
+    original_name = "batch_norm_2.w_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -6782,6 +7400,7 @@ class Program_weight_tensor_parameter_617:
 
 class Program_weight_tensor_parameter_618:
     name = "parameter_618"
+    original_name = "batch_norm_2.w_2"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -6791,6 +7410,7 @@ class Program_weight_tensor_parameter_618:
 
 class Program_weight_tensor_parameter_619:
     name = "parameter_619"
+    original_name = "batch_norm_2.w_1"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -6800,6 +7420,7 @@ class Program_weight_tensor_parameter_619:
 
 class Program_weight_tensor_parameter_620:
     name = "parameter_620"
+    original_name = "conv2d_2.w_0"
     shape = [48, 96, 1, 1]
     dtype = "float32"
     min_val = float("-0.177415")
@@ -6811,6 +7432,7 @@ class Program_weight_tensor_parameter_620:
 
 class Program_weight_tensor_parameter_621:
     name = "parameter_621"
+    original_name = "batch_norm_1.b_0"
     shape = [96]
     dtype = "float32"
     min_val = float("-3.60809")
@@ -6822,6 +7444,7 @@ class Program_weight_tensor_parameter_621:
 
 class Program_weight_tensor_parameter_622:
     name = "parameter_622"
+    original_name = "batch_norm_1.w_0"
     shape = [96]
     dtype = "float32"
     min_val = float("1.92978")
@@ -6833,6 +7456,7 @@ class Program_weight_tensor_parameter_622:
 
 class Program_weight_tensor_parameter_623:
     name = "parameter_623"
+    original_name = "batch_norm_1.w_2"
     shape = [96]
     dtype = "float32"
     min_val = float("0.0551065")
@@ -6844,6 +7468,7 @@ class Program_weight_tensor_parameter_623:
 
 class Program_weight_tensor_parameter_624:
     name = "parameter_624"
+    original_name = "batch_norm_1.w_1"
     shape = [96]
     dtype = "float32"
     min_val = float("-1.4826")
@@ -6855,6 +7480,7 @@ class Program_weight_tensor_parameter_624:
 
 class Program_weight_tensor_parameter_625:
     name = "parameter_625"
+    original_name = "conv2d_1.w_0"
     shape = [96, 24, 3, 3]
     dtype = "float32"
     min_val = float("-0.389744")
@@ -6866,6 +7492,7 @@ class Program_weight_tensor_parameter_625:
 
 class Program_weight_tensor_parameter_626:
     name = "parameter_626"
+    original_name = "batch_norm_0.b_0"
     shape = [24]
     dtype = "float32"
     min_val = float("0")
@@ -6875,6 +7502,7 @@ class Program_weight_tensor_parameter_626:
 
 class Program_weight_tensor_parameter_627:
     name = "parameter_627"
+    original_name = "batch_norm_0.w_0"
     shape = [24]
     dtype = "float32"
     min_val = float("0")
@@ -6884,6 +7512,7 @@ class Program_weight_tensor_parameter_627:
 
 class Program_weight_tensor_parameter_628:
     name = "parameter_628"
+    original_name = "batch_norm_0.w_2"
     shape = [24]
     dtype = "float32"
     min_val = float("0")
@@ -6893,6 +7522,7 @@ class Program_weight_tensor_parameter_628:
 
 class Program_weight_tensor_parameter_629:
     name = "parameter_629"
+    original_name = "batch_norm_0.w_1"
     shape = [24]
     dtype = "float32"
     min_val = float("0")
@@ -6902,6 +7532,7 @@ class Program_weight_tensor_parameter_629:
 
 class Program_weight_tensor_parameter_630:
     name = "parameter_630"
+    original_name = "conv2d_0.w_0"
     shape = [24, 3, 3, 3]
     dtype = "float32"
     min_val = float("-0.062676")

--- a/paddle_samples/PaddleX/MobileNetV4_hybrid_medium/subgraph_0/input_meta.py
+++ b/paddle_samples/PaddleX/MobileNetV4_hybrid_medium/subgraph_0/input_meta.py
@@ -1,5 +1,6 @@
 class Program_weight_tensor_data_0:
     name = "data_0"
+    original_name = "param_30"
     shape = [80]
     dtype = "float32"
     min_val = float("-2.76274")
@@ -11,6 +12,7 @@ class Program_weight_tensor_data_0:
 
 class Program_weight_tensor_data_1:
     name = "data_1"
+    original_name = "param_31"
     shape = [80]
     dtype = "float32"
     min_val = float("-1.41258")
@@ -22,6 +24,7 @@ class Program_weight_tensor_data_1:
 
 class Program_weight_tensor_data_2:
     name = "data_2"
+    original_name = "param_32"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.89881")
@@ -33,6 +36,7 @@ class Program_weight_tensor_data_2:
 
 class Program_weight_tensor_data_3:
     name = "data_3"
+    original_name = "param_33"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.971696")
@@ -44,6 +48,7 @@ class Program_weight_tensor_data_3:
 
 class Program_weight_tensor_data_4:
     name = "data_4"
+    original_name = "param_34"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.677994")
@@ -55,6 +60,7 @@ class Program_weight_tensor_data_4:
 
 class Program_weight_tensor_data_5:
     name = "data_5"
+    original_name = "param_35"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.810245")
@@ -66,6 +72,7 @@ class Program_weight_tensor_data_5:
 
 class Program_weight_tensor_data_6:
     name = "data_6"
+    original_name = "param_36"
     shape = [160]
     dtype = "float32"
     min_val = float("-1.51299")
@@ -77,6 +84,7 @@ class Program_weight_tensor_data_6:
 
 class Program_weight_tensor_data_7:
     name = "data_7"
+    original_name = "param_37"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.968888")
@@ -88,6 +96,7 @@ class Program_weight_tensor_data_7:
 
 class Program_weight_tensor_data_8:
     name = "data_8"
+    original_name = "param_38"
     shape = [160]
     dtype = "float32"
     min_val = float("-4.18515")
@@ -99,6 +108,7 @@ class Program_weight_tensor_data_8:
 
 class Program_weight_tensor_data_9:
     name = "data_9"
+    original_name = "param_39"
     shape = [160]
     dtype = "float32"
     min_val = float("-1.11061")
@@ -110,6 +120,7 @@ class Program_weight_tensor_data_9:
 
 class Program_weight_tensor_data_10:
     name = "data_10"
+    original_name = "param_40"
     shape = [160]
     dtype = "float32"
     min_val = float("-4.79678")
@@ -121,6 +132,7 @@ class Program_weight_tensor_data_10:
 
 class Program_weight_tensor_data_11:
     name = "data_11"
+    original_name = "param_41"
     shape = [160]
     dtype = "float32"
     min_val = float("-1.93839")
@@ -132,6 +144,7 @@ class Program_weight_tensor_data_11:
 
 class Program_weight_tensor_data_12:
     name = "data_12"
+    original_name = "param_42"
     shape = [160]
     dtype = "float32"
     min_val = float("-4.11024")
@@ -143,6 +156,7 @@ class Program_weight_tensor_data_12:
 
 class Program_weight_tensor_data_13:
     name = "data_13"
+    original_name = "param_43"
     shape = [160]
     dtype = "float32"
     min_val = float("-5.01894")
@@ -154,6 +168,7 @@ class Program_weight_tensor_data_13:
 
 class Program_weight_tensor_data_14:
     name = "data_14"
+    original_name = "param_44"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.36578")
@@ -165,6 +180,7 @@ class Program_weight_tensor_data_14:
 
 class Program_weight_tensor_data_15:
     name = "data_15"
+    original_name = "param_45"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.620924")
@@ -176,6 +192,7 @@ class Program_weight_tensor_data_15:
 
 class Program_weight_tensor_data_16:
     name = "data_16"
+    original_name = "param_46"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.559085")
@@ -187,6 +204,7 @@ class Program_weight_tensor_data_16:
 
 class Program_weight_tensor_data_17:
     name = "data_17"
+    original_name = "param_47"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.813264")
@@ -198,6 +216,7 @@ class Program_weight_tensor_data_17:
 
 class Program_weight_tensor_data_18:
     name = "data_18"
+    original_name = "param_48"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.622399")
@@ -209,6 +228,7 @@ class Program_weight_tensor_data_18:
 
 class Program_weight_tensor_data_19:
     name = "data_19"
+    original_name = "param_49"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.641245")
@@ -220,6 +240,7 @@ class Program_weight_tensor_data_19:
 
 class Program_weight_tensor_data_20:
     name = "data_20"
+    original_name = "param_50"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.878394")
@@ -231,6 +252,7 @@ class Program_weight_tensor_data_20:
 
 class Program_weight_tensor_data_21:
     name = "data_21"
+    original_name = "param_51"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.733214")
@@ -242,6 +264,7 @@ class Program_weight_tensor_data_21:
 
 class Program_weight_tensor_data_22:
     name = "data_22"
+    original_name = "param_52"
     shape = [256]
     dtype = "float32"
     min_val = float("-2.63435")
@@ -253,6 +276,7 @@ class Program_weight_tensor_data_22:
 
 class Program_weight_tensor_data_23:
     name = "data_23"
+    original_name = "param_53"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.679309")
@@ -264,6 +288,7 @@ class Program_weight_tensor_data_23:
 
 class Program_weight_tensor_data_24:
     name = "data_24"
+    original_name = "param_54"
     shape = [256]
     dtype = "float32"
     min_val = float("-2.32209")
@@ -275,6 +300,7 @@ class Program_weight_tensor_data_24:
 
 class Program_weight_tensor_data_25:
     name = "data_25"
+    original_name = "param_55"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.745947")
@@ -286,6 +312,7 @@ class Program_weight_tensor_data_25:
 
 class Program_weight_tensor_data_26:
     name = "data_26"
+    original_name = "param_56"
     shape = [256]
     dtype = "float32"
     min_val = float("-2.16125")
@@ -297,6 +324,7 @@ class Program_weight_tensor_data_26:
 
 class Program_weight_tensor_data_27:
     name = "data_27"
+    original_name = "param_57"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.832511")
@@ -308,6 +336,7 @@ class Program_weight_tensor_data_27:
 
 class Program_weight_tensor_data_28:
     name = "data_28"
+    original_name = "param_58"
     shape = [256]
     dtype = "float32"
     min_val = float("-3.37759")
@@ -319,6 +348,7 @@ class Program_weight_tensor_data_28:
 
 class Program_weight_tensor_data_29:
     name = "data_29"
+    original_name = "param_59"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.74768")
@@ -330,6 +360,7 @@ class Program_weight_tensor_data_29:
 
 class Program_weight_tensor_data_30:
     name = "data_30"
+    original_name = "var_699"
     shape = [60, 3, 224, 224]
     dtype = "float32"
     min_val = float("-4.43116")

--- a/paddle_samples/PaddleX/MobileNetV4_hybrid_medium/subgraph_0/weight_meta.py
+++ b/paddle_samples/PaddleX/MobileNetV4_hybrid_medium/subgraph_0/weight_meta.py
@@ -1,5 +1,6 @@
 class Program_weight_tensor_parameter_0:
     name = "parameter_0"
+    original_name = "linear_0.b_0"
     shape = [102]
     dtype = "float32"
     min_val = float("-0.109698")
@@ -11,6 +12,7 @@ class Program_weight_tensor_parameter_0:
 
 class Program_weight_tensor_parameter_1:
     name = "parameter_1"
+    original_name = "linear_0.w_0"
     shape = [1280, 102]
     dtype = "float32"
     min_val = float("-0.297496")
@@ -22,6 +24,7 @@ class Program_weight_tensor_parameter_1:
 
 class Program_weight_tensor_parameter_2:
     name = "parameter_2"
+    original_name = "batch_norm_95.b_0"
     shape = [1280]
     dtype = "float32"
     min_val = float("-1.74046")
@@ -33,6 +36,7 @@ class Program_weight_tensor_parameter_2:
 
 class Program_weight_tensor_parameter_3:
     name = "parameter_3"
+    original_name = "batch_norm_95.w_0"
     shape = [1280]
     dtype = "float32"
     min_val = float("0.407571")
@@ -44,6 +48,7 @@ class Program_weight_tensor_parameter_3:
 
 class Program_weight_tensor_parameter_4:
     name = "parameter_4"
+    original_name = "batch_norm_95.w_2"
     shape = [1280]
     dtype = "float32"
     min_val = float("0.0387801")
@@ -55,6 +60,7 @@ class Program_weight_tensor_parameter_4:
 
 class Program_weight_tensor_parameter_5:
     name = "parameter_5"
+    original_name = "batch_norm_95.w_1"
     shape = [1280]
     dtype = "float32"
     min_val = float("-0.516898")
@@ -66,6 +72,7 @@ class Program_weight_tensor_parameter_5:
 
 class Program_weight_tensor_parameter_6:
     name = "parameter_6"
+    original_name = "conv2d_119.w_0"
     shape = [1280, 960, 1, 1]
     dtype = "float32"
     min_val = float("-0.378983")
@@ -77,6 +84,7 @@ class Program_weight_tensor_parameter_6:
 
 class Program_weight_tensor_parameter_7:
     name = "parameter_7"
+    original_name = "batch_norm_94.b_0"
     shape = [960]
     dtype = "float32"
     min_val = float("-2.80404")
@@ -88,6 +96,7 @@ class Program_weight_tensor_parameter_7:
 
 class Program_weight_tensor_parameter_8:
     name = "parameter_8"
+    original_name = "batch_norm_94.w_0"
     shape = [960]
     dtype = "float32"
     min_val = float("0.00355617")
@@ -99,6 +108,7 @@ class Program_weight_tensor_parameter_8:
 
 class Program_weight_tensor_parameter_9:
     name = "parameter_9"
+    original_name = "batch_norm_94.w_2"
     shape = [960]
     dtype = "float32"
     min_val = float("4515.69")
@@ -110,6 +120,7 @@ class Program_weight_tensor_parameter_9:
 
 class Program_weight_tensor_parameter_10:
     name = "parameter_10"
+    original_name = "batch_norm_94.w_1"
     shape = [960]
     dtype = "float32"
     min_val = float("-137.084")
@@ -121,6 +132,7 @@ class Program_weight_tensor_parameter_10:
 
 class Program_weight_tensor_parameter_11:
     name = "parameter_11"
+    original_name = "conv2d_118.w_0"
     shape = [960, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.297642")
@@ -132,6 +144,7 @@ class Program_weight_tensor_parameter_11:
 
 class Program_weight_tensor_parameter_12:
     name = "parameter_12"
+    original_name = "batch_norm_93.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.1106")
@@ -143,6 +156,7 @@ class Program_weight_tensor_parameter_12:
 
 class Program_weight_tensor_parameter_13:
     name = "parameter_13"
+    original_name = "batch_norm_93.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.823492")
@@ -154,6 +168,7 @@ class Program_weight_tensor_parameter_13:
 
 class Program_weight_tensor_parameter_14:
     name = "parameter_14"
+    original_name = "batch_norm_93.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.167155")
@@ -165,6 +180,7 @@ class Program_weight_tensor_parameter_14:
 
 class Program_weight_tensor_parameter_15:
     name = "parameter_15"
+    original_name = "batch_norm_93.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.394914")
@@ -176,6 +192,7 @@ class Program_weight_tensor_parameter_15:
 
 class Program_weight_tensor_parameter_16:
     name = "parameter_16"
+    original_name = "conv2d_117.w_0"
     shape = [256, 1024, 1, 1]
     dtype = "float32"
     min_val = float("-0.300127")
@@ -187,6 +204,7 @@ class Program_weight_tensor_parameter_16:
 
 class Program_weight_tensor_parameter_17:
     name = "parameter_17"
+    original_name = "batch_norm_92.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-6.23811")
@@ -198,6 +216,7 @@ class Program_weight_tensor_parameter_17:
 
 class Program_weight_tensor_parameter_18:
     name = "parameter_18"
+    original_name = "batch_norm_92.w_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("0.00181757")
@@ -209,6 +228,7 @@ class Program_weight_tensor_parameter_18:
 
 class Program_weight_tensor_parameter_19:
     name = "parameter_19"
+    original_name = "batch_norm_92.w_2"
     shape = [1024]
     dtype = "float32"
     min_val = float("0.283647")
@@ -220,6 +240,7 @@ class Program_weight_tensor_parameter_19:
 
 class Program_weight_tensor_parameter_20:
     name = "parameter_20"
+    original_name = "batch_norm_92.w_1"
     shape = [1024]
     dtype = "float32"
     min_val = float("-1.16686")
@@ -231,6 +252,7 @@ class Program_weight_tensor_parameter_20:
 
 class Program_weight_tensor_parameter_21:
     name = "parameter_21"
+    original_name = "conv2d_116.w_0"
     shape = [1024, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.410583")
@@ -242,6 +264,7 @@ class Program_weight_tensor_parameter_21:
 
 class Program_weight_tensor_parameter_22:
     name = "parameter_22"
+    original_name = "batch_norm_91.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.6492")
@@ -253,6 +276,7 @@ class Program_weight_tensor_parameter_22:
 
 class Program_weight_tensor_parameter_23:
     name = "parameter_23"
+    original_name = "batch_norm_91.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.57827")
@@ -264,6 +288,7 @@ class Program_weight_tensor_parameter_23:
 
 class Program_weight_tensor_parameter_24:
     name = "parameter_24"
+    original_name = "batch_norm_91.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("93.1919")
@@ -275,6 +300,7 @@ class Program_weight_tensor_parameter_24:
 
 class Program_weight_tensor_parameter_25:
     name = "parameter_25"
+    original_name = "batch_norm_91.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-21.5691")
@@ -286,6 +312,7 @@ class Program_weight_tensor_parameter_25:
 
 class Program_weight_tensor_parameter_26:
     name = "parameter_26"
+    original_name = "conv2d_115.w_0"
     shape = [256, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.519751")
@@ -297,6 +324,7 @@ class Program_weight_tensor_parameter_26:
 
 class Program_weight_tensor_parameter_27:
     name = "parameter_27"
+    original_name = "conv2d_114.w_0"
     shape = [256, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.386377")
@@ -308,6 +336,7 @@ class Program_weight_tensor_parameter_27:
 
 class Program_weight_tensor_parameter_28:
     name = "parameter_28"
+    original_name = "conv2d_113.w_0"
     shape = [64, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.377827")
@@ -319,6 +348,7 @@ class Program_weight_tensor_parameter_28:
 
 class Program_weight_tensor_parameter_29:
     name = "parameter_29"
+    original_name = "conv2d_112.w_0"
     shape = [64, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.33135")
@@ -330,6 +360,7 @@ class Program_weight_tensor_parameter_29:
 
 class Program_weight_tensor_parameter_30:
     name = "parameter_30"
+    original_name = "conv2d_111.w_0"
     shape = [256, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.331923")
@@ -341,6 +372,7 @@ class Program_weight_tensor_parameter_30:
 
 class Program_weight_tensor_parameter_31:
     name = "parameter_31"
+    original_name = "batch_norm_90.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.85324")
@@ -352,6 +384,7 @@ class Program_weight_tensor_parameter_31:
 
 class Program_weight_tensor_parameter_32:
     name = "parameter_32"
+    original_name = "batch_norm_90.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.300161")
@@ -363,6 +396,7 @@ class Program_weight_tensor_parameter_32:
 
 class Program_weight_tensor_parameter_33:
     name = "parameter_33"
+    original_name = "batch_norm_90.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("788.619")
@@ -374,6 +408,7 @@ class Program_weight_tensor_parameter_33:
 
 class Program_weight_tensor_parameter_34:
     name = "parameter_34"
+    original_name = "batch_norm_90.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-35.0449")
@@ -385,6 +420,7 @@ class Program_weight_tensor_parameter_34:
 
 class Program_weight_tensor_parameter_35:
     name = "parameter_35"
+    original_name = "batch_norm_89.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.980217")
@@ -396,6 +432,7 @@ class Program_weight_tensor_parameter_35:
 
 class Program_weight_tensor_parameter_36:
     name = "parameter_36"
+    original_name = "batch_norm_89.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.816533")
@@ -407,6 +444,7 @@ class Program_weight_tensor_parameter_36:
 
 class Program_weight_tensor_parameter_37:
     name = "parameter_37"
+    original_name = "batch_norm_89.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.0522279")
@@ -418,6 +456,7 @@ class Program_weight_tensor_parameter_37:
 
 class Program_weight_tensor_parameter_38:
     name = "parameter_38"
+    original_name = "batch_norm_89.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.232943")
@@ -429,6 +468,7 @@ class Program_weight_tensor_parameter_38:
 
 class Program_weight_tensor_parameter_39:
     name = "parameter_39"
+    original_name = "conv2d_110.w_0"
     shape = [256, 1024, 1, 1]
     dtype = "float32"
     min_val = float("-0.333673")
@@ -440,6 +480,7 @@ class Program_weight_tensor_parameter_39:
 
 class Program_weight_tensor_parameter_40:
     name = "parameter_40"
+    original_name = "batch_norm_88.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-2.94065")
@@ -451,6 +492,7 @@ class Program_weight_tensor_parameter_40:
 
 class Program_weight_tensor_parameter_41:
     name = "parameter_41"
+    original_name = "batch_norm_88.w_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.045859")
@@ -462,6 +504,7 @@ class Program_weight_tensor_parameter_41:
 
 class Program_weight_tensor_parameter_42:
     name = "parameter_42"
+    original_name = "batch_norm_88.w_2"
     shape = [1024]
     dtype = "float32"
     min_val = float("0.204496")
@@ -473,6 +516,7 @@ class Program_weight_tensor_parameter_42:
 
 class Program_weight_tensor_parameter_43:
     name = "parameter_43"
+    original_name = "batch_norm_88.w_1"
     shape = [1024]
     dtype = "float32"
     min_val = float("-1.5245")
@@ -484,6 +528,7 @@ class Program_weight_tensor_parameter_43:
 
 class Program_weight_tensor_parameter_44:
     name = "parameter_44"
+    original_name = "conv2d_109.w_0"
     shape = [1024, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.277699")
@@ -495,6 +540,7 @@ class Program_weight_tensor_parameter_44:
 
 class Program_weight_tensor_parameter_45:
     name = "parameter_45"
+    original_name = "batch_norm_87.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.31946")
@@ -506,6 +552,7 @@ class Program_weight_tensor_parameter_45:
 
 class Program_weight_tensor_parameter_46:
     name = "parameter_46"
+    original_name = "batch_norm_87.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.330508")
@@ -517,6 +564,7 @@ class Program_weight_tensor_parameter_46:
 
 class Program_weight_tensor_parameter_47:
     name = "parameter_47"
+    original_name = "batch_norm_87.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("152.443")
@@ -528,6 +576,7 @@ class Program_weight_tensor_parameter_47:
 
 class Program_weight_tensor_parameter_48:
     name = "parameter_48"
+    original_name = "batch_norm_87.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-32.9414")
@@ -539,6 +588,7 @@ class Program_weight_tensor_parameter_48:
 
 class Program_weight_tensor_parameter_49:
     name = "parameter_49"
+    original_name = "conv2d_108.w_0"
     shape = [256, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.379053")
@@ -550,6 +600,7 @@ class Program_weight_tensor_parameter_49:
 
 class Program_weight_tensor_parameter_50:
     name = "parameter_50"
+    original_name = "conv2d_107.w_0"
     shape = [256, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.377005")
@@ -561,6 +612,7 @@ class Program_weight_tensor_parameter_50:
 
 class Program_weight_tensor_parameter_51:
     name = "parameter_51"
+    original_name = "conv2d_106.w_0"
     shape = [64, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.387955")
@@ -572,6 +624,7 @@ class Program_weight_tensor_parameter_51:
 
 class Program_weight_tensor_parameter_52:
     name = "parameter_52"
+    original_name = "conv2d_105.w_0"
     shape = [64, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.341311")
@@ -583,6 +636,7 @@ class Program_weight_tensor_parameter_52:
 
 class Program_weight_tensor_parameter_53:
     name = "parameter_53"
+    original_name = "conv2d_104.w_0"
     shape = [256, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.322789")
@@ -594,6 +648,7 @@ class Program_weight_tensor_parameter_53:
 
 class Program_weight_tensor_parameter_54:
     name = "parameter_54"
+    original_name = "batch_norm_86.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.15303")
@@ -605,6 +660,7 @@ class Program_weight_tensor_parameter_54:
 
 class Program_weight_tensor_parameter_55:
     name = "parameter_55"
+    original_name = "batch_norm_86.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.691397")
@@ -616,6 +672,7 @@ class Program_weight_tensor_parameter_55:
 
 class Program_weight_tensor_parameter_56:
     name = "parameter_56"
+    original_name = "batch_norm_86.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("627.138")
@@ -627,6 +684,7 @@ class Program_weight_tensor_parameter_56:
 
 class Program_weight_tensor_parameter_57:
     name = "parameter_57"
+    original_name = "batch_norm_86.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-30.7197")
@@ -638,6 +696,7 @@ class Program_weight_tensor_parameter_57:
 
 class Program_weight_tensor_parameter_58:
     name = "parameter_58"
+    original_name = "batch_norm_85.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.910597")
@@ -649,6 +708,7 @@ class Program_weight_tensor_parameter_58:
 
 class Program_weight_tensor_parameter_59:
     name = "parameter_59"
+    original_name = "batch_norm_85.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.526403")
@@ -660,6 +720,7 @@ class Program_weight_tensor_parameter_59:
 
 class Program_weight_tensor_parameter_60:
     name = "parameter_60"
+    original_name = "batch_norm_85.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.723623")
@@ -671,6 +732,7 @@ class Program_weight_tensor_parameter_60:
 
 class Program_weight_tensor_parameter_61:
     name = "parameter_61"
+    original_name = "batch_norm_85.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-2.84352")
@@ -682,6 +744,7 @@ class Program_weight_tensor_parameter_61:
 
 class Program_weight_tensor_parameter_62:
     name = "parameter_62"
+    original_name = "conv2d_103.w_0"
     shape = [256, 1024, 1, 1]
     dtype = "float32"
     min_val = float("-0.30737")
@@ -693,6 +756,7 @@ class Program_weight_tensor_parameter_62:
 
 class Program_weight_tensor_parameter_63:
     name = "parameter_63"
+    original_name = "batch_norm_84.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-5.09398")
@@ -704,6 +768,7 @@ class Program_weight_tensor_parameter_63:
 
 class Program_weight_tensor_parameter_64:
     name = "parameter_64"
+    original_name = "batch_norm_84.w_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("0.28883")
@@ -715,6 +780,7 @@ class Program_weight_tensor_parameter_64:
 
 class Program_weight_tensor_parameter_65:
     name = "parameter_65"
+    original_name = "batch_norm_84.w_2"
     shape = [1024]
     dtype = "float32"
     min_val = float("6.48801e-43")
@@ -726,6 +792,7 @@ class Program_weight_tensor_parameter_65:
 
 class Program_weight_tensor_parameter_66:
     name = "parameter_66"
+    original_name = "batch_norm_84.w_1"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.857116")
@@ -737,6 +804,7 @@ class Program_weight_tensor_parameter_66:
 
 class Program_weight_tensor_parameter_67:
     name = "parameter_67"
+    original_name = "conv2d_102.w_0"
     shape = [1024, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.369556")
@@ -748,6 +816,7 @@ class Program_weight_tensor_parameter_67:
 
 class Program_weight_tensor_parameter_68:
     name = "parameter_68"
+    original_name = "batch_norm_83.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-1.87234")
@@ -759,6 +828,7 @@ class Program_weight_tensor_parameter_68:
 
 class Program_weight_tensor_parameter_69:
     name = "parameter_69"
+    original_name = "batch_norm_83.w_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("0.08136")
@@ -770,6 +840,7 @@ class Program_weight_tensor_parameter_69:
 
 class Program_weight_tensor_parameter_70:
     name = "parameter_70"
+    original_name = "batch_norm_83.w_2"
     shape = [1024]
     dtype = "float32"
     min_val = float("6.61694e-25")
@@ -781,6 +852,7 @@ class Program_weight_tensor_parameter_70:
 
 class Program_weight_tensor_parameter_71:
     name = "parameter_71"
+    original_name = "batch_norm_83.w_1"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.947938")
@@ -792,6 +864,7 @@ class Program_weight_tensor_parameter_71:
 
 class Program_weight_tensor_parameter_72:
     name = "parameter_72"
+    original_name = "conv2d_101.w_0"
     shape = [1024, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.329446")
@@ -803,6 +876,7 @@ class Program_weight_tensor_parameter_72:
 
 class Program_weight_tensor_parameter_73:
     name = "parameter_73"
+    original_name = "batch_norm_82.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.11352")
@@ -814,6 +888,7 @@ class Program_weight_tensor_parameter_73:
 
 class Program_weight_tensor_parameter_74:
     name = "parameter_74"
+    original_name = "batch_norm_82.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.509347")
@@ -825,6 +900,7 @@ class Program_weight_tensor_parameter_74:
 
 class Program_weight_tensor_parameter_75:
     name = "parameter_75"
+    original_name = "batch_norm_82.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("151.982")
@@ -836,6 +912,7 @@ class Program_weight_tensor_parameter_75:
 
 class Program_weight_tensor_parameter_76:
     name = "parameter_76"
+    original_name = "batch_norm_82.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-28.3251")
@@ -847,6 +924,7 @@ class Program_weight_tensor_parameter_76:
 
 class Program_weight_tensor_parameter_77:
     name = "parameter_77"
+    original_name = "conv2d_100.w_0"
     shape = [256, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.458315")
@@ -858,6 +936,7 @@ class Program_weight_tensor_parameter_77:
 
 class Program_weight_tensor_parameter_78:
     name = "parameter_78"
+    original_name = "conv2d_99.w_0"
     shape = [256, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.319188")
@@ -869,6 +948,7 @@ class Program_weight_tensor_parameter_78:
 
 class Program_weight_tensor_parameter_79:
     name = "parameter_79"
+    original_name = "conv2d_98.w_0"
     shape = [64, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.379211")
@@ -880,6 +960,7 @@ class Program_weight_tensor_parameter_79:
 
 class Program_weight_tensor_parameter_80:
     name = "parameter_80"
+    original_name = "conv2d_97.w_0"
     shape = [64, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.379864")
@@ -891,6 +972,7 @@ class Program_weight_tensor_parameter_80:
 
 class Program_weight_tensor_parameter_81:
     name = "parameter_81"
+    original_name = "conv2d_96.w_0"
     shape = [256, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.330773")
@@ -902,6 +984,7 @@ class Program_weight_tensor_parameter_81:
 
 class Program_weight_tensor_parameter_82:
     name = "parameter_82"
+    original_name = "batch_norm_81.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.57846")
@@ -913,6 +996,7 @@ class Program_weight_tensor_parameter_82:
 
 class Program_weight_tensor_parameter_83:
     name = "parameter_83"
+    original_name = "batch_norm_81.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.699774")
@@ -924,6 +1008,7 @@ class Program_weight_tensor_parameter_83:
 
 class Program_weight_tensor_parameter_84:
     name = "parameter_84"
+    original_name = "batch_norm_81.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("191.748")
@@ -935,6 +1020,7 @@ class Program_weight_tensor_parameter_84:
 
 class Program_weight_tensor_parameter_85:
     name = "parameter_85"
+    original_name = "batch_norm_81.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-28.4933")
@@ -946,6 +1032,7 @@ class Program_weight_tensor_parameter_85:
 
 class Program_weight_tensor_parameter_86:
     name = "parameter_86"
+    original_name = "batch_norm_80.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.752429")
@@ -957,6 +1044,7 @@ class Program_weight_tensor_parameter_86:
 
 class Program_weight_tensor_parameter_87:
     name = "parameter_87"
+    original_name = "batch_norm_80.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.272372")
@@ -968,6 +1056,7 @@ class Program_weight_tensor_parameter_87:
 
 class Program_weight_tensor_parameter_88:
     name = "parameter_88"
+    original_name = "batch_norm_80.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.105312")
@@ -979,6 +1068,7 @@ class Program_weight_tensor_parameter_88:
 
 class Program_weight_tensor_parameter_89:
     name = "parameter_89"
+    original_name = "batch_norm_80.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.200413")
@@ -990,6 +1080,7 @@ class Program_weight_tensor_parameter_89:
 
 class Program_weight_tensor_parameter_90:
     name = "parameter_90"
+    original_name = "conv2d_95.w_0"
     shape = [256, 1024, 1, 1]
     dtype = "float32"
     min_val = float("-0.300859")
@@ -1001,6 +1092,7 @@ class Program_weight_tensor_parameter_90:
 
 class Program_weight_tensor_parameter_91:
     name = "parameter_91"
+    original_name = "batch_norm_79.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-2.98639")
@@ -1012,6 +1104,7 @@ class Program_weight_tensor_parameter_91:
 
 class Program_weight_tensor_parameter_92:
     name = "parameter_92"
+    original_name = "batch_norm_79.w_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("0.0903115")
@@ -1023,6 +1116,7 @@ class Program_weight_tensor_parameter_92:
 
 class Program_weight_tensor_parameter_93:
     name = "parameter_93"
+    original_name = "batch_norm_79.w_2"
     shape = [1024]
     dtype = "float32"
     min_val = float("0.252212")
@@ -1034,6 +1128,7 @@ class Program_weight_tensor_parameter_93:
 
 class Program_weight_tensor_parameter_94:
     name = "parameter_94"
+    original_name = "batch_norm_79.w_1"
     shape = [1024]
     dtype = "float32"
     min_val = float("-1.68452")
@@ -1045,6 +1140,7 @@ class Program_weight_tensor_parameter_94:
 
 class Program_weight_tensor_parameter_95:
     name = "parameter_95"
+    original_name = "conv2d_94.w_0"
     shape = [1024, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.298976")
@@ -1056,6 +1152,7 @@ class Program_weight_tensor_parameter_95:
 
 class Program_weight_tensor_parameter_96:
     name = "parameter_96"
+    original_name = "batch_norm_78.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.93301")
@@ -1067,6 +1164,7 @@ class Program_weight_tensor_parameter_96:
 
 class Program_weight_tensor_parameter_97:
     name = "parameter_97"
+    original_name = "batch_norm_78.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.357626")
@@ -1078,6 +1176,7 @@ class Program_weight_tensor_parameter_97:
 
 class Program_weight_tensor_parameter_98:
     name = "parameter_98"
+    original_name = "batch_norm_78.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("10.1169")
@@ -1089,6 +1188,7 @@ class Program_weight_tensor_parameter_98:
 
 class Program_weight_tensor_parameter_99:
     name = "parameter_99"
+    original_name = "batch_norm_78.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-14.9434")
@@ -1100,6 +1200,7 @@ class Program_weight_tensor_parameter_99:
 
 class Program_weight_tensor_parameter_100:
     name = "parameter_100"
+    original_name = "conv2d_93.w_0"
     shape = [256, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.358136")
@@ -1111,6 +1212,7 @@ class Program_weight_tensor_parameter_100:
 
 class Program_weight_tensor_parameter_101:
     name = "parameter_101"
+    original_name = "conv2d_92.w_0"
     shape = [256, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.35339")
@@ -1122,6 +1224,7 @@ class Program_weight_tensor_parameter_101:
 
 class Program_weight_tensor_parameter_102:
     name = "parameter_102"
+    original_name = "conv2d_91.w_0"
     shape = [64, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.364022")
@@ -1133,6 +1236,7 @@ class Program_weight_tensor_parameter_102:
 
 class Program_weight_tensor_parameter_103:
     name = "parameter_103"
+    original_name = "conv2d_90.w_0"
     shape = [64, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.308563")
@@ -1144,6 +1248,7 @@ class Program_weight_tensor_parameter_103:
 
 class Program_weight_tensor_parameter_104:
     name = "parameter_104"
+    original_name = "conv2d_89.w_0"
     shape = [256, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.354829")
@@ -1155,6 +1260,7 @@ class Program_weight_tensor_parameter_104:
 
 class Program_weight_tensor_parameter_105:
     name = "parameter_105"
+    original_name = "batch_norm_77.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.19354")
@@ -1166,6 +1272,7 @@ class Program_weight_tensor_parameter_105:
 
 class Program_weight_tensor_parameter_106:
     name = "parameter_106"
+    original_name = "batch_norm_77.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.538126")
@@ -1177,6 +1284,7 @@ class Program_weight_tensor_parameter_106:
 
 class Program_weight_tensor_parameter_107:
     name = "parameter_107"
+    original_name = "batch_norm_77.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.0391763")
@@ -1188,6 +1296,7 @@ class Program_weight_tensor_parameter_107:
 
 class Program_weight_tensor_parameter_108:
     name = "parameter_108"
+    original_name = "batch_norm_77.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-2.39009")
@@ -1199,6 +1308,7 @@ class Program_weight_tensor_parameter_108:
 
 class Program_weight_tensor_parameter_109:
     name = "parameter_109"
+    original_name = "batch_norm_76.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.634645")
@@ -1210,6 +1320,7 @@ class Program_weight_tensor_parameter_109:
 
 class Program_weight_tensor_parameter_110:
     name = "parameter_110"
+    original_name = "batch_norm_76.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.490869")
@@ -1221,6 +1332,7 @@ class Program_weight_tensor_parameter_110:
 
 class Program_weight_tensor_parameter_111:
     name = "parameter_111"
+    original_name = "batch_norm_76.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.0848407")
@@ -1232,6 +1344,7 @@ class Program_weight_tensor_parameter_111:
 
 class Program_weight_tensor_parameter_112:
     name = "parameter_112"
+    original_name = "batch_norm_76.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.298559")
@@ -1243,6 +1356,7 @@ class Program_weight_tensor_parameter_112:
 
 class Program_weight_tensor_parameter_113:
     name = "parameter_113"
+    original_name = "conv2d_88.w_0"
     shape = [256, 1024, 1, 1]
     dtype = "float32"
     min_val = float("-0.311585")
@@ -1254,6 +1368,7 @@ class Program_weight_tensor_parameter_113:
 
 class Program_weight_tensor_parameter_114:
     name = "parameter_114"
+    original_name = "batch_norm_75.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-2.76344")
@@ -1265,6 +1380,7 @@ class Program_weight_tensor_parameter_114:
 
 class Program_weight_tensor_parameter_115:
     name = "parameter_115"
+    original_name = "batch_norm_75.w_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("0.0601779")
@@ -1276,6 +1392,7 @@ class Program_weight_tensor_parameter_115:
 
 class Program_weight_tensor_parameter_116:
     name = "parameter_116"
+    original_name = "batch_norm_75.w_2"
     shape = [1024]
     dtype = "float32"
     min_val = float("9.66694e-22")
@@ -1287,6 +1404,7 @@ class Program_weight_tensor_parameter_116:
 
 class Program_weight_tensor_parameter_117:
     name = "parameter_117"
+    original_name = "batch_norm_75.w_1"
     shape = [1024]
     dtype = "float32"
     min_val = float("-1.61336")
@@ -1298,6 +1416,7 @@ class Program_weight_tensor_parameter_117:
 
 class Program_weight_tensor_parameter_118:
     name = "parameter_118"
+    original_name = "conv2d_87.w_0"
     shape = [1024, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.30422")
@@ -1309,6 +1428,7 @@ class Program_weight_tensor_parameter_118:
 
 class Program_weight_tensor_parameter_119:
     name = "parameter_119"
+    original_name = "batch_norm_74.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.740617")
@@ -1320,6 +1440,7 @@ class Program_weight_tensor_parameter_119:
 
 class Program_weight_tensor_parameter_120:
     name = "parameter_120"
+    original_name = "batch_norm_74.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.730344")
@@ -1331,6 +1452,7 @@ class Program_weight_tensor_parameter_120:
 
 class Program_weight_tensor_parameter_121:
     name = "parameter_121"
+    original_name = "batch_norm_74.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.101248")
@@ -1342,6 +1464,7 @@ class Program_weight_tensor_parameter_121:
 
 class Program_weight_tensor_parameter_122:
     name = "parameter_122"
+    original_name = "batch_norm_74.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.223015")
@@ -1353,6 +1476,7 @@ class Program_weight_tensor_parameter_122:
 
 class Program_weight_tensor_parameter_123:
     name = "parameter_123"
+    original_name = "conv2d_86.w_0"
     shape = [256, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.315798")
@@ -1364,6 +1488,7 @@ class Program_weight_tensor_parameter_123:
 
 class Program_weight_tensor_parameter_124:
     name = "parameter_124"
+    original_name = "batch_norm_73.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-2.48714")
@@ -1375,6 +1500,7 @@ class Program_weight_tensor_parameter_124:
 
 class Program_weight_tensor_parameter_125:
     name = "parameter_125"
+    original_name = "batch_norm_73.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("0.291531")
@@ -1386,6 +1512,7 @@ class Program_weight_tensor_parameter_125:
 
 class Program_weight_tensor_parameter_126:
     name = "parameter_126"
+    original_name = "batch_norm_73.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("0.724073")
@@ -1397,6 +1524,7 @@ class Program_weight_tensor_parameter_126:
 
 class Program_weight_tensor_parameter_127:
     name = "parameter_127"
+    original_name = "batch_norm_73.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-1.41239")
@@ -1408,6 +1536,7 @@ class Program_weight_tensor_parameter_127:
 
 class Program_weight_tensor_parameter_128:
     name = "parameter_128"
+    original_name = "conv2d_85.w_0"
     shape = [512, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.378847")
@@ -1419,6 +1548,7 @@ class Program_weight_tensor_parameter_128:
 
 class Program_weight_tensor_parameter_129:
     name = "parameter_129"
+    original_name = "batch_norm_72.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.762249")
@@ -1430,6 +1560,7 @@ class Program_weight_tensor_parameter_129:
 
 class Program_weight_tensor_parameter_130:
     name = "parameter_130"
+    original_name = "batch_norm_72.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.244588")
@@ -1441,6 +1572,7 @@ class Program_weight_tensor_parameter_130:
 
 class Program_weight_tensor_parameter_131:
     name = "parameter_131"
+    original_name = "batch_norm_72.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.29115")
@@ -1452,6 +1584,7 @@ class Program_weight_tensor_parameter_131:
 
 class Program_weight_tensor_parameter_132:
     name = "parameter_132"
+    original_name = "batch_norm_72.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-2.96863")
@@ -1463,6 +1596,7 @@ class Program_weight_tensor_parameter_132:
 
 class Program_weight_tensor_parameter_133:
     name = "parameter_133"
+    original_name = "conv2d_84.w_0"
     shape = [256, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.368986")
@@ -1474,6 +1608,7 @@ class Program_weight_tensor_parameter_133:
 
 class Program_weight_tensor_parameter_134:
     name = "parameter_134"
+    original_name = "batch_norm_71.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-4.63246")
@@ -1485,6 +1620,7 @@ class Program_weight_tensor_parameter_134:
 
 class Program_weight_tensor_parameter_135:
     name = "parameter_135"
+    original_name = "batch_norm_71.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("0.192903")
@@ -1496,6 +1632,7 @@ class Program_weight_tensor_parameter_135:
 
 class Program_weight_tensor_parameter_136:
     name = "parameter_136"
+    original_name = "batch_norm_71.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("5.25487e-43")
@@ -1507,6 +1644,7 @@ class Program_weight_tensor_parameter_136:
 
 class Program_weight_tensor_parameter_137:
     name = "parameter_137"
+    original_name = "batch_norm_71.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.625126")
@@ -1518,6 +1656,7 @@ class Program_weight_tensor_parameter_137:
 
 class Program_weight_tensor_parameter_138:
     name = "parameter_138"
+    original_name = "conv2d_83.w_0"
     shape = [512, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.333384")
@@ -1529,6 +1668,7 @@ class Program_weight_tensor_parameter_138:
 
 class Program_weight_tensor_parameter_139:
     name = "parameter_139"
+    original_name = "batch_norm_70.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-1.60863")
@@ -1540,6 +1680,7 @@ class Program_weight_tensor_parameter_139:
 
 class Program_weight_tensor_parameter_140:
     name = "parameter_140"
+    original_name = "batch_norm_70.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("0.0986059")
@@ -1551,6 +1692,7 @@ class Program_weight_tensor_parameter_140:
 
 class Program_weight_tensor_parameter_141:
     name = "parameter_141"
+    original_name = "batch_norm_70.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("3.27579e-27")
@@ -1562,6 +1704,7 @@ class Program_weight_tensor_parameter_141:
 
 class Program_weight_tensor_parameter_142:
     name = "parameter_142"
+    original_name = "batch_norm_70.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-1.04317")
@@ -1573,6 +1716,7 @@ class Program_weight_tensor_parameter_142:
 
 class Program_weight_tensor_parameter_143:
     name = "parameter_143"
+    original_name = "conv2d_82.w_0"
     shape = [512, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.461294")
@@ -1584,6 +1728,7 @@ class Program_weight_tensor_parameter_143:
 
 class Program_weight_tensor_parameter_144:
     name = "parameter_144"
+    original_name = "batch_norm_69.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.8304")
@@ -1595,6 +1740,7 @@ class Program_weight_tensor_parameter_144:
 
 class Program_weight_tensor_parameter_145:
     name = "parameter_145"
+    original_name = "batch_norm_69.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.418119")
@@ -1606,6 +1752,7 @@ class Program_weight_tensor_parameter_145:
 
 class Program_weight_tensor_parameter_146:
     name = "parameter_146"
+    original_name = "batch_norm_69.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.000750539")
@@ -1617,6 +1764,7 @@ class Program_weight_tensor_parameter_146:
 
 class Program_weight_tensor_parameter_147:
     name = "parameter_147"
+    original_name = "batch_norm_69.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.279692")
@@ -1628,6 +1776,7 @@ class Program_weight_tensor_parameter_147:
 
 class Program_weight_tensor_parameter_148:
     name = "parameter_148"
+    original_name = "conv2d_81.w_0"
     shape = [256, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.406986")
@@ -1639,6 +1788,7 @@ class Program_weight_tensor_parameter_148:
 
 class Program_weight_tensor_parameter_149:
     name = "parameter_149"
+    original_name = "batch_norm_68.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.499286")
@@ -1650,6 +1800,7 @@ class Program_weight_tensor_parameter_149:
 
 class Program_weight_tensor_parameter_150:
     name = "parameter_150"
+    original_name = "batch_norm_68.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.713407")
@@ -1661,6 +1812,7 @@ class Program_weight_tensor_parameter_150:
 
 class Program_weight_tensor_parameter_151:
     name = "parameter_151"
+    original_name = "batch_norm_68.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.118691")
@@ -1672,6 +1824,7 @@ class Program_weight_tensor_parameter_151:
 
 class Program_weight_tensor_parameter_152:
     name = "parameter_152"
+    original_name = "batch_norm_68.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.387288")
@@ -1683,6 +1836,7 @@ class Program_weight_tensor_parameter_152:
 
 class Program_weight_tensor_parameter_153:
     name = "parameter_153"
+    original_name = "conv2d_80.w_0"
     shape = [256, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.327455")
@@ -1694,6 +1848,7 @@ class Program_weight_tensor_parameter_153:
 
 class Program_weight_tensor_parameter_154:
     name = "parameter_154"
+    original_name = "batch_norm_67.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-2.21566")
@@ -1705,6 +1860,7 @@ class Program_weight_tensor_parameter_154:
 
 class Program_weight_tensor_parameter_155:
     name = "parameter_155"
+    original_name = "batch_norm_67.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("0.391266")
@@ -1716,6 +1872,7 @@ class Program_weight_tensor_parameter_155:
 
 class Program_weight_tensor_parameter_156:
     name = "parameter_156"
+    original_name = "batch_norm_67.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("0.770267")
@@ -1727,6 +1884,7 @@ class Program_weight_tensor_parameter_156:
 
 class Program_weight_tensor_parameter_157:
     name = "parameter_157"
+    original_name = "batch_norm_67.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.912367")
@@ -1738,6 +1896,7 @@ class Program_weight_tensor_parameter_157:
 
 class Program_weight_tensor_parameter_158:
     name = "parameter_158"
+    original_name = "conv2d_79.w_0"
     shape = [512, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.320711")
@@ -1749,6 +1908,7 @@ class Program_weight_tensor_parameter_158:
 
 class Program_weight_tensor_parameter_159:
     name = "parameter_159"
+    original_name = "batch_norm_66.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.23515")
@@ -1760,6 +1920,7 @@ class Program_weight_tensor_parameter_159:
 
 class Program_weight_tensor_parameter_160:
     name = "parameter_160"
+    original_name = "batch_norm_66.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.5518")
@@ -1771,6 +1932,7 @@ class Program_weight_tensor_parameter_160:
 
 class Program_weight_tensor_parameter_161:
     name = "parameter_161"
+    original_name = "batch_norm_66.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("1.00602")
@@ -1782,6 +1944,7 @@ class Program_weight_tensor_parameter_161:
 
 class Program_weight_tensor_parameter_162:
     name = "parameter_162"
+    original_name = "batch_norm_66.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-3.53988")
@@ -1793,6 +1956,7 @@ class Program_weight_tensor_parameter_162:
 
 class Program_weight_tensor_parameter_163:
     name = "parameter_163"
+    original_name = "conv2d_78.w_0"
     shape = [256, 1024, 1, 1]
     dtype = "float32"
     min_val = float("-0.350887")
@@ -1804,6 +1968,7 @@ class Program_weight_tensor_parameter_163:
 
 class Program_weight_tensor_parameter_164:
     name = "parameter_164"
+    original_name = "batch_norm_65.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-4.94413")
@@ -1815,6 +1980,7 @@ class Program_weight_tensor_parameter_164:
 
 class Program_weight_tensor_parameter_165:
     name = "parameter_165"
+    original_name = "batch_norm_65.w_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("0.261528")
@@ -1826,6 +1992,7 @@ class Program_weight_tensor_parameter_165:
 
 class Program_weight_tensor_parameter_166:
     name = "parameter_166"
+    original_name = "batch_norm_65.w_2"
     shape = [1024]
     dtype = "float32"
     min_val = float("7.09057e-43")
@@ -1837,6 +2004,7 @@ class Program_weight_tensor_parameter_166:
 
 class Program_weight_tensor_parameter_167:
     name = "parameter_167"
+    original_name = "batch_norm_65.w_1"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.647796")
@@ -1848,6 +2016,7 @@ class Program_weight_tensor_parameter_167:
 
 class Program_weight_tensor_parameter_168:
     name = "parameter_168"
+    original_name = "conv2d_77.w_0"
     shape = [1024, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.542694")
@@ -1859,6 +2028,7 @@ class Program_weight_tensor_parameter_168:
 
 class Program_weight_tensor_parameter_169:
     name = "parameter_169"
+    original_name = "batch_norm_64.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-1.68167")
@@ -1870,6 +2040,7 @@ class Program_weight_tensor_parameter_169:
 
 class Program_weight_tensor_parameter_170:
     name = "parameter_170"
+    original_name = "batch_norm_64.w_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("0.142046")
@@ -1881,6 +2052,7 @@ class Program_weight_tensor_parameter_170:
 
 class Program_weight_tensor_parameter_171:
     name = "parameter_171"
+    original_name = "batch_norm_64.w_2"
     shape = [1024]
     dtype = "float32"
     min_val = float("9.08226e-25")
@@ -1892,6 +2064,7 @@ class Program_weight_tensor_parameter_171:
 
 class Program_weight_tensor_parameter_172:
     name = "parameter_172"
+    original_name = "batch_norm_64.w_1"
     shape = [1024]
     dtype = "float32"
     min_val = float("-1.21709")
@@ -1903,6 +2076,7 @@ class Program_weight_tensor_parameter_172:
 
 class Program_weight_tensor_parameter_173:
     name = "parameter_173"
+    original_name = "conv2d_76.w_0"
     shape = [1024, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.337161")
@@ -1914,6 +2088,7 @@ class Program_weight_tensor_parameter_173:
 
 class Program_weight_tensor_parameter_174:
     name = "parameter_174"
+    original_name = "batch_norm_63.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.31683")
@@ -1925,6 +2100,7 @@ class Program_weight_tensor_parameter_174:
 
 class Program_weight_tensor_parameter_175:
     name = "parameter_175"
+    original_name = "batch_norm_63.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.337841")
@@ -1936,6 +2112,7 @@ class Program_weight_tensor_parameter_175:
 
 class Program_weight_tensor_parameter_176:
     name = "parameter_176"
+    original_name = "batch_norm_63.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("5.60044e-05")
@@ -1947,6 +2124,7 @@ class Program_weight_tensor_parameter_176:
 
 class Program_weight_tensor_parameter_177:
     name = "parameter_177"
+    original_name = "batch_norm_63.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.13311")
@@ -1958,6 +2136,7 @@ class Program_weight_tensor_parameter_177:
 
 class Program_weight_tensor_parameter_178:
     name = "parameter_178"
+    original_name = "conv2d_75.w_0"
     shape = [256, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.41024")
@@ -1969,6 +2148,7 @@ class Program_weight_tensor_parameter_178:
 
 class Program_weight_tensor_parameter_179:
     name = "parameter_179"
+    original_name = "batch_norm_62.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.936599")
@@ -1980,6 +2160,7 @@ class Program_weight_tensor_parameter_179:
 
 class Program_weight_tensor_parameter_180:
     name = "parameter_180"
+    original_name = "batch_norm_62.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.325337")
@@ -1991,6 +2172,7 @@ class Program_weight_tensor_parameter_180:
 
 class Program_weight_tensor_parameter_181:
     name = "parameter_181"
+    original_name = "batch_norm_62.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.673456")
@@ -2002,6 +2184,7 @@ class Program_weight_tensor_parameter_181:
 
 class Program_weight_tensor_parameter_182:
     name = "parameter_182"
+    original_name = "batch_norm_62.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-2.05422")
@@ -2013,6 +2196,7 @@ class Program_weight_tensor_parameter_182:
 
 class Program_weight_tensor_parameter_183:
     name = "parameter_183"
+    original_name = "conv2d_74.w_0"
     shape = [256, 1024, 1, 1]
     dtype = "float32"
     min_val = float("-0.500632")
@@ -2024,6 +2208,7 @@ class Program_weight_tensor_parameter_183:
 
 class Program_weight_tensor_parameter_184:
     name = "parameter_184"
+    original_name = "batch_norm_61.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-5.58701")
@@ -2035,6 +2220,7 @@ class Program_weight_tensor_parameter_184:
 
 class Program_weight_tensor_parameter_185:
     name = "parameter_185"
+    original_name = "batch_norm_61.w_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("0.137449")
@@ -2046,6 +2232,7 @@ class Program_weight_tensor_parameter_185:
 
 class Program_weight_tensor_parameter_186:
     name = "parameter_186"
+    original_name = "batch_norm_61.w_2"
     shape = [1024]
     dtype = "float32"
     min_val = float("6.74025e-43")
@@ -2057,6 +2244,7 @@ class Program_weight_tensor_parameter_186:
 
 class Program_weight_tensor_parameter_187:
     name = "parameter_187"
+    original_name = "batch_norm_61.w_1"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.841972")
@@ -2068,6 +2256,7 @@ class Program_weight_tensor_parameter_187:
 
 class Program_weight_tensor_parameter_188:
     name = "parameter_188"
+    original_name = "conv2d_73.w_0"
     shape = [1024, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.277406")
@@ -2079,6 +2268,7 @@ class Program_weight_tensor_parameter_188:
 
 class Program_weight_tensor_parameter_189:
     name = "parameter_189"
+    original_name = "batch_norm_60.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-1.3781")
@@ -2090,6 +2280,7 @@ class Program_weight_tensor_parameter_189:
 
 class Program_weight_tensor_parameter_190:
     name = "parameter_190"
+    original_name = "batch_norm_60.w_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("0.123831")
@@ -2101,6 +2292,7 @@ class Program_weight_tensor_parameter_190:
 
 class Program_weight_tensor_parameter_191:
     name = "parameter_191"
+    original_name = "batch_norm_60.w_2"
     shape = [1024]
     dtype = "float32"
     min_val = float("8.46262e-26")
@@ -2112,6 +2304,7 @@ class Program_weight_tensor_parameter_191:
 
 class Program_weight_tensor_parameter_192:
     name = "parameter_192"
+    original_name = "batch_norm_60.w_1"
     shape = [1024]
     dtype = "float32"
     min_val = float("-1.36721")
@@ -2123,6 +2316,7 @@ class Program_weight_tensor_parameter_192:
 
 class Program_weight_tensor_parameter_193:
     name = "parameter_193"
+    original_name = "conv2d_72.w_0"
     shape = [1024, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.386927")
@@ -2134,6 +2328,7 @@ class Program_weight_tensor_parameter_193:
 
 class Program_weight_tensor_parameter_194:
     name = "parameter_194"
+    original_name = "batch_norm_59.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.36001")
@@ -2145,6 +2340,7 @@ class Program_weight_tensor_parameter_194:
 
 class Program_weight_tensor_parameter_195:
     name = "parameter_195"
+    original_name = "batch_norm_59.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.515131")
@@ -2156,6 +2352,7 @@ class Program_weight_tensor_parameter_195:
 
 class Program_weight_tensor_parameter_196:
     name = "parameter_196"
+    original_name = "batch_norm_59.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("3.95124e-06")
@@ -2167,6 +2364,7 @@ class Program_weight_tensor_parameter_196:
 
 class Program_weight_tensor_parameter_197:
     name = "parameter_197"
+    original_name = "batch_norm_59.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.364164")
@@ -2178,6 +2376,7 @@ class Program_weight_tensor_parameter_197:
 
 class Program_weight_tensor_parameter_198:
     name = "parameter_198"
+    original_name = "conv2d_71.w_0"
     shape = [256, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.398905")
@@ -2189,6 +2388,7 @@ class Program_weight_tensor_parameter_198:
 
 class Program_weight_tensor_parameter_199:
     name = "parameter_199"
+    original_name = "batch_norm_58.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.801084")
@@ -2200,6 +2400,7 @@ class Program_weight_tensor_parameter_199:
 
 class Program_weight_tensor_parameter_200:
     name = "parameter_200"
+    original_name = "batch_norm_58.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.49256")
@@ -2211,6 +2412,7 @@ class Program_weight_tensor_parameter_200:
 
 class Program_weight_tensor_parameter_201:
     name = "parameter_201"
+    original_name = "batch_norm_58.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("1.28812")
@@ -2222,6 +2424,7 @@ class Program_weight_tensor_parameter_201:
 
 class Program_weight_tensor_parameter_202:
     name = "parameter_202"
+    original_name = "batch_norm_58.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-3.02296")
@@ -2233,6 +2436,7 @@ class Program_weight_tensor_parameter_202:
 
 class Program_weight_tensor_parameter_203:
     name = "parameter_203"
+    original_name = "conv2d_70.w_0"
     shape = [256, 1024, 1, 1]
     dtype = "float32"
     min_val = float("-0.344031")
@@ -2244,6 +2448,7 @@ class Program_weight_tensor_parameter_203:
 
 class Program_weight_tensor_parameter_204:
     name = "parameter_204"
+    original_name = "batch_norm_57.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-4.4735")
@@ -2255,6 +2460,7 @@ class Program_weight_tensor_parameter_204:
 
 class Program_weight_tensor_parameter_205:
     name = "parameter_205"
+    original_name = "batch_norm_57.w_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("0.242319")
@@ -2266,6 +2472,7 @@ class Program_weight_tensor_parameter_205:
 
 class Program_weight_tensor_parameter_206:
     name = "parameter_206"
+    original_name = "batch_norm_57.w_2"
     shape = [1024]
     dtype = "float32"
     min_val = float("6.93643e-43")
@@ -2277,6 +2484,7 @@ class Program_weight_tensor_parameter_206:
 
 class Program_weight_tensor_parameter_207:
     name = "parameter_207"
+    original_name = "batch_norm_57.w_1"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.643842")
@@ -2288,6 +2496,7 @@ class Program_weight_tensor_parameter_207:
 
 class Program_weight_tensor_parameter_208:
     name = "parameter_208"
+    original_name = "conv2d_69.w_0"
     shape = [1024, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.290963")
@@ -2299,6 +2508,7 @@ class Program_weight_tensor_parameter_208:
 
 class Program_weight_tensor_parameter_209:
     name = "parameter_209"
+    original_name = "batch_norm_56.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-1.1668")
@@ -2310,6 +2520,7 @@ class Program_weight_tensor_parameter_209:
 
 class Program_weight_tensor_parameter_210:
     name = "parameter_210"
+    original_name = "batch_norm_56.w_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("0.10526")
@@ -2321,6 +2532,7 @@ class Program_weight_tensor_parameter_210:
 
 class Program_weight_tensor_parameter_211:
     name = "parameter_211"
+    original_name = "batch_norm_56.w_2"
     shape = [1024]
     dtype = "float32"
     min_val = float("6.55046e-26")
@@ -2332,6 +2544,7 @@ class Program_weight_tensor_parameter_211:
 
 class Program_weight_tensor_parameter_212:
     name = "parameter_212"
+    original_name = "batch_norm_56.w_1"
     shape = [1024]
     dtype = "float32"
     min_val = float("-1.25038")
@@ -2343,6 +2556,7 @@ class Program_weight_tensor_parameter_212:
 
 class Program_weight_tensor_parameter_213:
     name = "parameter_213"
+    original_name = "conv2d_68.w_0"
     shape = [1024, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.36066")
@@ -2354,6 +2568,7 @@ class Program_weight_tensor_parameter_213:
 
 class Program_weight_tensor_parameter_214:
     name = "parameter_214"
+    original_name = "batch_norm_55.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.34285")
@@ -2365,6 +2580,7 @@ class Program_weight_tensor_parameter_214:
 
 class Program_weight_tensor_parameter_215:
     name = "parameter_215"
+    original_name = "batch_norm_55.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.424948")
@@ -2376,6 +2592,7 @@ class Program_weight_tensor_parameter_215:
 
 class Program_weight_tensor_parameter_216:
     name = "parameter_216"
+    original_name = "batch_norm_55.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("1.15348e-05")
@@ -2387,6 +2604,7 @@ class Program_weight_tensor_parameter_216:
 
 class Program_weight_tensor_parameter_217:
     name = "parameter_217"
+    original_name = "batch_norm_55.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.504262")
@@ -2398,6 +2616,7 @@ class Program_weight_tensor_parameter_217:
 
 class Program_weight_tensor_parameter_218:
     name = "parameter_218"
+    original_name = "conv2d_67.w_0"
     shape = [256, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.428499")
@@ -2409,6 +2628,7 @@ class Program_weight_tensor_parameter_218:
 
 class Program_weight_tensor_parameter_219:
     name = "parameter_219"
+    original_name = "batch_norm_54.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-2.01949")
@@ -2420,6 +2640,7 @@ class Program_weight_tensor_parameter_219:
 
 class Program_weight_tensor_parameter_220:
     name = "parameter_220"
+    original_name = "batch_norm_54.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.206313")
@@ -2431,6 +2652,7 @@ class Program_weight_tensor_parameter_220:
 
 class Program_weight_tensor_parameter_221:
     name = "parameter_221"
+    original_name = "batch_norm_54.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("1.59832")
@@ -2442,6 +2664,7 @@ class Program_weight_tensor_parameter_221:
 
 class Program_weight_tensor_parameter_222:
     name = "parameter_222"
+    original_name = "batch_norm_54.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-8.64458")
@@ -2453,6 +2676,7 @@ class Program_weight_tensor_parameter_222:
 
 class Program_weight_tensor_parameter_223:
     name = "parameter_223"
+    original_name = "conv2d_66.w_0"
     shape = [256, 960, 1, 1]
     dtype = "float32"
     min_val = float("-0.44694")
@@ -2464,6 +2688,7 @@ class Program_weight_tensor_parameter_223:
 
 class Program_weight_tensor_parameter_224:
     name = "parameter_224"
+    original_name = "batch_norm_53.b_0"
     shape = [960]
     dtype = "float32"
     min_val = float("-4.55844")
@@ -2475,6 +2700,7 @@ class Program_weight_tensor_parameter_224:
 
 class Program_weight_tensor_parameter_225:
     name = "parameter_225"
+    original_name = "batch_norm_53.w_0"
     shape = [960]
     dtype = "float32"
     min_val = float("0.305741")
@@ -2486,6 +2712,7 @@ class Program_weight_tensor_parameter_225:
 
 class Program_weight_tensor_parameter_226:
     name = "parameter_226"
+    original_name = "batch_norm_53.w_2"
     shape = [960]
     dtype = "float32"
     min_val = float("6.48801e-43")
@@ -2497,6 +2724,7 @@ class Program_weight_tensor_parameter_226:
 
 class Program_weight_tensor_parameter_227:
     name = "parameter_227"
+    original_name = "batch_norm_53.w_1"
     shape = [960]
     dtype = "float32"
     min_val = float("-0.947507")
@@ -2508,6 +2736,7 @@ class Program_weight_tensor_parameter_227:
 
 class Program_weight_tensor_parameter_228:
     name = "parameter_228"
+    original_name = "conv2d_65.w_0"
     shape = [960, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.302757")
@@ -2519,6 +2748,7 @@ class Program_weight_tensor_parameter_228:
 
 class Program_weight_tensor_parameter_229:
     name = "parameter_229"
+    original_name = "batch_norm_52.b_0"
     shape = [960]
     dtype = "float32"
     min_val = float("-1.38545")
@@ -2530,6 +2760,7 @@ class Program_weight_tensor_parameter_229:
 
 class Program_weight_tensor_parameter_230:
     name = "parameter_230"
+    original_name = "batch_norm_52.w_0"
     shape = [960]
     dtype = "float32"
     min_val = float("0.1141")
@@ -2541,6 +2772,7 @@ class Program_weight_tensor_parameter_230:
 
 class Program_weight_tensor_parameter_231:
     name = "parameter_231"
+    original_name = "batch_norm_52.w_2"
     shape = [960]
     dtype = "float32"
     min_val = float("1.09383e-25")
@@ -2552,6 +2784,7 @@ class Program_weight_tensor_parameter_231:
 
 class Program_weight_tensor_parameter_232:
     name = "parameter_232"
+    original_name = "batch_norm_52.w_1"
     shape = [960]
     dtype = "float32"
     min_val = float("-0.776413")
@@ -2563,6 +2796,7 @@ class Program_weight_tensor_parameter_232:
 
 class Program_weight_tensor_parameter_233:
     name = "parameter_233"
+    original_name = "conv2d_64.w_0"
     shape = [960, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.436938")
@@ -2574,6 +2808,7 @@ class Program_weight_tensor_parameter_233:
 
 class Program_weight_tensor_parameter_234:
     name = "parameter_234"
+    original_name = "batch_norm_51.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-1.09452")
@@ -2585,6 +2820,7 @@ class Program_weight_tensor_parameter_234:
 
 class Program_weight_tensor_parameter_235:
     name = "parameter_235"
+    original_name = "batch_norm_51.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.329597")
@@ -2596,6 +2832,7 @@ class Program_weight_tensor_parameter_235:
 
 class Program_weight_tensor_parameter_236:
     name = "parameter_236"
+    original_name = "batch_norm_51.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("8.01497")
@@ -2607,6 +2844,7 @@ class Program_weight_tensor_parameter_236:
 
 class Program_weight_tensor_parameter_237:
     name = "parameter_237"
+    original_name = "batch_norm_51.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-25.7268")
@@ -2618,6 +2856,7 @@ class Program_weight_tensor_parameter_237:
 
 class Program_weight_tensor_parameter_238:
     name = "parameter_238"
+    original_name = "conv2d_63.w_0"
     shape = [160, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.522488")
@@ -2629,6 +2868,7 @@ class Program_weight_tensor_parameter_238:
 
 class Program_weight_tensor_parameter_239:
     name = "parameter_239"
+    original_name = "batch_norm_50.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-2.52456")
@@ -2640,6 +2880,7 @@ class Program_weight_tensor_parameter_239:
 
 class Program_weight_tensor_parameter_240:
     name = "parameter_240"
+    original_name = "batch_norm_50.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.426758")
@@ -2651,6 +2892,7 @@ class Program_weight_tensor_parameter_240:
 
 class Program_weight_tensor_parameter_241:
     name = "parameter_241"
+    original_name = "batch_norm_50.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.144449")
@@ -2662,6 +2904,7 @@ class Program_weight_tensor_parameter_241:
 
 class Program_weight_tensor_parameter_242:
     name = "parameter_242"
+    original_name = "batch_norm_50.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.661594")
@@ -2673,6 +2916,7 @@ class Program_weight_tensor_parameter_242:
 
 class Program_weight_tensor_parameter_243:
     name = "parameter_243"
+    original_name = "conv2d_62.w_0"
     shape = [160, 640, 1, 1]
     dtype = "float32"
     min_val = float("-0.399685")
@@ -2684,6 +2928,7 @@ class Program_weight_tensor_parameter_243:
 
 class Program_weight_tensor_parameter_244:
     name = "parameter_244"
+    original_name = "batch_norm_49.b_0"
     shape = [640]
     dtype = "float32"
     min_val = float("-2.9725")
@@ -2695,6 +2940,7 @@ class Program_weight_tensor_parameter_244:
 
 class Program_weight_tensor_parameter_245:
     name = "parameter_245"
+    original_name = "batch_norm_49.w_0"
     shape = [640]
     dtype = "float32"
     min_val = float("0.305936")
@@ -2706,6 +2952,7 @@ class Program_weight_tensor_parameter_245:
 
 class Program_weight_tensor_parameter_246:
     name = "parameter_246"
+    original_name = "batch_norm_49.w_2"
     shape = [640]
     dtype = "float32"
     min_val = float("0.147109")
@@ -2717,6 +2964,7 @@ class Program_weight_tensor_parameter_246:
 
 class Program_weight_tensor_parameter_247:
     name = "parameter_247"
+    original_name = "batch_norm_49.w_1"
     shape = [640]
     dtype = "float32"
     min_val = float("-0.970727")
@@ -2728,6 +2976,7 @@ class Program_weight_tensor_parameter_247:
 
 class Program_weight_tensor_parameter_248:
     name = "parameter_248"
+    original_name = "conv2d_61.w_0"
     shape = [640, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.441196")
@@ -2739,6 +2988,7 @@ class Program_weight_tensor_parameter_248:
 
 class Program_weight_tensor_parameter_249:
     name = "parameter_249"
+    original_name = "batch_norm_48.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-1.24881")
@@ -2750,6 +3000,7 @@ class Program_weight_tensor_parameter_249:
 
 class Program_weight_tensor_parameter_250:
     name = "parameter_250"
+    original_name = "batch_norm_48.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.171878")
@@ -2761,6 +3012,7 @@ class Program_weight_tensor_parameter_250:
 
 class Program_weight_tensor_parameter_251:
     name = "parameter_251"
+    original_name = "batch_norm_48.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.65286")
@@ -2772,6 +3024,7 @@ class Program_weight_tensor_parameter_251:
 
 class Program_weight_tensor_parameter_252:
     name = "parameter_252"
+    original_name = "batch_norm_48.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-10.7642")
@@ -2783,6 +3036,7 @@ class Program_weight_tensor_parameter_252:
 
 class Program_weight_tensor_parameter_253:
     name = "parameter_253"
+    original_name = "conv2d_60.w_0"
     shape = [160, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.403313")
@@ -2794,6 +3048,7 @@ class Program_weight_tensor_parameter_253:
 
 class Program_weight_tensor_parameter_254:
     name = "parameter_254"
+    original_name = "conv2d_59.w_0"
     shape = [160, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.352577")
@@ -2805,6 +3060,7 @@ class Program_weight_tensor_parameter_254:
 
 class Program_weight_tensor_parameter_255:
     name = "parameter_255"
+    original_name = "conv2d_58.w_0"
     shape = [64, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.397186")
@@ -2816,6 +3072,7 @@ class Program_weight_tensor_parameter_255:
 
 class Program_weight_tensor_parameter_256:
     name = "parameter_256"
+    original_name = "batch_norm_47.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.696428")
@@ -2827,6 +3084,7 @@ class Program_weight_tensor_parameter_256:
 
 class Program_weight_tensor_parameter_257:
     name = "parameter_257"
+    original_name = "batch_norm_47.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-2.21974")
@@ -2838,6 +3096,7 @@ class Program_weight_tensor_parameter_257:
 
 class Program_weight_tensor_parameter_258:
     name = "parameter_258"
+    original_name = "batch_norm_47.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.000107779")
@@ -2849,6 +3108,7 @@ class Program_weight_tensor_parameter_258:
 
 class Program_weight_tensor_parameter_259:
     name = "parameter_259"
+    original_name = "batch_norm_47.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.336737")
@@ -2860,6 +3120,7 @@ class Program_weight_tensor_parameter_259:
 
 class Program_weight_tensor_parameter_260:
     name = "parameter_260"
+    original_name = "conv2d_56.w_0"
     shape = [160, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.300901")
@@ -2871,6 +3132,7 @@ class Program_weight_tensor_parameter_260:
 
 class Program_weight_tensor_parameter_261:
     name = "parameter_261"
+    original_name = "conv2d_57.w_0"
     shape = [64, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.369754")
@@ -2882,6 +3144,7 @@ class Program_weight_tensor_parameter_261:
 
 class Program_weight_tensor_parameter_262:
     name = "parameter_262"
+    original_name = "batch_norm_46.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-1.35549")
@@ -2893,6 +3156,7 @@ class Program_weight_tensor_parameter_262:
 
 class Program_weight_tensor_parameter_263:
     name = "parameter_263"
+    original_name = "batch_norm_46.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-1.32573")
@@ -2904,6 +3168,7 @@ class Program_weight_tensor_parameter_263:
 
 class Program_weight_tensor_parameter_264:
     name = "parameter_264"
+    original_name = "batch_norm_46.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.000151146")
@@ -2915,6 +3180,7 @@ class Program_weight_tensor_parameter_264:
 
 class Program_weight_tensor_parameter_265:
     name = "parameter_265"
+    original_name = "batch_norm_46.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-1.31821")
@@ -2926,6 +3192,7 @@ class Program_weight_tensor_parameter_265:
 
 class Program_weight_tensor_parameter_266:
     name = "parameter_266"
+    original_name = "conv2d_55.w_0"
     shape = [160, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.320677")
@@ -2937,6 +3204,7 @@ class Program_weight_tensor_parameter_266:
 
 class Program_weight_tensor_parameter_267:
     name = "parameter_267"
+    original_name = "conv2d_54.w_0"
     shape = [256, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.370749")
@@ -2948,6 +3216,7 @@ class Program_weight_tensor_parameter_267:
 
 class Program_weight_tensor_parameter_268:
     name = "parameter_268"
+    original_name = "batch_norm_45.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-2.88871")
@@ -2959,6 +3228,7 @@ class Program_weight_tensor_parameter_268:
 
 class Program_weight_tensor_parameter_269:
     name = "parameter_269"
+    original_name = "batch_norm_45.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-1.77687")
@@ -2970,6 +3240,7 @@ class Program_weight_tensor_parameter_269:
 
 class Program_weight_tensor_parameter_270:
     name = "parameter_270"
+    original_name = "batch_norm_45.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("6.15399")
@@ -2981,6 +3252,7 @@ class Program_weight_tensor_parameter_270:
 
 class Program_weight_tensor_parameter_271:
     name = "parameter_271"
+    original_name = "batch_norm_45.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-21.8401")
@@ -2992,6 +3264,7 @@ class Program_weight_tensor_parameter_271:
 
 class Program_weight_tensor_parameter_272:
     name = "parameter_272"
+    original_name = "batch_norm_44.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-1.59732")
@@ -3003,6 +3276,7 @@ class Program_weight_tensor_parameter_272:
 
 class Program_weight_tensor_parameter_273:
     name = "parameter_273"
+    original_name = "batch_norm_44.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.0455825")
@@ -3014,6 +3288,7 @@ class Program_weight_tensor_parameter_273:
 
 class Program_weight_tensor_parameter_274:
     name = "parameter_274"
+    original_name = "batch_norm_44.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.419365")
@@ -3025,6 +3300,7 @@ class Program_weight_tensor_parameter_274:
 
 class Program_weight_tensor_parameter_275:
     name = "parameter_275"
+    original_name = "batch_norm_44.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-1.95985")
@@ -3036,6 +3312,7 @@ class Program_weight_tensor_parameter_275:
 
 class Program_weight_tensor_parameter_276:
     name = "parameter_276"
+    original_name = "conv2d_53.w_0"
     shape = [160, 640, 1, 1]
     dtype = "float32"
     min_val = float("-0.353206")
@@ -3047,6 +3324,7 @@ class Program_weight_tensor_parameter_276:
 
 class Program_weight_tensor_parameter_277:
     name = "parameter_277"
+    original_name = "batch_norm_43.b_0"
     shape = [640]
     dtype = "float32"
     min_val = float("-2.68788")
@@ -3058,6 +3336,7 @@ class Program_weight_tensor_parameter_277:
 
 class Program_weight_tensor_parameter_278:
     name = "parameter_278"
+    original_name = "batch_norm_43.w_0"
     shape = [640]
     dtype = "float32"
     min_val = float("0.114301")
@@ -3069,6 +3348,7 @@ class Program_weight_tensor_parameter_278:
 
 class Program_weight_tensor_parameter_279:
     name = "parameter_279"
+    original_name = "batch_norm_43.w_2"
     shape = [640]
     dtype = "float32"
     min_val = float("6.22177e-43")
@@ -3080,6 +3360,7 @@ class Program_weight_tensor_parameter_279:
 
 class Program_weight_tensor_parameter_280:
     name = "parameter_280"
+    original_name = "batch_norm_43.w_1"
     shape = [640]
     dtype = "float32"
     min_val = float("-0.353629")
@@ -3091,6 +3372,7 @@ class Program_weight_tensor_parameter_280:
 
 class Program_weight_tensor_parameter_281:
     name = "parameter_281"
+    original_name = "conv2d_52.w_0"
     shape = [640, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.257232")
@@ -3102,6 +3384,7 @@ class Program_weight_tensor_parameter_281:
 
 class Program_weight_tensor_parameter_282:
     name = "parameter_282"
+    original_name = "batch_norm_42.b_0"
     shape = [640]
     dtype = "float32"
     min_val = float("-1.14505")
@@ -3113,6 +3396,7 @@ class Program_weight_tensor_parameter_282:
 
 class Program_weight_tensor_parameter_283:
     name = "parameter_283"
+    original_name = "batch_norm_42.w_0"
     shape = [640]
     dtype = "float32"
     min_val = float("0.123181")
@@ -3124,6 +3408,7 @@ class Program_weight_tensor_parameter_283:
 
 class Program_weight_tensor_parameter_284:
     name = "parameter_284"
+    original_name = "batch_norm_42.w_2"
     shape = [640]
     dtype = "float32"
     min_val = float("2.0717e-26")
@@ -3135,6 +3420,7 @@ class Program_weight_tensor_parameter_284:
 
 class Program_weight_tensor_parameter_285:
     name = "parameter_285"
+    original_name = "batch_norm_42.w_1"
     shape = [640]
     dtype = "float32"
     min_val = float("-0.946539")
@@ -3146,6 +3432,7 @@ class Program_weight_tensor_parameter_285:
 
 class Program_weight_tensor_parameter_286:
     name = "parameter_286"
+    original_name = "conv2d_51.w_0"
     shape = [640, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.409706")
@@ -3157,6 +3444,7 @@ class Program_weight_tensor_parameter_286:
 
 class Program_weight_tensor_parameter_287:
     name = "parameter_287"
+    original_name = "batch_norm_41.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-1.34873")
@@ -3168,6 +3456,7 @@ class Program_weight_tensor_parameter_287:
 
 class Program_weight_tensor_parameter_288:
     name = "parameter_288"
+    original_name = "batch_norm_41.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.291359")
@@ -3179,6 +3468,7 @@ class Program_weight_tensor_parameter_288:
 
 class Program_weight_tensor_parameter_289:
     name = "parameter_289"
+    original_name = "batch_norm_41.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.0814993")
@@ -3190,6 +3480,7 @@ class Program_weight_tensor_parameter_289:
 
 class Program_weight_tensor_parameter_290:
     name = "parameter_290"
+    original_name = "batch_norm_41.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-15.1892")
@@ -3201,6 +3492,7 @@ class Program_weight_tensor_parameter_290:
 
 class Program_weight_tensor_parameter_291:
     name = "parameter_291"
+    original_name = "conv2d_50.w_0"
     shape = [160, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.423602")
@@ -3212,6 +3504,7 @@ class Program_weight_tensor_parameter_291:
 
 class Program_weight_tensor_parameter_292:
     name = "parameter_292"
+    original_name = "conv2d_49.w_0"
     shape = [160, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.339719")
@@ -3223,6 +3516,7 @@ class Program_weight_tensor_parameter_292:
 
 class Program_weight_tensor_parameter_293:
     name = "parameter_293"
+    original_name = "conv2d_48.w_0"
     shape = [64, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.420312")
@@ -3234,6 +3528,7 @@ class Program_weight_tensor_parameter_293:
 
 class Program_weight_tensor_parameter_294:
     name = "parameter_294"
+    original_name = "batch_norm_40.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.575488")
@@ -3245,6 +3540,7 @@ class Program_weight_tensor_parameter_294:
 
 class Program_weight_tensor_parameter_295:
     name = "parameter_295"
+    original_name = "batch_norm_40.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-2.01471")
@@ -3256,6 +3552,7 @@ class Program_weight_tensor_parameter_295:
 
 class Program_weight_tensor_parameter_296:
     name = "parameter_296"
+    original_name = "batch_norm_40.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.000317715")
@@ -3267,6 +3564,7 @@ class Program_weight_tensor_parameter_296:
 
 class Program_weight_tensor_parameter_297:
     name = "parameter_297"
+    original_name = "batch_norm_40.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.462244")
@@ -3278,6 +3576,7 @@ class Program_weight_tensor_parameter_297:
 
 class Program_weight_tensor_parameter_298:
     name = "parameter_298"
+    original_name = "conv2d_46.w_0"
     shape = [160, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.30264")
@@ -3289,6 +3588,7 @@ class Program_weight_tensor_parameter_298:
 
 class Program_weight_tensor_parameter_299:
     name = "parameter_299"
+    original_name = "conv2d_47.w_0"
     shape = [64, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.4118")
@@ -3300,6 +3600,7 @@ class Program_weight_tensor_parameter_299:
 
 class Program_weight_tensor_parameter_300:
     name = "parameter_300"
+    original_name = "batch_norm_39.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-1.63715")
@@ -3311,6 +3612,7 @@ class Program_weight_tensor_parameter_300:
 
 class Program_weight_tensor_parameter_301:
     name = "parameter_301"
+    original_name = "batch_norm_39.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.638255")
@@ -3322,6 +3624,7 @@ class Program_weight_tensor_parameter_301:
 
 class Program_weight_tensor_parameter_302:
     name = "parameter_302"
+    original_name = "batch_norm_39.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.000676513")
@@ -3333,6 +3636,7 @@ class Program_weight_tensor_parameter_302:
 
 class Program_weight_tensor_parameter_303:
     name = "parameter_303"
+    original_name = "batch_norm_39.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.701249")
@@ -3344,6 +3648,7 @@ class Program_weight_tensor_parameter_303:
 
 class Program_weight_tensor_parameter_304:
     name = "parameter_304"
+    original_name = "conv2d_45.w_0"
     shape = [160, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.324885")
@@ -3355,6 +3660,7 @@ class Program_weight_tensor_parameter_304:
 
 class Program_weight_tensor_parameter_305:
     name = "parameter_305"
+    original_name = "conv2d_44.w_0"
     shape = [256, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.347544")
@@ -3366,6 +3672,7 @@ class Program_weight_tensor_parameter_305:
 
 class Program_weight_tensor_parameter_306:
     name = "parameter_306"
+    original_name = "batch_norm_38.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-3.04781")
@@ -3377,6 +3684,7 @@ class Program_weight_tensor_parameter_306:
 
 class Program_weight_tensor_parameter_307:
     name = "parameter_307"
+    original_name = "batch_norm_38.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.253692")
@@ -3388,6 +3696,7 @@ class Program_weight_tensor_parameter_307:
 
 class Program_weight_tensor_parameter_308:
     name = "parameter_308"
+    original_name = "batch_norm_38.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("1.17565")
@@ -3399,6 +3708,7 @@ class Program_weight_tensor_parameter_308:
 
 class Program_weight_tensor_parameter_309:
     name = "parameter_309"
+    original_name = "batch_norm_38.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-22.8388")
@@ -3410,6 +3720,7 @@ class Program_weight_tensor_parameter_309:
 
 class Program_weight_tensor_parameter_310:
     name = "parameter_310"
+    original_name = "batch_norm_37.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-2.01756")
@@ -3421,6 +3732,7 @@ class Program_weight_tensor_parameter_310:
 
 class Program_weight_tensor_parameter_311:
     name = "parameter_311"
+    original_name = "batch_norm_37.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.0213933")
@@ -3432,6 +3744,7 @@ class Program_weight_tensor_parameter_311:
 
 class Program_weight_tensor_parameter_312:
     name = "parameter_312"
+    original_name = "batch_norm_37.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.145956")
@@ -3443,6 +3756,7 @@ class Program_weight_tensor_parameter_312:
 
 class Program_weight_tensor_parameter_313:
     name = "parameter_313"
+    original_name = "batch_norm_37.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.538253")
@@ -3454,6 +3768,7 @@ class Program_weight_tensor_parameter_313:
 
 class Program_weight_tensor_parameter_314:
     name = "parameter_314"
+    original_name = "conv2d_43.w_0"
     shape = [160, 640, 1, 1]
     dtype = "float32"
     min_val = float("-0.453174")
@@ -3465,6 +3780,7 @@ class Program_weight_tensor_parameter_314:
 
 class Program_weight_tensor_parameter_315:
     name = "parameter_315"
+    original_name = "batch_norm_36.b_0"
     shape = [640]
     dtype = "float32"
     min_val = float("-3.74682")
@@ -3476,6 +3792,7 @@ class Program_weight_tensor_parameter_315:
 
 class Program_weight_tensor_parameter_316:
     name = "parameter_316"
+    original_name = "batch_norm_36.w_0"
     shape = [640]
     dtype = "float32"
     min_val = float("0.22692")
@@ -3487,6 +3804,7 @@ class Program_weight_tensor_parameter_316:
 
 class Program_weight_tensor_parameter_317:
     name = "parameter_317"
+    original_name = "batch_norm_36.w_2"
     shape = [640]
     dtype = "float32"
     min_val = float("9.03661e-08")
@@ -3498,6 +3816,7 @@ class Program_weight_tensor_parameter_317:
 
 class Program_weight_tensor_parameter_318:
     name = "parameter_318"
+    original_name = "batch_norm_36.w_1"
     shape = [640]
     dtype = "float32"
     min_val = float("-0.849755")
@@ -3509,6 +3828,7 @@ class Program_weight_tensor_parameter_318:
 
 class Program_weight_tensor_parameter_319:
     name = "parameter_319"
+    original_name = "conv2d_42.w_0"
     shape = [640, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.60905")
@@ -3520,6 +3840,7 @@ class Program_weight_tensor_parameter_319:
 
 class Program_weight_tensor_parameter_320:
     name = "parameter_320"
+    original_name = "batch_norm_35.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-1.26323")
@@ -3531,6 +3852,7 @@ class Program_weight_tensor_parameter_320:
 
 class Program_weight_tensor_parameter_321:
     name = "parameter_321"
+    original_name = "batch_norm_35.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.0327906")
@@ -3542,6 +3864,7 @@ class Program_weight_tensor_parameter_321:
 
 class Program_weight_tensor_parameter_322:
     name = "parameter_322"
+    original_name = "batch_norm_35.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.028468")
@@ -3553,6 +3876,7 @@ class Program_weight_tensor_parameter_322:
 
 class Program_weight_tensor_parameter_323:
     name = "parameter_323"
+    original_name = "batch_norm_35.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-4.67567")
@@ -3564,6 +3888,7 @@ class Program_weight_tensor_parameter_323:
 
 class Program_weight_tensor_parameter_324:
     name = "parameter_324"
+    original_name = "conv2d_41.w_0"
     shape = [160, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.432781")
@@ -3575,6 +3900,7 @@ class Program_weight_tensor_parameter_324:
 
 class Program_weight_tensor_parameter_325:
     name = "parameter_325"
+    original_name = "conv2d_40.w_0"
     shape = [160, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.372441")
@@ -3586,6 +3912,7 @@ class Program_weight_tensor_parameter_325:
 
 class Program_weight_tensor_parameter_326:
     name = "parameter_326"
+    original_name = "conv2d_39.w_0"
     shape = [64, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.355451")
@@ -3597,6 +3924,7 @@ class Program_weight_tensor_parameter_326:
 
 class Program_weight_tensor_parameter_327:
     name = "parameter_327"
+    original_name = "batch_norm_34.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-1.08422")
@@ -3608,6 +3936,7 @@ class Program_weight_tensor_parameter_327:
 
 class Program_weight_tensor_parameter_328:
     name = "parameter_328"
+    original_name = "batch_norm_34.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.521785")
@@ -3619,6 +3948,7 @@ class Program_weight_tensor_parameter_328:
 
 class Program_weight_tensor_parameter_329:
     name = "parameter_329"
+    original_name = "batch_norm_34.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.00118857")
@@ -3630,6 +3960,7 @@ class Program_weight_tensor_parameter_329:
 
 class Program_weight_tensor_parameter_330:
     name = "parameter_330"
+    original_name = "batch_norm_34.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.915471")
@@ -3641,6 +3972,7 @@ class Program_weight_tensor_parameter_330:
 
 class Program_weight_tensor_parameter_331:
     name = "parameter_331"
+    original_name = "conv2d_37.w_0"
     shape = [160, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.322334")
@@ -3652,6 +3984,7 @@ class Program_weight_tensor_parameter_331:
 
 class Program_weight_tensor_parameter_332:
     name = "parameter_332"
+    original_name = "conv2d_38.w_0"
     shape = [64, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.346199")
@@ -3663,6 +3996,7 @@ class Program_weight_tensor_parameter_332:
 
 class Program_weight_tensor_parameter_333:
     name = "parameter_333"
+    original_name = "batch_norm_33.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-1.64151")
@@ -3674,6 +4008,7 @@ class Program_weight_tensor_parameter_333:
 
 class Program_weight_tensor_parameter_334:
     name = "parameter_334"
+    original_name = "batch_norm_33.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-1.61378")
@@ -3685,6 +4020,7 @@ class Program_weight_tensor_parameter_334:
 
 class Program_weight_tensor_parameter_335:
     name = "parameter_335"
+    original_name = "batch_norm_33.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.00203974")
@@ -3696,6 +4032,7 @@ class Program_weight_tensor_parameter_335:
 
 class Program_weight_tensor_parameter_336:
     name = "parameter_336"
+    original_name = "batch_norm_33.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.156245")
@@ -3707,6 +4044,7 @@ class Program_weight_tensor_parameter_336:
 
 class Program_weight_tensor_parameter_337:
     name = "parameter_337"
+    original_name = "conv2d_36.w_0"
     shape = [160, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.320197")
@@ -3718,6 +4056,7 @@ class Program_weight_tensor_parameter_337:
 
 class Program_weight_tensor_parameter_338:
     name = "parameter_338"
+    original_name = "conv2d_35.w_0"
     shape = [256, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.347968")
@@ -3729,6 +4068,7 @@ class Program_weight_tensor_parameter_338:
 
 class Program_weight_tensor_parameter_339:
     name = "parameter_339"
+    original_name = "batch_norm_32.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-4.0167")
@@ -3740,6 +4080,7 @@ class Program_weight_tensor_parameter_339:
 
 class Program_weight_tensor_parameter_340:
     name = "parameter_340"
+    original_name = "batch_norm_32.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.0216524")
@@ -3751,6 +4092,7 @@ class Program_weight_tensor_parameter_340:
 
 class Program_weight_tensor_parameter_341:
     name = "parameter_341"
+    original_name = "batch_norm_32.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.872134")
@@ -3762,6 +4104,7 @@ class Program_weight_tensor_parameter_341:
 
 class Program_weight_tensor_parameter_342:
     name = "parameter_342"
+    original_name = "batch_norm_32.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-19.2529")
@@ -3773,6 +4116,7 @@ class Program_weight_tensor_parameter_342:
 
 class Program_weight_tensor_parameter_343:
     name = "parameter_343"
+    original_name = "batch_norm_31.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-1.63132")
@@ -3784,6 +4128,7 @@ class Program_weight_tensor_parameter_343:
 
 class Program_weight_tensor_parameter_344:
     name = "parameter_344"
+    original_name = "batch_norm_31.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.0587486")
@@ -3795,6 +4140,7 @@ class Program_weight_tensor_parameter_344:
 
 class Program_weight_tensor_parameter_345:
     name = "parameter_345"
+    original_name = "batch_norm_31.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.442284")
@@ -3806,6 +4152,7 @@ class Program_weight_tensor_parameter_345:
 
 class Program_weight_tensor_parameter_346:
     name = "parameter_346"
+    original_name = "batch_norm_31.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-1.49187")
@@ -3817,6 +4164,7 @@ class Program_weight_tensor_parameter_346:
 
 class Program_weight_tensor_parameter_347:
     name = "parameter_347"
+    original_name = "conv2d_34.w_0"
     shape = [160, 640, 1, 1]
     dtype = "float32"
     min_val = float("-0.361866")
@@ -3828,6 +4176,7 @@ class Program_weight_tensor_parameter_347:
 
 class Program_weight_tensor_parameter_348:
     name = "parameter_348"
+    original_name = "batch_norm_30.b_0"
     shape = [640]
     dtype = "float32"
     min_val = float("-3.32935")
@@ -3839,6 +4188,7 @@ class Program_weight_tensor_parameter_348:
 
 class Program_weight_tensor_parameter_349:
     name = "parameter_349"
+    original_name = "batch_norm_30.w_0"
     shape = [640]
     dtype = "float32"
     min_val = float("0.145414")
@@ -3850,6 +4200,7 @@ class Program_weight_tensor_parameter_349:
 
 class Program_weight_tensor_parameter_350:
     name = "parameter_350"
+    original_name = "batch_norm_30.w_2"
     shape = [640]
     dtype = "float32"
     min_val = float("7.21669e-43")
@@ -3861,6 +4212,7 @@ class Program_weight_tensor_parameter_350:
 
 class Program_weight_tensor_parameter_351:
     name = "parameter_351"
+    original_name = "batch_norm_30.w_1"
     shape = [640]
     dtype = "float32"
     min_val = float("-0.49827")
@@ -3872,6 +4224,7 @@ class Program_weight_tensor_parameter_351:
 
 class Program_weight_tensor_parameter_352:
     name = "parameter_352"
+    original_name = "conv2d_33.w_0"
     shape = [640, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.30283")
@@ -3883,6 +4236,7 @@ class Program_weight_tensor_parameter_352:
 
 class Program_weight_tensor_parameter_353:
     name = "parameter_353"
+    original_name = "batch_norm_29.b_0"
     shape = [640]
     dtype = "float32"
     min_val = float("-1.38184")
@@ -3894,6 +4248,7 @@ class Program_weight_tensor_parameter_353:
 
 class Program_weight_tensor_parameter_354:
     name = "parameter_354"
+    original_name = "batch_norm_29.w_0"
     shape = [640]
     dtype = "float32"
     min_val = float("0.160277")
@@ -3905,6 +4260,7 @@ class Program_weight_tensor_parameter_354:
 
 class Program_weight_tensor_parameter_355:
     name = "parameter_355"
+    original_name = "batch_norm_29.w_2"
     shape = [640]
     dtype = "float32"
     min_val = float("3.53449e-26")
@@ -3916,6 +4272,7 @@ class Program_weight_tensor_parameter_355:
 
 class Program_weight_tensor_parameter_356:
     name = "parameter_356"
+    original_name = "batch_norm_29.w_1"
     shape = [640]
     dtype = "float32"
     min_val = float("-1.04305")
@@ -3927,6 +4284,7 @@ class Program_weight_tensor_parameter_356:
 
 class Program_weight_tensor_parameter_357:
     name = "parameter_357"
+    original_name = "conv2d_32.w_0"
     shape = [640, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.344982")
@@ -3938,6 +4296,7 @@ class Program_weight_tensor_parameter_357:
 
 class Program_weight_tensor_parameter_358:
     name = "parameter_358"
+    original_name = "batch_norm_28.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-1.39259")
@@ -3949,6 +4308,7 @@ class Program_weight_tensor_parameter_358:
 
 class Program_weight_tensor_parameter_359:
     name = "parameter_359"
+    original_name = "batch_norm_28.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.0654333")
@@ -3960,6 +4320,7 @@ class Program_weight_tensor_parameter_359:
 
 class Program_weight_tensor_parameter_360:
     name = "parameter_360"
+    original_name = "batch_norm_28.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.0830431")
@@ -3971,6 +4332,7 @@ class Program_weight_tensor_parameter_360:
 
 class Program_weight_tensor_parameter_361:
     name = "parameter_361"
+    original_name = "batch_norm_28.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-6.46719")
@@ -3982,6 +4344,7 @@ class Program_weight_tensor_parameter_361:
 
 class Program_weight_tensor_parameter_362:
     name = "parameter_362"
+    original_name = "conv2d_31.w_0"
     shape = [160, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.431742")
@@ -3993,6 +4356,7 @@ class Program_weight_tensor_parameter_362:
 
 class Program_weight_tensor_parameter_363:
     name = "parameter_363"
+    original_name = "conv2d_30.w_0"
     shape = [160, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.378248")
@@ -4004,6 +4368,7 @@ class Program_weight_tensor_parameter_363:
 
 class Program_weight_tensor_parameter_364:
     name = "parameter_364"
+    original_name = "conv2d_29.w_0"
     shape = [64, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.379858")
@@ -4015,6 +4380,7 @@ class Program_weight_tensor_parameter_364:
 
 class Program_weight_tensor_parameter_365:
     name = "parameter_365"
+    original_name = "batch_norm_27.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.898663")
@@ -4026,6 +4392,7 @@ class Program_weight_tensor_parameter_365:
 
 class Program_weight_tensor_parameter_366:
     name = "parameter_366"
+    original_name = "batch_norm_27.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-1.24638")
@@ -4037,6 +4404,7 @@ class Program_weight_tensor_parameter_366:
 
 class Program_weight_tensor_parameter_367:
     name = "parameter_367"
+    original_name = "batch_norm_27.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("3.09401e-05")
@@ -4048,6 +4416,7 @@ class Program_weight_tensor_parameter_367:
 
 class Program_weight_tensor_parameter_368:
     name = "parameter_368"
+    original_name = "batch_norm_27.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.75771")
@@ -4059,6 +4428,7 @@ class Program_weight_tensor_parameter_368:
 
 class Program_weight_tensor_parameter_369:
     name = "parameter_369"
+    original_name = "conv2d_27.w_0"
     shape = [160, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.313703")
@@ -4070,6 +4440,7 @@ class Program_weight_tensor_parameter_369:
 
 class Program_weight_tensor_parameter_370:
     name = "parameter_370"
+    original_name = "conv2d_28.w_0"
     shape = [64, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.365041")
@@ -4081,6 +4452,7 @@ class Program_weight_tensor_parameter_370:
 
 class Program_weight_tensor_parameter_371:
     name = "parameter_371"
+    original_name = "batch_norm_26.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-1.36956")
@@ -4092,6 +4464,7 @@ class Program_weight_tensor_parameter_371:
 
 class Program_weight_tensor_parameter_372:
     name = "parameter_372"
+    original_name = "batch_norm_26.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-1.61019")
@@ -4103,6 +4476,7 @@ class Program_weight_tensor_parameter_372:
 
 class Program_weight_tensor_parameter_373:
     name = "parameter_373"
+    original_name = "batch_norm_26.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("4.40987e-05")
@@ -4114,6 +4488,7 @@ class Program_weight_tensor_parameter_373:
 
 class Program_weight_tensor_parameter_374:
     name = "parameter_374"
+    original_name = "batch_norm_26.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.643971")
@@ -4125,6 +4500,7 @@ class Program_weight_tensor_parameter_374:
 
 class Program_weight_tensor_parameter_375:
     name = "parameter_375"
+    original_name = "conv2d_26.w_0"
     shape = [160, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.278009")
@@ -4136,6 +4512,7 @@ class Program_weight_tensor_parameter_375:
 
 class Program_weight_tensor_parameter_376:
     name = "parameter_376"
+    original_name = "conv2d_25.w_0"
     shape = [256, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.348846")
@@ -4147,6 +4524,7 @@ class Program_weight_tensor_parameter_376:
 
 class Program_weight_tensor_parameter_377:
     name = "parameter_377"
+    original_name = "batch_norm_25.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-2.85089")
@@ -4158,6 +4536,7 @@ class Program_weight_tensor_parameter_377:
 
 class Program_weight_tensor_parameter_378:
     name = "parameter_378"
+    original_name = "batch_norm_25.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.790186")
@@ -4169,6 +4548,7 @@ class Program_weight_tensor_parameter_378:
 
 class Program_weight_tensor_parameter_379:
     name = "parameter_379"
+    original_name = "batch_norm_25.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.00326161")
@@ -4180,6 +4560,7 @@ class Program_weight_tensor_parameter_379:
 
 class Program_weight_tensor_parameter_380:
     name = "parameter_380"
+    original_name = "batch_norm_25.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-1.0015")
@@ -4191,6 +4572,7 @@ class Program_weight_tensor_parameter_380:
 
 class Program_weight_tensor_parameter_381:
     name = "parameter_381"
+    original_name = "batch_norm_24.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-1.96122")
@@ -4202,6 +4584,7 @@ class Program_weight_tensor_parameter_381:
 
 class Program_weight_tensor_parameter_382:
     name = "parameter_382"
+    original_name = "batch_norm_24.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.0816593")
@@ -4213,6 +4596,7 @@ class Program_weight_tensor_parameter_382:
 
 class Program_weight_tensor_parameter_383:
     name = "parameter_383"
+    original_name = "batch_norm_24.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.44683")
@@ -4224,6 +4608,7 @@ class Program_weight_tensor_parameter_383:
 
 class Program_weight_tensor_parameter_384:
     name = "parameter_384"
+    original_name = "batch_norm_24.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-1.33542")
@@ -4235,6 +4620,7 @@ class Program_weight_tensor_parameter_384:
 
 class Program_weight_tensor_parameter_385:
     name = "parameter_385"
+    original_name = "conv2d_24.w_0"
     shape = [160, 640, 1, 1]
     dtype = "float32"
     min_val = float("-0.383852")
@@ -4246,6 +4632,7 @@ class Program_weight_tensor_parameter_385:
 
 class Program_weight_tensor_parameter_386:
     name = "parameter_386"
+    original_name = "batch_norm_23.b_0"
     shape = [640]
     dtype = "float32"
     min_val = float("-4.34182")
@@ -4257,6 +4644,7 @@ class Program_weight_tensor_parameter_386:
 
 class Program_weight_tensor_parameter_387:
     name = "parameter_387"
+    original_name = "batch_norm_23.w_0"
     shape = [640]
     dtype = "float32"
     min_val = float("0.125845")
@@ -4268,6 +4656,7 @@ class Program_weight_tensor_parameter_387:
 
 class Program_weight_tensor_parameter_388:
     name = "parameter_388"
+    original_name = "batch_norm_23.w_2"
     shape = [640]
     dtype = "float32"
     min_val = float("5.75934e-43")
@@ -4279,6 +4668,7 @@ class Program_weight_tensor_parameter_388:
 
 class Program_weight_tensor_parameter_389:
     name = "parameter_389"
+    original_name = "batch_norm_23.w_1"
     shape = [640]
     dtype = "float32"
     min_val = float("-0.942875")
@@ -4290,6 +4680,7 @@ class Program_weight_tensor_parameter_389:
 
 class Program_weight_tensor_parameter_390:
     name = "parameter_390"
+    original_name = "conv2d_23.w_0"
     shape = [640, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.338868")
@@ -4301,6 +4692,7 @@ class Program_weight_tensor_parameter_390:
 
 class Program_weight_tensor_parameter_391:
     name = "parameter_391"
+    original_name = "batch_norm_22.b_0"
     shape = [640]
     dtype = "float32"
     min_val = float("-1.15046")
@@ -4312,6 +4704,7 @@ class Program_weight_tensor_parameter_391:
 
 class Program_weight_tensor_parameter_392:
     name = "parameter_392"
+    original_name = "batch_norm_22.w_0"
     shape = [640]
     dtype = "float32"
     min_val = float("0.137722")
@@ -4323,6 +4716,7 @@ class Program_weight_tensor_parameter_392:
 
 class Program_weight_tensor_parameter_393:
     name = "parameter_393"
+    original_name = "batch_norm_22.w_2"
     shape = [640]
     dtype = "float32"
     min_val = float("9.05038e-27")
@@ -4334,6 +4728,7 @@ class Program_weight_tensor_parameter_393:
 
 class Program_weight_tensor_parameter_394:
     name = "parameter_394"
+    original_name = "batch_norm_22.w_1"
     shape = [640]
     dtype = "float32"
     min_val = float("-0.88565")
@@ -4345,6 +4740,7 @@ class Program_weight_tensor_parameter_394:
 
 class Program_weight_tensor_parameter_395:
     name = "parameter_395"
+    original_name = "conv2d_22.w_0"
     shape = [640, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.425192")
@@ -4356,6 +4752,7 @@ class Program_weight_tensor_parameter_395:
 
 class Program_weight_tensor_parameter_396:
     name = "parameter_396"
+    original_name = "batch_norm_21.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-1.33314")
@@ -4367,6 +4764,7 @@ class Program_weight_tensor_parameter_396:
 
 class Program_weight_tensor_parameter_397:
     name = "parameter_397"
+    original_name = "batch_norm_21.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.236549")
@@ -4378,6 +4776,7 @@ class Program_weight_tensor_parameter_397:
 
 class Program_weight_tensor_parameter_398:
     name = "parameter_398"
+    original_name = "batch_norm_21.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("4.0206e-05")
@@ -4389,6 +4788,7 @@ class Program_weight_tensor_parameter_398:
 
 class Program_weight_tensor_parameter_399:
     name = "parameter_399"
+    original_name = "batch_norm_21.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.468456")
@@ -4400,6 +4800,7 @@ class Program_weight_tensor_parameter_399:
 
 class Program_weight_tensor_parameter_400:
     name = "parameter_400"
+    original_name = "conv2d_21.w_0"
     shape = [160, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.386278")
@@ -4411,6 +4812,7 @@ class Program_weight_tensor_parameter_400:
 
 class Program_weight_tensor_parameter_401:
     name = "parameter_401"
+    original_name = "batch_norm_20.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-1.26748")
@@ -4422,6 +4824,7 @@ class Program_weight_tensor_parameter_401:
 
 class Program_weight_tensor_parameter_402:
     name = "parameter_402"
+    original_name = "batch_norm_20.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.131969")
@@ -4433,6 +4836,7 @@ class Program_weight_tensor_parameter_402:
 
 class Program_weight_tensor_parameter_403:
     name = "parameter_403"
+    original_name = "batch_norm_20.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.600136")
@@ -4444,6 +4848,7 @@ class Program_weight_tensor_parameter_403:
 
 class Program_weight_tensor_parameter_404:
     name = "parameter_404"
+    original_name = "batch_norm_20.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-1.24065")
@@ -4455,6 +4860,7 @@ class Program_weight_tensor_parameter_404:
 
 class Program_weight_tensor_parameter_405:
     name = "parameter_405"
+    original_name = "conv2d_20.w_0"
     shape = [160, 640, 1, 1]
     dtype = "float32"
     min_val = float("-0.496751")
@@ -4466,6 +4872,7 @@ class Program_weight_tensor_parameter_405:
 
 class Program_weight_tensor_parameter_406:
     name = "parameter_406"
+    original_name = "batch_norm_19.b_0"
     shape = [640]
     dtype = "float32"
     min_val = float("-3.3716")
@@ -4477,6 +4884,7 @@ class Program_weight_tensor_parameter_406:
 
 class Program_weight_tensor_parameter_407:
     name = "parameter_407"
+    original_name = "batch_norm_19.w_0"
     shape = [640]
     dtype = "float32"
     min_val = float("0.19459")
@@ -4488,6 +4896,7 @@ class Program_weight_tensor_parameter_407:
 
 class Program_weight_tensor_parameter_408:
     name = "parameter_408"
+    original_name = "batch_norm_19.w_2"
     shape = [640]
     dtype = "float32"
     min_val = float("6.23578e-43")
@@ -4499,6 +4908,7 @@ class Program_weight_tensor_parameter_408:
 
 class Program_weight_tensor_parameter_409:
     name = "parameter_409"
+    original_name = "batch_norm_19.w_1"
     shape = [640]
     dtype = "float32"
     min_val = float("-0.418662")
@@ -4510,6 +4920,7 @@ class Program_weight_tensor_parameter_409:
 
 class Program_weight_tensor_parameter_410:
     name = "parameter_410"
+    original_name = "conv2d_19.w_0"
     shape = [640, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.32203")
@@ -4521,6 +4932,7 @@ class Program_weight_tensor_parameter_410:
 
 class Program_weight_tensor_parameter_411:
     name = "parameter_411"
+    original_name = "batch_norm_18.b_0"
     shape = [640]
     dtype = "float32"
     min_val = float("-1.11832")
@@ -4532,6 +4944,7 @@ class Program_weight_tensor_parameter_411:
 
 class Program_weight_tensor_parameter_412:
     name = "parameter_412"
+    original_name = "batch_norm_18.w_0"
     shape = [640]
     dtype = "float32"
     min_val = float("-0.0124616")
@@ -4543,6 +4956,7 @@ class Program_weight_tensor_parameter_412:
 
 class Program_weight_tensor_parameter_413:
     name = "parameter_413"
+    original_name = "batch_norm_18.w_2"
     shape = [640]
     dtype = "float32"
     min_val = float("8.22979e-27")
@@ -4554,6 +4968,7 @@ class Program_weight_tensor_parameter_413:
 
 class Program_weight_tensor_parameter_414:
     name = "parameter_414"
+    original_name = "batch_norm_18.w_1"
     shape = [640]
     dtype = "float32"
     min_val = float("-0.838013")
@@ -4565,6 +4980,7 @@ class Program_weight_tensor_parameter_414:
 
 class Program_weight_tensor_parameter_415:
     name = "parameter_415"
+    original_name = "conv2d_18.w_0"
     shape = [640, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.347318")
@@ -4576,6 +4992,7 @@ class Program_weight_tensor_parameter_415:
 
 class Program_weight_tensor_parameter_416:
     name = "parameter_416"
+    original_name = "batch_norm_17.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-1.18837")
@@ -4587,6 +5004,7 @@ class Program_weight_tensor_parameter_416:
 
 class Program_weight_tensor_parameter_417:
     name = "parameter_417"
+    original_name = "batch_norm_17.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.243216")
@@ -4598,6 +5016,7 @@ class Program_weight_tensor_parameter_417:
 
 class Program_weight_tensor_parameter_418:
     name = "parameter_418"
+    original_name = "batch_norm_17.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("2.04448e-06")
@@ -4609,6 +5028,7 @@ class Program_weight_tensor_parameter_418:
 
 class Program_weight_tensor_parameter_419:
     name = "parameter_419"
+    original_name = "batch_norm_17.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.700448")
@@ -4620,6 +5040,7 @@ class Program_weight_tensor_parameter_419:
 
 class Program_weight_tensor_parameter_420:
     name = "parameter_420"
+    original_name = "conv2d_17.w_0"
     shape = [160, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.450486")
@@ -4631,6 +5052,7 @@ class Program_weight_tensor_parameter_420:
 
 class Program_weight_tensor_parameter_421:
     name = "parameter_421"
+    original_name = "batch_norm_16.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.612576")
@@ -4642,6 +5064,7 @@ class Program_weight_tensor_parameter_421:
 
 class Program_weight_tensor_parameter_422:
     name = "parameter_422"
+    original_name = "batch_norm_16.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.707977")
@@ -4653,6 +5076,7 @@ class Program_weight_tensor_parameter_422:
 
 class Program_weight_tensor_parameter_423:
     name = "parameter_423"
+    original_name = "batch_norm_16.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.122628")
@@ -4664,6 +5088,7 @@ class Program_weight_tensor_parameter_423:
 
 class Program_weight_tensor_parameter_424:
     name = "parameter_424"
+    original_name = "batch_norm_16.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.35571")
@@ -4675,6 +5100,7 @@ class Program_weight_tensor_parameter_424:
 
 class Program_weight_tensor_parameter_425:
     name = "parameter_425"
+    original_name = "conv2d_16.w_0"
     shape = [160, 320, 1, 1]
     dtype = "float32"
     min_val = float("-0.363628")
@@ -4686,6 +5112,7 @@ class Program_weight_tensor_parameter_425:
 
 class Program_weight_tensor_parameter_426:
     name = "parameter_426"
+    original_name = "batch_norm_15.b_0"
     shape = [320]
     dtype = "float32"
     min_val = float("-2.81637")
@@ -4697,6 +5124,7 @@ class Program_weight_tensor_parameter_426:
 
 class Program_weight_tensor_parameter_427:
     name = "parameter_427"
+    original_name = "batch_norm_15.w_0"
     shape = [320]
     dtype = "float32"
     min_val = float("0.342459")
@@ -4708,6 +5136,7 @@ class Program_weight_tensor_parameter_427:
 
 class Program_weight_tensor_parameter_428:
     name = "parameter_428"
+    original_name = "batch_norm_15.w_2"
     shape = [320]
     dtype = "float32"
     min_val = float("0.273675")
@@ -4719,6 +5148,7 @@ class Program_weight_tensor_parameter_428:
 
 class Program_weight_tensor_parameter_429:
     name = "parameter_429"
+    original_name = "batch_norm_15.w_1"
     shape = [320]
     dtype = "float32"
     min_val = float("-0.651072")
@@ -4730,6 +5160,7 @@ class Program_weight_tensor_parameter_429:
 
 class Program_weight_tensor_parameter_430:
     name = "parameter_430"
+    original_name = "conv2d_15.w_0"
     shape = [320, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.449129")
@@ -4741,6 +5172,7 @@ class Program_weight_tensor_parameter_430:
 
 class Program_weight_tensor_parameter_431:
     name = "parameter_431"
+    original_name = "batch_norm_14.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-2.65917")
@@ -4752,6 +5184,7 @@ class Program_weight_tensor_parameter_431:
 
 class Program_weight_tensor_parameter_432:
     name = "parameter_432"
+    original_name = "batch_norm_14.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.0694491")
@@ -4763,6 +5196,7 @@ class Program_weight_tensor_parameter_432:
 
 class Program_weight_tensor_parameter_433:
     name = "parameter_433"
+    original_name = "batch_norm_14.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("1.26893")
@@ -4774,6 +5208,7 @@ class Program_weight_tensor_parameter_433:
 
 class Program_weight_tensor_parameter_434:
     name = "parameter_434"
+    original_name = "batch_norm_14.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-3.76184")
@@ -4785,6 +5220,7 @@ class Program_weight_tensor_parameter_434:
 
 class Program_weight_tensor_parameter_435:
     name = "parameter_435"
+    original_name = "conv2d_14.w_0"
     shape = [160, 480, 1, 1]
     dtype = "float32"
     min_val = float("-0.416282")
@@ -4796,6 +5232,7 @@ class Program_weight_tensor_parameter_435:
 
 class Program_weight_tensor_parameter_436:
     name = "parameter_436"
+    original_name = "batch_norm_13.b_0"
     shape = [480]
     dtype = "float32"
     min_val = float("-1.10248")
@@ -4807,6 +5244,7 @@ class Program_weight_tensor_parameter_436:
 
 class Program_weight_tensor_parameter_437:
     name = "parameter_437"
+    original_name = "batch_norm_13.w_0"
     shape = [480]
     dtype = "float32"
     min_val = float("0.22788")
@@ -4818,6 +5256,7 @@ class Program_weight_tensor_parameter_437:
 
 class Program_weight_tensor_parameter_438:
     name = "parameter_438"
+    original_name = "batch_norm_13.w_2"
     shape = [480]
     dtype = "float32"
     min_val = float("1.77589e-05")
@@ -4829,6 +5268,7 @@ class Program_weight_tensor_parameter_438:
 
 class Program_weight_tensor_parameter_439:
     name = "parameter_439"
+    original_name = "batch_norm_13.w_1"
     shape = [480]
     dtype = "float32"
     min_val = float("-1.35637")
@@ -4840,6 +5280,7 @@ class Program_weight_tensor_parameter_439:
 
 class Program_weight_tensor_parameter_440:
     name = "parameter_440"
+    original_name = "conv2d_13.w_0"
     shape = [480, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.336938")
@@ -4851,6 +5292,7 @@ class Program_weight_tensor_parameter_440:
 
 class Program_weight_tensor_parameter_441:
     name = "parameter_441"
+    original_name = "batch_norm_12.b_0"
     shape = [480]
     dtype = "float32"
     min_val = float("-1.05142")
@@ -4862,6 +5304,7 @@ class Program_weight_tensor_parameter_441:
 
 class Program_weight_tensor_parameter_442:
     name = "parameter_442"
+    original_name = "batch_norm_12.w_0"
     shape = [480]
     dtype = "float32"
     min_val = float("0.0750992")
@@ -4873,6 +5316,7 @@ class Program_weight_tensor_parameter_442:
 
 class Program_weight_tensor_parameter_443:
     name = "parameter_443"
+    original_name = "batch_norm_12.w_2"
     shape = [480]
     dtype = "float32"
     min_val = float("0.218594")
@@ -4884,6 +5328,7 @@ class Program_weight_tensor_parameter_443:
 
 class Program_weight_tensor_parameter_444:
     name = "parameter_444"
+    original_name = "batch_norm_12.w_1"
     shape = [480]
     dtype = "float32"
     min_val = float("-0.727059")
@@ -4895,6 +5340,7 @@ class Program_weight_tensor_parameter_444:
 
 class Program_weight_tensor_parameter_445:
     name = "parameter_445"
+    original_name = "conv2d_12.w_0"
     shape = [480, 80, 1, 1]
     dtype = "float32"
     min_val = float("-0.442088")
@@ -4906,6 +5352,7 @@ class Program_weight_tensor_parameter_445:
 
 class Program_weight_tensor_parameter_446:
     name = "parameter_446"
+    original_name = "batch_norm_11.b_0"
     shape = [80]
     dtype = "float32"
     min_val = float("-1.33769")
@@ -4917,6 +5364,7 @@ class Program_weight_tensor_parameter_446:
 
 class Program_weight_tensor_parameter_447:
     name = "parameter_447"
+    original_name = "batch_norm_11.w_0"
     shape = [80]
     dtype = "float32"
     min_val = float("0.398649")
@@ -4928,6 +5376,7 @@ class Program_weight_tensor_parameter_447:
 
 class Program_weight_tensor_parameter_448:
     name = "parameter_448"
+    original_name = "batch_norm_11.w_2"
     shape = [80]
     dtype = "float32"
     min_val = float("0.00759468")
@@ -4939,6 +5388,7 @@ class Program_weight_tensor_parameter_448:
 
 class Program_weight_tensor_parameter_449:
     name = "parameter_449"
+    original_name = "batch_norm_11.w_1"
     shape = [80]
     dtype = "float32"
     min_val = float("-0.593186")
@@ -4950,6 +5400,7 @@ class Program_weight_tensor_parameter_449:
 
 class Program_weight_tensor_parameter_450:
     name = "parameter_450"
+    original_name = "conv2d_11.w_0"
     shape = [80, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.263257")
@@ -4961,6 +5412,7 @@ class Program_weight_tensor_parameter_450:
 
 class Program_weight_tensor_parameter_451:
     name = "parameter_451"
+    original_name = "batch_norm_10.b_0"
     shape = [80]
     dtype = "float32"
     min_val = float("-1.54472")
@@ -4972,6 +5424,7 @@ class Program_weight_tensor_parameter_451:
 
 class Program_weight_tensor_parameter_452:
     name = "parameter_452"
+    original_name = "batch_norm_10.w_0"
     shape = [80]
     dtype = "float32"
     min_val = float("-0.0344433")
@@ -4983,6 +5436,7 @@ class Program_weight_tensor_parameter_452:
 
 class Program_weight_tensor_parameter_453:
     name = "parameter_453"
+    original_name = "batch_norm_10.w_2"
     shape = [80]
     dtype = "float32"
     min_val = float("0.181101")
@@ -4994,6 +5448,7 @@ class Program_weight_tensor_parameter_453:
 
 class Program_weight_tensor_parameter_454:
     name = "parameter_454"
+    original_name = "batch_norm_10.w_1"
     shape = [80]
     dtype = "float32"
     min_val = float("-1.54011")
@@ -5005,6 +5460,7 @@ class Program_weight_tensor_parameter_454:
 
 class Program_weight_tensor_parameter_455:
     name = "parameter_455"
+    original_name = "conv2d_10.w_0"
     shape = [80, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.316365")
@@ -5016,6 +5472,7 @@ class Program_weight_tensor_parameter_455:
 
 class Program_weight_tensor_parameter_456:
     name = "parameter_456"
+    original_name = "batch_norm_9.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-3.0971")
@@ -5027,6 +5484,7 @@ class Program_weight_tensor_parameter_456:
 
 class Program_weight_tensor_parameter_457:
     name = "parameter_457"
+    original_name = "batch_norm_9.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.178138")
@@ -5038,6 +5496,7 @@ class Program_weight_tensor_parameter_457:
 
 class Program_weight_tensor_parameter_458:
     name = "parameter_458"
+    original_name = "batch_norm_9.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.00011398")
@@ -5049,6 +5508,7 @@ class Program_weight_tensor_parameter_458:
 
 class Program_weight_tensor_parameter_459:
     name = "parameter_459"
+    original_name = "batch_norm_9.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.444")
@@ -5060,6 +5520,7 @@ class Program_weight_tensor_parameter_459:
 
 class Program_weight_tensor_parameter_460:
     name = "parameter_460"
+    original_name = "conv2d_9.w_0"
     shape = [160, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.345514")
@@ -5071,6 +5532,7 @@ class Program_weight_tensor_parameter_460:
 
 class Program_weight_tensor_parameter_461:
     name = "parameter_461"
+    original_name = "batch_norm_8.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.95199")
@@ -5082,6 +5544,7 @@ class Program_weight_tensor_parameter_461:
 
 class Program_weight_tensor_parameter_462:
     name = "parameter_462"
+    original_name = "batch_norm_8.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.231542")
@@ -5093,6 +5556,7 @@ class Program_weight_tensor_parameter_462:
 
 class Program_weight_tensor_parameter_463:
     name = "parameter_463"
+    original_name = "batch_norm_8.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.218408")
@@ -5104,6 +5568,7 @@ class Program_weight_tensor_parameter_463:
 
 class Program_weight_tensor_parameter_464:
     name = "parameter_464"
+    original_name = "batch_norm_8.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.581288")
@@ -5115,6 +5580,7 @@ class Program_weight_tensor_parameter_464:
 
 class Program_weight_tensor_parameter_465:
     name = "parameter_465"
+    original_name = "conv2d_8.w_0"
     shape = [160, 80, 1, 1]
     dtype = "float32"
     min_val = float("-0.358905")
@@ -5126,6 +5592,7 @@ class Program_weight_tensor_parameter_465:
 
 class Program_weight_tensor_parameter_466:
     name = "parameter_466"
+    original_name = "batch_norm_7.b_0"
     shape = [80]
     dtype = "float32"
     min_val = float("-1.34949")
@@ -5137,6 +5604,7 @@ class Program_weight_tensor_parameter_466:
 
 class Program_weight_tensor_parameter_467:
     name = "parameter_467"
+    original_name = "batch_norm_7.w_0"
     shape = [80]
     dtype = "float32"
     min_val = float("-0.210599")
@@ -5148,6 +5616,7 @@ class Program_weight_tensor_parameter_467:
 
 class Program_weight_tensor_parameter_468:
     name = "parameter_468"
+    original_name = "batch_norm_7.w_2"
     shape = [80]
     dtype = "float32"
     min_val = float("0.000255494")
@@ -5159,6 +5628,7 @@ class Program_weight_tensor_parameter_468:
 
 class Program_weight_tensor_parameter_469:
     name = "parameter_469"
+    original_name = "batch_norm_7.w_1"
     shape = [80]
     dtype = "float32"
     min_val = float("-0.346022")
@@ -5170,6 +5640,7 @@ class Program_weight_tensor_parameter_469:
 
 class Program_weight_tensor_parameter_470:
     name = "parameter_470"
+    original_name = "conv2d_7.w_0"
     shape = [80, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.314785")
@@ -5181,6 +5652,7 @@ class Program_weight_tensor_parameter_470:
 
 class Program_weight_tensor_parameter_471:
     name = "parameter_471"
+    original_name = "batch_norm_6.b_0"
     shape = [80]
     dtype = "float32"
     min_val = float("-2.50409")
@@ -5192,6 +5664,7 @@ class Program_weight_tensor_parameter_471:
 
 class Program_weight_tensor_parameter_472:
     name = "parameter_472"
+    original_name = "batch_norm_6.w_0"
     shape = [80]
     dtype = "float32"
     min_val = float("0.41998")
@@ -5203,6 +5676,7 @@ class Program_weight_tensor_parameter_472:
 
 class Program_weight_tensor_parameter_473:
     name = "parameter_473"
+    original_name = "batch_norm_6.w_2"
     shape = [80]
     dtype = "float32"
     min_val = float("0.377263")
@@ -5214,6 +5688,7 @@ class Program_weight_tensor_parameter_473:
 
 class Program_weight_tensor_parameter_474:
     name = "parameter_474"
+    original_name = "batch_norm_6.w_1"
     shape = [80]
     dtype = "float32"
     min_val = float("-2.89255")
@@ -5225,6 +5700,7 @@ class Program_weight_tensor_parameter_474:
 
 class Program_weight_tensor_parameter_475:
     name = "parameter_475"
+    original_name = "conv2d_6.w_0"
     shape = [80, 192, 1, 1]
     dtype = "float32"
     min_val = float("-0.368453")
@@ -5236,6 +5712,7 @@ class Program_weight_tensor_parameter_475:
 
 class Program_weight_tensor_parameter_476:
     name = "parameter_476"
+    original_name = "batch_norm_5.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.574554")
@@ -5247,6 +5724,7 @@ class Program_weight_tensor_parameter_476:
 
 class Program_weight_tensor_parameter_477:
     name = "parameter_477"
+    original_name = "batch_norm_5.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("0.271042")
@@ -5258,6 +5736,7 @@ class Program_weight_tensor_parameter_477:
 
 class Program_weight_tensor_parameter_478:
     name = "parameter_478"
+    original_name = "batch_norm_5.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("0.00116341")
@@ -5269,6 +5748,7 @@ class Program_weight_tensor_parameter_478:
 
 class Program_weight_tensor_parameter_479:
     name = "parameter_479"
+    original_name = "batch_norm_5.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-1.03425")
@@ -5280,6 +5760,7 @@ class Program_weight_tensor_parameter_479:
 
 class Program_weight_tensor_parameter_480:
     name = "parameter_480"
+    original_name = "conv2d_5.w_0"
     shape = [192, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.318277")
@@ -5291,6 +5772,7 @@ class Program_weight_tensor_parameter_480:
 
 class Program_weight_tensor_parameter_481:
     name = "parameter_481"
+    original_name = "batch_norm_4.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.98538")
@@ -5302,6 +5784,7 @@ class Program_weight_tensor_parameter_481:
 
 class Program_weight_tensor_parameter_482:
     name = "parameter_482"
+    original_name = "batch_norm_4.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("0.275652")
@@ -5313,6 +5796,7 @@ class Program_weight_tensor_parameter_482:
 
 class Program_weight_tensor_parameter_483:
     name = "parameter_483"
+    original_name = "batch_norm_4.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("0.111293")
@@ -5324,6 +5808,7 @@ class Program_weight_tensor_parameter_483:
 
 class Program_weight_tensor_parameter_484:
     name = "parameter_484"
+    original_name = "batch_norm_4.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.434962")
@@ -5335,6 +5820,7 @@ class Program_weight_tensor_parameter_484:
 
 class Program_weight_tensor_parameter_485:
     name = "parameter_485"
+    original_name = "conv2d_4.w_0"
     shape = [192, 48, 1, 1]
     dtype = "float32"
     min_val = float("-0.513254")
@@ -5346,6 +5832,7 @@ class Program_weight_tensor_parameter_485:
 
 class Program_weight_tensor_parameter_486:
     name = "parameter_486"
+    original_name = "batch_norm_3.b_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -5355,6 +5842,7 @@ class Program_weight_tensor_parameter_486:
 
 class Program_weight_tensor_parameter_487:
     name = "parameter_487"
+    original_name = "batch_norm_3.w_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -5364,6 +5852,7 @@ class Program_weight_tensor_parameter_487:
 
 class Program_weight_tensor_parameter_488:
     name = "parameter_488"
+    original_name = "batch_norm_3.w_2"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -5373,6 +5862,7 @@ class Program_weight_tensor_parameter_488:
 
 class Program_weight_tensor_parameter_489:
     name = "parameter_489"
+    original_name = "batch_norm_3.w_1"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -5382,6 +5872,7 @@ class Program_weight_tensor_parameter_489:
 
 class Program_weight_tensor_parameter_490:
     name = "parameter_490"
+    original_name = "conv2d_3.w_0"
     shape = [48, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.272606")
@@ -5393,6 +5884,7 @@ class Program_weight_tensor_parameter_490:
 
 class Program_weight_tensor_parameter_491:
     name = "parameter_491"
+    original_name = "batch_norm_2.b_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -5402,6 +5894,7 @@ class Program_weight_tensor_parameter_491:
 
 class Program_weight_tensor_parameter_492:
     name = "parameter_492"
+    original_name = "batch_norm_2.w_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -5411,6 +5904,7 @@ class Program_weight_tensor_parameter_492:
 
 class Program_weight_tensor_parameter_493:
     name = "parameter_493"
+    original_name = "batch_norm_2.w_2"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -5420,6 +5914,7 @@ class Program_weight_tensor_parameter_493:
 
 class Program_weight_tensor_parameter_494:
     name = "parameter_494"
+    original_name = "batch_norm_2.w_1"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -5429,6 +5924,7 @@ class Program_weight_tensor_parameter_494:
 
 class Program_weight_tensor_parameter_495:
     name = "parameter_495"
+    original_name = "conv2d_2.w_0"
     shape = [48, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.347591")
@@ -5440,6 +5936,7 @@ class Program_weight_tensor_parameter_495:
 
 class Program_weight_tensor_parameter_496:
     name = "parameter_496"
+    original_name = "batch_norm_1.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-6.29432")
@@ -5451,6 +5948,7 @@ class Program_weight_tensor_parameter_496:
 
 class Program_weight_tensor_parameter_497:
     name = "parameter_497"
+    original_name = "batch_norm_1.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.197473")
@@ -5462,6 +5960,7 @@ class Program_weight_tensor_parameter_497:
 
 class Program_weight_tensor_parameter_498:
     name = "parameter_498"
+    original_name = "batch_norm_1.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("3.08122")
@@ -5473,6 +5972,7 @@ class Program_weight_tensor_parameter_498:
 
 class Program_weight_tensor_parameter_499:
     name = "parameter_499"
+    original_name = "batch_norm_1.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-7.45781")
@@ -5484,6 +5984,7 @@ class Program_weight_tensor_parameter_499:
 
 class Program_weight_tensor_parameter_500:
     name = "parameter_500"
+    original_name = "conv2d_1.w_0"
     shape = [128, 32, 3, 3]
     dtype = "float32"
     min_val = float("-0.657108")
@@ -5495,6 +5996,7 @@ class Program_weight_tensor_parameter_500:
 
 class Program_weight_tensor_parameter_501:
     name = "parameter_501"
+    original_name = "batch_norm_0.b_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -5504,6 +6006,7 @@ class Program_weight_tensor_parameter_501:
 
 class Program_weight_tensor_parameter_502:
     name = "parameter_502"
+    original_name = "batch_norm_0.w_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -5513,6 +6016,7 @@ class Program_weight_tensor_parameter_502:
 
 class Program_weight_tensor_parameter_503:
     name = "parameter_503"
+    original_name = "batch_norm_0.w_2"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -5522,6 +6026,7 @@ class Program_weight_tensor_parameter_503:
 
 class Program_weight_tensor_parameter_504:
     name = "parameter_504"
+    original_name = "batch_norm_0.w_1"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -5531,6 +6036,7 @@ class Program_weight_tensor_parameter_504:
 
 class Program_weight_tensor_parameter_505:
     name = "parameter_505"
+    original_name = "conv2d_0.w_0"
     shape = [32, 3, 3, 3]
     dtype = "float32"
     min_val = float("-0.243601")

--- a/paddle_samples/PaddleX/Nonstationary/subgraph_10/input_meta.py
+++ b/paddle_samples/PaddleX/Nonstationary/subgraph_10/input_meta.py
@@ -1,5 +1,6 @@
 class Program_weight_tensor_data_0:
     name = "data_0"
+    original_name = "args_0"
     shape = []
     dtype = "int64"
     data = [3]
@@ -7,6 +8,7 @@ class Program_weight_tensor_data_0:
 
 class Program_weight_tensor_data_1:
     name = "data_1"
+    original_name = "var_473"
     shape = [3, 96, 1]
     dtype = "float32"
     min_val = float("-1.36201")
@@ -18,6 +20,7 @@ class Program_weight_tensor_data_1:
 
 class Program_weight_tensor_data_2:
     name = "data_2"
+    original_name = "var_474"
     shape = [3, 192, 4]
     dtype = "float32"
     min_val = float("-0.5")
@@ -29,6 +32,7 @@ class Program_weight_tensor_data_2:
 
 class Program_weight_tensor_data_3:
     name = "data_3"
+    original_name = "var_519"
     shape = [1, 5000, 512]
     dtype = "float32"
     min_val = float("-1.0")
@@ -40,6 +44,7 @@ class Program_weight_tensor_data_3:
 
 class Program_weight_tensor_data_4:
     name = "data_4"
+    original_name = "var_613"
     shape = [1, 5000, 512]
     dtype = "float32"
     min_val = float("-1.0")

--- a/paddle_samples/PaddleX/Nonstationary/subgraph_10/weight_meta.py
+++ b/paddle_samples/PaddleX/Nonstationary/subgraph_10/weight_meta.py
@@ -1,5 +1,6 @@
 class Program_weight_tensor_parameter_0:
     name = "parameter_0"
+    original_name = "linear_1.w_0"
     shape = [4, 512]
     dtype = "float32"
     min_val = float("-0.516648")
@@ -11,6 +12,7 @@ class Program_weight_tensor_parameter_0:
 
 class Program_weight_tensor_parameter_1:
     name = "parameter_1"
+    original_name = "conv1d_1.w_0"
     shape = [512, 1, 3]
     dtype = "float32"
     min_val = float("-2.48717")
@@ -22,6 +24,7 @@ class Program_weight_tensor_parameter_1:
 
 class Program_weight_tensor_parameter_2:
     name = "parameter_2"
+    original_name = "layer_norm_4.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.00299459")
@@ -33,6 +36,7 @@ class Program_weight_tensor_parameter_2:
 
 class Program_weight_tensor_parameter_3:
     name = "parameter_3"
+    original_name = "layer_norm_4.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("0.990188")
@@ -44,6 +48,7 @@ class Program_weight_tensor_parameter_3:
 
 class Program_weight_tensor_parameter_4:
     name = "parameter_4"
+    original_name = "layer_norm_3.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.00234111")
@@ -55,6 +60,7 @@ class Program_weight_tensor_parameter_4:
 
 class Program_weight_tensor_parameter_5:
     name = "parameter_5"
+    original_name = "layer_norm_3.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("0.992512")
@@ -66,6 +72,7 @@ class Program_weight_tensor_parameter_5:
 
 class Program_weight_tensor_parameter_6:
     name = "parameter_6"
+    original_name = "conv1d_5.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.0022546")
@@ -77,6 +84,7 @@ class Program_weight_tensor_parameter_6:
 
 class Program_weight_tensor_parameter_7:
     name = "parameter_7"
+    original_name = "conv1d_5.w_0"
     shape = [512, 2048, 1]
     dtype = "float32"
     min_val = float("-0.142078")
@@ -88,6 +96,7 @@ class Program_weight_tensor_parameter_7:
 
 class Program_weight_tensor_parameter_8:
     name = "parameter_8"
+    original_name = "conv1d_4.b_0"
     shape = [2048]
     dtype = "float32"
     min_val = float("-0.00586633")
@@ -99,6 +108,7 @@ class Program_weight_tensor_parameter_8:
 
 class Program_weight_tensor_parameter_9:
     name = "parameter_9"
+    original_name = "conv1d_4.w_0"
     shape = [2048, 512, 1]
     dtype = "float32"
     min_val = float("-0.289242")
@@ -110,6 +120,7 @@ class Program_weight_tensor_parameter_9:
 
 class Program_weight_tensor_parameter_10:
     name = "parameter_10"
+    original_name = "layer_norm_2.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.00225662")
@@ -121,6 +132,7 @@ class Program_weight_tensor_parameter_10:
 
 class Program_weight_tensor_parameter_11:
     name = "parameter_11"
+    original_name = "layer_norm_2.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("0.99061")
@@ -132,6 +144,7 @@ class Program_weight_tensor_parameter_11:
 
 class Program_weight_tensor_parameter_12:
     name = "parameter_12"
+    original_name = "linear_9.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.0435265")
@@ -143,6 +156,7 @@ class Program_weight_tensor_parameter_12:
 
 class Program_weight_tensor_parameter_13:
     name = "parameter_13"
+    original_name = "linear_9.w_0"
     shape = [512, 512]
     dtype = "float32"
     min_val = float("-0.054725")
@@ -154,6 +168,7 @@ class Program_weight_tensor_parameter_13:
 
 class Program_weight_tensor_parameter_14:
     name = "parameter_14"
+    original_name = "linear_8.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.0448786")
@@ -165,6 +180,7 @@ class Program_weight_tensor_parameter_14:
 
 class Program_weight_tensor_parameter_15:
     name = "parameter_15"
+    original_name = "linear_8.w_0"
     shape = [512, 512]
     dtype = "float32"
     min_val = float("-0.0552115")
@@ -176,6 +192,7 @@ class Program_weight_tensor_parameter_15:
 
 class Program_weight_tensor_parameter_16:
     name = "parameter_16"
+    original_name = "linear_7.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.0437686")
@@ -187,6 +204,7 @@ class Program_weight_tensor_parameter_16:
 
 class Program_weight_tensor_parameter_17:
     name = "parameter_17"
+    original_name = "linear_7.w_0"
     shape = [512, 512]
     dtype = "float32"
     min_val = float("-0.0580188")
@@ -198,6 +216,7 @@ class Program_weight_tensor_parameter_17:
 
 class Program_weight_tensor_parameter_18:
     name = "parameter_18"
+    original_name = "linear_6.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.0439347")
@@ -209,6 +228,7 @@ class Program_weight_tensor_parameter_18:
 
 class Program_weight_tensor_parameter_19:
     name = "parameter_19"
+    original_name = "linear_6.w_0"
     shape = [512, 512]
     dtype = "float32"
     min_val = float("-0.0580408")
@@ -220,6 +240,7 @@ class Program_weight_tensor_parameter_19:
 
 class Program_weight_tensor_parameter_20:
     name = "parameter_20"
+    original_name = "layer_norm_1.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.00212544")
@@ -231,6 +252,7 @@ class Program_weight_tensor_parameter_20:
 
 class Program_weight_tensor_parameter_21:
     name = "parameter_21"
+    original_name = "layer_norm_1.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("0.989608")
@@ -242,6 +264,7 @@ class Program_weight_tensor_parameter_21:
 
 class Program_weight_tensor_parameter_22:
     name = "parameter_22"
+    original_name = "conv1d_3.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.00190863")
@@ -253,6 +276,7 @@ class Program_weight_tensor_parameter_22:
 
 class Program_weight_tensor_parameter_23:
     name = "parameter_23"
+    original_name = "conv1d_3.w_0"
     shape = [512, 2048, 1]
     dtype = "float32"
     min_val = float("-0.159284")
@@ -264,6 +288,7 @@ class Program_weight_tensor_parameter_23:
 
 class Program_weight_tensor_parameter_24:
     name = "parameter_24"
+    original_name = "conv1d_2.b_0"
     shape = [2048]
     dtype = "float32"
     min_val = float("-0.00493774")
@@ -275,6 +300,7 @@ class Program_weight_tensor_parameter_24:
 
 class Program_weight_tensor_parameter_25:
     name = "parameter_25"
+    original_name = "conv1d_2.w_0"
     shape = [2048, 512, 1]
     dtype = "float32"
     min_val = float("-0.28545")
@@ -286,6 +312,7 @@ class Program_weight_tensor_parameter_25:
 
 class Program_weight_tensor_parameter_26:
     name = "parameter_26"
+    original_name = "layer_norm_0.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.00392048")
@@ -297,6 +324,7 @@ class Program_weight_tensor_parameter_26:
 
 class Program_weight_tensor_parameter_27:
     name = "parameter_27"
+    original_name = "layer_norm_0.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("0.992844")
@@ -308,6 +336,7 @@ class Program_weight_tensor_parameter_27:
 
 class Program_weight_tensor_parameter_28:
     name = "parameter_28"
+    original_name = "linear_5.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.0453684")
@@ -319,6 +348,7 @@ class Program_weight_tensor_parameter_28:
 
 class Program_weight_tensor_parameter_29:
     name = "parameter_29"
+    original_name = "linear_5.w_0"
     shape = [512, 512]
     dtype = "float32"
     min_val = float("-0.0537899")
@@ -330,6 +360,7 @@ class Program_weight_tensor_parameter_29:
 
 class Program_weight_tensor_parameter_30:
     name = "parameter_30"
+    original_name = "linear_4.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.0444344")
@@ -341,6 +372,7 @@ class Program_weight_tensor_parameter_30:
 
 class Program_weight_tensor_parameter_31:
     name = "parameter_31"
+    original_name = "linear_4.w_0"
     shape = [512, 512]
     dtype = "float32"
     min_val = float("-0.0655739")
@@ -352,6 +384,7 @@ class Program_weight_tensor_parameter_31:
 
 class Program_weight_tensor_parameter_32:
     name = "parameter_32"
+    original_name = "linear_3.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.044085")
@@ -363,6 +396,7 @@ class Program_weight_tensor_parameter_32:
 
 class Program_weight_tensor_parameter_33:
     name = "parameter_33"
+    original_name = "linear_3.w_0"
     shape = [512, 512]
     dtype = "float32"
     min_val = float("-0.0670256")
@@ -374,6 +408,7 @@ class Program_weight_tensor_parameter_33:
 
 class Program_weight_tensor_parameter_34:
     name = "parameter_34"
+    original_name = "linear_2.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.0448112")
@@ -385,6 +420,7 @@ class Program_weight_tensor_parameter_34:
 
 class Program_weight_tensor_parameter_35:
     name = "parameter_35"
+    original_name = "linear_2.w_0"
     shape = [512, 512]
     dtype = "float32"
     min_val = float("-0.0651913")
@@ -396,6 +432,7 @@ class Program_weight_tensor_parameter_35:
 
 class Program_weight_tensor_parameter_36:
     name = "parameter_36"
+    original_name = "linear_0.w_0"
     shape = [4, 512]
     dtype = "float32"
     min_val = float("-0.518061")
@@ -407,6 +444,7 @@ class Program_weight_tensor_parameter_36:
 
 class Program_weight_tensor_parameter_37:
     name = "parameter_37"
+    original_name = "conv1d_0.w_0"
     shape = [512, 1, 3]
     dtype = "float32"
     min_val = float("-2.59087")
@@ -418,6 +456,7 @@ class Program_weight_tensor_parameter_37:
 
 class Program_weight_tensor_parameter_38:
     name = "parameter_38"
+    original_name = "linear_24.w_0"
     shape = [256, 96]
     dtype = "float32"
     min_val = float("-0.0788252")
@@ -429,6 +468,7 @@ class Program_weight_tensor_parameter_38:
 
 class Program_weight_tensor_parameter_39:
     name = "parameter_39"
+    original_name = "linear_23.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.0644514")
@@ -440,6 +480,7 @@ class Program_weight_tensor_parameter_39:
 
 class Program_weight_tensor_parameter_40:
     name = "parameter_40"
+    original_name = "linear_23.w_0"
     shape = [256, 256]
     dtype = "float32"
     min_val = float("-0.0735758")
@@ -451,6 +492,7 @@ class Program_weight_tensor_parameter_40:
 
 class Program_weight_tensor_parameter_41:
     name = "parameter_41"
+    original_name = "linear_22.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.705481")
@@ -462,6 +504,7 @@ class Program_weight_tensor_parameter_41:
 
 class Program_weight_tensor_parameter_42:
     name = "parameter_42"
+    original_name = "linear_22.w_0"
     shape = [2, 256]
     dtype = "float32"
     min_val = float("-0.718397")
@@ -473,6 +516,7 @@ class Program_weight_tensor_parameter_42:
 
 class Program_weight_tensor_parameter_43:
     name = "parameter_43"
+    original_name = "conv1d_9.w_0"
     shape = [1, 96, 3]
     dtype = "float32"
     min_val = float("-0.258786")
@@ -484,6 +528,7 @@ class Program_weight_tensor_parameter_43:
 
 class Program_weight_tensor_parameter_44:
     name = "parameter_44"
+    original_name = "linear_21.w_0"
     shape = [256, 1]
     dtype = "float32"
     min_val = float("-0.0631182")
@@ -495,6 +540,7 @@ class Program_weight_tensor_parameter_44:
 
 class Program_weight_tensor_parameter_45:
     name = "parameter_45"
+    original_name = "linear_20.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.06438")
@@ -506,6 +552,7 @@ class Program_weight_tensor_parameter_45:
 
 class Program_weight_tensor_parameter_46:
     name = "parameter_46"
+    original_name = "linear_20.w_0"
     shape = [256, 256]
     dtype = "float32"
     min_val = float("-0.0911308")
@@ -517,6 +564,7 @@ class Program_weight_tensor_parameter_46:
 
 class Program_weight_tensor_parameter_47:
     name = "parameter_47"
+    original_name = "linear_19.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.703553")
@@ -528,6 +576,7 @@ class Program_weight_tensor_parameter_47:
 
 class Program_weight_tensor_parameter_48:
     name = "parameter_48"
+    original_name = "linear_19.w_0"
     shape = [2, 256]
     dtype = "float32"
     min_val = float("-0.712464")
@@ -539,6 +588,7 @@ class Program_weight_tensor_parameter_48:
 
 class Program_weight_tensor_parameter_49:
     name = "parameter_49"
+    original_name = "conv1d_8.w_0"
     shape = [1, 96, 3]
     dtype = "float32"
     min_val = float("-0.24203")

--- a/paddle_samples/PaddleX/Nonstationary/subgraph_11/input_meta.py
+++ b/paddle_samples/PaddleX/Nonstationary/subgraph_11/input_meta.py
@@ -1,5 +1,6 @@
 class Program_weight_tensor_data_0:
     name = "data_0"
+    original_name = "args_0"
     shape = []
     dtype = "int64"
     data = [16]
@@ -7,6 +8,7 @@ class Program_weight_tensor_data_0:
 
 class Program_weight_tensor_data_1:
     name = "data_1"
+    original_name = "var_734"
     shape = [16, 96, 1]
     dtype = "float32"
     min_val = float("-2.06142")
@@ -18,6 +20,7 @@ class Program_weight_tensor_data_1:
 
 class Program_weight_tensor_data_2:
     name = "data_2"
+    original_name = "var_735"
     shape = [16, 192, 4]
     dtype = "float32"
     min_val = float("-0.5")
@@ -29,6 +32,7 @@ class Program_weight_tensor_data_2:
 
 class Program_weight_tensor_data_3:
     name = "data_3"
+    original_name = "var_780"
     shape = [1, 5000, 512]
     dtype = "float32"
     min_val = float("-1.0")
@@ -40,6 +44,7 @@ class Program_weight_tensor_data_3:
 
 class Program_weight_tensor_data_4:
     name = "data_4"
+    original_name = "var_874"
     shape = [1, 5000, 512]
     dtype = "float32"
     min_val = float("-1.0")

--- a/paddle_samples/PaddleX/Nonstationary/subgraph_11/weight_meta.py
+++ b/paddle_samples/PaddleX/Nonstationary/subgraph_11/weight_meta.py
@@ -1,5 +1,6 @@
 class Program_weight_tensor_parameter_0:
     name = "parameter_0"
+    original_name = "linear_1.w_0"
     shape = [4, 512]
     dtype = "float32"
     min_val = float("-0.516677")
@@ -11,6 +12,7 @@ class Program_weight_tensor_parameter_0:
 
 class Program_weight_tensor_parameter_1:
     name = "parameter_1"
+    original_name = "conv1d_1.w_0"
     shape = [512, 1, 3]
     dtype = "float32"
     min_val = float("-2.48719")
@@ -22,6 +24,7 @@ class Program_weight_tensor_parameter_1:
 
 class Program_weight_tensor_parameter_2:
     name = "parameter_2"
+    original_name = "layer_norm_4.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.00305979")
@@ -33,6 +36,7 @@ class Program_weight_tensor_parameter_2:
 
 class Program_weight_tensor_parameter_3:
     name = "parameter_3"
+    original_name = "layer_norm_4.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("0.990193")
@@ -44,6 +48,7 @@ class Program_weight_tensor_parameter_3:
 
 class Program_weight_tensor_parameter_4:
     name = "parameter_4"
+    original_name = "layer_norm_3.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.00235936")
@@ -55,6 +60,7 @@ class Program_weight_tensor_parameter_4:
 
 class Program_weight_tensor_parameter_5:
     name = "parameter_5"
+    original_name = "layer_norm_3.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("0.992481")
@@ -66,6 +72,7 @@ class Program_weight_tensor_parameter_5:
 
 class Program_weight_tensor_parameter_6:
     name = "parameter_6"
+    original_name = "conv1d_5.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.00227089")
@@ -77,6 +84,7 @@ class Program_weight_tensor_parameter_6:
 
 class Program_weight_tensor_parameter_7:
     name = "parameter_7"
+    original_name = "conv1d_5.w_0"
     shape = [512, 2048, 1]
     dtype = "float32"
     min_val = float("-0.142082")
@@ -88,6 +96,7 @@ class Program_weight_tensor_parameter_7:
 
 class Program_weight_tensor_parameter_8:
     name = "parameter_8"
+    original_name = "conv1d_4.b_0"
     shape = [2048]
     dtype = "float32"
     min_val = float("-0.00589507")
@@ -99,6 +108,7 @@ class Program_weight_tensor_parameter_8:
 
 class Program_weight_tensor_parameter_9:
     name = "parameter_9"
+    original_name = "conv1d_4.w_0"
     shape = [2048, 512, 1]
     dtype = "float32"
     min_val = float("-0.28923")
@@ -110,6 +120,7 @@ class Program_weight_tensor_parameter_9:
 
 class Program_weight_tensor_parameter_10:
     name = "parameter_10"
+    original_name = "layer_norm_2.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.00228257")
@@ -121,6 +132,7 @@ class Program_weight_tensor_parameter_10:
 
 class Program_weight_tensor_parameter_11:
     name = "parameter_11"
+    original_name = "layer_norm_2.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("0.99054")
@@ -132,6 +144,7 @@ class Program_weight_tensor_parameter_11:
 
 class Program_weight_tensor_parameter_12:
     name = "parameter_12"
+    original_name = "linear_9.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.0434872")
@@ -143,6 +156,7 @@ class Program_weight_tensor_parameter_12:
 
 class Program_weight_tensor_parameter_13:
     name = "parameter_13"
+    original_name = "linear_9.w_0"
     shape = [512, 512]
     dtype = "float32"
     min_val = float("-0.0547241")
@@ -154,6 +168,7 @@ class Program_weight_tensor_parameter_13:
 
 class Program_weight_tensor_parameter_14:
     name = "parameter_14"
+    original_name = "linear_8.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.0448612")
@@ -165,6 +180,7 @@ class Program_weight_tensor_parameter_14:
 
 class Program_weight_tensor_parameter_15:
     name = "parameter_15"
+    original_name = "linear_8.w_0"
     shape = [512, 512]
     dtype = "float32"
     min_val = float("-0.055098")
@@ -176,6 +192,7 @@ class Program_weight_tensor_parameter_15:
 
 class Program_weight_tensor_parameter_16:
     name = "parameter_16"
+    original_name = "linear_7.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.0437686")
@@ -187,6 +204,7 @@ class Program_weight_tensor_parameter_16:
 
 class Program_weight_tensor_parameter_17:
     name = "parameter_17"
+    original_name = "linear_7.w_0"
     shape = [512, 512]
     dtype = "float32"
     min_val = float("-0.0580123")
@@ -198,6 +216,7 @@ class Program_weight_tensor_parameter_17:
 
 class Program_weight_tensor_parameter_18:
     name = "parameter_18"
+    original_name = "linear_6.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.0438837")
@@ -209,6 +228,7 @@ class Program_weight_tensor_parameter_18:
 
 class Program_weight_tensor_parameter_19:
     name = "parameter_19"
+    original_name = "linear_6.w_0"
     shape = [512, 512]
     dtype = "float32"
     min_val = float("-0.0580541")
@@ -220,6 +240,7 @@ class Program_weight_tensor_parameter_19:
 
 class Program_weight_tensor_parameter_20:
     name = "parameter_20"
+    original_name = "layer_norm_1.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.00218964")
@@ -231,6 +252,7 @@ class Program_weight_tensor_parameter_20:
 
 class Program_weight_tensor_parameter_21:
     name = "parameter_21"
+    original_name = "layer_norm_1.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("0.98961")
@@ -242,6 +264,7 @@ class Program_weight_tensor_parameter_21:
 
 class Program_weight_tensor_parameter_22:
     name = "parameter_22"
+    original_name = "conv1d_3.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.0019689")
@@ -253,6 +276,7 @@ class Program_weight_tensor_parameter_22:
 
 class Program_weight_tensor_parameter_23:
     name = "parameter_23"
+    original_name = "conv1d_3.w_0"
     shape = [512, 2048, 1]
     dtype = "float32"
     min_val = float("-0.159276")
@@ -264,6 +288,7 @@ class Program_weight_tensor_parameter_23:
 
 class Program_weight_tensor_parameter_24:
     name = "parameter_24"
+    original_name = "conv1d_2.b_0"
     shape = [2048]
     dtype = "float32"
     min_val = float("-0.00498069")
@@ -275,6 +300,7 @@ class Program_weight_tensor_parameter_24:
 
 class Program_weight_tensor_parameter_25:
     name = "parameter_25"
+    original_name = "conv1d_2.w_0"
     shape = [2048, 512, 1]
     dtype = "float32"
     min_val = float("-0.285435")
@@ -286,6 +312,7 @@ class Program_weight_tensor_parameter_25:
 
 class Program_weight_tensor_parameter_26:
     name = "parameter_26"
+    original_name = "layer_norm_0.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.00395776")
@@ -297,6 +324,7 @@ class Program_weight_tensor_parameter_26:
 
 class Program_weight_tensor_parameter_27:
     name = "parameter_27"
+    original_name = "layer_norm_0.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("0.992855")
@@ -308,6 +336,7 @@ class Program_weight_tensor_parameter_27:
 
 class Program_weight_tensor_parameter_28:
     name = "parameter_28"
+    original_name = "linear_5.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.0454154")
@@ -319,6 +348,7 @@ class Program_weight_tensor_parameter_28:
 
 class Program_weight_tensor_parameter_29:
     name = "parameter_29"
+    original_name = "linear_5.w_0"
     shape = [512, 512]
     dtype = "float32"
     min_val = float("-0.0537288")
@@ -330,6 +360,7 @@ class Program_weight_tensor_parameter_29:
 
 class Program_weight_tensor_parameter_30:
     name = "parameter_30"
+    original_name = "linear_4.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.0444457")
@@ -341,6 +372,7 @@ class Program_weight_tensor_parameter_30:
 
 class Program_weight_tensor_parameter_31:
     name = "parameter_31"
+    original_name = "linear_4.w_0"
     shape = [512, 512]
     dtype = "float32"
     min_val = float("-0.065649")
@@ -352,6 +384,7 @@ class Program_weight_tensor_parameter_31:
 
 class Program_weight_tensor_parameter_32:
     name = "parameter_32"
+    original_name = "linear_3.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.044085")
@@ -363,6 +396,7 @@ class Program_weight_tensor_parameter_32:
 
 class Program_weight_tensor_parameter_33:
     name = "parameter_33"
+    original_name = "linear_3.w_0"
     shape = [512, 512]
     dtype = "float32"
     min_val = float("-0.0670579")
@@ -374,6 +408,7 @@ class Program_weight_tensor_parameter_33:
 
 class Program_weight_tensor_parameter_34:
     name = "parameter_34"
+    original_name = "linear_2.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.0448819")
@@ -385,6 +420,7 @@ class Program_weight_tensor_parameter_34:
 
 class Program_weight_tensor_parameter_35:
     name = "parameter_35"
+    original_name = "linear_2.w_0"
     shape = [512, 512]
     dtype = "float32"
     min_val = float("-0.065153")
@@ -396,6 +432,7 @@ class Program_weight_tensor_parameter_35:
 
 class Program_weight_tensor_parameter_36:
     name = "parameter_36"
+    original_name = "linear_0.w_0"
     shape = [4, 512]
     dtype = "float32"
     min_val = float("-0.518066")
@@ -407,6 +444,7 @@ class Program_weight_tensor_parameter_36:
 
 class Program_weight_tensor_parameter_37:
     name = "parameter_37"
+    original_name = "conv1d_0.w_0"
     shape = [512, 1, 3]
     dtype = "float32"
     min_val = float("-2.59084")
@@ -418,6 +456,7 @@ class Program_weight_tensor_parameter_37:
 
 class Program_weight_tensor_parameter_38:
     name = "parameter_38"
+    original_name = "linear_24.w_0"
     shape = [256, 96]
     dtype = "float32"
     min_val = float("-0.0789143")
@@ -429,6 +468,7 @@ class Program_weight_tensor_parameter_38:
 
 class Program_weight_tensor_parameter_39:
     name = "parameter_39"
+    original_name = "linear_23.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.0644954")
@@ -440,6 +480,7 @@ class Program_weight_tensor_parameter_39:
 
 class Program_weight_tensor_parameter_40:
     name = "parameter_40"
+    original_name = "linear_23.w_0"
     shape = [256, 256]
     dtype = "float32"
     min_val = float("-0.0736171")
@@ -451,6 +492,7 @@ class Program_weight_tensor_parameter_40:
 
 class Program_weight_tensor_parameter_41:
     name = "parameter_41"
+    original_name = "linear_22.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.705511")
@@ -462,6 +504,7 @@ class Program_weight_tensor_parameter_41:
 
 class Program_weight_tensor_parameter_42:
     name = "parameter_42"
+    original_name = "linear_22.w_0"
     shape = [2, 256]
     dtype = "float32"
     min_val = float("-0.718449")
@@ -473,6 +516,7 @@ class Program_weight_tensor_parameter_42:
 
 class Program_weight_tensor_parameter_43:
     name = "parameter_43"
+    original_name = "conv1d_9.w_0"
     shape = [1, 96, 3]
     dtype = "float32"
     min_val = float("-0.258775")
@@ -484,6 +528,7 @@ class Program_weight_tensor_parameter_43:
 
 class Program_weight_tensor_parameter_44:
     name = "parameter_44"
+    original_name = "linear_21.w_0"
     shape = [256, 1]
     dtype = "float32"
     min_val = float("-0.0631358")
@@ -495,6 +540,7 @@ class Program_weight_tensor_parameter_44:
 
 class Program_weight_tensor_parameter_45:
     name = "parameter_45"
+    original_name = "linear_20.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.06438")
@@ -506,6 +552,7 @@ class Program_weight_tensor_parameter_45:
 
 class Program_weight_tensor_parameter_46:
     name = "parameter_46"
+    original_name = "linear_20.w_0"
     shape = [256, 256]
     dtype = "float32"
     min_val = float("-0.0911485")
@@ -517,6 +564,7 @@ class Program_weight_tensor_parameter_46:
 
 class Program_weight_tensor_parameter_47:
     name = "parameter_47"
+    original_name = "linear_19.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.703553")
@@ -528,6 +576,7 @@ class Program_weight_tensor_parameter_47:
 
 class Program_weight_tensor_parameter_48:
     name = "parameter_48"
+    original_name = "linear_19.w_0"
     shape = [2, 256]
     dtype = "float32"
     min_val = float("-0.712457")
@@ -539,6 +588,7 @@ class Program_weight_tensor_parameter_48:
 
 class Program_weight_tensor_parameter_49:
     name = "parameter_49"
+    original_name = "conv1d_8.w_0"
     shape = [1, 96, 3]
     dtype = "float32"
     min_val = float("-0.242026")

--- a/paddle_samples/PaddleX/Nonstationary/subgraph_8/input_meta.py
+++ b/paddle_samples/PaddleX/Nonstationary/subgraph_8/input_meta.py
@@ -1,5 +1,6 @@
 class Program_weight_tensor_data_0:
     name = "data_0"
+    original_name = "var_0"
     shape = [16, 96, 1]
     dtype = "float32"
     min_val = float("-1.42933")
@@ -11,6 +12,7 @@ class Program_weight_tensor_data_0:
 
 class Program_weight_tensor_data_1:
     name = "data_1"
+    original_name = "var_1"
     shape = [16, 192, 4]
     dtype = "float32"
     min_val = float("-0.5")
@@ -22,6 +24,7 @@ class Program_weight_tensor_data_1:
 
 class Program_weight_tensor_data_2:
     name = "data_2"
+    original_name = "var_116"
     shape = [1, 5000, 512]
     dtype = "float32"
     min_val = float("-1.0")
@@ -33,6 +36,7 @@ class Program_weight_tensor_data_2:
 
 class Program_weight_tensor_data_3:
     name = "data_3"
+    original_name = "var_44"
     shape = [1, 5000, 512]
     dtype = "float32"
     min_val = float("-1.0")

--- a/paddle_samples/PaddleX/Nonstationary/subgraph_8/weight_meta.py
+++ b/paddle_samples/PaddleX/Nonstationary/subgraph_8/weight_meta.py
@@ -1,5 +1,6 @@
 class Program_weight_tensor_parameter_0:
     name = "parameter_0"
+    original_name = "linear_1.w_0"
     shape = [4, 512]
     dtype = "float32"
     min_val = float("-0.499894")
@@ -11,6 +12,7 @@ class Program_weight_tensor_parameter_0:
 
 class Program_weight_tensor_parameter_1:
     name = "parameter_1"
+    original_name = "conv1d_1.w_0"
     shape = [512, 1, 3]
     dtype = "float32"
     min_val = float("-2.48586")
@@ -22,6 +24,7 @@ class Program_weight_tensor_parameter_1:
 
 class Program_weight_tensor_parameter_2:
     name = "parameter_2"
+    original_name = "layer_norm_4.b_0"
     shape = [512]
     dtype = "float32"
     data = None
@@ -29,6 +32,7 @@ class Program_weight_tensor_parameter_2:
 
 class Program_weight_tensor_parameter_3:
     name = "parameter_3"
+    original_name = "layer_norm_4.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("1.0")
@@ -39,6 +43,7 @@ class Program_weight_tensor_parameter_3:
 
 class Program_weight_tensor_parameter_4:
     name = "parameter_4"
+    original_name = "layer_norm_3.b_0"
     shape = [512]
     dtype = "float32"
     data = None
@@ -46,6 +51,7 @@ class Program_weight_tensor_parameter_4:
 
 class Program_weight_tensor_parameter_5:
     name = "parameter_5"
+    original_name = "layer_norm_3.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("1.0")
@@ -56,6 +62,7 @@ class Program_weight_tensor_parameter_5:
 
 class Program_weight_tensor_parameter_6:
     name = "parameter_6"
+    original_name = "conv1d_5.b_0"
     shape = [512]
     dtype = "float32"
     data = None
@@ -63,6 +70,7 @@ class Program_weight_tensor_parameter_6:
 
 class Program_weight_tensor_parameter_7:
     name = "parameter_7"
+    original_name = "conv1d_5.w_0"
     shape = [512, 2048, 1]
     dtype = "float32"
     min_val = float("-0.145888")
@@ -74,6 +82,7 @@ class Program_weight_tensor_parameter_7:
 
 class Program_weight_tensor_parameter_8:
     name = "parameter_8"
+    original_name = "conv1d_4.b_0"
     shape = [2048]
     dtype = "float32"
     data = None
@@ -81,6 +90,7 @@ class Program_weight_tensor_parameter_8:
 
 class Program_weight_tensor_parameter_9:
     name = "parameter_9"
+    original_name = "conv1d_4.w_0"
     shape = [2048, 512, 1]
     dtype = "float32"
     min_val = float("-0.291176")
@@ -92,6 +102,7 @@ class Program_weight_tensor_parameter_9:
 
 class Program_weight_tensor_parameter_10:
     name = "parameter_10"
+    original_name = "layer_norm_2.b_0"
     shape = [512]
     dtype = "float32"
     data = None
@@ -99,6 +110,7 @@ class Program_weight_tensor_parameter_10:
 
 class Program_weight_tensor_parameter_11:
     name = "parameter_11"
+    original_name = "layer_norm_2.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("1.0")
@@ -109,6 +121,7 @@ class Program_weight_tensor_parameter_11:
 
 class Program_weight_tensor_parameter_12:
     name = "parameter_12"
+    original_name = "linear_9.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.0438756")
@@ -120,6 +133,7 @@ class Program_weight_tensor_parameter_12:
 
 class Program_weight_tensor_parameter_13:
     name = "parameter_13"
+    original_name = "linear_9.w_0"
     shape = [512, 512]
     dtype = "float32"
     min_val = float("-0.044194")
@@ -131,6 +145,7 @@ class Program_weight_tensor_parameter_13:
 
 class Program_weight_tensor_parameter_14:
     name = "parameter_14"
+    original_name = "linear_8.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.0441873")
@@ -142,6 +157,7 @@ class Program_weight_tensor_parameter_14:
 
 class Program_weight_tensor_parameter_15:
     name = "parameter_15"
+    original_name = "linear_8.w_0"
     shape = [512, 512]
     dtype = "float32"
     min_val = float("-0.0441941")
@@ -153,6 +169,7 @@ class Program_weight_tensor_parameter_15:
 
 class Program_weight_tensor_parameter_16:
     name = "parameter_16"
+    original_name = "linear_7.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.0437687")
@@ -164,6 +181,7 @@ class Program_weight_tensor_parameter_16:
 
 class Program_weight_tensor_parameter_17:
     name = "parameter_17"
+    original_name = "linear_7.w_0"
     shape = [512, 512]
     dtype = "float32"
     min_val = float("-0.0441933")
@@ -175,6 +193,7 @@ class Program_weight_tensor_parameter_17:
 
 class Program_weight_tensor_parameter_18:
     name = "parameter_18"
+    original_name = "linear_6.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.043746")
@@ -186,6 +205,7 @@ class Program_weight_tensor_parameter_18:
 
 class Program_weight_tensor_parameter_19:
     name = "parameter_19"
+    original_name = "linear_6.w_0"
     shape = [512, 512]
     dtype = "float32"
     min_val = float("-0.0441941")
@@ -197,6 +217,7 @@ class Program_weight_tensor_parameter_19:
 
 class Program_weight_tensor_parameter_20:
     name = "parameter_20"
+    original_name = "layer_norm_1.b_0"
     shape = [512]
     dtype = "float32"
     data = None
@@ -204,6 +225,7 @@ class Program_weight_tensor_parameter_20:
 
 class Program_weight_tensor_parameter_21:
     name = "parameter_21"
+    original_name = "layer_norm_1.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("1.0")
@@ -214,6 +236,7 @@ class Program_weight_tensor_parameter_21:
 
 class Program_weight_tensor_parameter_22:
     name = "parameter_22"
+    original_name = "conv1d_3.b_0"
     shape = [512]
     dtype = "float32"
     data = None
@@ -221,6 +244,7 @@ class Program_weight_tensor_parameter_22:
 
 class Program_weight_tensor_parameter_23:
     name = "parameter_23"
+    original_name = "conv1d_3.w_0"
     shape = [512, 2048, 1]
     dtype = "float32"
     min_val = float("-0.159572")
@@ -232,6 +256,7 @@ class Program_weight_tensor_parameter_23:
 
 class Program_weight_tensor_parameter_24:
     name = "parameter_24"
+    original_name = "conv1d_2.b_0"
     shape = [2048]
     dtype = "float32"
     data = None
@@ -239,6 +264,7 @@ class Program_weight_tensor_parameter_24:
 
 class Program_weight_tensor_parameter_25:
     name = "parameter_25"
+    original_name = "conv1d_2.w_0"
     shape = [2048, 512, 1]
     dtype = "float32"
     min_val = float("-0.288011")
@@ -250,6 +276,7 @@ class Program_weight_tensor_parameter_25:
 
 class Program_weight_tensor_parameter_26:
     name = "parameter_26"
+    original_name = "layer_norm_0.b_0"
     shape = [512]
     dtype = "float32"
     data = None
@@ -257,6 +284,7 @@ class Program_weight_tensor_parameter_26:
 
 class Program_weight_tensor_parameter_27:
     name = "parameter_27"
+    original_name = "layer_norm_0.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("1.0")
@@ -267,6 +295,7 @@ class Program_weight_tensor_parameter_27:
 
 class Program_weight_tensor_parameter_28:
     name = "parameter_28"
+    original_name = "linear_5.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.0438269")
@@ -278,6 +307,7 @@ class Program_weight_tensor_parameter_28:
 
 class Program_weight_tensor_parameter_29:
     name = "parameter_29"
+    original_name = "linear_5.w_0"
     shape = [512, 512]
     dtype = "float32"
     min_val = float("-0.044194")
@@ -289,6 +319,7 @@ class Program_weight_tensor_parameter_29:
 
 class Program_weight_tensor_parameter_30:
     name = "parameter_30"
+    original_name = "linear_4.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.0439395")
@@ -300,6 +331,7 @@ class Program_weight_tensor_parameter_30:
 
 class Program_weight_tensor_parameter_31:
     name = "parameter_31"
+    original_name = "linear_4.w_0"
     shape = [512, 512]
     dtype = "float32"
     min_val = float("-0.044194")
@@ -311,6 +343,7 @@ class Program_weight_tensor_parameter_31:
 
 class Program_weight_tensor_parameter_32:
     name = "parameter_32"
+    original_name = "linear_3.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.0440848")
@@ -322,6 +355,7 @@ class Program_weight_tensor_parameter_32:
 
 class Program_weight_tensor_parameter_33:
     name = "parameter_33"
+    original_name = "linear_3.w_0"
     shape = [512, 512]
     dtype = "float32"
     min_val = float("-0.0441942")
@@ -333,6 +367,7 @@ class Program_weight_tensor_parameter_33:
 
 class Program_weight_tensor_parameter_34:
     name = "parameter_34"
+    original_name = "linear_2.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.0441163")
@@ -344,6 +379,7 @@ class Program_weight_tensor_parameter_34:
 
 class Program_weight_tensor_parameter_35:
     name = "parameter_35"
+    original_name = "linear_2.w_0"
     shape = [512, 512]
     dtype = "float32"
     min_val = float("-0.0441942")
@@ -355,6 +391,7 @@ class Program_weight_tensor_parameter_35:
 
 class Program_weight_tensor_parameter_36:
     name = "parameter_36"
+    original_name = "linear_0.w_0"
     shape = [4, 512]
     dtype = "float32"
     min_val = float("-0.499228")
@@ -366,6 +403,7 @@ class Program_weight_tensor_parameter_36:
 
 class Program_weight_tensor_parameter_37:
     name = "parameter_37"
+    original_name = "conv1d_0.w_0"
     shape = [512, 1, 3]
     dtype = "float32"
     min_val = float("-2.58358")
@@ -377,6 +415,7 @@ class Program_weight_tensor_parameter_37:
 
 class Program_weight_tensor_parameter_38:
     name = "parameter_38"
+    original_name = "linear_24.w_0"
     shape = [256, 96]
     dtype = "float32"
     min_val = float("-0.0624998")
@@ -388,6 +427,7 @@ class Program_weight_tensor_parameter_38:
 
 class Program_weight_tensor_parameter_39:
     name = "parameter_39"
+    original_name = "linear_23.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.0621955")
@@ -399,6 +439,7 @@ class Program_weight_tensor_parameter_39:
 
 class Program_weight_tensor_parameter_40:
     name = "parameter_40"
+    original_name = "linear_23.w_0"
     shape = [256, 256]
     dtype = "float32"
     min_val = float("-0.062496")
@@ -410,6 +451,7 @@ class Program_weight_tensor_parameter_40:
 
 class Program_weight_tensor_parameter_41:
     name = "parameter_41"
+    original_name = "linear_22.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.703797")
@@ -421,6 +463,7 @@ class Program_weight_tensor_parameter_41:
 
 class Program_weight_tensor_parameter_42:
     name = "parameter_42"
+    original_name = "linear_22.w_0"
     shape = [2, 256]
     dtype = "float32"
     min_val = float("-0.701713")
@@ -432,6 +475,7 @@ class Program_weight_tensor_parameter_42:
 
 class Program_weight_tensor_parameter_43:
     name = "parameter_43"
+    original_name = "conv1d_9.w_0"
     shape = [1, 96, 3]
     dtype = "float32"
     min_val = float("-0.278402")
@@ -443,6 +487,7 @@ class Program_weight_tensor_parameter_43:
 
 class Program_weight_tensor_parameter_44:
     name = "parameter_44"
+    original_name = "linear_21.w_0"
     shape = [256, 1]
     dtype = "float32"
     min_val = float("-0.0611586")
@@ -454,6 +499,7 @@ class Program_weight_tensor_parameter_44:
 
 class Program_weight_tensor_parameter_45:
     name = "parameter_45"
+    original_name = "linear_20.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.0623299")
@@ -465,6 +511,7 @@ class Program_weight_tensor_parameter_45:
 
 class Program_weight_tensor_parameter_46:
     name = "parameter_46"
+    original_name = "linear_20.w_0"
     shape = [256, 256]
     dtype = "float32"
     min_val = float("-0.062497")
@@ -476,6 +523,7 @@ class Program_weight_tensor_parameter_46:
 
 class Program_weight_tensor_parameter_47:
     name = "parameter_47"
+    original_name = "linear_19.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.703553")
@@ -487,6 +535,7 @@ class Program_weight_tensor_parameter_47:
 
 class Program_weight_tensor_parameter_48:
     name = "parameter_48"
+    original_name = "linear_19.w_0"
     shape = [2, 256]
     dtype = "float32"
     min_val = float("-0.706659")
@@ -498,6 +547,7 @@ class Program_weight_tensor_parameter_48:
 
 class Program_weight_tensor_parameter_49:
     name = "parameter_49"
+    original_name = "conv1d_8.w_0"
     shape = [1, 96, 3]
     dtype = "float32"
     min_val = float("-0.243955")

--- a/paddle_samples/PaddleX/Nonstationary_ad/subgraph_0/input_meta.py
+++ b/paddle_samples/PaddleX/Nonstationary_ad/subgraph_0/input_meta.py
@@ -1,5 +1,6 @@
 class Program_weight_tensor_data_0:
     name = "data_0"
+    original_name = "var_231"
     shape = [16, 96, 2]
     dtype = "float32"
     min_val = float("-6.37408")
@@ -11,6 +12,7 @@ class Program_weight_tensor_data_0:
 
 class Program_weight_tensor_data_1:
     name = "data_1"
+    original_name = "var_265"
     shape = [1, 5000, 64]
     dtype = "float32"
     min_val = float("-1.0")

--- a/paddle_samples/PaddleX/Nonstationary_ad/subgraph_0/weight_meta.py
+++ b/paddle_samples/PaddleX/Nonstationary_ad/subgraph_0/weight_meta.py
@@ -1,5 +1,6 @@
 class Program_weight_tensor_parameter_0:
     name = "parameter_0"
+    original_name = "linear_15.b_0"
     shape = [2]
     dtype = "float32"
     min_val = float("0")
@@ -9,6 +10,7 @@ class Program_weight_tensor_parameter_0:
 
 class Program_weight_tensor_parameter_1:
     name = "parameter_1"
+    original_name = "linear_15.w_0"
     shape = [64, 2]
     dtype = "float32"
     min_val = float("-0.141455")
@@ -20,6 +22,7 @@ class Program_weight_tensor_parameter_1:
 
 class Program_weight_tensor_parameter_2:
     name = "parameter_2"
+    original_name = "layer_norm_4.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -29,6 +32,7 @@ class Program_weight_tensor_parameter_2:
 
 class Program_weight_tensor_parameter_3:
     name = "parameter_3"
+    original_name = "layer_norm_4.w_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -38,6 +42,7 @@ class Program_weight_tensor_parameter_3:
 
 class Program_weight_tensor_parameter_4:
     name = "parameter_4"
+    original_name = "layer_norm_3.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -47,6 +52,7 @@ class Program_weight_tensor_parameter_4:
 
 class Program_weight_tensor_parameter_5:
     name = "parameter_5"
+    original_name = "layer_norm_3.w_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -56,6 +62,7 @@ class Program_weight_tensor_parameter_5:
 
 class Program_weight_tensor_parameter_6:
     name = "parameter_6"
+    original_name = "conv1d_4.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -65,6 +72,7 @@ class Program_weight_tensor_parameter_6:
 
 class Program_weight_tensor_parameter_7:
     name = "parameter_7"
+    original_name = "conv1d_4.w_0"
     shape = [64, 64, 1]
     dtype = "float32"
     min_val = float("-0.633601")
@@ -76,6 +84,7 @@ class Program_weight_tensor_parameter_7:
 
 class Program_weight_tensor_parameter_8:
     name = "parameter_8"
+    original_name = "conv1d_3.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -85,6 +94,7 @@ class Program_weight_tensor_parameter_8:
 
 class Program_weight_tensor_parameter_9:
     name = "parameter_9"
+    original_name = "conv1d_3.w_0"
     shape = [64, 64, 1]
     dtype = "float32"
     min_val = float("-0.647119")
@@ -96,6 +106,7 @@ class Program_weight_tensor_parameter_9:
 
 class Program_weight_tensor_parameter_10:
     name = "parameter_10"
+    original_name = "layer_norm_2.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -105,6 +116,7 @@ class Program_weight_tensor_parameter_10:
 
 class Program_weight_tensor_parameter_11:
     name = "parameter_11"
+    original_name = "layer_norm_2.w_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -114,6 +126,7 @@ class Program_weight_tensor_parameter_11:
 
 class Program_weight_tensor_parameter_12:
     name = "parameter_12"
+    original_name = "linear_8.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -123,6 +136,7 @@ class Program_weight_tensor_parameter_12:
 
 class Program_weight_tensor_parameter_13:
     name = "parameter_13"
+    original_name = "linear_8.w_0"
     shape = [64, 64]
     dtype = "float32"
     min_val = float("-0.210044")
@@ -134,6 +148,7 @@ class Program_weight_tensor_parameter_13:
 
 class Program_weight_tensor_parameter_14:
     name = "parameter_14"
+    original_name = "linear_7.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -143,6 +158,7 @@ class Program_weight_tensor_parameter_14:
 
 class Program_weight_tensor_parameter_15:
     name = "parameter_15"
+    original_name = "linear_7.w_0"
     shape = [64, 64]
     dtype = "float32"
     min_val = float("-0.255086")
@@ -154,6 +170,7 @@ class Program_weight_tensor_parameter_15:
 
 class Program_weight_tensor_parameter_16:
     name = "parameter_16"
+    original_name = "linear_6.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -163,6 +180,7 @@ class Program_weight_tensor_parameter_16:
 
 class Program_weight_tensor_parameter_17:
     name = "parameter_17"
+    original_name = "linear_6.w_0"
     shape = [64, 64]
     dtype = "float32"
     min_val = float("-0.375404")
@@ -174,6 +192,7 @@ class Program_weight_tensor_parameter_17:
 
 class Program_weight_tensor_parameter_18:
     name = "parameter_18"
+    original_name = "linear_5.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -183,6 +202,7 @@ class Program_weight_tensor_parameter_18:
 
 class Program_weight_tensor_parameter_19:
     name = "parameter_19"
+    original_name = "linear_5.w_0"
     shape = [64, 64]
     dtype = "float32"
     min_val = float("-0.271836")
@@ -194,6 +214,7 @@ class Program_weight_tensor_parameter_19:
 
 class Program_weight_tensor_parameter_20:
     name = "parameter_20"
+    original_name = "layer_norm_1.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -203,6 +224,7 @@ class Program_weight_tensor_parameter_20:
 
 class Program_weight_tensor_parameter_21:
     name = "parameter_21"
+    original_name = "layer_norm_1.w_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -212,6 +234,7 @@ class Program_weight_tensor_parameter_21:
 
 class Program_weight_tensor_parameter_22:
     name = "parameter_22"
+    original_name = "conv1d_2.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -221,6 +244,7 @@ class Program_weight_tensor_parameter_22:
 
 class Program_weight_tensor_parameter_23:
     name = "parameter_23"
+    original_name = "conv1d_2.w_0"
     shape = [64, 64, 1]
     dtype = "float32"
     min_val = float("-0.626788")
@@ -232,6 +256,7 @@ class Program_weight_tensor_parameter_23:
 
 class Program_weight_tensor_parameter_24:
     name = "parameter_24"
+    original_name = "conv1d_1.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -241,6 +266,7 @@ class Program_weight_tensor_parameter_24:
 
 class Program_weight_tensor_parameter_25:
     name = "parameter_25"
+    original_name = "conv1d_1.w_0"
     shape = [64, 64, 1]
     dtype = "float32"
     min_val = float("-0.657247")
@@ -252,6 +278,7 @@ class Program_weight_tensor_parameter_25:
 
 class Program_weight_tensor_parameter_26:
     name = "parameter_26"
+    original_name = "layer_norm_0.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -261,6 +288,7 @@ class Program_weight_tensor_parameter_26:
 
 class Program_weight_tensor_parameter_27:
     name = "parameter_27"
+    original_name = "layer_norm_0.w_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -270,6 +298,7 @@ class Program_weight_tensor_parameter_27:
 
 class Program_weight_tensor_parameter_28:
     name = "parameter_28"
+    original_name = "linear_4.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -279,6 +308,7 @@ class Program_weight_tensor_parameter_28:
 
 class Program_weight_tensor_parameter_29:
     name = "parameter_29"
+    original_name = "linear_4.w_0"
     shape = [64, 64]
     dtype = "float32"
     min_val = float("-0.217793")
@@ -290,6 +320,7 @@ class Program_weight_tensor_parameter_29:
 
 class Program_weight_tensor_parameter_30:
     name = "parameter_30"
+    original_name = "linear_3.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -299,6 +330,7 @@ class Program_weight_tensor_parameter_30:
 
 class Program_weight_tensor_parameter_31:
     name = "parameter_31"
+    original_name = "linear_3.w_0"
     shape = [64, 64]
     dtype = "float32"
     min_val = float("-0.233407")
@@ -310,6 +342,7 @@ class Program_weight_tensor_parameter_31:
 
 class Program_weight_tensor_parameter_32:
     name = "parameter_32"
+    original_name = "linear_2.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -319,6 +352,7 @@ class Program_weight_tensor_parameter_32:
 
 class Program_weight_tensor_parameter_33:
     name = "parameter_33"
+    original_name = "linear_2.w_0"
     shape = [64, 64]
     dtype = "float32"
     min_val = float("-0.342534")
@@ -330,6 +364,7 @@ class Program_weight_tensor_parameter_33:
 
 class Program_weight_tensor_parameter_34:
     name = "parameter_34"
+    original_name = "linear_1.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -339,6 +374,7 @@ class Program_weight_tensor_parameter_34:
 
 class Program_weight_tensor_parameter_35:
     name = "parameter_35"
+    original_name = "linear_1.w_0"
     shape = [64, 64]
     dtype = "float32"
     min_val = float("-0.396937")
@@ -350,6 +386,7 @@ class Program_weight_tensor_parameter_35:
 
 class Program_weight_tensor_parameter_36:
     name = "parameter_36"
+    original_name = "conv1d_0.w_0"
     shape = [64, 2, 3]
     dtype = "float32"
     min_val = float("-1.50755")
@@ -361,6 +398,7 @@ class Program_weight_tensor_parameter_36:
 
 class Program_weight_tensor_parameter_37:
     name = "parameter_37"
+    original_name = "linear_14.w_0"
     shape = [32, 96]
     dtype = "float32"
     min_val = float("-0.285764")
@@ -372,6 +410,7 @@ class Program_weight_tensor_parameter_37:
 
 class Program_weight_tensor_parameter_38:
     name = "parameter_38"
+    original_name = "linear_13.b_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -381,6 +420,7 @@ class Program_weight_tensor_parameter_38:
 
 class Program_weight_tensor_parameter_39:
     name = "parameter_39"
+    original_name = "linear_13.w_0"
     shape = [32, 32]
     dtype = "float32"
     min_val = float("-0.228148")
@@ -392,6 +432,7 @@ class Program_weight_tensor_parameter_39:
 
 class Program_weight_tensor_parameter_40:
     name = "parameter_40"
+    original_name = "linear_12.b_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -401,6 +442,7 @@ class Program_weight_tensor_parameter_40:
 
 class Program_weight_tensor_parameter_41:
     name = "parameter_41"
+    original_name = "linear_12.w_0"
     shape = [4, 32]
     dtype = "float32"
     min_val = float("-0.522794")
@@ -412,6 +454,7 @@ class Program_weight_tensor_parameter_41:
 
 class Program_weight_tensor_parameter_42:
     name = "parameter_42"
+    original_name = "conv1d_6.w_0"
     shape = [1, 96, 3]
     dtype = "float32"
     min_val = float("-0.260908")
@@ -423,6 +466,7 @@ class Program_weight_tensor_parameter_42:
 
 class Program_weight_tensor_parameter_43:
     name = "parameter_43"
+    original_name = "linear_11.w_0"
     shape = [32, 1]
     dtype = "float32"
     min_val = float("0")
@@ -432,6 +476,7 @@ class Program_weight_tensor_parameter_43:
 
 class Program_weight_tensor_parameter_44:
     name = "parameter_44"
+    original_name = "linear_10.b_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -441,6 +486,7 @@ class Program_weight_tensor_parameter_44:
 
 class Program_weight_tensor_parameter_45:
     name = "parameter_45"
+    original_name = "linear_10.w_0"
     shape = [32, 32]
     dtype = "float32"
     min_val = float("-0.301475")
@@ -452,6 +498,7 @@ class Program_weight_tensor_parameter_45:
 
 class Program_weight_tensor_parameter_46:
     name = "parameter_46"
+    original_name = "linear_9.b_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -461,6 +508,7 @@ class Program_weight_tensor_parameter_46:
 
 class Program_weight_tensor_parameter_47:
     name = "parameter_47"
+    original_name = "linear_9.w_0"
     shape = [4, 32]
     dtype = "float32"
     min_val = float("-0.46337")
@@ -472,6 +520,7 @@ class Program_weight_tensor_parameter_47:
 
 class Program_weight_tensor_parameter_48:
     name = "parameter_48"
+    original_name = "conv1d_5.w_0"
     shape = [1, 96, 3]
     dtype = "float32"
     min_val = float("-0.199972")

--- a/paddle_samples/PaddleX/Nonstationary_ad/subgraph_1/input_meta.py
+++ b/paddle_samples/PaddleX/Nonstationary_ad/subgraph_1/input_meta.py
@@ -1,5 +1,6 @@
 class Program_weight_tensor_data_0:
     name = "data_0"
+    original_name = "var_103"
     shape = [2, 96, 2]
     dtype = "float32"
     min_val = float("-1.15597")
@@ -11,6 +12,7 @@ class Program_weight_tensor_data_0:
 
 class Program_weight_tensor_data_1:
     name = "data_1"
+    original_name = "var_137"
     shape = [1, 5000, 64]
     dtype = "float32"
     min_val = float("-1.0")

--- a/paddle_samples/PaddleX/Nonstationary_ad/subgraph_1/weight_meta.py
+++ b/paddle_samples/PaddleX/Nonstationary_ad/subgraph_1/weight_meta.py
@@ -1,5 +1,6 @@
 class Program_weight_tensor_parameter_0:
     name = "parameter_0"
+    original_name = "linear_15.b_0"
     shape = [2]
     dtype = "float32"
     min_val = float("0")
@@ -9,6 +10,7 @@ class Program_weight_tensor_parameter_0:
 
 class Program_weight_tensor_parameter_1:
     name = "parameter_1"
+    original_name = "linear_15.w_0"
     shape = [64, 2]
     dtype = "float32"
     min_val = float("-0.141457")
@@ -20,6 +22,7 @@ class Program_weight_tensor_parameter_1:
 
 class Program_weight_tensor_parameter_2:
     name = "parameter_2"
+    original_name = "layer_norm_4.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -29,6 +32,7 @@ class Program_weight_tensor_parameter_2:
 
 class Program_weight_tensor_parameter_3:
     name = "parameter_3"
+    original_name = "layer_norm_4.w_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -38,6 +42,7 @@ class Program_weight_tensor_parameter_3:
 
 class Program_weight_tensor_parameter_4:
     name = "parameter_4"
+    original_name = "layer_norm_3.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -47,6 +52,7 @@ class Program_weight_tensor_parameter_4:
 
 class Program_weight_tensor_parameter_5:
     name = "parameter_5"
+    original_name = "layer_norm_3.w_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -56,6 +62,7 @@ class Program_weight_tensor_parameter_5:
 
 class Program_weight_tensor_parameter_6:
     name = "parameter_6"
+    original_name = "conv1d_4.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -65,6 +72,7 @@ class Program_weight_tensor_parameter_6:
 
 class Program_weight_tensor_parameter_7:
     name = "parameter_7"
+    original_name = "conv1d_4.w_0"
     shape = [64, 64, 1]
     dtype = "float32"
     min_val = float("-0.633632")
@@ -76,6 +84,7 @@ class Program_weight_tensor_parameter_7:
 
 class Program_weight_tensor_parameter_8:
     name = "parameter_8"
+    original_name = "conv1d_3.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -85,6 +94,7 @@ class Program_weight_tensor_parameter_8:
 
 class Program_weight_tensor_parameter_9:
     name = "parameter_9"
+    original_name = "conv1d_3.w_0"
     shape = [64, 64, 1]
     dtype = "float32"
     min_val = float("-0.647121")
@@ -96,6 +106,7 @@ class Program_weight_tensor_parameter_9:
 
 class Program_weight_tensor_parameter_10:
     name = "parameter_10"
+    original_name = "layer_norm_2.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -105,6 +116,7 @@ class Program_weight_tensor_parameter_10:
 
 class Program_weight_tensor_parameter_11:
     name = "parameter_11"
+    original_name = "layer_norm_2.w_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -114,6 +126,7 @@ class Program_weight_tensor_parameter_11:
 
 class Program_weight_tensor_parameter_12:
     name = "parameter_12"
+    original_name = "linear_8.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -123,6 +136,7 @@ class Program_weight_tensor_parameter_12:
 
 class Program_weight_tensor_parameter_13:
     name = "parameter_13"
+    original_name = "linear_8.w_0"
     shape = [64, 64]
     dtype = "float32"
     min_val = float("-0.210024")
@@ -134,6 +148,7 @@ class Program_weight_tensor_parameter_13:
 
 class Program_weight_tensor_parameter_14:
     name = "parameter_14"
+    original_name = "linear_7.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -143,6 +158,7 @@ class Program_weight_tensor_parameter_14:
 
 class Program_weight_tensor_parameter_15:
     name = "parameter_15"
+    original_name = "linear_7.w_0"
     shape = [64, 64]
     dtype = "float32"
     min_val = float("-0.255079")
@@ -154,6 +170,7 @@ class Program_weight_tensor_parameter_15:
 
 class Program_weight_tensor_parameter_16:
     name = "parameter_16"
+    original_name = "linear_6.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -163,6 +180,7 @@ class Program_weight_tensor_parameter_16:
 
 class Program_weight_tensor_parameter_17:
     name = "parameter_17"
+    original_name = "linear_6.w_0"
     shape = [64, 64]
     dtype = "float32"
     min_val = float("-0.375351")
@@ -174,6 +192,7 @@ class Program_weight_tensor_parameter_17:
 
 class Program_weight_tensor_parameter_18:
     name = "parameter_18"
+    original_name = "linear_5.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -183,6 +202,7 @@ class Program_weight_tensor_parameter_18:
 
 class Program_weight_tensor_parameter_19:
     name = "parameter_19"
+    original_name = "linear_5.w_0"
     shape = [64, 64]
     dtype = "float32"
     min_val = float("-0.271848")
@@ -194,6 +214,7 @@ class Program_weight_tensor_parameter_19:
 
 class Program_weight_tensor_parameter_20:
     name = "parameter_20"
+    original_name = "layer_norm_1.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -203,6 +224,7 @@ class Program_weight_tensor_parameter_20:
 
 class Program_weight_tensor_parameter_21:
     name = "parameter_21"
+    original_name = "layer_norm_1.w_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -212,6 +234,7 @@ class Program_weight_tensor_parameter_21:
 
 class Program_weight_tensor_parameter_22:
     name = "parameter_22"
+    original_name = "conv1d_2.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -221,6 +244,7 @@ class Program_weight_tensor_parameter_22:
 
 class Program_weight_tensor_parameter_23:
     name = "parameter_23"
+    original_name = "conv1d_2.w_0"
     shape = [64, 64, 1]
     dtype = "float32"
     min_val = float("-0.626838")
@@ -232,6 +256,7 @@ class Program_weight_tensor_parameter_23:
 
 class Program_weight_tensor_parameter_24:
     name = "parameter_24"
+    original_name = "conv1d_1.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -241,6 +266,7 @@ class Program_weight_tensor_parameter_24:
 
 class Program_weight_tensor_parameter_25:
     name = "parameter_25"
+    original_name = "conv1d_1.w_0"
     shape = [64, 64, 1]
     dtype = "float32"
     min_val = float("-0.657079")
@@ -252,6 +278,7 @@ class Program_weight_tensor_parameter_25:
 
 class Program_weight_tensor_parameter_26:
     name = "parameter_26"
+    original_name = "layer_norm_0.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -261,6 +288,7 @@ class Program_weight_tensor_parameter_26:
 
 class Program_weight_tensor_parameter_27:
     name = "parameter_27"
+    original_name = "layer_norm_0.w_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -270,6 +298,7 @@ class Program_weight_tensor_parameter_27:
 
 class Program_weight_tensor_parameter_28:
     name = "parameter_28"
+    original_name = "linear_4.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -279,6 +308,7 @@ class Program_weight_tensor_parameter_28:
 
 class Program_weight_tensor_parameter_29:
     name = "parameter_29"
+    original_name = "linear_4.w_0"
     shape = [64, 64]
     dtype = "float32"
     min_val = float("-0.21783")
@@ -290,6 +320,7 @@ class Program_weight_tensor_parameter_29:
 
 class Program_weight_tensor_parameter_30:
     name = "parameter_30"
+    original_name = "linear_3.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -299,6 +330,7 @@ class Program_weight_tensor_parameter_30:
 
 class Program_weight_tensor_parameter_31:
     name = "parameter_31"
+    original_name = "linear_3.w_0"
     shape = [64, 64]
     dtype = "float32"
     min_val = float("-0.233227")
@@ -310,6 +342,7 @@ class Program_weight_tensor_parameter_31:
 
 class Program_weight_tensor_parameter_32:
     name = "parameter_32"
+    original_name = "linear_2.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -319,6 +352,7 @@ class Program_weight_tensor_parameter_32:
 
 class Program_weight_tensor_parameter_33:
     name = "parameter_33"
+    original_name = "linear_2.w_0"
     shape = [64, 64]
     dtype = "float32"
     min_val = float("-0.342549")
@@ -330,6 +364,7 @@ class Program_weight_tensor_parameter_33:
 
 class Program_weight_tensor_parameter_34:
     name = "parameter_34"
+    original_name = "linear_1.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -339,6 +374,7 @@ class Program_weight_tensor_parameter_34:
 
 class Program_weight_tensor_parameter_35:
     name = "parameter_35"
+    original_name = "linear_1.w_0"
     shape = [64, 64]
     dtype = "float32"
     min_val = float("-0.396718")
@@ -350,6 +386,7 @@ class Program_weight_tensor_parameter_35:
 
 class Program_weight_tensor_parameter_36:
     name = "parameter_36"
+    original_name = "conv1d_0.w_0"
     shape = [64, 2, 3]
     dtype = "float32"
     min_val = float("-1.50754")
@@ -361,6 +398,7 @@ class Program_weight_tensor_parameter_36:
 
 class Program_weight_tensor_parameter_37:
     name = "parameter_37"
+    original_name = "linear_14.w_0"
     shape = [32, 96]
     dtype = "float32"
     min_val = float("-0.285754")
@@ -372,6 +410,7 @@ class Program_weight_tensor_parameter_37:
 
 class Program_weight_tensor_parameter_38:
     name = "parameter_38"
+    original_name = "linear_13.b_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -381,6 +420,7 @@ class Program_weight_tensor_parameter_38:
 
 class Program_weight_tensor_parameter_39:
     name = "parameter_39"
+    original_name = "linear_13.w_0"
     shape = [32, 32]
     dtype = "float32"
     min_val = float("-0.22818")
@@ -392,6 +432,7 @@ class Program_weight_tensor_parameter_39:
 
 class Program_weight_tensor_parameter_40:
     name = "parameter_40"
+    original_name = "linear_12.b_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -401,6 +442,7 @@ class Program_weight_tensor_parameter_40:
 
 class Program_weight_tensor_parameter_41:
     name = "parameter_41"
+    original_name = "linear_12.w_0"
     shape = [4, 32]
     dtype = "float32"
     min_val = float("-0.522756")
@@ -412,6 +454,7 @@ class Program_weight_tensor_parameter_41:
 
 class Program_weight_tensor_parameter_42:
     name = "parameter_42"
+    original_name = "conv1d_6.w_0"
     shape = [1, 96, 3]
     dtype = "float32"
     min_val = float("-0.260799")
@@ -423,6 +466,7 @@ class Program_weight_tensor_parameter_42:
 
 class Program_weight_tensor_parameter_43:
     name = "parameter_43"
+    original_name = "linear_11.w_0"
     shape = [32, 1]
     dtype = "float32"
     min_val = float("0")
@@ -432,6 +476,7 @@ class Program_weight_tensor_parameter_43:
 
 class Program_weight_tensor_parameter_44:
     name = "parameter_44"
+    original_name = "linear_10.b_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -441,6 +486,7 @@ class Program_weight_tensor_parameter_44:
 
 class Program_weight_tensor_parameter_45:
     name = "parameter_45"
+    original_name = "linear_10.w_0"
     shape = [32, 32]
     dtype = "float32"
     min_val = float("-0.301475")
@@ -452,6 +498,7 @@ class Program_weight_tensor_parameter_45:
 
 class Program_weight_tensor_parameter_46:
     name = "parameter_46"
+    original_name = "linear_9.b_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -461,6 +508,7 @@ class Program_weight_tensor_parameter_46:
 
 class Program_weight_tensor_parameter_47:
     name = "parameter_47"
+    original_name = "linear_9.w_0"
     shape = [4, 32]
     dtype = "float32"
     min_val = float("-0.463346")
@@ -472,6 +520,7 @@ class Program_weight_tensor_parameter_47:
 
 class Program_weight_tensor_parameter_48:
     name = "parameter_48"
+    original_name = "conv1d_5.w_0"
     shape = [1, 96, 3]
     dtype = "float32"
     min_val = float("-0.199974")

--- a/paddle_samples/PaddleX/Nonstationary_ad/subgraph_2/input_meta.py
+++ b/paddle_samples/PaddleX/Nonstationary_ad/subgraph_2/input_meta.py
@@ -1,5 +1,6 @@
 class Program_weight_tensor_data_0:
     name = "data_0"
+    original_name = "var_0"
     shape = [16, 96, 2]
     dtype = "float32"
     min_val = float("-2.41022")
@@ -11,6 +12,7 @@ class Program_weight_tensor_data_0:
 
 class Program_weight_tensor_data_1:
     name = "data_1"
+    original_name = "var_32"
     shape = [1, 5000, 64]
     dtype = "float32"
     min_val = float("-1.0")

--- a/paddle_samples/PaddleX/Nonstationary_ad/subgraph_2/weight_meta.py
+++ b/paddle_samples/PaddleX/Nonstationary_ad/subgraph_2/weight_meta.py
@@ -1,5 +1,6 @@
 class Program_weight_tensor_parameter_0:
     name = "parameter_0"
+    original_name = "linear_15.b_0"
     shape = [2]
     dtype = "float32"
     min_val = float("0")
@@ -9,6 +10,7 @@ class Program_weight_tensor_parameter_0:
 
 class Program_weight_tensor_parameter_1:
     name = "parameter_1"
+    original_name = "linear_15.w_0"
     shape = [64, 2]
     dtype = "float32"
     min_val = float("-0.124107")
@@ -20,6 +22,7 @@ class Program_weight_tensor_parameter_1:
 
 class Program_weight_tensor_parameter_2:
     name = "parameter_2"
+    original_name = "layer_norm_4.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -29,6 +32,7 @@ class Program_weight_tensor_parameter_2:
 
 class Program_weight_tensor_parameter_3:
     name = "parameter_3"
+    original_name = "layer_norm_4.w_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -38,6 +42,7 @@ class Program_weight_tensor_parameter_3:
 
 class Program_weight_tensor_parameter_4:
     name = "parameter_4"
+    original_name = "layer_norm_3.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -47,6 +52,7 @@ class Program_weight_tensor_parameter_4:
 
 class Program_weight_tensor_parameter_5:
     name = "parameter_5"
+    original_name = "layer_norm_3.w_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -56,6 +62,7 @@ class Program_weight_tensor_parameter_5:
 
 class Program_weight_tensor_parameter_6:
     name = "parameter_6"
+    original_name = "conv1d_4.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -65,6 +72,7 @@ class Program_weight_tensor_parameter_6:
 
 class Program_weight_tensor_parameter_7:
     name = "parameter_7"
+    original_name = "conv1d_4.w_0"
     shape = [64, 64, 1]
     dtype = "float32"
     min_val = float("-0.597194")
@@ -76,6 +84,7 @@ class Program_weight_tensor_parameter_7:
 
 class Program_weight_tensor_parameter_8:
     name = "parameter_8"
+    original_name = "conv1d_3.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -85,6 +94,7 @@ class Program_weight_tensor_parameter_8:
 
 class Program_weight_tensor_parameter_9:
     name = "parameter_9"
+    original_name = "conv1d_3.w_0"
     shape = [64, 64, 1]
     dtype = "float32"
     min_val = float("-0.590334")
@@ -96,6 +106,7 @@ class Program_weight_tensor_parameter_9:
 
 class Program_weight_tensor_parameter_10:
     name = "parameter_10"
+    original_name = "layer_norm_2.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -105,6 +116,7 @@ class Program_weight_tensor_parameter_10:
 
 class Program_weight_tensor_parameter_11:
     name = "parameter_11"
+    original_name = "layer_norm_2.w_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -114,6 +126,7 @@ class Program_weight_tensor_parameter_11:
 
 class Program_weight_tensor_parameter_12:
     name = "parameter_12"
+    original_name = "linear_8.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -123,6 +136,7 @@ class Program_weight_tensor_parameter_12:
 
 class Program_weight_tensor_parameter_13:
     name = "parameter_13"
+    original_name = "linear_8.w_0"
     shape = [64, 64]
     dtype = "float32"
     min_val = float("-0.124979")
@@ -134,6 +148,7 @@ class Program_weight_tensor_parameter_13:
 
 class Program_weight_tensor_parameter_14:
     name = "parameter_14"
+    original_name = "linear_7.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -143,6 +158,7 @@ class Program_weight_tensor_parameter_14:
 
 class Program_weight_tensor_parameter_15:
     name = "parameter_15"
+    original_name = "linear_7.w_0"
     shape = [64, 64]
     dtype = "float32"
     min_val = float("-0.124789")
@@ -154,6 +170,7 @@ class Program_weight_tensor_parameter_15:
 
 class Program_weight_tensor_parameter_16:
     name = "parameter_16"
+    original_name = "linear_6.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -163,6 +180,7 @@ class Program_weight_tensor_parameter_16:
 
 class Program_weight_tensor_parameter_17:
     name = "parameter_17"
+    original_name = "linear_6.w_0"
     shape = [64, 64]
     dtype = "float32"
     min_val = float("-0.124971")
@@ -174,6 +192,7 @@ class Program_weight_tensor_parameter_17:
 
 class Program_weight_tensor_parameter_18:
     name = "parameter_18"
+    original_name = "linear_5.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -183,6 +202,7 @@ class Program_weight_tensor_parameter_18:
 
 class Program_weight_tensor_parameter_19:
     name = "parameter_19"
+    original_name = "linear_5.w_0"
     shape = [64, 64]
     dtype = "float32"
     min_val = float("-0.124987")
@@ -194,6 +214,7 @@ class Program_weight_tensor_parameter_19:
 
 class Program_weight_tensor_parameter_20:
     name = "parameter_20"
+    original_name = "layer_norm_1.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -203,6 +224,7 @@ class Program_weight_tensor_parameter_20:
 
 class Program_weight_tensor_parameter_21:
     name = "parameter_21"
+    original_name = "layer_norm_1.w_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -212,6 +234,7 @@ class Program_weight_tensor_parameter_21:
 
 class Program_weight_tensor_parameter_22:
     name = "parameter_22"
+    original_name = "conv1d_2.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -221,6 +244,7 @@ class Program_weight_tensor_parameter_22:
 
 class Program_weight_tensor_parameter_23:
     name = "parameter_23"
+    original_name = "conv1d_2.w_0"
     shape = [64, 64, 1]
     dtype = "float32"
     min_val = float("-0.616161")
@@ -232,6 +256,7 @@ class Program_weight_tensor_parameter_23:
 
 class Program_weight_tensor_parameter_24:
     name = "parameter_24"
+    original_name = "conv1d_1.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -241,6 +266,7 @@ class Program_weight_tensor_parameter_24:
 
 class Program_weight_tensor_parameter_25:
     name = "parameter_25"
+    original_name = "conv1d_1.w_0"
     shape = [64, 64, 1]
     dtype = "float32"
     min_val = float("-0.644333")
@@ -252,6 +278,7 @@ class Program_weight_tensor_parameter_25:
 
 class Program_weight_tensor_parameter_26:
     name = "parameter_26"
+    original_name = "layer_norm_0.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -261,6 +288,7 @@ class Program_weight_tensor_parameter_26:
 
 class Program_weight_tensor_parameter_27:
     name = "parameter_27"
+    original_name = "layer_norm_0.w_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -270,6 +298,7 @@ class Program_weight_tensor_parameter_27:
 
 class Program_weight_tensor_parameter_28:
     name = "parameter_28"
+    original_name = "linear_4.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -279,6 +308,7 @@ class Program_weight_tensor_parameter_28:
 
 class Program_weight_tensor_parameter_29:
     name = "parameter_29"
+    original_name = "linear_4.w_0"
     shape = [64, 64]
     dtype = "float32"
     min_val = float("-0.124972")
@@ -290,6 +320,7 @@ class Program_weight_tensor_parameter_29:
 
 class Program_weight_tensor_parameter_30:
     name = "parameter_30"
+    original_name = "linear_3.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -299,6 +330,7 @@ class Program_weight_tensor_parameter_30:
 
 class Program_weight_tensor_parameter_31:
     name = "parameter_31"
+    original_name = "linear_3.w_0"
     shape = [64, 64]
     dtype = "float32"
     min_val = float("-0.124974")
@@ -310,6 +342,7 @@ class Program_weight_tensor_parameter_31:
 
 class Program_weight_tensor_parameter_32:
     name = "parameter_32"
+    original_name = "linear_2.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -319,6 +352,7 @@ class Program_weight_tensor_parameter_32:
 
 class Program_weight_tensor_parameter_33:
     name = "parameter_33"
+    original_name = "linear_2.w_0"
     shape = [64, 64]
     dtype = "float32"
     min_val = float("-0.124994")
@@ -330,6 +364,7 @@ class Program_weight_tensor_parameter_33:
 
 class Program_weight_tensor_parameter_34:
     name = "parameter_34"
+    original_name = "linear_1.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -339,6 +374,7 @@ class Program_weight_tensor_parameter_34:
 
 class Program_weight_tensor_parameter_35:
     name = "parameter_35"
+    original_name = "linear_1.w_0"
     shape = [64, 64]
     dtype = "float32"
     min_val = float("-0.12498")
@@ -350,6 +386,7 @@ class Program_weight_tensor_parameter_35:
 
 class Program_weight_tensor_parameter_36:
     name = "parameter_36"
+    original_name = "conv1d_0.w_0"
     shape = [64, 2, 3]
     dtype = "float32"
     min_val = float("-1.41825")
@@ -361,6 +398,7 @@ class Program_weight_tensor_parameter_36:
 
 class Program_weight_tensor_parameter_37:
     name = "parameter_37"
+    original_name = "linear_14.w_0"
     shape = [32, 96]
     dtype = "float32"
     min_val = float("-0.176699")
@@ -372,6 +410,7 @@ class Program_weight_tensor_parameter_37:
 
 class Program_weight_tensor_parameter_38:
     name = "parameter_38"
+    original_name = "linear_13.b_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -381,6 +420,7 @@ class Program_weight_tensor_parameter_38:
 
 class Program_weight_tensor_parameter_39:
     name = "parameter_39"
+    original_name = "linear_13.w_0"
     shape = [32, 32]
     dtype = "float32"
     min_val = float("-0.176413")
@@ -392,6 +432,7 @@ class Program_weight_tensor_parameter_39:
 
 class Program_weight_tensor_parameter_40:
     name = "parameter_40"
+    original_name = "linear_12.b_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -401,6 +442,7 @@ class Program_weight_tensor_parameter_40:
 
 class Program_weight_tensor_parameter_41:
     name = "parameter_41"
+    original_name = "linear_12.w_0"
     shape = [4, 32]
     dtype = "float32"
     min_val = float("-0.498723")
@@ -412,6 +454,7 @@ class Program_weight_tensor_parameter_41:
 
 class Program_weight_tensor_parameter_42:
     name = "parameter_42"
+    original_name = "conv1d_6.w_0"
     shape = [1, 96, 3]
     dtype = "float32"
     min_val = float("-0.248121")
@@ -423,6 +466,7 @@ class Program_weight_tensor_parameter_42:
 
 class Program_weight_tensor_parameter_43:
     name = "parameter_43"
+    original_name = "linear_11.w_0"
     shape = [32, 1]
     dtype = "float32"
     min_val = float("0")
@@ -432,6 +476,7 @@ class Program_weight_tensor_parameter_43:
 
 class Program_weight_tensor_parameter_44:
     name = "parameter_44"
+    original_name = "linear_10.b_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -441,6 +486,7 @@ class Program_weight_tensor_parameter_44:
 
 class Program_weight_tensor_parameter_45:
     name = "parameter_45"
+    original_name = "linear_10.w_0"
     shape = [32, 32]
     dtype = "float32"
     min_val = float("-0.176707")
@@ -452,6 +498,7 @@ class Program_weight_tensor_parameter_45:
 
 class Program_weight_tensor_parameter_46:
     name = "parameter_46"
+    original_name = "linear_9.b_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -461,6 +508,7 @@ class Program_weight_tensor_parameter_46:
 
 class Program_weight_tensor_parameter_47:
     name = "parameter_47"
+    original_name = "linear_9.w_0"
     shape = [4, 32]
     dtype = "float32"
     min_val = float("-0.494135")
@@ -472,6 +520,7 @@ class Program_weight_tensor_parameter_47:
 
 class Program_weight_tensor_parameter_48:
     name = "parameter_48"
+    original_name = "conv1d_5.w_0"
     shape = [1, 96, 3]
     dtype = "float32"
     min_val = float("-0.197469")

--- a/paddle_samples/PaddleX/PicoDet-L/subgraph_15/input_meta.py
+++ b/paddle_samples/PaddleX/PicoDet-L/subgraph_15/input_meta.py
@@ -1,5 +1,6 @@
 class Program_weight_tensor_data_0:
     name = "data_0"
+    original_name = "var_658"
     shape = [8, 3, 576, 576]
     dtype = "float32"
     min_val = float("-2.71972")
@@ -11,6 +12,7 @@ class Program_weight_tensor_data_0:
 
 class Program_weight_tensor_data_1:
     name = "data_1"
+    original_name = "var_907"
     shape = [8]
     dtype = "float32"
     data = [0.0, 1.0, 2.0, 3.0003, 4.0, 5.0, 6.0006, 7.0]

--- a/paddle_samples/PaddleX/PicoDet-L/subgraph_15/weight_meta.py
+++ b/paddle_samples/PaddleX/PicoDet-L/subgraph_15/weight_meta.py
@@ -1,5 +1,6 @@
 class Program_weight_tensor_parameter_0:
     name = "parameter_0"
+    original_name = "batch_norm2d_97.b_0"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -9,6 +10,7 @@ class Program_weight_tensor_parameter_0:
 
 class Program_weight_tensor_parameter_1:
     name = "parameter_1"
+    original_name = "batch_norm2d_97.w_0"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -18,6 +20,7 @@ class Program_weight_tensor_parameter_1:
 
 class Program_weight_tensor_parameter_2:
     name = "parameter_2"
+    original_name = "batch_norm2d_97.w_2"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -27,6 +30,7 @@ class Program_weight_tensor_parameter_2:
 
 class Program_weight_tensor_parameter_3:
     name = "parameter_3"
+    original_name = "batch_norm2d_97.w_1"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -36,6 +40,7 @@ class Program_weight_tensor_parameter_3:
 
 class Program_weight_tensor_parameter_4:
     name = "parameter_4"
+    original_name = "conv2d_115.w_0"
     shape = [1, 1, 1, 1]
     dtype = "float32"
     min_val = float("0")
@@ -45,6 +50,7 @@ class Program_weight_tensor_parameter_4:
 
 class Program_weight_tensor_parameter_5:
     name = "parameter_5"
+    original_name = "batch_norm2d_96.b_0"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -54,6 +60,7 @@ class Program_weight_tensor_parameter_5:
 
 class Program_weight_tensor_parameter_6:
     name = "parameter_6"
+    original_name = "batch_norm2d_96.w_0"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -63,6 +70,7 @@ class Program_weight_tensor_parameter_6:
 
 class Program_weight_tensor_parameter_7:
     name = "parameter_7"
+    original_name = "batch_norm2d_96.w_2"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -72,6 +80,7 @@ class Program_weight_tensor_parameter_7:
 
 class Program_weight_tensor_parameter_8:
     name = "parameter_8"
+    original_name = "batch_norm2d_96.w_1"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -81,6 +90,7 @@ class Program_weight_tensor_parameter_8:
 
 class Program_weight_tensor_parameter_9:
     name = "parameter_9"
+    original_name = "conv2d_114.w_0"
     shape = [1, 160, 5, 5]
     dtype = "float32"
     min_val = float("-0.356213")
@@ -92,6 +102,7 @@ class Program_weight_tensor_parameter_9:
 
 class Program_weight_tensor_parameter_10:
     name = "parameter_10"
+    original_name = "conv2d_113.b_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -101,6 +112,7 @@ class Program_weight_tensor_parameter_10:
 
 class Program_weight_tensor_parameter_11:
     name = "parameter_11"
+    original_name = "conv2d_113.w_0"
     shape = [32, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.496682")
@@ -112,6 +124,7 @@ class Program_weight_tensor_parameter_11:
 
 class Program_weight_tensor_parameter_12:
     name = "parameter_12"
+    original_name = "conv2d_112.b_0"
     shape = [4]
     dtype = "float32"
     min_val = float("0")
@@ -121,6 +134,7 @@ class Program_weight_tensor_parameter_12:
 
 class Program_weight_tensor_parameter_13:
     name = "parameter_13"
+    original_name = "conv2d_112.w_0"
     shape = [4, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.0285946")
@@ -132,6 +146,7 @@ class Program_weight_tensor_parameter_13:
 
 class Program_weight_tensor_parameter_14:
     name = "parameter_14"
+    original_name = "batch_norm2d_89.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.521588")
@@ -143,6 +158,7 @@ class Program_weight_tensor_parameter_14:
 
 class Program_weight_tensor_parameter_15:
     name = "parameter_15"
+    original_name = "batch_norm2d_89.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.699247")
@@ -154,6 +170,7 @@ class Program_weight_tensor_parameter_15:
 
 class Program_weight_tensor_parameter_16:
     name = "parameter_16"
+    original_name = "batch_norm2d_89.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.00922686")
@@ -165,6 +182,7 @@ class Program_weight_tensor_parameter_16:
 
 class Program_weight_tensor_parameter_17:
     name = "parameter_17"
+    original_name = "batch_norm2d_89.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.215667")
@@ -176,6 +194,7 @@ class Program_weight_tensor_parameter_17:
 
 class Program_weight_tensor_parameter_18:
     name = "parameter_18"
+    original_name = "conv2d_97.w_0"
     shape = [160, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.29073")
@@ -187,6 +206,7 @@ class Program_weight_tensor_parameter_18:
 
 class Program_weight_tensor_parameter_19:
     name = "parameter_19"
+    original_name = "conv2d_96.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.0496633")
@@ -198,6 +218,7 @@ class Program_weight_tensor_parameter_19:
 
 class Program_weight_tensor_parameter_20:
     name = "parameter_20"
+    original_name = "conv2d_96.w_0"
     shape = [160, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.174508")
@@ -209,6 +230,7 @@ class Program_weight_tensor_parameter_20:
 
 class Program_weight_tensor_parameter_21:
     name = "parameter_21"
+    original_name = "batch_norm2d_88.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-2.24548")
@@ -220,6 +242,7 @@ class Program_weight_tensor_parameter_21:
 
 class Program_weight_tensor_parameter_22:
     name = "parameter_22"
+    original_name = "batch_norm2d_88.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.520968")
@@ -231,6 +254,7 @@ class Program_weight_tensor_parameter_22:
 
 class Program_weight_tensor_parameter_23:
     name = "parameter_23"
+    original_name = "batch_norm2d_88.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.0500075")
@@ -242,6 +266,7 @@ class Program_weight_tensor_parameter_23:
 
 class Program_weight_tensor_parameter_24:
     name = "parameter_24"
+    original_name = "batch_norm2d_88.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.635151")
@@ -253,6 +278,7 @@ class Program_weight_tensor_parameter_24:
 
 class Program_weight_tensor_parameter_25:
     name = "parameter_25"
+    original_name = "conv2d_95.w_0"
     shape = [160, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.424473")
@@ -264,6 +290,7 @@ class Program_weight_tensor_parameter_25:
 
 class Program_weight_tensor_parameter_26:
     name = "parameter_26"
+    original_name = "batch_norm2d_87.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.987313")
@@ -275,6 +302,7 @@ class Program_weight_tensor_parameter_26:
 
 class Program_weight_tensor_parameter_27:
     name = "parameter_27"
+    original_name = "batch_norm2d_87.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.486931")
@@ -286,6 +314,7 @@ class Program_weight_tensor_parameter_27:
 
 class Program_weight_tensor_parameter_28:
     name = "parameter_28"
+    original_name = "batch_norm2d_87.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.0035558")
@@ -297,6 +326,7 @@ class Program_weight_tensor_parameter_28:
 
 class Program_weight_tensor_parameter_29:
     name = "parameter_29"
+    original_name = "batch_norm2d_87.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.408654")
@@ -308,6 +338,7 @@ class Program_weight_tensor_parameter_29:
 
 class Program_weight_tensor_parameter_30:
     name = "parameter_30"
+    original_name = "conv2d_94.w_0"
     shape = [160, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.364153")
@@ -319,6 +350,7 @@ class Program_weight_tensor_parameter_30:
 
 class Program_weight_tensor_parameter_31:
     name = "parameter_31"
+    original_name = "batch_norm2d_86.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.98674")
@@ -330,6 +362,7 @@ class Program_weight_tensor_parameter_31:
 
 class Program_weight_tensor_parameter_32:
     name = "parameter_32"
+    original_name = "batch_norm2d_86.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.378473")
@@ -341,6 +374,7 @@ class Program_weight_tensor_parameter_32:
 
 class Program_weight_tensor_parameter_33:
     name = "parameter_33"
+    original_name = "batch_norm2d_86.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.0351055")
@@ -352,6 +386,7 @@ class Program_weight_tensor_parameter_33:
 
 class Program_weight_tensor_parameter_34:
     name = "parameter_34"
+    original_name = "batch_norm2d_86.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.875832")
@@ -363,6 +398,7 @@ class Program_weight_tensor_parameter_34:
 
 class Program_weight_tensor_parameter_35:
     name = "parameter_35"
+    original_name = "conv2d_93.w_0"
     shape = [160, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.368076")
@@ -374,6 +410,7 @@ class Program_weight_tensor_parameter_35:
 
 class Program_weight_tensor_parameter_36:
     name = "parameter_36"
+    original_name = "batch_norm2d_85.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-1.46439")
@@ -385,6 +422,7 @@ class Program_weight_tensor_parameter_36:
 
 class Program_weight_tensor_parameter_37:
     name = "parameter_37"
+    original_name = "batch_norm2d_85.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.608107")
@@ -396,6 +434,7 @@ class Program_weight_tensor_parameter_37:
 
 class Program_weight_tensor_parameter_38:
     name = "parameter_38"
+    original_name = "batch_norm2d_85.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.00131516")
@@ -407,6 +446,7 @@ class Program_weight_tensor_parameter_38:
 
 class Program_weight_tensor_parameter_39:
     name = "parameter_39"
+    original_name = "batch_norm2d_85.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.375697")
@@ -418,6 +458,7 @@ class Program_weight_tensor_parameter_39:
 
 class Program_weight_tensor_parameter_40:
     name = "parameter_40"
+    original_name = "conv2d_92.w_0"
     shape = [160, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.244634")
@@ -429,6 +470,7 @@ class Program_weight_tensor_parameter_40:
 
 class Program_weight_tensor_parameter_41:
     name = "parameter_41"
+    original_name = "batch_norm2d_84.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-1.18063")
@@ -440,6 +482,7 @@ class Program_weight_tensor_parameter_41:
 
 class Program_weight_tensor_parameter_42:
     name = "parameter_42"
+    original_name = "batch_norm2d_84.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.254918")
@@ -451,6 +494,7 @@ class Program_weight_tensor_parameter_42:
 
 class Program_weight_tensor_parameter_43:
     name = "parameter_43"
+    original_name = "batch_norm2d_84.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.0857115")
@@ -462,6 +506,7 @@ class Program_weight_tensor_parameter_43:
 
 class Program_weight_tensor_parameter_44:
     name = "parameter_44"
+    original_name = "batch_norm2d_84.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.718851")
@@ -473,6 +518,7 @@ class Program_weight_tensor_parameter_44:
 
 class Program_weight_tensor_parameter_45:
     name = "parameter_45"
+    original_name = "conv2d_91.w_0"
     shape = [160, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.300988")
@@ -484,6 +530,7 @@ class Program_weight_tensor_parameter_45:
 
 class Program_weight_tensor_parameter_46:
     name = "parameter_46"
+    original_name = "batch_norm2d_83.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-1.06698")
@@ -495,6 +542,7 @@ class Program_weight_tensor_parameter_46:
 
 class Program_weight_tensor_parameter_47:
     name = "parameter_47"
+    original_name = "batch_norm2d_83.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.633603")
@@ -506,6 +554,7 @@ class Program_weight_tensor_parameter_47:
 
 class Program_weight_tensor_parameter_48:
     name = "parameter_48"
+    original_name = "batch_norm2d_83.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.00605325")
@@ -517,6 +566,7 @@ class Program_weight_tensor_parameter_48:
 
 class Program_weight_tensor_parameter_49:
     name = "parameter_49"
+    original_name = "batch_norm2d_83.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.406151")
@@ -528,6 +578,7 @@ class Program_weight_tensor_parameter_49:
 
 class Program_weight_tensor_parameter_50:
     name = "parameter_50"
+    original_name = "conv2d_90.w_0"
     shape = [160, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.224753")
@@ -539,6 +590,7 @@ class Program_weight_tensor_parameter_50:
 
 class Program_weight_tensor_parameter_51:
     name = "parameter_51"
+    original_name = "batch_norm2d_82.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.765194")
@@ -550,6 +602,7 @@ class Program_weight_tensor_parameter_51:
 
 class Program_weight_tensor_parameter_52:
     name = "parameter_52"
+    original_name = "batch_norm2d_82.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.333245")
@@ -561,6 +614,7 @@ class Program_weight_tensor_parameter_52:
 
 class Program_weight_tensor_parameter_53:
     name = "parameter_53"
+    original_name = "batch_norm2d_82.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.0983311")
@@ -572,6 +626,7 @@ class Program_weight_tensor_parameter_53:
 
 class Program_weight_tensor_parameter_54:
     name = "parameter_54"
+    original_name = "batch_norm2d_82.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.47563")
@@ -583,6 +638,7 @@ class Program_weight_tensor_parameter_54:
 
 class Program_weight_tensor_parameter_55:
     name = "parameter_55"
+    original_name = "conv2d_89.w_0"
     shape = [160, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.403106")
@@ -594,6 +650,7 @@ class Program_weight_tensor_parameter_55:
 
 class Program_weight_tensor_parameter_56:
     name = "parameter_56"
+    original_name = "batch_norm2d_81.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.916828")
@@ -605,6 +662,7 @@ class Program_weight_tensor_parameter_56:
 
 class Program_weight_tensor_parameter_57:
     name = "parameter_57"
+    original_name = "batch_norm2d_81.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.620762")
@@ -616,6 +674,7 @@ class Program_weight_tensor_parameter_57:
 
 class Program_weight_tensor_parameter_58:
     name = "parameter_58"
+    original_name = "batch_norm2d_81.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.000209633")
@@ -627,6 +686,7 @@ class Program_weight_tensor_parameter_58:
 
 class Program_weight_tensor_parameter_59:
     name = "parameter_59"
+    original_name = "batch_norm2d_81.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.329898")
@@ -638,6 +698,7 @@ class Program_weight_tensor_parameter_59:
 
 class Program_weight_tensor_parameter_60:
     name = "parameter_60"
+    original_name = "conv2d_88.w_0"
     shape = [160, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.374497")
@@ -649,6 +710,7 @@ class Program_weight_tensor_parameter_60:
 
 class Program_weight_tensor_parameter_61:
     name = "parameter_61"
+    original_name = "batch_norm2d_95.b_0"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -658,6 +720,7 @@ class Program_weight_tensor_parameter_61:
 
 class Program_weight_tensor_parameter_62:
     name = "parameter_62"
+    original_name = "batch_norm2d_95.w_0"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -667,6 +730,7 @@ class Program_weight_tensor_parameter_62:
 
 class Program_weight_tensor_parameter_63:
     name = "parameter_63"
+    original_name = "batch_norm2d_95.w_2"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -676,6 +740,7 @@ class Program_weight_tensor_parameter_63:
 
 class Program_weight_tensor_parameter_64:
     name = "parameter_64"
+    original_name = "batch_norm2d_95.w_1"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -685,6 +750,7 @@ class Program_weight_tensor_parameter_64:
 
 class Program_weight_tensor_parameter_65:
     name = "parameter_65"
+    original_name = "conv2d_111.w_0"
     shape = [1, 1, 1, 1]
     dtype = "float32"
     min_val = float("0")
@@ -694,6 +760,7 @@ class Program_weight_tensor_parameter_65:
 
 class Program_weight_tensor_parameter_66:
     name = "parameter_66"
+    original_name = "batch_norm2d_94.b_0"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -703,6 +770,7 @@ class Program_weight_tensor_parameter_66:
 
 class Program_weight_tensor_parameter_67:
     name = "parameter_67"
+    original_name = "batch_norm2d_94.w_0"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -712,6 +780,7 @@ class Program_weight_tensor_parameter_67:
 
 class Program_weight_tensor_parameter_68:
     name = "parameter_68"
+    original_name = "batch_norm2d_94.w_2"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -721,6 +790,7 @@ class Program_weight_tensor_parameter_68:
 
 class Program_weight_tensor_parameter_69:
     name = "parameter_69"
+    original_name = "batch_norm2d_94.w_1"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -730,6 +800,7 @@ class Program_weight_tensor_parameter_69:
 
 class Program_weight_tensor_parameter_70:
     name = "parameter_70"
+    original_name = "conv2d_110.w_0"
     shape = [1, 160, 5, 5]
     dtype = "float32"
     min_val = float("-0.343969")
@@ -741,6 +812,7 @@ class Program_weight_tensor_parameter_70:
 
 class Program_weight_tensor_parameter_71:
     name = "parameter_71"
+    original_name = "conv2d_109.b_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -750,6 +822,7 @@ class Program_weight_tensor_parameter_71:
 
 class Program_weight_tensor_parameter_72:
     name = "parameter_72"
+    original_name = "conv2d_109.w_0"
     shape = [32, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.427166")
@@ -761,6 +834,7 @@ class Program_weight_tensor_parameter_72:
 
 class Program_weight_tensor_parameter_73:
     name = "parameter_73"
+    original_name = "conv2d_108.b_0"
     shape = [4]
     dtype = "float32"
     min_val = float("0")
@@ -770,6 +844,7 @@ class Program_weight_tensor_parameter_73:
 
 class Program_weight_tensor_parameter_74:
     name = "parameter_74"
+    original_name = "conv2d_108.w_0"
     shape = [4, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.0360218")
@@ -781,6 +856,7 @@ class Program_weight_tensor_parameter_74:
 
 class Program_weight_tensor_parameter_75:
     name = "parameter_75"
+    original_name = "batch_norm2d_80.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.296128")
@@ -792,6 +868,7 @@ class Program_weight_tensor_parameter_75:
 
 class Program_weight_tensor_parameter_76:
     name = "parameter_76"
+    original_name = "batch_norm2d_80.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.620996")
@@ -803,6 +880,7 @@ class Program_weight_tensor_parameter_76:
 
 class Program_weight_tensor_parameter_77:
     name = "parameter_77"
+    original_name = "batch_norm2d_80.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.00908919")
@@ -814,6 +892,7 @@ class Program_weight_tensor_parameter_77:
 
 class Program_weight_tensor_parameter_78:
     name = "parameter_78"
+    original_name = "batch_norm2d_80.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.385999")
@@ -825,6 +904,7 @@ class Program_weight_tensor_parameter_78:
 
 class Program_weight_tensor_parameter_79:
     name = "parameter_79"
+    original_name = "conv2d_87.w_0"
     shape = [160, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.306014")
@@ -836,6 +916,7 @@ class Program_weight_tensor_parameter_79:
 
 class Program_weight_tensor_parameter_80:
     name = "parameter_80"
+    original_name = "conv2d_86.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.0468568")
@@ -847,6 +928,7 @@ class Program_weight_tensor_parameter_80:
 
 class Program_weight_tensor_parameter_81:
     name = "parameter_81"
+    original_name = "conv2d_86.w_0"
     shape = [160, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.181727")
@@ -858,6 +940,7 @@ class Program_weight_tensor_parameter_81:
 
 class Program_weight_tensor_parameter_82:
     name = "parameter_82"
+    original_name = "batch_norm2d_79.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.964429")
@@ -869,6 +952,7 @@ class Program_weight_tensor_parameter_82:
 
 class Program_weight_tensor_parameter_83:
     name = "parameter_83"
+    original_name = "batch_norm2d_79.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.548972")
@@ -880,6 +964,7 @@ class Program_weight_tensor_parameter_83:
 
 class Program_weight_tensor_parameter_84:
     name = "parameter_84"
+    original_name = "batch_norm2d_79.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.0289161")
@@ -891,6 +976,7 @@ class Program_weight_tensor_parameter_84:
 
 class Program_weight_tensor_parameter_85:
     name = "parameter_85"
+    original_name = "batch_norm2d_79.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-1.30101")
@@ -902,6 +988,7 @@ class Program_weight_tensor_parameter_85:
 
 class Program_weight_tensor_parameter_86:
     name = "parameter_86"
+    original_name = "conv2d_85.w_0"
     shape = [160, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.381939")
@@ -913,6 +1000,7 @@ class Program_weight_tensor_parameter_86:
 
 class Program_weight_tensor_parameter_87:
     name = "parameter_87"
+    original_name = "batch_norm2d_78.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.498737")
@@ -924,6 +1012,7 @@ class Program_weight_tensor_parameter_87:
 
 class Program_weight_tensor_parameter_88:
     name = "parameter_88"
+    original_name = "batch_norm2d_78.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.389067")
@@ -935,6 +1024,7 @@ class Program_weight_tensor_parameter_88:
 
 class Program_weight_tensor_parameter_89:
     name = "parameter_89"
+    original_name = "batch_norm2d_78.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.00363149")
@@ -946,6 +1036,7 @@ class Program_weight_tensor_parameter_89:
 
 class Program_weight_tensor_parameter_90:
     name = "parameter_90"
+    original_name = "batch_norm2d_78.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.212867")
@@ -957,6 +1048,7 @@ class Program_weight_tensor_parameter_90:
 
 class Program_weight_tensor_parameter_91:
     name = "parameter_91"
+    original_name = "conv2d_84.w_0"
     shape = [160, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.376161")
@@ -968,6 +1060,7 @@ class Program_weight_tensor_parameter_91:
 
 class Program_weight_tensor_parameter_92:
     name = "parameter_92"
+    original_name = "batch_norm2d_77.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.563776")
@@ -979,6 +1072,7 @@ class Program_weight_tensor_parameter_92:
 
 class Program_weight_tensor_parameter_93:
     name = "parameter_93"
+    original_name = "batch_norm2d_77.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.302869")
@@ -990,6 +1084,7 @@ class Program_weight_tensor_parameter_93:
 
 class Program_weight_tensor_parameter_94:
     name = "parameter_94"
+    original_name = "batch_norm2d_77.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.043748")
@@ -1001,6 +1096,7 @@ class Program_weight_tensor_parameter_94:
 
 class Program_weight_tensor_parameter_95:
     name = "parameter_95"
+    original_name = "batch_norm2d_77.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.501377")
@@ -1012,6 +1108,7 @@ class Program_weight_tensor_parameter_95:
 
 class Program_weight_tensor_parameter_96:
     name = "parameter_96"
+    original_name = "conv2d_83.w_0"
     shape = [160, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.417684")
@@ -1023,6 +1120,7 @@ class Program_weight_tensor_parameter_96:
 
 class Program_weight_tensor_parameter_97:
     name = "parameter_97"
+    original_name = "batch_norm2d_76.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.428443")
@@ -1034,6 +1132,7 @@ class Program_weight_tensor_parameter_97:
 
 class Program_weight_tensor_parameter_98:
     name = "parameter_98"
+    original_name = "batch_norm2d_76.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.547845")
@@ -1045,6 +1144,7 @@ class Program_weight_tensor_parameter_98:
 
 class Program_weight_tensor_parameter_99:
     name = "parameter_99"
+    original_name = "batch_norm2d_76.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.00192855")
@@ -1056,6 +1156,7 @@ class Program_weight_tensor_parameter_99:
 
 class Program_weight_tensor_parameter_100:
     name = "parameter_100"
+    original_name = "batch_norm2d_76.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.298802")
@@ -1067,6 +1168,7 @@ class Program_weight_tensor_parameter_100:
 
 class Program_weight_tensor_parameter_101:
     name = "parameter_101"
+    original_name = "conv2d_82.w_0"
     shape = [160, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.250864")
@@ -1078,6 +1180,7 @@ class Program_weight_tensor_parameter_101:
 
 class Program_weight_tensor_parameter_102:
     name = "parameter_102"
+    original_name = "batch_norm2d_75.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.811368")
@@ -1089,6 +1192,7 @@ class Program_weight_tensor_parameter_102:
 
 class Program_weight_tensor_parameter_103:
     name = "parameter_103"
+    original_name = "batch_norm2d_75.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.125487")
@@ -1100,6 +1204,7 @@ class Program_weight_tensor_parameter_103:
 
 class Program_weight_tensor_parameter_104:
     name = "parameter_104"
+    original_name = "batch_norm2d_75.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.0428115")
@@ -1111,6 +1216,7 @@ class Program_weight_tensor_parameter_104:
 
 class Program_weight_tensor_parameter_105:
     name = "parameter_105"
+    original_name = "batch_norm2d_75.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.664097")
@@ -1122,6 +1228,7 @@ class Program_weight_tensor_parameter_105:
 
 class Program_weight_tensor_parameter_106:
     name = "parameter_106"
+    original_name = "conv2d_81.w_0"
     shape = [160, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.335423")
@@ -1133,6 +1240,7 @@ class Program_weight_tensor_parameter_106:
 
 class Program_weight_tensor_parameter_107:
     name = "parameter_107"
+    original_name = "batch_norm2d_74.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.298506")
@@ -1144,6 +1252,7 @@ class Program_weight_tensor_parameter_107:
 
 class Program_weight_tensor_parameter_108:
     name = "parameter_108"
+    original_name = "batch_norm2d_74.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.572945")
@@ -1155,6 +1264,7 @@ class Program_weight_tensor_parameter_108:
 
 class Program_weight_tensor_parameter_109:
     name = "parameter_109"
+    original_name = "batch_norm2d_74.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.00664615")
@@ -1166,6 +1276,7 @@ class Program_weight_tensor_parameter_109:
 
 class Program_weight_tensor_parameter_110:
     name = "parameter_110"
+    original_name = "batch_norm2d_74.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.237412")
@@ -1177,6 +1288,7 @@ class Program_weight_tensor_parameter_110:
 
 class Program_weight_tensor_parameter_111:
     name = "parameter_111"
+    original_name = "conv2d_80.w_0"
     shape = [160, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.279558")
@@ -1188,6 +1300,7 @@ class Program_weight_tensor_parameter_111:
 
 class Program_weight_tensor_parameter_112:
     name = "parameter_112"
+    original_name = "batch_norm2d_73.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.307654")
@@ -1199,6 +1312,7 @@ class Program_weight_tensor_parameter_112:
 
 class Program_weight_tensor_parameter_113:
     name = "parameter_113"
+    original_name = "batch_norm2d_73.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.303106")
@@ -1210,6 +1324,7 @@ class Program_weight_tensor_parameter_113:
 
 class Program_weight_tensor_parameter_114:
     name = "parameter_114"
+    original_name = "batch_norm2d_73.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.052102")
@@ -1221,6 +1336,7 @@ class Program_weight_tensor_parameter_114:
 
 class Program_weight_tensor_parameter_115:
     name = "parameter_115"
+    original_name = "batch_norm2d_73.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.609228")
@@ -1232,6 +1348,7 @@ class Program_weight_tensor_parameter_115:
 
 class Program_weight_tensor_parameter_116:
     name = "parameter_116"
+    original_name = "conv2d_79.w_0"
     shape = [160, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.27644")
@@ -1243,6 +1360,7 @@ class Program_weight_tensor_parameter_116:
 
 class Program_weight_tensor_parameter_117:
     name = "parameter_117"
+    original_name = "batch_norm2d_72.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.129436")
@@ -1254,6 +1372,7 @@ class Program_weight_tensor_parameter_117:
 
 class Program_weight_tensor_parameter_118:
     name = "parameter_118"
+    original_name = "batch_norm2d_72.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.535914")
@@ -1265,6 +1384,7 @@ class Program_weight_tensor_parameter_118:
 
 class Program_weight_tensor_parameter_119:
     name = "parameter_119"
+    original_name = "batch_norm2d_72.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.00348142")
@@ -1276,6 +1396,7 @@ class Program_weight_tensor_parameter_119:
 
 class Program_weight_tensor_parameter_120:
     name = "parameter_120"
+    original_name = "batch_norm2d_72.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.593781")
@@ -1287,6 +1408,7 @@ class Program_weight_tensor_parameter_120:
 
 class Program_weight_tensor_parameter_121:
     name = "parameter_121"
+    original_name = "conv2d_78.w_0"
     shape = [160, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.291443")
@@ -1298,6 +1420,7 @@ class Program_weight_tensor_parameter_121:
 
 class Program_weight_tensor_parameter_122:
     name = "parameter_122"
+    original_name = "batch_norm2d_93.b_0"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -1307,6 +1430,7 @@ class Program_weight_tensor_parameter_122:
 
 class Program_weight_tensor_parameter_123:
     name = "parameter_123"
+    original_name = "batch_norm2d_93.w_0"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -1316,6 +1440,7 @@ class Program_weight_tensor_parameter_123:
 
 class Program_weight_tensor_parameter_124:
     name = "parameter_124"
+    original_name = "batch_norm2d_93.w_2"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -1325,6 +1450,7 @@ class Program_weight_tensor_parameter_124:
 
 class Program_weight_tensor_parameter_125:
     name = "parameter_125"
+    original_name = "batch_norm2d_93.w_1"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -1334,6 +1460,7 @@ class Program_weight_tensor_parameter_125:
 
 class Program_weight_tensor_parameter_126:
     name = "parameter_126"
+    original_name = "conv2d_107.w_0"
     shape = [1, 1, 1, 1]
     dtype = "float32"
     min_val = float("0")
@@ -1343,6 +1470,7 @@ class Program_weight_tensor_parameter_126:
 
 class Program_weight_tensor_parameter_127:
     name = "parameter_127"
+    original_name = "batch_norm2d_92.b_0"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -1352,6 +1480,7 @@ class Program_weight_tensor_parameter_127:
 
 class Program_weight_tensor_parameter_128:
     name = "parameter_128"
+    original_name = "batch_norm2d_92.w_0"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -1361,6 +1490,7 @@ class Program_weight_tensor_parameter_128:
 
 class Program_weight_tensor_parameter_129:
     name = "parameter_129"
+    original_name = "batch_norm2d_92.w_2"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -1370,6 +1500,7 @@ class Program_weight_tensor_parameter_129:
 
 class Program_weight_tensor_parameter_130:
     name = "parameter_130"
+    original_name = "batch_norm2d_92.w_1"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -1379,6 +1510,7 @@ class Program_weight_tensor_parameter_130:
 
 class Program_weight_tensor_parameter_131:
     name = "parameter_131"
+    original_name = "conv2d_106.w_0"
     shape = [1, 160, 5, 5]
     dtype = "float32"
     min_val = float("-0.099178")
@@ -1390,6 +1522,7 @@ class Program_weight_tensor_parameter_131:
 
 class Program_weight_tensor_parameter_132:
     name = "parameter_132"
+    original_name = "conv2d_105.b_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -1399,6 +1532,7 @@ class Program_weight_tensor_parameter_132:
 
 class Program_weight_tensor_parameter_133:
     name = "parameter_133"
+    original_name = "conv2d_105.w_0"
     shape = [32, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.447913")
@@ -1410,6 +1544,7 @@ class Program_weight_tensor_parameter_133:
 
 class Program_weight_tensor_parameter_134:
     name = "parameter_134"
+    original_name = "conv2d_104.b_0"
     shape = [4]
     dtype = "float32"
     min_val = float("0")
@@ -1419,6 +1554,7 @@ class Program_weight_tensor_parameter_134:
 
 class Program_weight_tensor_parameter_135:
     name = "parameter_135"
+    original_name = "conv2d_104.w_0"
     shape = [4, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.0351169")
@@ -1430,6 +1566,7 @@ class Program_weight_tensor_parameter_135:
 
 class Program_weight_tensor_parameter_136:
     name = "parameter_136"
+    original_name = "batch_norm2d_71.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.911162")
@@ -1441,6 +1578,7 @@ class Program_weight_tensor_parameter_136:
 
 class Program_weight_tensor_parameter_137:
     name = "parameter_137"
+    original_name = "batch_norm2d_71.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.429813")
@@ -1452,6 +1590,7 @@ class Program_weight_tensor_parameter_137:
 
 class Program_weight_tensor_parameter_138:
     name = "parameter_138"
+    original_name = "batch_norm2d_71.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.0165991")
@@ -1463,6 +1602,7 @@ class Program_weight_tensor_parameter_138:
 
 class Program_weight_tensor_parameter_139:
     name = "parameter_139"
+    original_name = "batch_norm2d_71.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.61907")
@@ -1474,6 +1614,7 @@ class Program_weight_tensor_parameter_139:
 
 class Program_weight_tensor_parameter_140:
     name = "parameter_140"
+    original_name = "conv2d_77.w_0"
     shape = [160, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.408275")
@@ -1485,6 +1626,7 @@ class Program_weight_tensor_parameter_140:
 
 class Program_weight_tensor_parameter_141:
     name = "parameter_141"
+    original_name = "conv2d_76.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.0411954")
@@ -1496,6 +1638,7 @@ class Program_weight_tensor_parameter_141:
 
 class Program_weight_tensor_parameter_142:
     name = "parameter_142"
+    original_name = "conv2d_76.w_0"
     shape = [160, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.261471")
@@ -1507,6 +1650,7 @@ class Program_weight_tensor_parameter_142:
 
 class Program_weight_tensor_parameter_143:
     name = "parameter_143"
+    original_name = "batch_norm2d_70.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-1.39548")
@@ -1518,6 +1662,7 @@ class Program_weight_tensor_parameter_143:
 
 class Program_weight_tensor_parameter_144:
     name = "parameter_144"
+    original_name = "batch_norm2d_70.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.731932")
@@ -1529,6 +1674,7 @@ class Program_weight_tensor_parameter_144:
 
 class Program_weight_tensor_parameter_145:
     name = "parameter_145"
+    original_name = "batch_norm2d_70.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.0336047")
@@ -1540,6 +1686,7 @@ class Program_weight_tensor_parameter_145:
 
 class Program_weight_tensor_parameter_146:
     name = "parameter_146"
+    original_name = "batch_norm2d_70.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-1.15328")
@@ -1551,6 +1698,7 @@ class Program_weight_tensor_parameter_146:
 
 class Program_weight_tensor_parameter_147:
     name = "parameter_147"
+    original_name = "conv2d_75.w_0"
     shape = [160, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.386287")
@@ -1562,6 +1710,7 @@ class Program_weight_tensor_parameter_147:
 
 class Program_weight_tensor_parameter_148:
     name = "parameter_148"
+    original_name = "batch_norm2d_69.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.341554")
@@ -1573,6 +1722,7 @@ class Program_weight_tensor_parameter_148:
 
 class Program_weight_tensor_parameter_149:
     name = "parameter_149"
+    original_name = "batch_norm2d_69.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.481569")
@@ -1584,6 +1734,7 @@ class Program_weight_tensor_parameter_149:
 
 class Program_weight_tensor_parameter_150:
     name = "parameter_150"
+    original_name = "batch_norm2d_69.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.00312318")
@@ -1595,6 +1746,7 @@ class Program_weight_tensor_parameter_150:
 
 class Program_weight_tensor_parameter_151:
     name = "parameter_151"
+    original_name = "batch_norm2d_69.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.268555")
@@ -1606,6 +1758,7 @@ class Program_weight_tensor_parameter_151:
 
 class Program_weight_tensor_parameter_152:
     name = "parameter_152"
+    original_name = "conv2d_74.w_0"
     shape = [160, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.409956")
@@ -1617,6 +1770,7 @@ class Program_weight_tensor_parameter_152:
 
 class Program_weight_tensor_parameter_153:
     name = "parameter_153"
+    original_name = "batch_norm2d_68.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.778698")
@@ -1628,6 +1782,7 @@ class Program_weight_tensor_parameter_153:
 
 class Program_weight_tensor_parameter_154:
     name = "parameter_154"
+    original_name = "batch_norm2d_68.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.184088")
@@ -1639,6 +1794,7 @@ class Program_weight_tensor_parameter_154:
 
 class Program_weight_tensor_parameter_155:
     name = "parameter_155"
+    original_name = "batch_norm2d_68.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.048143")
@@ -1650,6 +1806,7 @@ class Program_weight_tensor_parameter_155:
 
 class Program_weight_tensor_parameter_156:
     name = "parameter_156"
+    original_name = "batch_norm2d_68.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.523079")
@@ -1661,6 +1818,7 @@ class Program_weight_tensor_parameter_156:
 
 class Program_weight_tensor_parameter_157:
     name = "parameter_157"
+    original_name = "conv2d_73.w_0"
     shape = [160, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.335091")
@@ -1672,6 +1830,7 @@ class Program_weight_tensor_parameter_157:
 
 class Program_weight_tensor_parameter_158:
     name = "parameter_158"
+    original_name = "batch_norm2d_67.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.335059")
@@ -1683,6 +1842,7 @@ class Program_weight_tensor_parameter_158:
 
 class Program_weight_tensor_parameter_159:
     name = "parameter_159"
+    original_name = "batch_norm2d_67.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.572128")
@@ -1694,6 +1854,7 @@ class Program_weight_tensor_parameter_159:
 
 class Program_weight_tensor_parameter_160:
     name = "parameter_160"
+    original_name = "batch_norm2d_67.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.00107233")
@@ -1705,6 +1866,7 @@ class Program_weight_tensor_parameter_160:
 
 class Program_weight_tensor_parameter_161:
     name = "parameter_161"
+    original_name = "batch_norm2d_67.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.25453")
@@ -1716,6 +1878,7 @@ class Program_weight_tensor_parameter_161:
 
 class Program_weight_tensor_parameter_162:
     name = "parameter_162"
+    original_name = "conv2d_72.w_0"
     shape = [160, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.248719")
@@ -1727,6 +1890,7 @@ class Program_weight_tensor_parameter_162:
 
 class Program_weight_tensor_parameter_163:
     name = "parameter_163"
+    original_name = "batch_norm2d_66.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.347887")
@@ -1738,6 +1902,7 @@ class Program_weight_tensor_parameter_163:
 
 class Program_weight_tensor_parameter_164:
     name = "parameter_164"
+    original_name = "batch_norm2d_66.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.119691")
@@ -1749,6 +1914,7 @@ class Program_weight_tensor_parameter_164:
 
 class Program_weight_tensor_parameter_165:
     name = "parameter_165"
+    original_name = "batch_norm2d_66.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.0648214")
@@ -1760,6 +1926,7 @@ class Program_weight_tensor_parameter_165:
 
 class Program_weight_tensor_parameter_166:
     name = "parameter_166"
+    original_name = "batch_norm2d_66.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.545448")
@@ -1771,6 +1938,7 @@ class Program_weight_tensor_parameter_166:
 
 class Program_weight_tensor_parameter_167:
     name = "parameter_167"
+    original_name = "conv2d_71.w_0"
     shape = [160, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.331429")
@@ -1782,6 +1950,7 @@ class Program_weight_tensor_parameter_167:
 
 class Program_weight_tensor_parameter_168:
     name = "parameter_168"
+    original_name = "batch_norm2d_65.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.278153")
@@ -1793,6 +1962,7 @@ class Program_weight_tensor_parameter_168:
 
 class Program_weight_tensor_parameter_169:
     name = "parameter_169"
+    original_name = "batch_norm2d_65.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.540952")
@@ -1804,6 +1974,7 @@ class Program_weight_tensor_parameter_169:
 
 class Program_weight_tensor_parameter_170:
     name = "parameter_170"
+    original_name = "batch_norm2d_65.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.00145926")
@@ -1815,6 +1986,7 @@ class Program_weight_tensor_parameter_170:
 
 class Program_weight_tensor_parameter_171:
     name = "parameter_171"
+    original_name = "batch_norm2d_65.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.292019")
@@ -1826,6 +1998,7 @@ class Program_weight_tensor_parameter_171:
 
 class Program_weight_tensor_parameter_172:
     name = "parameter_172"
+    original_name = "conv2d_70.w_0"
     shape = [160, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.299693")
@@ -1837,6 +2010,7 @@ class Program_weight_tensor_parameter_172:
 
 class Program_weight_tensor_parameter_173:
     name = "parameter_173"
+    original_name = "batch_norm2d_64.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.527016")
@@ -1848,6 +2022,7 @@ class Program_weight_tensor_parameter_173:
 
 class Program_weight_tensor_parameter_174:
     name = "parameter_174"
+    original_name = "batch_norm2d_64.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.156107")
@@ -1859,6 +2034,7 @@ class Program_weight_tensor_parameter_174:
 
 class Program_weight_tensor_parameter_175:
     name = "parameter_175"
+    original_name = "batch_norm2d_64.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.0849134")
@@ -1870,6 +2046,7 @@ class Program_weight_tensor_parameter_175:
 
 class Program_weight_tensor_parameter_176:
     name = "parameter_176"
+    original_name = "batch_norm2d_64.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.636739")
@@ -1881,6 +2058,7 @@ class Program_weight_tensor_parameter_176:
 
 class Program_weight_tensor_parameter_177:
     name = "parameter_177"
+    original_name = "conv2d_69.w_0"
     shape = [160, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.369454")
@@ -1892,6 +2070,7 @@ class Program_weight_tensor_parameter_177:
 
 class Program_weight_tensor_parameter_178:
     name = "parameter_178"
+    original_name = "batch_norm2d_63.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.147475")
@@ -1903,6 +2082,7 @@ class Program_weight_tensor_parameter_178:
 
 class Program_weight_tensor_parameter_179:
     name = "parameter_179"
+    original_name = "batch_norm2d_63.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.635942")
@@ -1914,6 +2094,7 @@ class Program_weight_tensor_parameter_179:
 
 class Program_weight_tensor_parameter_180:
     name = "parameter_180"
+    original_name = "batch_norm2d_63.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.0019277")
@@ -1925,6 +2106,7 @@ class Program_weight_tensor_parameter_180:
 
 class Program_weight_tensor_parameter_181:
     name = "parameter_181"
+    original_name = "batch_norm2d_63.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.143778")
@@ -1936,6 +2118,7 @@ class Program_weight_tensor_parameter_181:
 
 class Program_weight_tensor_parameter_182:
     name = "parameter_182"
+    original_name = "conv2d_68.w_0"
     shape = [160, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.247753")
@@ -1947,6 +2130,7 @@ class Program_weight_tensor_parameter_182:
 
 class Program_weight_tensor_parameter_183:
     name = "parameter_183"
+    original_name = "batch_norm2d_91.b_0"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -1956,6 +2140,7 @@ class Program_weight_tensor_parameter_183:
 
 class Program_weight_tensor_parameter_184:
     name = "parameter_184"
+    original_name = "batch_norm2d_91.w_0"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -1965,6 +2150,7 @@ class Program_weight_tensor_parameter_184:
 
 class Program_weight_tensor_parameter_185:
     name = "parameter_185"
+    original_name = "batch_norm2d_91.w_2"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -1974,6 +2160,7 @@ class Program_weight_tensor_parameter_185:
 
 class Program_weight_tensor_parameter_186:
     name = "parameter_186"
+    original_name = "batch_norm2d_91.w_1"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -1983,6 +2170,7 @@ class Program_weight_tensor_parameter_186:
 
 class Program_weight_tensor_parameter_187:
     name = "parameter_187"
+    original_name = "conv2d_103.w_0"
     shape = [1, 1, 1, 1]
     dtype = "float32"
     min_val = float("0")
@@ -1992,6 +2180,7 @@ class Program_weight_tensor_parameter_187:
 
 class Program_weight_tensor_parameter_188:
     name = "parameter_188"
+    original_name = "batch_norm2d_90.b_0"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -2001,6 +2190,7 @@ class Program_weight_tensor_parameter_188:
 
 class Program_weight_tensor_parameter_189:
     name = "parameter_189"
+    original_name = "batch_norm2d_90.w_0"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -2010,6 +2200,7 @@ class Program_weight_tensor_parameter_189:
 
 class Program_weight_tensor_parameter_190:
     name = "parameter_190"
+    original_name = "batch_norm2d_90.w_2"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -2019,6 +2210,7 @@ class Program_weight_tensor_parameter_190:
 
 class Program_weight_tensor_parameter_191:
     name = "parameter_191"
+    original_name = "batch_norm2d_90.w_1"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -2028,6 +2220,7 @@ class Program_weight_tensor_parameter_191:
 
 class Program_weight_tensor_parameter_192:
     name = "parameter_192"
+    original_name = "conv2d_102.w_0"
     shape = [1, 160, 5, 5]
     dtype = "float32"
     min_val = float("-0.343234")
@@ -2039,6 +2232,7 @@ class Program_weight_tensor_parameter_192:
 
 class Program_weight_tensor_parameter_193:
     name = "parameter_193"
+    original_name = "conv2d_101.b_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -2048,6 +2242,7 @@ class Program_weight_tensor_parameter_193:
 
 class Program_weight_tensor_parameter_194:
     name = "parameter_194"
+    original_name = "conv2d_101.w_0"
     shape = [32, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.501342")
@@ -2059,6 +2254,7 @@ class Program_weight_tensor_parameter_194:
 
 class Program_weight_tensor_parameter_195:
     name = "parameter_195"
+    original_name = "conv2d_100.b_0"
     shape = [4]
     dtype = "float32"
     min_val = float("0")
@@ -2068,6 +2264,7 @@ class Program_weight_tensor_parameter_195:
 
 class Program_weight_tensor_parameter_196:
     name = "parameter_196"
+    original_name = "conv2d_100.w_0"
     shape = [4, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.0280642")
@@ -2079,6 +2276,7 @@ class Program_weight_tensor_parameter_196:
 
 class Program_weight_tensor_parameter_197:
     name = "parameter_197"
+    original_name = "batch_norm2d_62.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.175122")
@@ -2090,6 +2288,7 @@ class Program_weight_tensor_parameter_197:
 
 class Program_weight_tensor_parameter_198:
     name = "parameter_198"
+    original_name = "batch_norm2d_62.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.394882")
@@ -2101,6 +2300,7 @@ class Program_weight_tensor_parameter_198:
 
 class Program_weight_tensor_parameter_199:
     name = "parameter_199"
+    original_name = "batch_norm2d_62.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.0158578")
@@ -2112,6 +2312,7 @@ class Program_weight_tensor_parameter_199:
 
 class Program_weight_tensor_parameter_200:
     name = "parameter_200"
+    original_name = "batch_norm2d_62.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.379409")
@@ -2123,6 +2324,7 @@ class Program_weight_tensor_parameter_200:
 
 class Program_weight_tensor_parameter_201:
     name = "parameter_201"
+    original_name = "conv2d_67.w_0"
     shape = [160, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.486282")
@@ -2134,6 +2336,7 @@ class Program_weight_tensor_parameter_201:
 
 class Program_weight_tensor_parameter_202:
     name = "parameter_202"
+    original_name = "conv2d_66.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.0511428")
@@ -2145,6 +2348,7 @@ class Program_weight_tensor_parameter_202:
 
 class Program_weight_tensor_parameter_203:
     name = "parameter_203"
+    original_name = "conv2d_66.w_0"
     shape = [160, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.314123")
@@ -2156,6 +2360,7 @@ class Program_weight_tensor_parameter_203:
 
 class Program_weight_tensor_parameter_204:
     name = "parameter_204"
+    original_name = "batch_norm2d_61.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.824725")
@@ -2167,6 +2372,7 @@ class Program_weight_tensor_parameter_204:
 
 class Program_weight_tensor_parameter_205:
     name = "parameter_205"
+    original_name = "batch_norm2d_61.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.501982")
@@ -2178,6 +2384,7 @@ class Program_weight_tensor_parameter_205:
 
 class Program_weight_tensor_parameter_206:
     name = "parameter_206"
+    original_name = "batch_norm2d_61.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.0800728")
@@ -2189,6 +2396,7 @@ class Program_weight_tensor_parameter_206:
 
 class Program_weight_tensor_parameter_207:
     name = "parameter_207"
+    original_name = "batch_norm2d_61.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-1.28736")
@@ -2200,6 +2408,7 @@ class Program_weight_tensor_parameter_207:
 
 class Program_weight_tensor_parameter_208:
     name = "parameter_208"
+    original_name = "conv2d_65.w_0"
     shape = [160, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.576585")
@@ -2211,6 +2420,7 @@ class Program_weight_tensor_parameter_208:
 
 class Program_weight_tensor_parameter_209:
     name = "parameter_209"
+    original_name = "batch_norm2d_60.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.452338")
@@ -2222,6 +2432,7 @@ class Program_weight_tensor_parameter_209:
 
 class Program_weight_tensor_parameter_210:
     name = "parameter_210"
+    original_name = "batch_norm2d_60.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.494652")
@@ -2233,6 +2444,7 @@ class Program_weight_tensor_parameter_210:
 
 class Program_weight_tensor_parameter_211:
     name = "parameter_211"
+    original_name = "batch_norm2d_60.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.000334752")
@@ -2244,6 +2456,7 @@ class Program_weight_tensor_parameter_211:
 
 class Program_weight_tensor_parameter_212:
     name = "parameter_212"
+    original_name = "batch_norm2d_60.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.502907")
@@ -2255,6 +2468,7 @@ class Program_weight_tensor_parameter_212:
 
 class Program_weight_tensor_parameter_213:
     name = "parameter_213"
+    original_name = "conv2d_64.w_0"
     shape = [160, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.526094")
@@ -2266,6 +2480,7 @@ class Program_weight_tensor_parameter_213:
 
 class Program_weight_tensor_parameter_214:
     name = "parameter_214"
+    original_name = "batch_norm2d_59.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-1.34124")
@@ -2277,6 +2492,7 @@ class Program_weight_tensor_parameter_214:
 
 class Program_weight_tensor_parameter_215:
     name = "parameter_215"
+    original_name = "batch_norm2d_59.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.073236")
@@ -2288,6 +2504,7 @@ class Program_weight_tensor_parameter_215:
 
 class Program_weight_tensor_parameter_216:
     name = "parameter_216"
+    original_name = "batch_norm2d_59.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.0495117")
@@ -2299,6 +2516,7 @@ class Program_weight_tensor_parameter_216:
 
 class Program_weight_tensor_parameter_217:
     name = "parameter_217"
+    original_name = "batch_norm2d_59.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.898305")
@@ -2310,6 +2528,7 @@ class Program_weight_tensor_parameter_217:
 
 class Program_weight_tensor_parameter_218:
     name = "parameter_218"
+    original_name = "conv2d_63.w_0"
     shape = [160, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.474326")
@@ -2321,6 +2540,7 @@ class Program_weight_tensor_parameter_218:
 
 class Program_weight_tensor_parameter_219:
     name = "parameter_219"
+    original_name = "batch_norm2d_58.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.715354")
@@ -2332,6 +2552,7 @@ class Program_weight_tensor_parameter_219:
 
 class Program_weight_tensor_parameter_220:
     name = "parameter_220"
+    original_name = "batch_norm2d_58.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.480687")
@@ -2343,6 +2564,7 @@ class Program_weight_tensor_parameter_220:
 
 class Program_weight_tensor_parameter_221:
     name = "parameter_221"
+    original_name = "batch_norm2d_58.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.000587828")
@@ -2354,6 +2576,7 @@ class Program_weight_tensor_parameter_221:
 
 class Program_weight_tensor_parameter_222:
     name = "parameter_222"
+    original_name = "batch_norm2d_58.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.466902")
@@ -2365,6 +2588,7 @@ class Program_weight_tensor_parameter_222:
 
 class Program_weight_tensor_parameter_223:
     name = "parameter_223"
+    original_name = "conv2d_62.w_0"
     shape = [160, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.241124")
@@ -2376,6 +2600,7 @@ class Program_weight_tensor_parameter_223:
 
 class Program_weight_tensor_parameter_224:
     name = "parameter_224"
+    original_name = "batch_norm2d_57.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-1.10968")
@@ -2387,6 +2612,7 @@ class Program_weight_tensor_parameter_224:
 
 class Program_weight_tensor_parameter_225:
     name = "parameter_225"
+    original_name = "batch_norm2d_57.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.226811")
@@ -2398,6 +2624,7 @@ class Program_weight_tensor_parameter_225:
 
 class Program_weight_tensor_parameter_226:
     name = "parameter_226"
+    original_name = "batch_norm2d_57.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.0800117")
@@ -2409,6 +2636,7 @@ class Program_weight_tensor_parameter_226:
 
 class Program_weight_tensor_parameter_227:
     name = "parameter_227"
+    original_name = "batch_norm2d_57.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.700852")
@@ -2420,6 +2648,7 @@ class Program_weight_tensor_parameter_227:
 
 class Program_weight_tensor_parameter_228:
     name = "parameter_228"
+    original_name = "conv2d_61.w_0"
     shape = [160, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.347452")
@@ -2431,6 +2660,7 @@ class Program_weight_tensor_parameter_228:
 
 class Program_weight_tensor_parameter_229:
     name = "parameter_229"
+    original_name = "batch_norm2d_56.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.634156")
@@ -2442,6 +2672,7 @@ class Program_weight_tensor_parameter_229:
 
 class Program_weight_tensor_parameter_230:
     name = "parameter_230"
+    original_name = "batch_norm2d_56.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.516477")
@@ -2453,6 +2684,7 @@ class Program_weight_tensor_parameter_230:
 
 class Program_weight_tensor_parameter_231:
     name = "parameter_231"
+    original_name = "batch_norm2d_56.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.000686602")
@@ -2464,6 +2696,7 @@ class Program_weight_tensor_parameter_231:
 
 class Program_weight_tensor_parameter_232:
     name = "parameter_232"
+    original_name = "batch_norm2d_56.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.340383")
@@ -2475,6 +2708,7 @@ class Program_weight_tensor_parameter_232:
 
 class Program_weight_tensor_parameter_233:
     name = "parameter_233"
+    original_name = "conv2d_60.w_0"
     shape = [160, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.255099")
@@ -2486,6 +2720,7 @@ class Program_weight_tensor_parameter_233:
 
 class Program_weight_tensor_parameter_234:
     name = "parameter_234"
+    original_name = "batch_norm2d_55.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.814932")
@@ -2497,6 +2732,7 @@ class Program_weight_tensor_parameter_234:
 
 class Program_weight_tensor_parameter_235:
     name = "parameter_235"
+    original_name = "batch_norm2d_55.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.085747")
@@ -2508,6 +2744,7 @@ class Program_weight_tensor_parameter_235:
 
 class Program_weight_tensor_parameter_236:
     name = "parameter_236"
+    original_name = "batch_norm2d_55.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.0790936")
@@ -2519,6 +2756,7 @@ class Program_weight_tensor_parameter_236:
 
 class Program_weight_tensor_parameter_237:
     name = "parameter_237"
+    original_name = "batch_norm2d_55.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.996393")
@@ -2530,6 +2768,7 @@ class Program_weight_tensor_parameter_237:
 
 class Program_weight_tensor_parameter_238:
     name = "parameter_238"
+    original_name = "conv2d_59.w_0"
     shape = [160, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.370219")
@@ -2541,6 +2780,7 @@ class Program_weight_tensor_parameter_238:
 
 class Program_weight_tensor_parameter_239:
     name = "parameter_239"
+    original_name = "batch_norm2d_54.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.297084")
@@ -2552,6 +2792,7 @@ class Program_weight_tensor_parameter_239:
 
 class Program_weight_tensor_parameter_240:
     name = "parameter_240"
+    original_name = "batch_norm2d_54.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.535512")
@@ -2563,6 +2804,7 @@ class Program_weight_tensor_parameter_240:
 
 class Program_weight_tensor_parameter_241:
     name = "parameter_241"
+    original_name = "batch_norm2d_54.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.00114844")
@@ -2574,6 +2816,7 @@ class Program_weight_tensor_parameter_241:
 
 class Program_weight_tensor_parameter_242:
     name = "parameter_242"
+    original_name = "batch_norm2d_54.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.297837")
@@ -2585,6 +2828,7 @@ class Program_weight_tensor_parameter_242:
 
 class Program_weight_tensor_parameter_243:
     name = "parameter_243"
+    original_name = "conv2d_58.w_0"
     shape = [160, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.371922")
@@ -2596,6 +2840,7 @@ class Program_weight_tensor_parameter_243:
 
 class Program_weight_tensor_parameter_244:
     name = "parameter_244"
+    original_name = "batch_norm2d_33.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.0776264")
@@ -2607,6 +2852,7 @@ class Program_weight_tensor_parameter_244:
 
 class Program_weight_tensor_parameter_245:
     name = "parameter_245"
+    original_name = "batch_norm2d_33.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.0222149")
@@ -2618,6 +2864,7 @@ class Program_weight_tensor_parameter_245:
 
 class Program_weight_tensor_parameter_246:
     name = "parameter_246"
+    original_name = "batch_norm2d_33.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.000383356")
@@ -2629,6 +2876,7 @@ class Program_weight_tensor_parameter_246:
 
 class Program_weight_tensor_parameter_247:
     name = "parameter_247"
+    original_name = "batch_norm2d_33.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.0235314")
@@ -2640,6 +2888,7 @@ class Program_weight_tensor_parameter_247:
 
 class Program_weight_tensor_parameter_248:
     name = "parameter_248"
+    original_name = "conv2d_37.w_0"
     shape = [160, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.275386")
@@ -2651,6 +2900,7 @@ class Program_weight_tensor_parameter_248:
 
 class Program_weight_tensor_parameter_249:
     name = "parameter_249"
+    original_name = "batch_norm2d_32.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.274203")
@@ -2662,6 +2912,7 @@ class Program_weight_tensor_parameter_249:
 
 class Program_weight_tensor_parameter_250:
     name = "parameter_250"
+    original_name = "batch_norm2d_32.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.0556747")
@@ -2673,6 +2924,7 @@ class Program_weight_tensor_parameter_250:
 
 class Program_weight_tensor_parameter_251:
     name = "parameter_251"
+    original_name = "batch_norm2d_32.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.000754285")
@@ -2684,6 +2936,7 @@ class Program_weight_tensor_parameter_251:
 
 class Program_weight_tensor_parameter_252:
     name = "parameter_252"
+    original_name = "batch_norm2d_32.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.294575")
@@ -2695,6 +2948,7 @@ class Program_weight_tensor_parameter_252:
 
 class Program_weight_tensor_parameter_253:
     name = "parameter_253"
+    original_name = "conv2d_36.w_0"
     shape = [160, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.160648")
@@ -2706,6 +2960,7 @@ class Program_weight_tensor_parameter_253:
 
 class Program_weight_tensor_parameter_254:
     name = "parameter_254"
+    original_name = "batch_norm2d_31.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.102693")
@@ -2717,6 +2972,7 @@ class Program_weight_tensor_parameter_254:
 
 class Program_weight_tensor_parameter_255:
     name = "parameter_255"
+    original_name = "batch_norm2d_31.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.00393416")
@@ -2728,6 +2984,7 @@ class Program_weight_tensor_parameter_255:
 
 class Program_weight_tensor_parameter_256:
     name = "parameter_256"
+    original_name = "batch_norm2d_31.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.000100489")
@@ -2739,6 +2996,7 @@ class Program_weight_tensor_parameter_256:
 
 class Program_weight_tensor_parameter_257:
     name = "parameter_257"
+    original_name = "batch_norm2d_31.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.0145607")
@@ -2750,6 +3008,7 @@ class Program_weight_tensor_parameter_257:
 
 class Program_weight_tensor_parameter_258:
     name = "parameter_258"
+    original_name = "conv2d_35.w_0"
     shape = [160, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.375548")
@@ -2761,6 +3020,7 @@ class Program_weight_tensor_parameter_258:
 
 class Program_weight_tensor_parameter_259:
     name = "parameter_259"
+    original_name = "batch_norm2d_30.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.257622")
@@ -2772,6 +3032,7 @@ class Program_weight_tensor_parameter_259:
 
 class Program_weight_tensor_parameter_260:
     name = "parameter_260"
+    original_name = "batch_norm2d_30.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.0455946")
@@ -2783,6 +3044,7 @@ class Program_weight_tensor_parameter_260:
 
 class Program_weight_tensor_parameter_261:
     name = "parameter_261"
+    original_name = "batch_norm2d_30.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("1.21676e-05")
@@ -2794,6 +3056,7 @@ class Program_weight_tensor_parameter_261:
 
 class Program_weight_tensor_parameter_262:
     name = "parameter_262"
+    original_name = "batch_norm2d_30.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.042219")
@@ -2805,6 +3068,7 @@ class Program_weight_tensor_parameter_262:
 
 class Program_weight_tensor_parameter_263:
     name = "parameter_263"
+    original_name = "conv2d_34.w_0"
     shape = [160, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.108871")
@@ -2816,6 +3080,7 @@ class Program_weight_tensor_parameter_263:
 
 class Program_weight_tensor_parameter_264:
     name = "parameter_264"
+    original_name = "batch_norm2d_53.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-1.52748")
@@ -2827,6 +3092,7 @@ class Program_weight_tensor_parameter_264:
 
 class Program_weight_tensor_parameter_265:
     name = "parameter_265"
+    original_name = "batch_norm2d_53.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.111607")
@@ -2838,6 +3104,7 @@ class Program_weight_tensor_parameter_265:
 
 class Program_weight_tensor_parameter_266:
     name = "parameter_266"
+    original_name = "batch_norm2d_53.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.108642")
@@ -2849,6 +3116,7 @@ class Program_weight_tensor_parameter_266:
 
 class Program_weight_tensor_parameter_267:
     name = "parameter_267"
+    original_name = "batch_norm2d_53.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.48161")
@@ -2860,6 +3128,7 @@ class Program_weight_tensor_parameter_267:
 
 class Program_weight_tensor_parameter_268:
     name = "parameter_268"
+    original_name = "conv2d_57.w_0"
     shape = [160, 320, 1, 1]
     dtype = "float32"
     min_val = float("-0.346783")
@@ -2871,6 +3140,7 @@ class Program_weight_tensor_parameter_268:
 
 class Program_weight_tensor_parameter_269:
     name = "parameter_269"
+    original_name = "batch_norm2d_52.b_0"
     shape = [320]
     dtype = "float32"
     min_val = float("-0.675588")
@@ -2882,6 +3152,7 @@ class Program_weight_tensor_parameter_269:
 
 class Program_weight_tensor_parameter_270:
     name = "parameter_270"
+    original_name = "batch_norm2d_52.w_0"
     shape = [320]
     dtype = "float32"
     min_val = float("0.703317")
@@ -2893,6 +3164,7 @@ class Program_weight_tensor_parameter_270:
 
 class Program_weight_tensor_parameter_271:
     name = "parameter_271"
+    original_name = "batch_norm2d_52.w_2"
     shape = [320]
     dtype = "float32"
     min_val = float("0.00646518")
@@ -2904,6 +3176,7 @@ class Program_weight_tensor_parameter_271:
 
 class Program_weight_tensor_parameter_272:
     name = "parameter_272"
+    original_name = "batch_norm2d_52.w_1"
     shape = [320]
     dtype = "float32"
     min_val = float("-0.237349")
@@ -2915,6 +3188,7 @@ class Program_weight_tensor_parameter_272:
 
 class Program_weight_tensor_parameter_273:
     name = "parameter_273"
+    original_name = "conv2d_56.w_0"
     shape = [320, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.21214")
@@ -2926,6 +3200,7 @@ class Program_weight_tensor_parameter_273:
 
 class Program_weight_tensor_parameter_274:
     name = "parameter_274"
+    original_name = "batch_norm2d_51.b_0"
     shape = [320]
     dtype = "float32"
     min_val = float("-1.02069")
@@ -2937,6 +3212,7 @@ class Program_weight_tensor_parameter_274:
 
 class Program_weight_tensor_parameter_275:
     name = "parameter_275"
+    original_name = "batch_norm2d_51.w_0"
     shape = [320]
     dtype = "float32"
     min_val = float("0.581053")
@@ -2948,6 +3224,7 @@ class Program_weight_tensor_parameter_275:
 
 class Program_weight_tensor_parameter_276:
     name = "parameter_276"
+    original_name = "batch_norm2d_51.w_2"
     shape = [320]
     dtype = "float32"
     min_val = float("0.0972238")
@@ -2959,6 +3236,7 @@ class Program_weight_tensor_parameter_276:
 
 class Program_weight_tensor_parameter_277:
     name = "parameter_277"
+    original_name = "batch_norm2d_51.w_1"
     shape = [320]
     dtype = "float32"
     min_val = float("-0.79971")
@@ -2970,6 +3248,7 @@ class Program_weight_tensor_parameter_277:
 
 class Program_weight_tensor_parameter_278:
     name = "parameter_278"
+    original_name = "conv2d_55.w_0"
     shape = [320, 320, 1, 1]
     dtype = "float32"
     min_val = float("-0.372283")
@@ -2981,6 +3260,7 @@ class Program_weight_tensor_parameter_278:
 
 class Program_weight_tensor_parameter_279:
     name = "parameter_279"
+    original_name = "batch_norm2d_50.b_0"
     shape = [320]
     dtype = "float32"
     min_val = float("-1.061")
@@ -2992,6 +3272,7 @@ class Program_weight_tensor_parameter_279:
 
 class Program_weight_tensor_parameter_280:
     name = "parameter_280"
+    original_name = "batch_norm2d_50.w_0"
     shape = [320]
     dtype = "float32"
     min_val = float("0.573958")
@@ -3003,6 +3284,7 @@ class Program_weight_tensor_parameter_280:
 
 class Program_weight_tensor_parameter_281:
     name = "parameter_281"
+    original_name = "batch_norm2d_50.w_2"
     shape = [320]
     dtype = "float32"
     min_val = float("4.7199e-05")
@@ -3014,6 +3296,7 @@ class Program_weight_tensor_parameter_281:
 
 class Program_weight_tensor_parameter_282:
     name = "parameter_282"
+    original_name = "batch_norm2d_50.w_1"
     shape = [320]
     dtype = "float32"
     min_val = float("-0.0567058")
@@ -3025,6 +3308,7 @@ class Program_weight_tensor_parameter_282:
 
 class Program_weight_tensor_parameter_283:
     name = "parameter_283"
+    original_name = "conv2d_54.w_0"
     shape = [320, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.307453")
@@ -3036,6 +3320,7 @@ class Program_weight_tensor_parameter_283:
 
 class Program_weight_tensor_parameter_284:
     name = "parameter_284"
+    original_name = "batch_norm2d_49.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.0797481")
@@ -3047,6 +3332,7 @@ class Program_weight_tensor_parameter_284:
 
 class Program_weight_tensor_parameter_285:
     name = "parameter_285"
+    original_name = "batch_norm2d_49.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.0520047")
@@ -3058,6 +3344,7 @@ class Program_weight_tensor_parameter_285:
 
 class Program_weight_tensor_parameter_286:
     name = "parameter_286"
+    original_name = "batch_norm2d_49.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.000863668")
@@ -3069,6 +3356,7 @@ class Program_weight_tensor_parameter_286:
 
 class Program_weight_tensor_parameter_287:
     name = "parameter_287"
+    original_name = "batch_norm2d_49.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.0262194")
@@ -3080,6 +3368,7 @@ class Program_weight_tensor_parameter_287:
 
 class Program_weight_tensor_parameter_288:
     name = "parameter_288"
+    original_name = "conv2d_53.w_0"
     shape = [160, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.31709")
@@ -3091,6 +3380,7 @@ class Program_weight_tensor_parameter_288:
 
 class Program_weight_tensor_parameter_289:
     name = "parameter_289"
+    original_name = "batch_norm2d_48.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.219785")
@@ -3102,6 +3392,7 @@ class Program_weight_tensor_parameter_289:
 
 class Program_weight_tensor_parameter_290:
     name = "parameter_290"
+    original_name = "batch_norm2d_48.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.0410941")
@@ -3113,6 +3404,7 @@ class Program_weight_tensor_parameter_290:
 
 class Program_weight_tensor_parameter_291:
     name = "parameter_291"
+    original_name = "batch_norm2d_48.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.000551964")
@@ -3124,6 +3416,7 @@ class Program_weight_tensor_parameter_291:
 
 class Program_weight_tensor_parameter_292:
     name = "parameter_292"
+    original_name = "batch_norm2d_48.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.49201")
@@ -3135,6 +3428,7 @@ class Program_weight_tensor_parameter_292:
 
 class Program_weight_tensor_parameter_293:
     name = "parameter_293"
+    original_name = "conv2d_52.w_0"
     shape = [160, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.205028")
@@ -3146,6 +3440,7 @@ class Program_weight_tensor_parameter_293:
 
 class Program_weight_tensor_parameter_294:
     name = "parameter_294"
+    original_name = "batch_norm2d_47.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-1.34914")
@@ -3157,6 +3452,7 @@ class Program_weight_tensor_parameter_294:
 
 class Program_weight_tensor_parameter_295:
     name = "parameter_295"
+    original_name = "batch_norm2d_47.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.128997")
@@ -3168,6 +3464,7 @@ class Program_weight_tensor_parameter_295:
 
 class Program_weight_tensor_parameter_296:
     name = "parameter_296"
+    original_name = "batch_norm2d_47.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.149157")
@@ -3179,6 +3476,7 @@ class Program_weight_tensor_parameter_296:
 
 class Program_weight_tensor_parameter_297:
     name = "parameter_297"
+    original_name = "batch_norm2d_47.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.630963")
@@ -3190,6 +3488,7 @@ class Program_weight_tensor_parameter_297:
 
 class Program_weight_tensor_parameter_298:
     name = "parameter_298"
+    original_name = "conv2d_51.w_0"
     shape = [160, 320, 1, 1]
     dtype = "float32"
     min_val = float("-0.355558")
@@ -3201,6 +3500,7 @@ class Program_weight_tensor_parameter_298:
 
 class Program_weight_tensor_parameter_299:
     name = "parameter_299"
+    original_name = "batch_norm2d_46.b_0"
     shape = [320]
     dtype = "float32"
     min_val = float("-0.525227")
@@ -3212,6 +3512,7 @@ class Program_weight_tensor_parameter_299:
 
 class Program_weight_tensor_parameter_300:
     name = "parameter_300"
+    original_name = "batch_norm2d_46.w_0"
     shape = [320]
     dtype = "float32"
     min_val = float("0.621528")
@@ -3223,6 +3524,7 @@ class Program_weight_tensor_parameter_300:
 
 class Program_weight_tensor_parameter_301:
     name = "parameter_301"
+    original_name = "batch_norm2d_46.w_2"
     shape = [320]
     dtype = "float32"
     min_val = float("0.00609398")
@@ -3234,6 +3536,7 @@ class Program_weight_tensor_parameter_301:
 
 class Program_weight_tensor_parameter_302:
     name = "parameter_302"
+    original_name = "batch_norm2d_46.w_1"
     shape = [320]
     dtype = "float32"
     min_val = float("-0.276445")
@@ -3245,6 +3548,7 @@ class Program_weight_tensor_parameter_302:
 
 class Program_weight_tensor_parameter_303:
     name = "parameter_303"
+    original_name = "conv2d_50.w_0"
     shape = [320, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.265965")
@@ -3256,6 +3560,7 @@ class Program_weight_tensor_parameter_303:
 
 class Program_weight_tensor_parameter_304:
     name = "parameter_304"
+    original_name = "batch_norm2d_45.b_0"
     shape = [320]
     dtype = "float32"
     min_val = float("-0.969368")
@@ -3267,6 +3572,7 @@ class Program_weight_tensor_parameter_304:
 
 class Program_weight_tensor_parameter_305:
     name = "parameter_305"
+    original_name = "batch_norm2d_45.w_0"
     shape = [320]
     dtype = "float32"
     min_val = float("0.698841")
@@ -3278,6 +3584,7 @@ class Program_weight_tensor_parameter_305:
 
 class Program_weight_tensor_parameter_306:
     name = "parameter_306"
+    original_name = "batch_norm2d_45.w_2"
     shape = [320]
     dtype = "float32"
     min_val = float("0.140436")
@@ -3289,6 +3596,7 @@ class Program_weight_tensor_parameter_306:
 
 class Program_weight_tensor_parameter_307:
     name = "parameter_307"
+    original_name = "batch_norm2d_45.w_1"
     shape = [320]
     dtype = "float32"
     min_val = float("-0.630099")
@@ -3300,6 +3608,7 @@ class Program_weight_tensor_parameter_307:
 
 class Program_weight_tensor_parameter_308:
     name = "parameter_308"
+    original_name = "conv2d_49.w_0"
     shape = [320, 320, 1, 1]
     dtype = "float32"
     min_val = float("-0.326178")
@@ -3311,6 +3620,7 @@ class Program_weight_tensor_parameter_308:
 
 class Program_weight_tensor_parameter_309:
     name = "parameter_309"
+    original_name = "batch_norm2d_44.b_0"
     shape = [320]
     dtype = "float32"
     min_val = float("-0.888987")
@@ -3322,6 +3632,7 @@ class Program_weight_tensor_parameter_309:
 
 class Program_weight_tensor_parameter_310:
     name = "parameter_310"
+    original_name = "batch_norm2d_44.w_0"
     shape = [320]
     dtype = "float32"
     min_val = float("0.591745")
@@ -3333,6 +3644,7 @@ class Program_weight_tensor_parameter_310:
 
 class Program_weight_tensor_parameter_311:
     name = "parameter_311"
+    original_name = "batch_norm2d_44.w_2"
     shape = [320]
     dtype = "float32"
     min_val = float("6.33877e-05")
@@ -3344,6 +3656,7 @@ class Program_weight_tensor_parameter_311:
 
 class Program_weight_tensor_parameter_312:
     name = "parameter_312"
+    original_name = "batch_norm2d_44.w_1"
     shape = [320]
     dtype = "float32"
     min_val = float("-0.317697")
@@ -3355,6 +3668,7 @@ class Program_weight_tensor_parameter_312:
 
 class Program_weight_tensor_parameter_313:
     name = "parameter_313"
+    original_name = "conv2d_48.w_0"
     shape = [320, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.431316")
@@ -3366,6 +3680,7 @@ class Program_weight_tensor_parameter_313:
 
 class Program_weight_tensor_parameter_314:
     name = "parameter_314"
+    original_name = "batch_norm2d_43.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.232954")
@@ -3377,6 +3692,7 @@ class Program_weight_tensor_parameter_314:
 
 class Program_weight_tensor_parameter_315:
     name = "parameter_315"
+    original_name = "batch_norm2d_43.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.0392057")
@@ -3388,6 +3704,7 @@ class Program_weight_tensor_parameter_315:
 
 class Program_weight_tensor_parameter_316:
     name = "parameter_316"
+    original_name = "batch_norm2d_43.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.00111982")
@@ -3399,6 +3716,7 @@ class Program_weight_tensor_parameter_316:
 
 class Program_weight_tensor_parameter_317:
     name = "parameter_317"
+    original_name = "batch_norm2d_43.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.0513773")
@@ -3410,6 +3728,7 @@ class Program_weight_tensor_parameter_317:
 
 class Program_weight_tensor_parameter_318:
     name = "parameter_318"
+    original_name = "conv2d_47.w_0"
     shape = [160, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.398665")
@@ -3421,6 +3740,7 @@ class Program_weight_tensor_parameter_318:
 
 class Program_weight_tensor_parameter_319:
     name = "parameter_319"
+    original_name = "batch_norm2d_42.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.459841")
@@ -3432,6 +3752,7 @@ class Program_weight_tensor_parameter_319:
 
 class Program_weight_tensor_parameter_320:
     name = "parameter_320"
+    original_name = "batch_norm2d_42.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.0745243")
@@ -3443,6 +3764,7 @@ class Program_weight_tensor_parameter_320:
 
 class Program_weight_tensor_parameter_321:
     name = "parameter_321"
+    original_name = "batch_norm2d_42.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.00108003")
@@ -3454,6 +3776,7 @@ class Program_weight_tensor_parameter_321:
 
 class Program_weight_tensor_parameter_322:
     name = "parameter_322"
+    original_name = "batch_norm2d_42.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.54725")
@@ -3465,6 +3788,7 @@ class Program_weight_tensor_parameter_322:
 
 class Program_weight_tensor_parameter_323:
     name = "parameter_323"
+    original_name = "conv2d_46.w_0"
     shape = [160, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.264091")
@@ -3476,6 +3800,7 @@ class Program_weight_tensor_parameter_323:
 
 class Program_weight_tensor_parameter_324:
     name = "parameter_324"
+    original_name = "batch_norm2d_41.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-1.50543")
@@ -3487,6 +3812,7 @@ class Program_weight_tensor_parameter_324:
 
 class Program_weight_tensor_parameter_325:
     name = "parameter_325"
+    original_name = "batch_norm2d_41.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.170087")
@@ -3498,6 +3824,7 @@ class Program_weight_tensor_parameter_325:
 
 class Program_weight_tensor_parameter_326:
     name = "parameter_326"
+    original_name = "batch_norm2d_41.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.15311")
@@ -3509,6 +3836,7 @@ class Program_weight_tensor_parameter_326:
 
 class Program_weight_tensor_parameter_327:
     name = "parameter_327"
+    original_name = "batch_norm2d_41.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.860006")
@@ -3520,6 +3848,7 @@ class Program_weight_tensor_parameter_327:
 
 class Program_weight_tensor_parameter_328:
     name = "parameter_328"
+    original_name = "conv2d_45.w_0"
     shape = [160, 320, 1, 1]
     dtype = "float32"
     min_val = float("-0.491868")
@@ -3531,6 +3860,7 @@ class Program_weight_tensor_parameter_328:
 
 class Program_weight_tensor_parameter_329:
     name = "parameter_329"
+    original_name = "batch_norm2d_40.b_0"
     shape = [320]
     dtype = "float32"
     min_val = float("-1.20321")
@@ -3542,6 +3872,7 @@ class Program_weight_tensor_parameter_329:
 
 class Program_weight_tensor_parameter_330:
     name = "parameter_330"
+    original_name = "batch_norm2d_40.w_0"
     shape = [320]
     dtype = "float32"
     min_val = float("0.504597")
@@ -3553,6 +3884,7 @@ class Program_weight_tensor_parameter_330:
 
 class Program_weight_tensor_parameter_331:
     name = "parameter_331"
+    original_name = "batch_norm2d_40.w_2"
     shape = [320]
     dtype = "float32"
     min_val = float("0.000648541")
@@ -3564,6 +3896,7 @@ class Program_weight_tensor_parameter_331:
 
 class Program_weight_tensor_parameter_332:
     name = "parameter_332"
+    original_name = "batch_norm2d_40.w_1"
     shape = [320]
     dtype = "float32"
     min_val = float("-0.4102")
@@ -3575,6 +3908,7 @@ class Program_weight_tensor_parameter_332:
 
 class Program_weight_tensor_parameter_333:
     name = "parameter_333"
+    original_name = "conv2d_44.w_0"
     shape = [320, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.40733")
@@ -3586,6 +3920,7 @@ class Program_weight_tensor_parameter_333:
 
 class Program_weight_tensor_parameter_334:
     name = "parameter_334"
+    original_name = "batch_norm2d_39.b_0"
     shape = [320]
     dtype = "float32"
     min_val = float("-1.5156")
@@ -3597,6 +3932,7 @@ class Program_weight_tensor_parameter_334:
 
 class Program_weight_tensor_parameter_335:
     name = "parameter_335"
+    original_name = "batch_norm2d_39.w_0"
     shape = [320]
     dtype = "float32"
     min_val = float("0.198958")
@@ -3608,6 +3944,7 @@ class Program_weight_tensor_parameter_335:
 
 class Program_weight_tensor_parameter_336:
     name = "parameter_336"
+    original_name = "batch_norm2d_39.w_2"
     shape = [320]
     dtype = "float32"
     min_val = float("0.180136")
@@ -3619,6 +3956,7 @@ class Program_weight_tensor_parameter_336:
 
 class Program_weight_tensor_parameter_337:
     name = "parameter_337"
+    original_name = "batch_norm2d_39.w_1"
     shape = [320]
     dtype = "float32"
     min_val = float("-1.36426")
@@ -3630,6 +3968,7 @@ class Program_weight_tensor_parameter_337:
 
 class Program_weight_tensor_parameter_338:
     name = "parameter_338"
+    original_name = "conv2d_43.w_0"
     shape = [320, 320, 1, 1]
     dtype = "float32"
     min_val = float("-0.433226")
@@ -3641,6 +3980,7 @@ class Program_weight_tensor_parameter_338:
 
 class Program_weight_tensor_parameter_339:
     name = "parameter_339"
+    original_name = "batch_norm2d_38.b_0"
     shape = [320]
     dtype = "float32"
     min_val = float("-0.701698")
@@ -3652,6 +3992,7 @@ class Program_weight_tensor_parameter_339:
 
 class Program_weight_tensor_parameter_340:
     name = "parameter_340"
+    original_name = "batch_norm2d_38.w_0"
     shape = [320]
     dtype = "float32"
     min_val = float("0.524064")
@@ -3663,6 +4004,7 @@ class Program_weight_tensor_parameter_340:
 
 class Program_weight_tensor_parameter_341:
     name = "parameter_341"
+    original_name = "batch_norm2d_38.w_2"
     shape = [320]
     dtype = "float32"
     min_val = float("6.55891e-05")
@@ -3674,6 +4016,7 @@ class Program_weight_tensor_parameter_341:
 
 class Program_weight_tensor_parameter_342:
     name = "parameter_342"
+    original_name = "batch_norm2d_38.w_1"
     shape = [320]
     dtype = "float32"
     min_val = float("-0.657085")
@@ -3685,6 +4028,7 @@ class Program_weight_tensor_parameter_342:
 
 class Program_weight_tensor_parameter_343:
     name = "parameter_343"
+    original_name = "conv2d_42.w_0"
     shape = [320, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.464137")
@@ -3696,6 +4040,7 @@ class Program_weight_tensor_parameter_343:
 
 class Program_weight_tensor_parameter_344:
     name = "parameter_344"
+    original_name = "batch_norm2d_37.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.608429")
@@ -3707,6 +4052,7 @@ class Program_weight_tensor_parameter_344:
 
 class Program_weight_tensor_parameter_345:
     name = "parameter_345"
+    original_name = "batch_norm2d_37.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.206021")
@@ -3718,6 +4064,7 @@ class Program_weight_tensor_parameter_345:
 
 class Program_weight_tensor_parameter_346:
     name = "parameter_346"
+    original_name = "batch_norm2d_37.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.299854")
@@ -3729,6 +4076,7 @@ class Program_weight_tensor_parameter_346:
 
 class Program_weight_tensor_parameter_347:
     name = "parameter_347"
+    original_name = "batch_norm2d_37.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.879604")
@@ -3740,6 +4088,7 @@ class Program_weight_tensor_parameter_347:
 
 class Program_weight_tensor_parameter_348:
     name = "parameter_348"
+    original_name = "conv2d_41.w_0"
     shape = [160, 320, 1, 1]
     dtype = "float32"
     min_val = float("-0.360979")
@@ -3751,6 +4100,7 @@ class Program_weight_tensor_parameter_348:
 
 class Program_weight_tensor_parameter_349:
     name = "parameter_349"
+    original_name = "batch_norm2d_36.b_0"
     shape = [320]
     dtype = "float32"
     min_val = float("-0.737945")
@@ -3762,6 +4112,7 @@ class Program_weight_tensor_parameter_349:
 
 class Program_weight_tensor_parameter_350:
     name = "parameter_350"
+    original_name = "batch_norm2d_36.w_0"
     shape = [320]
     dtype = "float32"
     min_val = float("0.633454")
@@ -3773,6 +4124,7 @@ class Program_weight_tensor_parameter_350:
 
 class Program_weight_tensor_parameter_351:
     name = "parameter_351"
+    original_name = "batch_norm2d_36.w_2"
     shape = [320]
     dtype = "float32"
     min_val = float("0.00437483")
@@ -3784,6 +4136,7 @@ class Program_weight_tensor_parameter_351:
 
 class Program_weight_tensor_parameter_352:
     name = "parameter_352"
+    original_name = "batch_norm2d_36.w_1"
     shape = [320]
     dtype = "float32"
     min_val = float("-0.253492")
@@ -3795,6 +4148,7 @@ class Program_weight_tensor_parameter_352:
 
 class Program_weight_tensor_parameter_353:
     name = "parameter_353"
+    original_name = "conv2d_40.w_0"
     shape = [320, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.457778")
@@ -3806,6 +4160,7 @@ class Program_weight_tensor_parameter_353:
 
 class Program_weight_tensor_parameter_354:
     name = "parameter_354"
+    original_name = "batch_norm2d_35.b_0"
     shape = [320]
     dtype = "float32"
     min_val = float("-1.02393")
@@ -3817,6 +4172,7 @@ class Program_weight_tensor_parameter_354:
 
 class Program_weight_tensor_parameter_355:
     name = "parameter_355"
+    original_name = "batch_norm2d_35.w_0"
     shape = [320]
     dtype = "float32"
     min_val = float("0.37518")
@@ -3828,6 +4184,7 @@ class Program_weight_tensor_parameter_355:
 
 class Program_weight_tensor_parameter_356:
     name = "parameter_356"
+    original_name = "batch_norm2d_35.w_2"
     shape = [320]
     dtype = "float32"
     min_val = float("0.205656")
@@ -3839,6 +4196,7 @@ class Program_weight_tensor_parameter_356:
 
 class Program_weight_tensor_parameter_357:
     name = "parameter_357"
+    original_name = "batch_norm2d_35.w_1"
     shape = [320]
     dtype = "float32"
     min_val = float("-2.02876")
@@ -3850,6 +4208,7 @@ class Program_weight_tensor_parameter_357:
 
 class Program_weight_tensor_parameter_358:
     name = "parameter_358"
+    original_name = "conv2d_39.w_0"
     shape = [320, 320, 1, 1]
     dtype = "float32"
     min_val = float("-0.326346")
@@ -3861,6 +4220,7 @@ class Program_weight_tensor_parameter_358:
 
 class Program_weight_tensor_parameter_359:
     name = "parameter_359"
+    original_name = "batch_norm2d_34.b_0"
     shape = [320]
     dtype = "float32"
     min_val = float("-1.12876")
@@ -3872,6 +4232,7 @@ class Program_weight_tensor_parameter_359:
 
 class Program_weight_tensor_parameter_360:
     name = "parameter_360"
+    original_name = "batch_norm2d_34.w_0"
     shape = [320]
     dtype = "float32"
     min_val = float("0.708303")
@@ -3883,6 +4244,7 @@ class Program_weight_tensor_parameter_360:
 
 class Program_weight_tensor_parameter_361:
     name = "parameter_361"
+    original_name = "batch_norm2d_34.w_2"
     shape = [320]
     dtype = "float32"
     min_val = float("6.80597e-05")
@@ -3894,6 +4256,7 @@ class Program_weight_tensor_parameter_361:
 
 class Program_weight_tensor_parameter_362:
     name = "parameter_362"
+    original_name = "batch_norm2d_34.w_1"
     shape = [320]
     dtype = "float32"
     min_val = float("-0.0596173")
@@ -3905,6 +4268,7 @@ class Program_weight_tensor_parameter_362:
 
 class Program_weight_tensor_parameter_363:
     name = "parameter_363"
+    original_name = "conv2d_38.w_0"
     shape = [320, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.516653")
@@ -3916,6 +4280,7 @@ class Program_weight_tensor_parameter_363:
 
 class Program_weight_tensor_parameter_364:
     name = "parameter_364"
+    original_name = "batch_norm2d_29.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.264621")
@@ -3927,6 +4292,7 @@ class Program_weight_tensor_parameter_364:
 
 class Program_weight_tensor_parameter_365:
     name = "parameter_365"
+    original_name = "batch_norm2d_29.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.0624955")
@@ -3938,6 +4304,7 @@ class Program_weight_tensor_parameter_365:
 
 class Program_weight_tensor_parameter_366:
     name = "parameter_366"
+    original_name = "batch_norm2d_29.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("1.46386")
@@ -3949,6 +4316,7 @@ class Program_weight_tensor_parameter_366:
 
 class Program_weight_tensor_parameter_367:
     name = "parameter_367"
+    original_name = "batch_norm2d_29.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-1.33543")
@@ -3960,6 +4328,7 @@ class Program_weight_tensor_parameter_367:
 
 class Program_weight_tensor_parameter_368:
     name = "parameter_368"
+    original_name = "conv2d_33.w_0"
     shape = [160, 1024, 1, 1]
     dtype = "float32"
     min_val = float("-0.362272")
@@ -3971,6 +4340,7 @@ class Program_weight_tensor_parameter_368:
 
 class Program_weight_tensor_parameter_369:
     name = "parameter_369"
+    original_name = "batch_norm2d_28.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.106417")
@@ -3982,6 +4352,7 @@ class Program_weight_tensor_parameter_369:
 
 class Program_weight_tensor_parameter_370:
     name = "parameter_370"
+    original_name = "batch_norm2d_28.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.0452014")
@@ -3993,6 +4364,7 @@ class Program_weight_tensor_parameter_370:
 
 class Program_weight_tensor_parameter_371:
     name = "parameter_371"
+    original_name = "batch_norm2d_28.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.0400246")
@@ -4004,6 +4376,7 @@ class Program_weight_tensor_parameter_371:
 
 class Program_weight_tensor_parameter_372:
     name = "parameter_372"
+    original_name = "batch_norm2d_28.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.693646")
@@ -4015,6 +4388,7 @@ class Program_weight_tensor_parameter_372:
 
 class Program_weight_tensor_parameter_373:
     name = "parameter_373"
+    original_name = "conv2d_32.w_0"
     shape = [160, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.166546")
@@ -4026,6 +4400,7 @@ class Program_weight_tensor_parameter_373:
 
 class Program_weight_tensor_parameter_374:
     name = "parameter_374"
+    original_name = "batch_norm2d_27.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.153373")
@@ -4037,6 +4412,7 @@ class Program_weight_tensor_parameter_374:
 
 class Program_weight_tensor_parameter_375:
     name = "parameter_375"
+    original_name = "batch_norm2d_27.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.057394")
@@ -4048,6 +4424,7 @@ class Program_weight_tensor_parameter_375:
 
 class Program_weight_tensor_parameter_376:
     name = "parameter_376"
+    original_name = "batch_norm2d_27.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.0274508")
@@ -4059,6 +4436,7 @@ class Program_weight_tensor_parameter_376:
 
 class Program_weight_tensor_parameter_377:
     name = "parameter_377"
+    original_name = "batch_norm2d_27.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.947015")
@@ -4070,6 +4448,7 @@ class Program_weight_tensor_parameter_377:
 
 class Program_weight_tensor_parameter_378:
     name = "parameter_378"
+    original_name = "conv2d_31.w_0"
     shape = [160, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.270708")
@@ -4081,6 +4460,7 @@ class Program_weight_tensor_parameter_378:
 
 class Program_weight_tensor_parameter_379:
     name = "parameter_379"
+    original_name = "batch_norm2d_26.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-4.59365")
@@ -4092,6 +4472,7 @@ class Program_weight_tensor_parameter_379:
 
 class Program_weight_tensor_parameter_380:
     name = "parameter_380"
+    original_name = "batch_norm2d_26.w_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("1.80101")
@@ -4103,6 +4484,7 @@ class Program_weight_tensor_parameter_380:
 
 class Program_weight_tensor_parameter_381:
     name = "parameter_381"
+    original_name = "batch_norm2d_26.w_2"
     shape = [1024]
     dtype = "float32"
     min_val = float("0.0514259")
@@ -4114,6 +4496,7 @@ class Program_weight_tensor_parameter_381:
 
 class Program_weight_tensor_parameter_382:
     name = "parameter_382"
+    original_name = "batch_norm2d_26.w_1"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.54475")
@@ -4125,6 +4508,7 @@ class Program_weight_tensor_parameter_382:
 
 class Program_weight_tensor_parameter_383:
     name = "parameter_383"
+    original_name = "conv2d_30.w_0"
     shape = [1024, 1024, 1, 1]
     dtype = "float32"
     min_val = float("-0.26716")
@@ -4136,6 +4520,7 @@ class Program_weight_tensor_parameter_383:
 
 class Program_weight_tensor_parameter_384:
     name = "parameter_384"
+    original_name = "conv2d_29.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.0733213")
@@ -4147,6 +4532,7 @@ class Program_weight_tensor_parameter_384:
 
 class Program_weight_tensor_parameter_385:
     name = "parameter_385"
+    original_name = "conv2d_29.w_0"
     shape = [1024, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.352913")
@@ -4158,6 +4544,7 @@ class Program_weight_tensor_parameter_385:
 
 class Program_weight_tensor_parameter_386:
     name = "parameter_386"
+    original_name = "conv2d_28.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.011965")
@@ -4169,6 +4556,7 @@ class Program_weight_tensor_parameter_386:
 
 class Program_weight_tensor_parameter_387:
     name = "parameter_387"
+    original_name = "conv2d_28.w_0"
     shape = [256, 1024, 1, 1]
     dtype = "float32"
     min_val = float("-0.319719")
@@ -4180,6 +4568,7 @@ class Program_weight_tensor_parameter_387:
 
 class Program_weight_tensor_parameter_388:
     name = "parameter_388"
+    original_name = "batch_norm2d_25.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-4.03939")
@@ -4191,6 +4580,7 @@ class Program_weight_tensor_parameter_388:
 
 class Program_weight_tensor_parameter_389:
     name = "parameter_389"
+    original_name = "batch_norm2d_25.w_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("0.251665")
@@ -4202,6 +4592,7 @@ class Program_weight_tensor_parameter_389:
 
 class Program_weight_tensor_parameter_390:
     name = "parameter_390"
+    original_name = "batch_norm2d_25.w_2"
     shape = [1024]
     dtype = "float32"
     min_val = float("0.000143732")
@@ -4213,6 +4604,7 @@ class Program_weight_tensor_parameter_390:
 
 class Program_weight_tensor_parameter_391:
     name = "parameter_391"
+    original_name = "batch_norm2d_25.w_1"
     shape = [1024]
     dtype = "float32"
     min_val = float("-1.9961")
@@ -4224,6 +4616,7 @@ class Program_weight_tensor_parameter_391:
 
 class Program_weight_tensor_parameter_392:
     name = "parameter_392"
+    original_name = "conv2d_27.w_0"
     shape = [1024, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.51284")
@@ -4235,6 +4628,7 @@ class Program_weight_tensor_parameter_392:
 
 class Program_weight_tensor_parameter_393:
     name = "parameter_393"
+    original_name = "batch_norm2d_24.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-3.08876")
@@ -4246,6 +4640,7 @@ class Program_weight_tensor_parameter_393:
 
 class Program_weight_tensor_parameter_394:
     name = "parameter_394"
+    original_name = "batch_norm2d_24.w_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.0915281")
@@ -4257,6 +4652,7 @@ class Program_weight_tensor_parameter_394:
 
 class Program_weight_tensor_parameter_395:
     name = "parameter_395"
+    original_name = "batch_norm2d_24.w_2"
     shape = [1024]
     dtype = "float32"
     min_val = float("0.0741839")
@@ -4268,6 +4664,7 @@ class Program_weight_tensor_parameter_395:
 
 class Program_weight_tensor_parameter_396:
     name = "parameter_396"
+    original_name = "batch_norm2d_24.w_1"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.97736")
@@ -4279,6 +4676,7 @@ class Program_weight_tensor_parameter_396:
 
 class Program_weight_tensor_parameter_397:
     name = "parameter_397"
+    original_name = "conv2d_26.w_0"
     shape = [1024, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.346654")
@@ -4290,6 +4688,7 @@ class Program_weight_tensor_parameter_397:
 
 class Program_weight_tensor_parameter_398:
     name = "parameter_398"
+    original_name = "conv2d_25.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.112244")
@@ -4301,6 +4700,7 @@ class Program_weight_tensor_parameter_398:
 
 class Program_weight_tensor_parameter_399:
     name = "parameter_399"
+    original_name = "conv2d_25.w_0"
     shape = [512, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.294725")
@@ -4312,6 +4712,7 @@ class Program_weight_tensor_parameter_399:
 
 class Program_weight_tensor_parameter_400:
     name = "parameter_400"
+    original_name = "conv2d_24.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.00250126")
@@ -4323,6 +4724,7 @@ class Program_weight_tensor_parameter_400:
 
 class Program_weight_tensor_parameter_401:
     name = "parameter_401"
+    original_name = "conv2d_24.w_0"
     shape = [128, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.358129")
@@ -4334,6 +4736,7 @@ class Program_weight_tensor_parameter_401:
 
 class Program_weight_tensor_parameter_402:
     name = "parameter_402"
+    original_name = "batch_norm2d_23.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-1.41417")
@@ -4345,6 +4748,7 @@ class Program_weight_tensor_parameter_402:
 
 class Program_weight_tensor_parameter_403:
     name = "parameter_403"
+    original_name = "batch_norm2d_23.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("0.636173")
@@ -4356,6 +4760,7 @@ class Program_weight_tensor_parameter_403:
 
 class Program_weight_tensor_parameter_404:
     name = "parameter_404"
+    original_name = "batch_norm2d_23.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("0.000241562")
@@ -4367,6 +4772,7 @@ class Program_weight_tensor_parameter_404:
 
 class Program_weight_tensor_parameter_405:
     name = "parameter_405"
+    original_name = "batch_norm2d_23.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-1.44852")
@@ -4378,6 +4784,7 @@ class Program_weight_tensor_parameter_405:
 
 class Program_weight_tensor_parameter_406:
     name = "parameter_406"
+    original_name = "conv2d_23.w_0"
     shape = [512, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.244098")
@@ -4389,6 +4796,7 @@ class Program_weight_tensor_parameter_406:
 
 class Program_weight_tensor_parameter_407:
     name = "parameter_407"
+    original_name = "batch_norm2d_22.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-2.49345")
@@ -4400,6 +4808,7 @@ class Program_weight_tensor_parameter_407:
 
 class Program_weight_tensor_parameter_408:
     name = "parameter_408"
+    original_name = "batch_norm2d_22.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-1.02861")
@@ -4411,6 +4820,7 @@ class Program_weight_tensor_parameter_408:
 
 class Program_weight_tensor_parameter_409:
     name = "parameter_409"
+    original_name = "batch_norm2d_22.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("0.62293")
@@ -4422,6 +4832,7 @@ class Program_weight_tensor_parameter_409:
 
 class Program_weight_tensor_parameter_410:
     name = "parameter_410"
+    original_name = "batch_norm2d_22.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-4.31656")
@@ -4433,6 +4844,7 @@ class Program_weight_tensor_parameter_410:
 
 class Program_weight_tensor_parameter_411:
     name = "parameter_411"
+    original_name = "conv2d_22.w_0"
     shape = [512, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.506109")
@@ -4444,6 +4856,7 @@ class Program_weight_tensor_parameter_411:
 
 class Program_weight_tensor_parameter_412:
     name = "parameter_412"
+    original_name = "batch_norm2d_21.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-4.50514")
@@ -4455,6 +4868,7 @@ class Program_weight_tensor_parameter_412:
 
 class Program_weight_tensor_parameter_413:
     name = "parameter_413"
+    original_name = "batch_norm2d_21.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("0.536631")
@@ -4466,6 +4880,7 @@ class Program_weight_tensor_parameter_413:
 
 class Program_weight_tensor_parameter_414:
     name = "parameter_414"
+    original_name = "batch_norm2d_21.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("0.000220654")
@@ -4477,6 +4892,7 @@ class Program_weight_tensor_parameter_414:
 
 class Program_weight_tensor_parameter_415:
     name = "parameter_415"
+    original_name = "batch_norm2d_21.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-1.76512")
@@ -4488,6 +4904,7 @@ class Program_weight_tensor_parameter_415:
 
 class Program_weight_tensor_parameter_416:
     name = "parameter_416"
+    original_name = "conv2d_21.w_0"
     shape = [512, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.604975")
@@ -4499,6 +4916,7 @@ class Program_weight_tensor_parameter_416:
 
 class Program_weight_tensor_parameter_417:
     name = "parameter_417"
+    original_name = "batch_norm2d_20.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-3.05432")
@@ -4510,6 +4928,7 @@ class Program_weight_tensor_parameter_417:
 
 class Program_weight_tensor_parameter_418:
     name = "parameter_418"
+    original_name = "batch_norm2d_20.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.0930386")
@@ -4521,6 +4940,7 @@ class Program_weight_tensor_parameter_418:
 
 class Program_weight_tensor_parameter_419:
     name = "parameter_419"
+    original_name = "batch_norm2d_20.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("0.425756")
@@ -4532,6 +4952,7 @@ class Program_weight_tensor_parameter_419:
 
 class Program_weight_tensor_parameter_420:
     name = "parameter_420"
+    original_name = "batch_norm2d_20.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-4.57225")
@@ -4543,6 +4964,7 @@ class Program_weight_tensor_parameter_420:
 
 class Program_weight_tensor_parameter_421:
     name = "parameter_421"
+    original_name = "conv2d_20.w_0"
     shape = [512, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.62835")
@@ -4554,6 +4976,7 @@ class Program_weight_tensor_parameter_421:
 
 class Program_weight_tensor_parameter_422:
     name = "parameter_422"
+    original_name = "batch_norm2d_19.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-3.62744")
@@ -4565,6 +4988,7 @@ class Program_weight_tensor_parameter_422:
 
 class Program_weight_tensor_parameter_423:
     name = "parameter_423"
+    original_name = "batch_norm2d_19.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("0.452669")
@@ -4576,6 +5000,7 @@ class Program_weight_tensor_parameter_423:
 
 class Program_weight_tensor_parameter_424:
     name = "parameter_424"
+    original_name = "batch_norm2d_19.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("0.000285408")
@@ -4587,6 +5012,7 @@ class Program_weight_tensor_parameter_424:
 
 class Program_weight_tensor_parameter_425:
     name = "parameter_425"
+    original_name = "batch_norm2d_19.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-6.57435")
@@ -4598,6 +5024,7 @@ class Program_weight_tensor_parameter_425:
 
 class Program_weight_tensor_parameter_426:
     name = "parameter_426"
+    original_name = "conv2d_19.w_0"
     shape = [512, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.625084")
@@ -4609,6 +5036,7 @@ class Program_weight_tensor_parameter_426:
 
 class Program_weight_tensor_parameter_427:
     name = "parameter_427"
+    original_name = "batch_norm2d_18.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-3.62173")
@@ -4620,6 +5048,7 @@ class Program_weight_tensor_parameter_427:
 
 class Program_weight_tensor_parameter_428:
     name = "parameter_428"
+    original_name = "batch_norm2d_18.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("0.0580244")
@@ -4631,6 +5060,7 @@ class Program_weight_tensor_parameter_428:
 
 class Program_weight_tensor_parameter_429:
     name = "parameter_429"
+    original_name = "batch_norm2d_18.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("0.433457")
@@ -4642,6 +5072,7 @@ class Program_weight_tensor_parameter_429:
 
 class Program_weight_tensor_parameter_430:
     name = "parameter_430"
+    original_name = "batch_norm2d_18.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-3.60195")
@@ -4653,6 +5084,7 @@ class Program_weight_tensor_parameter_430:
 
 class Program_weight_tensor_parameter_431:
     name = "parameter_431"
+    original_name = "conv2d_18.w_0"
     shape = [512, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.468582")
@@ -4664,6 +5096,7 @@ class Program_weight_tensor_parameter_431:
 
 class Program_weight_tensor_parameter_432:
     name = "parameter_432"
+    original_name = "batch_norm2d_17.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-2.59305")
@@ -4675,6 +5108,7 @@ class Program_weight_tensor_parameter_432:
 
 class Program_weight_tensor_parameter_433:
     name = "parameter_433"
+    original_name = "batch_norm2d_17.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("0.439851")
@@ -4686,6 +5120,7 @@ class Program_weight_tensor_parameter_433:
 
 class Program_weight_tensor_parameter_434:
     name = "parameter_434"
+    original_name = "batch_norm2d_17.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("0.000183726")
@@ -4697,6 +5132,7 @@ class Program_weight_tensor_parameter_434:
 
 class Program_weight_tensor_parameter_435:
     name = "parameter_435"
+    original_name = "batch_norm2d_17.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-4.15279")
@@ -4708,6 +5144,7 @@ class Program_weight_tensor_parameter_435:
 
 class Program_weight_tensor_parameter_436:
     name = "parameter_436"
+    original_name = "conv2d_17.w_0"
     shape = [512, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.632949")
@@ -4719,6 +5156,7 @@ class Program_weight_tensor_parameter_436:
 
 class Program_weight_tensor_parameter_437:
     name = "parameter_437"
+    original_name = "batch_norm2d_16.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-2.83442")
@@ -4730,6 +5168,7 @@ class Program_weight_tensor_parameter_437:
 
 class Program_weight_tensor_parameter_438:
     name = "parameter_438"
+    original_name = "batch_norm2d_16.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("0.0560239")
@@ -4741,6 +5180,7 @@ class Program_weight_tensor_parameter_438:
 
 class Program_weight_tensor_parameter_439:
     name = "parameter_439"
+    original_name = "batch_norm2d_16.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("0.479833")
@@ -4752,6 +5192,7 @@ class Program_weight_tensor_parameter_439:
 
 class Program_weight_tensor_parameter_440:
     name = "parameter_440"
+    original_name = "batch_norm2d_16.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-4.34319")
@@ -4763,6 +5204,7 @@ class Program_weight_tensor_parameter_440:
 
 class Program_weight_tensor_parameter_441:
     name = "parameter_441"
+    original_name = "conv2d_16.w_0"
     shape = [512, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.560734")
@@ -4774,6 +5216,7 @@ class Program_weight_tensor_parameter_441:
 
 class Program_weight_tensor_parameter_442:
     name = "parameter_442"
+    original_name = "batch_norm2d_15.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-3.39033")
@@ -4785,6 +5228,7 @@ class Program_weight_tensor_parameter_442:
 
 class Program_weight_tensor_parameter_443:
     name = "parameter_443"
+    original_name = "batch_norm2d_15.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("0.47351")
@@ -4796,6 +5240,7 @@ class Program_weight_tensor_parameter_443:
 
 class Program_weight_tensor_parameter_444:
     name = "parameter_444"
+    original_name = "batch_norm2d_15.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("0.000181247")
@@ -4807,6 +5252,7 @@ class Program_weight_tensor_parameter_444:
 
 class Program_weight_tensor_parameter_445:
     name = "parameter_445"
+    original_name = "batch_norm2d_15.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-2.4042")
@@ -4818,6 +5264,7 @@ class Program_weight_tensor_parameter_445:
 
 class Program_weight_tensor_parameter_446:
     name = "parameter_446"
+    original_name = "conv2d_15.w_0"
     shape = [512, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.635638")
@@ -4829,6 +5276,7 @@ class Program_weight_tensor_parameter_446:
 
 class Program_weight_tensor_parameter_447:
     name = "parameter_447"
+    original_name = "batch_norm2d_14.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-2.94188")
@@ -4840,6 +5288,7 @@ class Program_weight_tensor_parameter_447:
 
 class Program_weight_tensor_parameter_448:
     name = "parameter_448"
+    original_name = "batch_norm2d_14.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.0810288")
@@ -4851,6 +5300,7 @@ class Program_weight_tensor_parameter_448:
 
 class Program_weight_tensor_parameter_449:
     name = "parameter_449"
+    original_name = "batch_norm2d_14.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("0.237089")
@@ -4862,6 +5312,7 @@ class Program_weight_tensor_parameter_449:
 
 class Program_weight_tensor_parameter_450:
     name = "parameter_450"
+    original_name = "batch_norm2d_14.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-2.90589")
@@ -4873,6 +5324,7 @@ class Program_weight_tensor_parameter_450:
 
 class Program_weight_tensor_parameter_451:
     name = "parameter_451"
+    original_name = "conv2d_14.w_0"
     shape = [512, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.593537")
@@ -4884,6 +5336,7 @@ class Program_weight_tensor_parameter_451:
 
 class Program_weight_tensor_parameter_452:
     name = "parameter_452"
+    original_name = "batch_norm2d_13.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-5.74784")
@@ -4895,6 +5348,7 @@ class Program_weight_tensor_parameter_452:
 
 class Program_weight_tensor_parameter_453:
     name = "parameter_453"
+    original_name = "batch_norm2d_13.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("0.434057")
@@ -4906,6 +5360,7 @@ class Program_weight_tensor_parameter_453:
 
 class Program_weight_tensor_parameter_454:
     name = "parameter_454"
+    original_name = "batch_norm2d_13.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("0.00016692")
@@ -4917,6 +5372,7 @@ class Program_weight_tensor_parameter_454:
 
 class Program_weight_tensor_parameter_455:
     name = "parameter_455"
+    original_name = "batch_norm2d_13.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-3.60746")
@@ -4928,6 +5384,7 @@ class Program_weight_tensor_parameter_455:
 
 class Program_weight_tensor_parameter_456:
     name = "parameter_456"
+    original_name = "conv2d_13.w_0"
     shape = [512, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.640575")
@@ -4939,6 +5396,7 @@ class Program_weight_tensor_parameter_456:
 
 class Program_weight_tensor_parameter_457:
     name = "parameter_457"
+    original_name = "batch_norm2d_12.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-1.80369")
@@ -4950,6 +5408,7 @@ class Program_weight_tensor_parameter_457:
 
 class Program_weight_tensor_parameter_458:
     name = "parameter_458"
+    original_name = "batch_norm2d_12.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.320572")
@@ -4961,6 +5420,7 @@ class Program_weight_tensor_parameter_458:
 
 class Program_weight_tensor_parameter_459:
     name = "parameter_459"
+    original_name = "batch_norm2d_12.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("0.255167")
@@ -4972,6 +5432,7 @@ class Program_weight_tensor_parameter_459:
 
 class Program_weight_tensor_parameter_460:
     name = "parameter_460"
+    original_name = "batch_norm2d_12.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-4.89251")
@@ -4983,6 +5444,7 @@ class Program_weight_tensor_parameter_460:
 
 class Program_weight_tensor_parameter_461:
     name = "parameter_461"
+    original_name = "conv2d_12.w_0"
     shape = [512, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.61087")
@@ -4994,6 +5456,7 @@ class Program_weight_tensor_parameter_461:
 
 class Program_weight_tensor_parameter_462:
     name = "parameter_462"
+    original_name = "batch_norm2d_11.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-2.50715")
@@ -5005,6 +5468,7 @@ class Program_weight_tensor_parameter_462:
 
 class Program_weight_tensor_parameter_463:
     name = "parameter_463"
+    original_name = "batch_norm2d_11.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.31472")
@@ -5016,6 +5480,7 @@ class Program_weight_tensor_parameter_463:
 
 class Program_weight_tensor_parameter_464:
     name = "parameter_464"
+    original_name = "batch_norm2d_11.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.000170891")
@@ -5027,6 +5492,7 @@ class Program_weight_tensor_parameter_464:
 
 class Program_weight_tensor_parameter_465:
     name = "parameter_465"
+    original_name = "batch_norm2d_11.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.27262")
@@ -5038,6 +5504,7 @@ class Program_weight_tensor_parameter_465:
 
 class Program_weight_tensor_parameter_466:
     name = "parameter_466"
+    original_name = "conv2d_11.w_0"
     shape = [256, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.275701")
@@ -5049,6 +5516,7 @@ class Program_weight_tensor_parameter_466:
 
 class Program_weight_tensor_parameter_467:
     name = "parameter_467"
+    original_name = "batch_norm2d_10.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-2.74922")
@@ -5060,6 +5528,7 @@ class Program_weight_tensor_parameter_467:
 
 class Program_weight_tensor_parameter_468:
     name = "parameter_468"
+    original_name = "batch_norm2d_10.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.0712531")
@@ -5071,6 +5540,7 @@ class Program_weight_tensor_parameter_468:
 
 class Program_weight_tensor_parameter_469:
     name = "parameter_469"
+    original_name = "batch_norm2d_10.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.154251")
@@ -5082,6 +5552,7 @@ class Program_weight_tensor_parameter_469:
 
 class Program_weight_tensor_parameter_470:
     name = "parameter_470"
+    original_name = "batch_norm2d_10.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-3.93395")
@@ -5093,6 +5564,7 @@ class Program_weight_tensor_parameter_470:
 
 class Program_weight_tensor_parameter_471:
     name = "parameter_471"
+    original_name = "conv2d_10.w_0"
     shape = [256, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.64204")
@@ -5104,6 +5576,7 @@ class Program_weight_tensor_parameter_471:
 
 class Program_weight_tensor_parameter_472:
     name = "parameter_472"
+    original_name = "batch_norm2d_9.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.91749")
@@ -5115,6 +5588,7 @@ class Program_weight_tensor_parameter_472:
 
 class Program_weight_tensor_parameter_473:
     name = "parameter_473"
+    original_name = "batch_norm2d_9.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.306293")
@@ -5126,6 +5600,7 @@ class Program_weight_tensor_parameter_473:
 
 class Program_weight_tensor_parameter_474:
     name = "parameter_474"
+    original_name = "batch_norm2d_9.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("5.82143e-05")
@@ -5137,6 +5612,7 @@ class Program_weight_tensor_parameter_474:
 
 class Program_weight_tensor_parameter_475:
     name = "parameter_475"
+    original_name = "batch_norm2d_9.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-3.10143")
@@ -5148,6 +5624,7 @@ class Program_weight_tensor_parameter_475:
 
 class Program_weight_tensor_parameter_476:
     name = "parameter_476"
+    original_name = "conv2d_9.w_0"
     shape = [256, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.836857")
@@ -5159,6 +5636,7 @@ class Program_weight_tensor_parameter_476:
 
 class Program_weight_tensor_parameter_477:
     name = "parameter_477"
+    original_name = "batch_norm2d_8.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.83389")
@@ -5170,6 +5648,7 @@ class Program_weight_tensor_parameter_477:
 
 class Program_weight_tensor_parameter_478:
     name = "parameter_478"
+    original_name = "batch_norm2d_8.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.391985")
@@ -5181,6 +5660,7 @@ class Program_weight_tensor_parameter_478:
 
 class Program_weight_tensor_parameter_479:
     name = "parameter_479"
+    original_name = "batch_norm2d_8.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.209021")
@@ -5192,6 +5672,7 @@ class Program_weight_tensor_parameter_479:
 
 class Program_weight_tensor_parameter_480:
     name = "parameter_480"
+    original_name = "batch_norm2d_8.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-6.49554")
@@ -5203,6 +5684,7 @@ class Program_weight_tensor_parameter_480:
 
 class Program_weight_tensor_parameter_481:
     name = "parameter_481"
+    original_name = "conv2d_8.w_0"
     shape = [256, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.780596")
@@ -5214,6 +5696,7 @@ class Program_weight_tensor_parameter_481:
 
 class Program_weight_tensor_parameter_482:
     name = "parameter_482"
+    original_name = "batch_norm2d_7.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-3.47533")
@@ -5225,6 +5708,7 @@ class Program_weight_tensor_parameter_482:
 
 class Program_weight_tensor_parameter_483:
     name = "parameter_483"
+    original_name = "batch_norm2d_7.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.69337")
@@ -5236,6 +5720,7 @@ class Program_weight_tensor_parameter_483:
 
 class Program_weight_tensor_parameter_484:
     name = "parameter_484"
+    original_name = "batch_norm2d_7.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.000142701")
@@ -5247,6 +5732,7 @@ class Program_weight_tensor_parameter_484:
 
 class Program_weight_tensor_parameter_485:
     name = "parameter_485"
+    original_name = "batch_norm2d_7.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.84146")
@@ -5258,6 +5744,7 @@ class Program_weight_tensor_parameter_485:
 
 class Program_weight_tensor_parameter_486:
     name = "parameter_486"
+    original_name = "conv2d_7.w_0"
     shape = [128, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.423886")
@@ -5269,6 +5756,7 @@ class Program_weight_tensor_parameter_486:
 
 class Program_weight_tensor_parameter_487:
     name = "parameter_487"
+    original_name = "batch_norm2d_6.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-2.39075")
@@ -5280,6 +5768,7 @@ class Program_weight_tensor_parameter_487:
 
 class Program_weight_tensor_parameter_488:
     name = "parameter_488"
+    original_name = "batch_norm2d_6.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.617548")
@@ -5291,6 +5780,7 @@ class Program_weight_tensor_parameter_488:
 
 class Program_weight_tensor_parameter_489:
     name = "parameter_489"
+    original_name = "batch_norm2d_6.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("2.14813")
@@ -5302,6 +5792,7 @@ class Program_weight_tensor_parameter_489:
 
 class Program_weight_tensor_parameter_490:
     name = "parameter_490"
+    original_name = "batch_norm2d_6.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-8.14333")
@@ -5313,6 +5804,7 @@ class Program_weight_tensor_parameter_490:
 
 class Program_weight_tensor_parameter_491:
     name = "parameter_491"
+    original_name = "conv2d_6.w_0"
     shape = [128, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.700292")
@@ -5324,6 +5816,7 @@ class Program_weight_tensor_parameter_491:
 
 class Program_weight_tensor_parameter_492:
     name = "parameter_492"
+    original_name = "batch_norm2d_5.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.46237")
@@ -5335,6 +5828,7 @@ class Program_weight_tensor_parameter_492:
 
 class Program_weight_tensor_parameter_493:
     name = "parameter_493"
+    original_name = "batch_norm2d_5.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.952509")
@@ -5346,6 +5840,7 @@ class Program_weight_tensor_parameter_493:
 
 class Program_weight_tensor_parameter_494:
     name = "parameter_494"
+    original_name = "batch_norm2d_5.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.000126647")
@@ -5357,6 +5852,7 @@ class Program_weight_tensor_parameter_494:
 
 class Program_weight_tensor_parameter_495:
     name = "parameter_495"
+    original_name = "batch_norm2d_5.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-2.7697")
@@ -5368,6 +5864,7 @@ class Program_weight_tensor_parameter_495:
 
 class Program_weight_tensor_parameter_496:
     name = "parameter_496"
+    original_name = "conv2d_5.w_0"
     shape = [128, 1, 3, 3]
     dtype = "float32"
     min_val = float("-1.57983")
@@ -5379,6 +5876,7 @@ class Program_weight_tensor_parameter_496:
 
 class Program_weight_tensor_parameter_497:
     name = "parameter_497"
+    original_name = "batch_norm2d_4.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-3.63336")
@@ -5390,6 +5888,7 @@ class Program_weight_tensor_parameter_497:
 
 class Program_weight_tensor_parameter_498:
     name = "parameter_498"
+    original_name = "batch_norm2d_4.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.28108")
@@ -5401,6 +5900,7 @@ class Program_weight_tensor_parameter_498:
 
 class Program_weight_tensor_parameter_499:
     name = "parameter_499"
+    original_name = "batch_norm2d_4.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.949669")
@@ -5412,6 +5912,7 @@ class Program_weight_tensor_parameter_499:
 
 class Program_weight_tensor_parameter_500:
     name = "parameter_500"
+    original_name = "batch_norm2d_4.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-12.4813")
@@ -5423,6 +5924,7 @@ class Program_weight_tensor_parameter_500:
 
 class Program_weight_tensor_parameter_501:
     name = "parameter_501"
+    original_name = "conv2d_4.w_0"
     shape = [128, 64, 1, 1]
     dtype = "float32"
     min_val = float("-0.824473")
@@ -5434,6 +5936,7 @@ class Program_weight_tensor_parameter_501:
 
 class Program_weight_tensor_parameter_502:
     name = "parameter_502"
+    original_name = "batch_norm2d_3.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -5443,6 +5946,7 @@ class Program_weight_tensor_parameter_502:
 
 class Program_weight_tensor_parameter_503:
     name = "parameter_503"
+    original_name = "batch_norm2d_3.w_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -5452,6 +5956,7 @@ class Program_weight_tensor_parameter_503:
 
 class Program_weight_tensor_parameter_504:
     name = "parameter_504"
+    original_name = "batch_norm2d_3.w_2"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -5461,6 +5966,7 @@ class Program_weight_tensor_parameter_504:
 
 class Program_weight_tensor_parameter_505:
     name = "parameter_505"
+    original_name = "batch_norm2d_3.w_1"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -5470,6 +5976,7 @@ class Program_weight_tensor_parameter_505:
 
 class Program_weight_tensor_parameter_506:
     name = "parameter_506"
+    original_name = "conv2d_3.w_0"
     shape = [64, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.380265")
@@ -5481,6 +5988,7 @@ class Program_weight_tensor_parameter_506:
 
 class Program_weight_tensor_parameter_507:
     name = "parameter_507"
+    original_name = "batch_norm2d_2.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -5490,6 +5998,7 @@ class Program_weight_tensor_parameter_507:
 
 class Program_weight_tensor_parameter_508:
     name = "parameter_508"
+    original_name = "batch_norm2d_2.w_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -5499,6 +6008,7 @@ class Program_weight_tensor_parameter_508:
 
 class Program_weight_tensor_parameter_509:
     name = "parameter_509"
+    original_name = "batch_norm2d_2.w_2"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -5508,6 +6018,7 @@ class Program_weight_tensor_parameter_509:
 
 class Program_weight_tensor_parameter_510:
     name = "parameter_510"
+    original_name = "batch_norm2d_2.w_1"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -5517,6 +6028,7 @@ class Program_weight_tensor_parameter_510:
 
 class Program_weight_tensor_parameter_511:
     name = "parameter_511"
+    original_name = "conv2d_2.w_0"
     shape = [64, 32, 1, 1]
     dtype = "float32"
     min_val = float("-1.24185")
@@ -5528,6 +6040,7 @@ class Program_weight_tensor_parameter_511:
 
 class Program_weight_tensor_parameter_512:
     name = "parameter_512"
+    original_name = "batch_norm2d_1.b_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -5537,6 +6050,7 @@ class Program_weight_tensor_parameter_512:
 
 class Program_weight_tensor_parameter_513:
     name = "parameter_513"
+    original_name = "batch_norm2d_1.w_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -5546,6 +6060,7 @@ class Program_weight_tensor_parameter_513:
 
 class Program_weight_tensor_parameter_514:
     name = "parameter_514"
+    original_name = "batch_norm2d_1.w_2"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -5555,6 +6070,7 @@ class Program_weight_tensor_parameter_514:
 
 class Program_weight_tensor_parameter_515:
     name = "parameter_515"
+    original_name = "batch_norm2d_1.w_1"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -5564,6 +6080,7 @@ class Program_weight_tensor_parameter_515:
 
 class Program_weight_tensor_parameter_516:
     name = "parameter_516"
+    original_name = "conv2d_1.w_0"
     shape = [32, 1, 3, 3]
     dtype = "float32"
     min_val = float("-1.89694")
@@ -5575,6 +6092,7 @@ class Program_weight_tensor_parameter_516:
 
 class Program_weight_tensor_parameter_517:
     name = "parameter_517"
+    original_name = "batch_norm2d_0.b_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -5584,6 +6102,7 @@ class Program_weight_tensor_parameter_517:
 
 class Program_weight_tensor_parameter_518:
     name = "parameter_518"
+    original_name = "batch_norm2d_0.w_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -5593,6 +6112,7 @@ class Program_weight_tensor_parameter_518:
 
 class Program_weight_tensor_parameter_519:
     name = "parameter_519"
+    original_name = "batch_norm2d_0.w_2"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -5602,6 +6122,7 @@ class Program_weight_tensor_parameter_519:
 
 class Program_weight_tensor_parameter_520:
     name = "parameter_520"
+    original_name = "batch_norm2d_0.w_1"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -5611,6 +6132,7 @@ class Program_weight_tensor_parameter_520:
 
 class Program_weight_tensor_parameter_521:
     name = "parameter_521"
+    original_name = "conv2d_0.w_0"
     shape = [32, 3, 3, 3]
     dtype = "float32"
     min_val = float("-0.652919")

--- a/paddle_samples/PaddleX/PicoDet-L/subgraph_7/input_meta.py
+++ b/paddle_samples/PaddleX/PicoDet-L/subgraph_7/input_meta.py
@@ -1,5 +1,6 @@
 class Program_weight_tensor_data_0:
     name = "data_0"
+    original_name = "var_1804"
     shape = [8, 3, 640, 640]
     dtype = "float32"
     min_val = float("-2.57228")
@@ -11,6 +12,7 @@ class Program_weight_tensor_data_0:
 
 class Program_weight_tensor_data_1:
     name = "data_1"
+    original_name = "var_2057"
     shape = [8]
     dtype = "float32"
     data = [0.0, 1.0, 2.0, 3.0003, 4.0, 5.0, 6.0006, 7.0]

--- a/paddle_samples/PaddleX/PicoDet-L/subgraph_7/weight_meta.py
+++ b/paddle_samples/PaddleX/PicoDet-L/subgraph_7/weight_meta.py
@@ -1,5 +1,6 @@
 class Program_weight_tensor_parameter_0:
     name = "parameter_0"
+    original_name = "batch_norm2d_97.b_0"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -9,6 +10,7 @@ class Program_weight_tensor_parameter_0:
 
 class Program_weight_tensor_parameter_1:
     name = "parameter_1"
+    original_name = "batch_norm2d_97.w_0"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -18,6 +20,7 @@ class Program_weight_tensor_parameter_1:
 
 class Program_weight_tensor_parameter_2:
     name = "parameter_2"
+    original_name = "batch_norm2d_97.w_2"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -27,6 +30,7 @@ class Program_weight_tensor_parameter_2:
 
 class Program_weight_tensor_parameter_3:
     name = "parameter_3"
+    original_name = "batch_norm2d_97.w_1"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -36,6 +40,7 @@ class Program_weight_tensor_parameter_3:
 
 class Program_weight_tensor_parameter_4:
     name = "parameter_4"
+    original_name = "conv2d_115.w_0"
     shape = [1, 1, 1, 1]
     dtype = "float32"
     min_val = float("0")
@@ -45,6 +50,7 @@ class Program_weight_tensor_parameter_4:
 
 class Program_weight_tensor_parameter_5:
     name = "parameter_5"
+    original_name = "batch_norm2d_96.b_0"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -54,6 +60,7 @@ class Program_weight_tensor_parameter_5:
 
 class Program_weight_tensor_parameter_6:
     name = "parameter_6"
+    original_name = "batch_norm2d_96.w_0"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -63,6 +70,7 @@ class Program_weight_tensor_parameter_6:
 
 class Program_weight_tensor_parameter_7:
     name = "parameter_7"
+    original_name = "batch_norm2d_96.w_2"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -72,6 +80,7 @@ class Program_weight_tensor_parameter_7:
 
 class Program_weight_tensor_parameter_8:
     name = "parameter_8"
+    original_name = "batch_norm2d_96.w_1"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -81,6 +90,7 @@ class Program_weight_tensor_parameter_8:
 
 class Program_weight_tensor_parameter_9:
     name = "parameter_9"
+    original_name = "conv2d_114.w_0"
     shape = [1, 160, 5, 5]
     dtype = "float32"
     min_val = float("-0.356212")
@@ -92,6 +102,7 @@ class Program_weight_tensor_parameter_9:
 
 class Program_weight_tensor_parameter_10:
     name = "parameter_10"
+    original_name = "conv2d_113.b_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -101,6 +112,7 @@ class Program_weight_tensor_parameter_10:
 
 class Program_weight_tensor_parameter_11:
     name = "parameter_11"
+    original_name = "conv2d_113.w_0"
     shape = [32, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.496682")
@@ -112,6 +124,7 @@ class Program_weight_tensor_parameter_11:
 
 class Program_weight_tensor_parameter_12:
     name = "parameter_12"
+    original_name = "conv2d_112.b_0"
     shape = [4]
     dtype = "float32"
     min_val = float("0")
@@ -121,6 +134,7 @@ class Program_weight_tensor_parameter_12:
 
 class Program_weight_tensor_parameter_13:
     name = "parameter_13"
+    original_name = "conv2d_112.w_0"
     shape = [4, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.0286105")
@@ -132,6 +146,7 @@ class Program_weight_tensor_parameter_13:
 
 class Program_weight_tensor_parameter_14:
     name = "parameter_14"
+    original_name = "batch_norm2d_89.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.521588")
@@ -143,6 +158,7 @@ class Program_weight_tensor_parameter_14:
 
 class Program_weight_tensor_parameter_15:
     name = "parameter_15"
+    original_name = "batch_norm2d_89.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.699248")
@@ -154,6 +170,7 @@ class Program_weight_tensor_parameter_15:
 
 class Program_weight_tensor_parameter_16:
     name = "parameter_16"
+    original_name = "batch_norm2d_89.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.00913058")
@@ -165,6 +182,7 @@ class Program_weight_tensor_parameter_16:
 
 class Program_weight_tensor_parameter_17:
     name = "parameter_17"
+    original_name = "batch_norm2d_89.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.215992")
@@ -176,6 +194,7 @@ class Program_weight_tensor_parameter_17:
 
 class Program_weight_tensor_parameter_18:
     name = "parameter_18"
+    original_name = "conv2d_97.w_0"
     shape = [160, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.29073")
@@ -187,6 +206,7 @@ class Program_weight_tensor_parameter_18:
 
 class Program_weight_tensor_parameter_19:
     name = "parameter_19"
+    original_name = "conv2d_96.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.0496633")
@@ -198,6 +218,7 @@ class Program_weight_tensor_parameter_19:
 
 class Program_weight_tensor_parameter_20:
     name = "parameter_20"
+    original_name = "conv2d_96.w_0"
     shape = [160, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.174508")
@@ -209,6 +230,7 @@ class Program_weight_tensor_parameter_20:
 
 class Program_weight_tensor_parameter_21:
     name = "parameter_21"
+    original_name = "batch_norm2d_88.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-2.24548")
@@ -220,6 +242,7 @@ class Program_weight_tensor_parameter_21:
 
 class Program_weight_tensor_parameter_22:
     name = "parameter_22"
+    original_name = "batch_norm2d_88.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.520968")
@@ -231,6 +254,7 @@ class Program_weight_tensor_parameter_22:
 
 class Program_weight_tensor_parameter_23:
     name = "parameter_23"
+    original_name = "batch_norm2d_88.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.0493586")
@@ -242,6 +266,7 @@ class Program_weight_tensor_parameter_23:
 
 class Program_weight_tensor_parameter_24:
     name = "parameter_24"
+    original_name = "batch_norm2d_88.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.635643")
@@ -253,6 +278,7 @@ class Program_weight_tensor_parameter_24:
 
 class Program_weight_tensor_parameter_25:
     name = "parameter_25"
+    original_name = "conv2d_95.w_0"
     shape = [160, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.424473")
@@ -264,6 +290,7 @@ class Program_weight_tensor_parameter_25:
 
 class Program_weight_tensor_parameter_26:
     name = "parameter_26"
+    original_name = "batch_norm2d_87.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.987313")
@@ -275,6 +302,7 @@ class Program_weight_tensor_parameter_26:
 
 class Program_weight_tensor_parameter_27:
     name = "parameter_27"
+    original_name = "batch_norm2d_87.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.486931")
@@ -286,6 +314,7 @@ class Program_weight_tensor_parameter_27:
 
 class Program_weight_tensor_parameter_28:
     name = "parameter_28"
+    original_name = "batch_norm2d_87.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.00354401")
@@ -297,6 +326,7 @@ class Program_weight_tensor_parameter_28:
 
 class Program_weight_tensor_parameter_29:
     name = "parameter_29"
+    original_name = "batch_norm2d_87.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.407717")
@@ -308,6 +338,7 @@ class Program_weight_tensor_parameter_29:
 
 class Program_weight_tensor_parameter_30:
     name = "parameter_30"
+    original_name = "conv2d_94.w_0"
     shape = [160, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.364153")
@@ -319,6 +350,7 @@ class Program_weight_tensor_parameter_30:
 
 class Program_weight_tensor_parameter_31:
     name = "parameter_31"
+    original_name = "batch_norm2d_86.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.98674")
@@ -330,6 +362,7 @@ class Program_weight_tensor_parameter_31:
 
 class Program_weight_tensor_parameter_32:
     name = "parameter_32"
+    original_name = "batch_norm2d_86.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.378473")
@@ -341,6 +374,7 @@ class Program_weight_tensor_parameter_32:
 
 class Program_weight_tensor_parameter_33:
     name = "parameter_33"
+    original_name = "batch_norm2d_86.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.03485")
@@ -352,6 +386,7 @@ class Program_weight_tensor_parameter_33:
 
 class Program_weight_tensor_parameter_34:
     name = "parameter_34"
+    original_name = "batch_norm2d_86.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.876605")
@@ -363,6 +398,7 @@ class Program_weight_tensor_parameter_34:
 
 class Program_weight_tensor_parameter_35:
     name = "parameter_35"
+    original_name = "conv2d_93.w_0"
     shape = [160, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.368076")
@@ -374,6 +410,7 @@ class Program_weight_tensor_parameter_35:
 
 class Program_weight_tensor_parameter_36:
     name = "parameter_36"
+    original_name = "batch_norm2d_85.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-1.46439")
@@ -385,6 +422,7 @@ class Program_weight_tensor_parameter_36:
 
 class Program_weight_tensor_parameter_37:
     name = "parameter_37"
+    original_name = "batch_norm2d_85.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.608107")
@@ -396,6 +434,7 @@ class Program_weight_tensor_parameter_37:
 
 class Program_weight_tensor_parameter_38:
     name = "parameter_38"
+    original_name = "batch_norm2d_85.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.00129459")
@@ -407,6 +446,7 @@ class Program_weight_tensor_parameter_38:
 
 class Program_weight_tensor_parameter_39:
     name = "parameter_39"
+    original_name = "batch_norm2d_85.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.375603")
@@ -418,6 +458,7 @@ class Program_weight_tensor_parameter_39:
 
 class Program_weight_tensor_parameter_40:
     name = "parameter_40"
+    original_name = "conv2d_92.w_0"
     shape = [160, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.244634")
@@ -429,6 +470,7 @@ class Program_weight_tensor_parameter_40:
 
 class Program_weight_tensor_parameter_41:
     name = "parameter_41"
+    original_name = "batch_norm2d_84.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-1.18063")
@@ -440,6 +482,7 @@ class Program_weight_tensor_parameter_41:
 
 class Program_weight_tensor_parameter_42:
     name = "parameter_42"
+    original_name = "batch_norm2d_84.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.254918")
@@ -451,6 +494,7 @@ class Program_weight_tensor_parameter_42:
 
 class Program_weight_tensor_parameter_43:
     name = "parameter_43"
+    original_name = "batch_norm2d_84.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.0854959")
@@ -462,6 +506,7 @@ class Program_weight_tensor_parameter_43:
 
 class Program_weight_tensor_parameter_44:
     name = "parameter_44"
+    original_name = "batch_norm2d_84.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.719714")
@@ -473,6 +518,7 @@ class Program_weight_tensor_parameter_44:
 
 class Program_weight_tensor_parameter_45:
     name = "parameter_45"
+    original_name = "conv2d_91.w_0"
     shape = [160, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.300988")
@@ -484,6 +530,7 @@ class Program_weight_tensor_parameter_45:
 
 class Program_weight_tensor_parameter_46:
     name = "parameter_46"
+    original_name = "batch_norm2d_83.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-1.06698")
@@ -495,6 +542,7 @@ class Program_weight_tensor_parameter_46:
 
 class Program_weight_tensor_parameter_47:
     name = "parameter_47"
+    original_name = "batch_norm2d_83.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.633603")
@@ -506,6 +554,7 @@ class Program_weight_tensor_parameter_47:
 
 class Program_weight_tensor_parameter_48:
     name = "parameter_48"
+    original_name = "batch_norm2d_83.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.00606744")
@@ -517,6 +566,7 @@ class Program_weight_tensor_parameter_48:
 
 class Program_weight_tensor_parameter_49:
     name = "parameter_49"
+    original_name = "batch_norm2d_83.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.406558")
@@ -528,6 +578,7 @@ class Program_weight_tensor_parameter_49:
 
 class Program_weight_tensor_parameter_50:
     name = "parameter_50"
+    original_name = "conv2d_90.w_0"
     shape = [160, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.224753")
@@ -539,6 +590,7 @@ class Program_weight_tensor_parameter_50:
 
 class Program_weight_tensor_parameter_51:
     name = "parameter_51"
+    original_name = "batch_norm2d_82.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.765194")
@@ -550,6 +602,7 @@ class Program_weight_tensor_parameter_51:
 
 class Program_weight_tensor_parameter_52:
     name = "parameter_52"
+    original_name = "batch_norm2d_82.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.333245")
@@ -561,6 +614,7 @@ class Program_weight_tensor_parameter_52:
 
 class Program_weight_tensor_parameter_53:
     name = "parameter_53"
+    original_name = "batch_norm2d_82.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.0971046")
@@ -572,6 +626,7 @@ class Program_weight_tensor_parameter_53:
 
 class Program_weight_tensor_parameter_54:
     name = "parameter_54"
+    original_name = "batch_norm2d_82.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.476141")
@@ -583,6 +638,7 @@ class Program_weight_tensor_parameter_54:
 
 class Program_weight_tensor_parameter_55:
     name = "parameter_55"
+    original_name = "conv2d_89.w_0"
     shape = [160, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.403105")
@@ -594,6 +650,7 @@ class Program_weight_tensor_parameter_55:
 
 class Program_weight_tensor_parameter_56:
     name = "parameter_56"
+    original_name = "batch_norm2d_81.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.916828")
@@ -605,6 +662,7 @@ class Program_weight_tensor_parameter_56:
 
 class Program_weight_tensor_parameter_57:
     name = "parameter_57"
+    original_name = "batch_norm2d_81.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.620762")
@@ -616,6 +674,7 @@ class Program_weight_tensor_parameter_57:
 
 class Program_weight_tensor_parameter_58:
     name = "parameter_58"
+    original_name = "batch_norm2d_81.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.000208718")
@@ -627,6 +686,7 @@ class Program_weight_tensor_parameter_58:
 
 class Program_weight_tensor_parameter_59:
     name = "parameter_59"
+    original_name = "batch_norm2d_81.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.328806")
@@ -638,6 +698,7 @@ class Program_weight_tensor_parameter_59:
 
 class Program_weight_tensor_parameter_60:
     name = "parameter_60"
+    original_name = "conv2d_88.w_0"
     shape = [160, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.374497")
@@ -649,6 +710,7 @@ class Program_weight_tensor_parameter_60:
 
 class Program_weight_tensor_parameter_61:
     name = "parameter_61"
+    original_name = "batch_norm2d_95.b_0"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -658,6 +720,7 @@ class Program_weight_tensor_parameter_61:
 
 class Program_weight_tensor_parameter_62:
     name = "parameter_62"
+    original_name = "batch_norm2d_95.w_0"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -667,6 +730,7 @@ class Program_weight_tensor_parameter_62:
 
 class Program_weight_tensor_parameter_63:
     name = "parameter_63"
+    original_name = "batch_norm2d_95.w_2"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -676,6 +740,7 @@ class Program_weight_tensor_parameter_63:
 
 class Program_weight_tensor_parameter_64:
     name = "parameter_64"
+    original_name = "batch_norm2d_95.w_1"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -685,6 +750,7 @@ class Program_weight_tensor_parameter_64:
 
 class Program_weight_tensor_parameter_65:
     name = "parameter_65"
+    original_name = "conv2d_111.w_0"
     shape = [1, 1, 1, 1]
     dtype = "float32"
     min_val = float("0")
@@ -694,6 +760,7 @@ class Program_weight_tensor_parameter_65:
 
 class Program_weight_tensor_parameter_66:
     name = "parameter_66"
+    original_name = "batch_norm2d_94.b_0"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -703,6 +770,7 @@ class Program_weight_tensor_parameter_66:
 
 class Program_weight_tensor_parameter_67:
     name = "parameter_67"
+    original_name = "batch_norm2d_94.w_0"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -712,6 +780,7 @@ class Program_weight_tensor_parameter_67:
 
 class Program_weight_tensor_parameter_68:
     name = "parameter_68"
+    original_name = "batch_norm2d_94.w_2"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -721,6 +790,7 @@ class Program_weight_tensor_parameter_68:
 
 class Program_weight_tensor_parameter_69:
     name = "parameter_69"
+    original_name = "batch_norm2d_94.w_1"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -730,6 +800,7 @@ class Program_weight_tensor_parameter_69:
 
 class Program_weight_tensor_parameter_70:
     name = "parameter_70"
+    original_name = "conv2d_110.w_0"
     shape = [1, 160, 5, 5]
     dtype = "float32"
     min_val = float("-0.34392")
@@ -741,6 +812,7 @@ class Program_weight_tensor_parameter_70:
 
 class Program_weight_tensor_parameter_71:
     name = "parameter_71"
+    original_name = "conv2d_109.b_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -750,6 +822,7 @@ class Program_weight_tensor_parameter_71:
 
 class Program_weight_tensor_parameter_72:
     name = "parameter_72"
+    original_name = "conv2d_109.w_0"
     shape = [32, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.427167")
@@ -761,6 +834,7 @@ class Program_weight_tensor_parameter_72:
 
 class Program_weight_tensor_parameter_73:
     name = "parameter_73"
+    original_name = "conv2d_108.b_0"
     shape = [4]
     dtype = "float32"
     min_val = float("0")
@@ -770,6 +844,7 @@ class Program_weight_tensor_parameter_73:
 
 class Program_weight_tensor_parameter_74:
     name = "parameter_74"
+    original_name = "conv2d_108.w_0"
     shape = [4, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.0360377")
@@ -781,6 +856,7 @@ class Program_weight_tensor_parameter_74:
 
 class Program_weight_tensor_parameter_75:
     name = "parameter_75"
+    original_name = "batch_norm2d_80.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.296128")
@@ -792,6 +868,7 @@ class Program_weight_tensor_parameter_75:
 
 class Program_weight_tensor_parameter_76:
     name = "parameter_76"
+    original_name = "batch_norm2d_80.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.620967")
@@ -803,6 +880,7 @@ class Program_weight_tensor_parameter_76:
 
 class Program_weight_tensor_parameter_77:
     name = "parameter_77"
+    original_name = "batch_norm2d_80.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.00899742")
@@ -814,6 +892,7 @@ class Program_weight_tensor_parameter_77:
 
 class Program_weight_tensor_parameter_78:
     name = "parameter_78"
+    original_name = "batch_norm2d_80.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.385855")
@@ -825,6 +904,7 @@ class Program_weight_tensor_parameter_78:
 
 class Program_weight_tensor_parameter_79:
     name = "parameter_79"
+    original_name = "conv2d_87.w_0"
     shape = [160, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.306001")
@@ -836,6 +916,7 @@ class Program_weight_tensor_parameter_79:
 
 class Program_weight_tensor_parameter_80:
     name = "parameter_80"
+    original_name = "conv2d_86.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.0468555")
@@ -847,6 +928,7 @@ class Program_weight_tensor_parameter_80:
 
 class Program_weight_tensor_parameter_81:
     name = "parameter_81"
+    original_name = "conv2d_86.w_0"
     shape = [160, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.181718")
@@ -858,6 +940,7 @@ class Program_weight_tensor_parameter_81:
 
 class Program_weight_tensor_parameter_82:
     name = "parameter_82"
+    original_name = "batch_norm2d_79.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.964429")
@@ -869,6 +952,7 @@ class Program_weight_tensor_parameter_82:
 
 class Program_weight_tensor_parameter_83:
     name = "parameter_83"
+    original_name = "batch_norm2d_79.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.548997")
@@ -880,6 +964,7 @@ class Program_weight_tensor_parameter_83:
 
 class Program_weight_tensor_parameter_84:
     name = "parameter_84"
+    original_name = "batch_norm2d_79.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.0290038")
@@ -891,6 +976,7 @@ class Program_weight_tensor_parameter_84:
 
 class Program_weight_tensor_parameter_85:
     name = "parameter_85"
+    original_name = "batch_norm2d_79.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-1.30173")
@@ -902,6 +988,7 @@ class Program_weight_tensor_parameter_85:
 
 class Program_weight_tensor_parameter_86:
     name = "parameter_86"
+    original_name = "conv2d_85.w_0"
     shape = [160, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.381947")
@@ -913,6 +1000,7 @@ class Program_weight_tensor_parameter_86:
 
 class Program_weight_tensor_parameter_87:
     name = "parameter_87"
+    original_name = "batch_norm2d_78.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.498733")
@@ -924,6 +1012,7 @@ class Program_weight_tensor_parameter_87:
 
 class Program_weight_tensor_parameter_88:
     name = "parameter_88"
+    original_name = "batch_norm2d_78.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.388965")
@@ -935,6 +1024,7 @@ class Program_weight_tensor_parameter_88:
 
 class Program_weight_tensor_parameter_89:
     name = "parameter_89"
+    original_name = "batch_norm2d_78.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.00368588")
@@ -946,6 +1036,7 @@ class Program_weight_tensor_parameter_89:
 
 class Program_weight_tensor_parameter_90:
     name = "parameter_90"
+    original_name = "batch_norm2d_78.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.212696")
@@ -957,6 +1048,7 @@ class Program_weight_tensor_parameter_90:
 
 class Program_weight_tensor_parameter_91:
     name = "parameter_91"
+    original_name = "conv2d_84.w_0"
     shape = [160, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.376147")
@@ -968,6 +1060,7 @@ class Program_weight_tensor_parameter_91:
 
 class Program_weight_tensor_parameter_92:
     name = "parameter_92"
+    original_name = "batch_norm2d_77.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.563809")
@@ -979,6 +1072,7 @@ class Program_weight_tensor_parameter_92:
 
 class Program_weight_tensor_parameter_93:
     name = "parameter_93"
+    original_name = "batch_norm2d_77.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.302864")
@@ -990,6 +1084,7 @@ class Program_weight_tensor_parameter_93:
 
 class Program_weight_tensor_parameter_94:
     name = "parameter_94"
+    original_name = "batch_norm2d_77.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.0435934")
@@ -1001,6 +1096,7 @@ class Program_weight_tensor_parameter_94:
 
 class Program_weight_tensor_parameter_95:
     name = "parameter_95"
+    original_name = "batch_norm2d_77.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.50118")
@@ -1012,6 +1108,7 @@ class Program_weight_tensor_parameter_95:
 
 class Program_weight_tensor_parameter_96:
     name = "parameter_96"
+    original_name = "conv2d_83.w_0"
     shape = [160, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.417702")
@@ -1023,6 +1120,7 @@ class Program_weight_tensor_parameter_96:
 
 class Program_weight_tensor_parameter_97:
     name = "parameter_97"
+    original_name = "batch_norm2d_76.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.428498")
@@ -1034,6 +1132,7 @@ class Program_weight_tensor_parameter_97:
 
 class Program_weight_tensor_parameter_98:
     name = "parameter_98"
+    original_name = "batch_norm2d_76.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.547875")
@@ -1045,6 +1144,7 @@ class Program_weight_tensor_parameter_98:
 
 class Program_weight_tensor_parameter_99:
     name = "parameter_99"
+    original_name = "batch_norm2d_76.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.0019344")
@@ -1056,6 +1156,7 @@ class Program_weight_tensor_parameter_99:
 
 class Program_weight_tensor_parameter_100:
     name = "parameter_100"
+    original_name = "batch_norm2d_76.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.298807")
@@ -1067,6 +1168,7 @@ class Program_weight_tensor_parameter_100:
 
 class Program_weight_tensor_parameter_101:
     name = "parameter_101"
+    original_name = "conv2d_82.w_0"
     shape = [160, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.250861")
@@ -1078,6 +1180,7 @@ class Program_weight_tensor_parameter_101:
 
 class Program_weight_tensor_parameter_102:
     name = "parameter_102"
+    original_name = "batch_norm2d_75.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.811359")
@@ -1089,6 +1192,7 @@ class Program_weight_tensor_parameter_102:
 
 class Program_weight_tensor_parameter_103:
     name = "parameter_103"
+    original_name = "batch_norm2d_75.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.125516")
@@ -1100,6 +1204,7 @@ class Program_weight_tensor_parameter_103:
 
 class Program_weight_tensor_parameter_104:
     name = "parameter_104"
+    original_name = "batch_norm2d_75.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.042198")
@@ -1111,6 +1216,7 @@ class Program_weight_tensor_parameter_104:
 
 class Program_weight_tensor_parameter_105:
     name = "parameter_105"
+    original_name = "batch_norm2d_75.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.663953")
@@ -1122,6 +1228,7 @@ class Program_weight_tensor_parameter_105:
 
 class Program_weight_tensor_parameter_106:
     name = "parameter_106"
+    original_name = "conv2d_81.w_0"
     shape = [160, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.335413")
@@ -1133,6 +1240,7 @@ class Program_weight_tensor_parameter_106:
 
 class Program_weight_tensor_parameter_107:
     name = "parameter_107"
+    original_name = "batch_norm2d_74.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.298503")
@@ -1144,6 +1252,7 @@ class Program_weight_tensor_parameter_107:
 
 class Program_weight_tensor_parameter_108:
     name = "parameter_108"
+    original_name = "batch_norm2d_74.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.572943")
@@ -1155,6 +1264,7 @@ class Program_weight_tensor_parameter_108:
 
 class Program_weight_tensor_parameter_109:
     name = "parameter_109"
+    original_name = "batch_norm2d_74.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.00667136")
@@ -1166,6 +1276,7 @@ class Program_weight_tensor_parameter_109:
 
 class Program_weight_tensor_parameter_110:
     name = "parameter_110"
+    original_name = "batch_norm2d_74.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.237689")
@@ -1177,6 +1288,7 @@ class Program_weight_tensor_parameter_110:
 
 class Program_weight_tensor_parameter_111:
     name = "parameter_111"
+    original_name = "conv2d_80.w_0"
     shape = [160, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.279603")
@@ -1188,6 +1300,7 @@ class Program_weight_tensor_parameter_111:
 
 class Program_weight_tensor_parameter_112:
     name = "parameter_112"
+    original_name = "batch_norm2d_73.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.307664")
@@ -1199,6 +1312,7 @@ class Program_weight_tensor_parameter_112:
 
 class Program_weight_tensor_parameter_113:
     name = "parameter_113"
+    original_name = "batch_norm2d_73.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.303124")
@@ -1210,6 +1324,7 @@ class Program_weight_tensor_parameter_113:
 
 class Program_weight_tensor_parameter_114:
     name = "parameter_114"
+    original_name = "batch_norm2d_73.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.0528052")
@@ -1221,6 +1336,7 @@ class Program_weight_tensor_parameter_114:
 
 class Program_weight_tensor_parameter_115:
     name = "parameter_115"
+    original_name = "batch_norm2d_73.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.609471")
@@ -1232,6 +1348,7 @@ class Program_weight_tensor_parameter_115:
 
 class Program_weight_tensor_parameter_116:
     name = "parameter_116"
+    original_name = "conv2d_79.w_0"
     shape = [160, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.276433")
@@ -1243,6 +1360,7 @@ class Program_weight_tensor_parameter_116:
 
 class Program_weight_tensor_parameter_117:
     name = "parameter_117"
+    original_name = "batch_norm2d_72.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.129438")
@@ -1254,6 +1372,7 @@ class Program_weight_tensor_parameter_117:
 
 class Program_weight_tensor_parameter_118:
     name = "parameter_118"
+    original_name = "batch_norm2d_72.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.535911")
@@ -1265,6 +1384,7 @@ class Program_weight_tensor_parameter_118:
 
 class Program_weight_tensor_parameter_119:
     name = "parameter_119"
+    original_name = "batch_norm2d_72.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.00347208")
@@ -1276,6 +1396,7 @@ class Program_weight_tensor_parameter_119:
 
 class Program_weight_tensor_parameter_120:
     name = "parameter_120"
+    original_name = "batch_norm2d_72.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.59298")
@@ -1287,6 +1408,7 @@ class Program_weight_tensor_parameter_120:
 
 class Program_weight_tensor_parameter_121:
     name = "parameter_121"
+    original_name = "conv2d_78.w_0"
     shape = [160, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.291457")
@@ -1298,6 +1420,7 @@ class Program_weight_tensor_parameter_121:
 
 class Program_weight_tensor_parameter_122:
     name = "parameter_122"
+    original_name = "batch_norm2d_93.b_0"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -1307,6 +1430,7 @@ class Program_weight_tensor_parameter_122:
 
 class Program_weight_tensor_parameter_123:
     name = "parameter_123"
+    original_name = "batch_norm2d_93.w_0"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -1316,6 +1440,7 @@ class Program_weight_tensor_parameter_123:
 
 class Program_weight_tensor_parameter_124:
     name = "parameter_124"
+    original_name = "batch_norm2d_93.w_2"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -1325,6 +1450,7 @@ class Program_weight_tensor_parameter_124:
 
 class Program_weight_tensor_parameter_125:
     name = "parameter_125"
+    original_name = "batch_norm2d_93.w_1"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -1334,6 +1460,7 @@ class Program_weight_tensor_parameter_125:
 
 class Program_weight_tensor_parameter_126:
     name = "parameter_126"
+    original_name = "conv2d_107.w_0"
     shape = [1, 1, 1, 1]
     dtype = "float32"
     min_val = float("0")
@@ -1343,6 +1470,7 @@ class Program_weight_tensor_parameter_126:
 
 class Program_weight_tensor_parameter_127:
     name = "parameter_127"
+    original_name = "batch_norm2d_92.b_0"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -1352,6 +1480,7 @@ class Program_weight_tensor_parameter_127:
 
 class Program_weight_tensor_parameter_128:
     name = "parameter_128"
+    original_name = "batch_norm2d_92.w_0"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -1361,6 +1490,7 @@ class Program_weight_tensor_parameter_128:
 
 class Program_weight_tensor_parameter_129:
     name = "parameter_129"
+    original_name = "batch_norm2d_92.w_2"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -1370,6 +1500,7 @@ class Program_weight_tensor_parameter_129:
 
 class Program_weight_tensor_parameter_130:
     name = "parameter_130"
+    original_name = "batch_norm2d_92.w_1"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -1379,6 +1510,7 @@ class Program_weight_tensor_parameter_130:
 
 class Program_weight_tensor_parameter_131:
     name = "parameter_131"
+    original_name = "conv2d_106.w_0"
     shape = [1, 160, 5, 5]
     dtype = "float32"
     min_val = float("-0.0991722")
@@ -1390,6 +1522,7 @@ class Program_weight_tensor_parameter_131:
 
 class Program_weight_tensor_parameter_132:
     name = "parameter_132"
+    original_name = "conv2d_105.b_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -1399,6 +1532,7 @@ class Program_weight_tensor_parameter_132:
 
 class Program_weight_tensor_parameter_133:
     name = "parameter_133"
+    original_name = "conv2d_105.w_0"
     shape = [32, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.447913")
@@ -1410,6 +1544,7 @@ class Program_weight_tensor_parameter_133:
 
 class Program_weight_tensor_parameter_134:
     name = "parameter_134"
+    original_name = "conv2d_104.b_0"
     shape = [4]
     dtype = "float32"
     min_val = float("0")
@@ -1419,6 +1554,7 @@ class Program_weight_tensor_parameter_134:
 
 class Program_weight_tensor_parameter_135:
     name = "parameter_135"
+    original_name = "conv2d_104.w_0"
     shape = [4, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.0354484")
@@ -1430,6 +1566,7 @@ class Program_weight_tensor_parameter_135:
 
 class Program_weight_tensor_parameter_136:
     name = "parameter_136"
+    original_name = "batch_norm2d_71.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.911157")
@@ -1441,6 +1578,7 @@ class Program_weight_tensor_parameter_136:
 
 class Program_weight_tensor_parameter_137:
     name = "parameter_137"
+    original_name = "batch_norm2d_71.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.429795")
@@ -1452,6 +1590,7 @@ class Program_weight_tensor_parameter_137:
 
 class Program_weight_tensor_parameter_138:
     name = "parameter_138"
+    original_name = "batch_norm2d_71.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.0167085")
@@ -1463,6 +1602,7 @@ class Program_weight_tensor_parameter_138:
 
 class Program_weight_tensor_parameter_139:
     name = "parameter_139"
+    original_name = "batch_norm2d_71.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.619424")
@@ -1474,6 +1614,7 @@ class Program_weight_tensor_parameter_139:
 
 class Program_weight_tensor_parameter_140:
     name = "parameter_140"
+    original_name = "conv2d_77.w_0"
     shape = [160, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.408258")
@@ -1485,6 +1626,7 @@ class Program_weight_tensor_parameter_140:
 
 class Program_weight_tensor_parameter_141:
     name = "parameter_141"
+    original_name = "conv2d_76.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.0411838")
@@ -1496,6 +1638,7 @@ class Program_weight_tensor_parameter_141:
 
 class Program_weight_tensor_parameter_142:
     name = "parameter_142"
+    original_name = "conv2d_76.w_0"
     shape = [160, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.261469")
@@ -1507,6 +1650,7 @@ class Program_weight_tensor_parameter_142:
 
 class Program_weight_tensor_parameter_143:
     name = "parameter_143"
+    original_name = "batch_norm2d_70.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-1.39549")
@@ -1518,6 +1662,7 @@ class Program_weight_tensor_parameter_143:
 
 class Program_weight_tensor_parameter_144:
     name = "parameter_144"
+    original_name = "batch_norm2d_70.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.731936")
@@ -1529,6 +1674,7 @@ class Program_weight_tensor_parameter_144:
 
 class Program_weight_tensor_parameter_145:
     name = "parameter_145"
+    original_name = "batch_norm2d_70.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.033241")
@@ -1540,6 +1686,7 @@ class Program_weight_tensor_parameter_145:
 
 class Program_weight_tensor_parameter_146:
     name = "parameter_146"
+    original_name = "batch_norm2d_70.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-1.15451")
@@ -1551,6 +1698,7 @@ class Program_weight_tensor_parameter_146:
 
 class Program_weight_tensor_parameter_147:
     name = "parameter_147"
+    original_name = "conv2d_75.w_0"
     shape = [160, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.386234")
@@ -1562,6 +1710,7 @@ class Program_weight_tensor_parameter_147:
 
 class Program_weight_tensor_parameter_148:
     name = "parameter_148"
+    original_name = "batch_norm2d_69.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.34156")
@@ -1573,6 +1722,7 @@ class Program_weight_tensor_parameter_148:
 
 class Program_weight_tensor_parameter_149:
     name = "parameter_149"
+    original_name = "batch_norm2d_69.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.481545")
@@ -1584,6 +1734,7 @@ class Program_weight_tensor_parameter_149:
 
 class Program_weight_tensor_parameter_150:
     name = "parameter_150"
+    original_name = "batch_norm2d_69.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.00314026")
@@ -1595,6 +1746,7 @@ class Program_weight_tensor_parameter_150:
 
 class Program_weight_tensor_parameter_151:
     name = "parameter_151"
+    original_name = "batch_norm2d_69.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.267509")
@@ -1606,6 +1758,7 @@ class Program_weight_tensor_parameter_151:
 
 class Program_weight_tensor_parameter_152:
     name = "parameter_152"
+    original_name = "conv2d_74.w_0"
     shape = [160, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.409951")
@@ -1617,6 +1770,7 @@ class Program_weight_tensor_parameter_152:
 
 class Program_weight_tensor_parameter_153:
     name = "parameter_153"
+    original_name = "batch_norm2d_68.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.778682")
@@ -1628,6 +1782,7 @@ class Program_weight_tensor_parameter_153:
 
 class Program_weight_tensor_parameter_154:
     name = "parameter_154"
+    original_name = "batch_norm2d_68.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.184092")
@@ -1639,6 +1794,7 @@ class Program_weight_tensor_parameter_154:
 
 class Program_weight_tensor_parameter_155:
     name = "parameter_155"
+    original_name = "batch_norm2d_68.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.0485223")
@@ -1650,6 +1806,7 @@ class Program_weight_tensor_parameter_155:
 
 class Program_weight_tensor_parameter_156:
     name = "parameter_156"
+    original_name = "batch_norm2d_68.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.523338")
@@ -1661,6 +1818,7 @@ class Program_weight_tensor_parameter_156:
 
 class Program_weight_tensor_parameter_157:
     name = "parameter_157"
+    original_name = "conv2d_73.w_0"
     shape = [160, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.335066")
@@ -1672,6 +1830,7 @@ class Program_weight_tensor_parameter_157:
 
 class Program_weight_tensor_parameter_158:
     name = "parameter_158"
+    original_name = "batch_norm2d_67.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.335061")
@@ -1683,6 +1842,7 @@ class Program_weight_tensor_parameter_158:
 
 class Program_weight_tensor_parameter_159:
     name = "parameter_159"
+    original_name = "batch_norm2d_67.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.572124")
@@ -1694,6 +1854,7 @@ class Program_weight_tensor_parameter_159:
 
 class Program_weight_tensor_parameter_160:
     name = "parameter_160"
+    original_name = "batch_norm2d_67.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.00109093")
@@ -1705,6 +1866,7 @@ class Program_weight_tensor_parameter_160:
 
 class Program_weight_tensor_parameter_161:
     name = "parameter_161"
+    original_name = "batch_norm2d_67.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.254237")
@@ -1716,6 +1878,7 @@ class Program_weight_tensor_parameter_161:
 
 class Program_weight_tensor_parameter_162:
     name = "parameter_162"
+    original_name = "conv2d_72.w_0"
     shape = [160, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.248765")
@@ -1727,6 +1890,7 @@ class Program_weight_tensor_parameter_162:
 
 class Program_weight_tensor_parameter_163:
     name = "parameter_163"
+    original_name = "batch_norm2d_66.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.347887")
@@ -1738,6 +1902,7 @@ class Program_weight_tensor_parameter_163:
 
 class Program_weight_tensor_parameter_164:
     name = "parameter_164"
+    original_name = "batch_norm2d_66.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.119675")
@@ -1749,6 +1914,7 @@ class Program_weight_tensor_parameter_164:
 
 class Program_weight_tensor_parameter_165:
     name = "parameter_165"
+    original_name = "batch_norm2d_66.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.0648245")
@@ -1760,6 +1926,7 @@ class Program_weight_tensor_parameter_165:
 
 class Program_weight_tensor_parameter_166:
     name = "parameter_166"
+    original_name = "batch_norm2d_66.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.545628")
@@ -1771,6 +1938,7 @@ class Program_weight_tensor_parameter_166:
 
 class Program_weight_tensor_parameter_167:
     name = "parameter_167"
+    original_name = "conv2d_71.w_0"
     shape = [160, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.331434")
@@ -1782,6 +1950,7 @@ class Program_weight_tensor_parameter_167:
 
 class Program_weight_tensor_parameter_168:
     name = "parameter_168"
+    original_name = "batch_norm2d_65.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.278151")
@@ -1793,6 +1962,7 @@ class Program_weight_tensor_parameter_168:
 
 class Program_weight_tensor_parameter_169:
     name = "parameter_169"
+    original_name = "batch_norm2d_65.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.54093")
@@ -1804,6 +1974,7 @@ class Program_weight_tensor_parameter_169:
 
 class Program_weight_tensor_parameter_170:
     name = "parameter_170"
+    original_name = "batch_norm2d_65.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.00147777")
@@ -1815,6 +1986,7 @@ class Program_weight_tensor_parameter_170:
 
 class Program_weight_tensor_parameter_171:
     name = "parameter_171"
+    original_name = "batch_norm2d_65.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.29215")
@@ -1826,6 +1998,7 @@ class Program_weight_tensor_parameter_171:
 
 class Program_weight_tensor_parameter_172:
     name = "parameter_172"
+    original_name = "conv2d_70.w_0"
     shape = [160, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.299695")
@@ -1837,6 +2010,7 @@ class Program_weight_tensor_parameter_172:
 
 class Program_weight_tensor_parameter_173:
     name = "parameter_173"
+    original_name = "batch_norm2d_64.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.527016")
@@ -1848,6 +2022,7 @@ class Program_weight_tensor_parameter_173:
 
 class Program_weight_tensor_parameter_174:
     name = "parameter_174"
+    original_name = "batch_norm2d_64.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.156099")
@@ -1859,6 +2034,7 @@ class Program_weight_tensor_parameter_174:
 
 class Program_weight_tensor_parameter_175:
     name = "parameter_175"
+    original_name = "batch_norm2d_64.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.0849881")
@@ -1870,6 +2046,7 @@ class Program_weight_tensor_parameter_175:
 
 class Program_weight_tensor_parameter_176:
     name = "parameter_176"
+    original_name = "batch_norm2d_64.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.636833")
@@ -1881,6 +2058,7 @@ class Program_weight_tensor_parameter_176:
 
 class Program_weight_tensor_parameter_177:
     name = "parameter_177"
+    original_name = "conv2d_69.w_0"
     shape = [160, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.369464")
@@ -1892,6 +2070,7 @@ class Program_weight_tensor_parameter_177:
 
 class Program_weight_tensor_parameter_178:
     name = "parameter_178"
+    original_name = "batch_norm2d_63.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.147481")
@@ -1903,6 +2082,7 @@ class Program_weight_tensor_parameter_178:
 
 class Program_weight_tensor_parameter_179:
     name = "parameter_179"
+    original_name = "batch_norm2d_63.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.635943")
@@ -1914,6 +2094,7 @@ class Program_weight_tensor_parameter_179:
 
 class Program_weight_tensor_parameter_180:
     name = "parameter_180"
+    original_name = "batch_norm2d_63.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.00190831")
@@ -1925,6 +2106,7 @@ class Program_weight_tensor_parameter_180:
 
 class Program_weight_tensor_parameter_181:
     name = "parameter_181"
+    original_name = "batch_norm2d_63.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.143772")
@@ -1936,6 +2118,7 @@ class Program_weight_tensor_parameter_181:
 
 class Program_weight_tensor_parameter_182:
     name = "parameter_182"
+    original_name = "conv2d_68.w_0"
     shape = [160, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.247739")
@@ -1947,6 +2130,7 @@ class Program_weight_tensor_parameter_182:
 
 class Program_weight_tensor_parameter_183:
     name = "parameter_183"
+    original_name = "batch_norm2d_91.b_0"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -1956,6 +2140,7 @@ class Program_weight_tensor_parameter_183:
 
 class Program_weight_tensor_parameter_184:
     name = "parameter_184"
+    original_name = "batch_norm2d_91.w_0"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -1965,6 +2150,7 @@ class Program_weight_tensor_parameter_184:
 
 class Program_weight_tensor_parameter_185:
     name = "parameter_185"
+    original_name = "batch_norm2d_91.w_2"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -1974,6 +2160,7 @@ class Program_weight_tensor_parameter_185:
 
 class Program_weight_tensor_parameter_186:
     name = "parameter_186"
+    original_name = "batch_norm2d_91.w_1"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -1983,6 +2170,7 @@ class Program_weight_tensor_parameter_186:
 
 class Program_weight_tensor_parameter_187:
     name = "parameter_187"
+    original_name = "conv2d_103.w_0"
     shape = [1, 1, 1, 1]
     dtype = "float32"
     min_val = float("0")
@@ -1992,6 +2180,7 @@ class Program_weight_tensor_parameter_187:
 
 class Program_weight_tensor_parameter_188:
     name = "parameter_188"
+    original_name = "batch_norm2d_90.b_0"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -2001,6 +2190,7 @@ class Program_weight_tensor_parameter_188:
 
 class Program_weight_tensor_parameter_189:
     name = "parameter_189"
+    original_name = "batch_norm2d_90.w_0"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -2010,6 +2200,7 @@ class Program_weight_tensor_parameter_189:
 
 class Program_weight_tensor_parameter_190:
     name = "parameter_190"
+    original_name = "batch_norm2d_90.w_2"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -2019,6 +2210,7 @@ class Program_weight_tensor_parameter_190:
 
 class Program_weight_tensor_parameter_191:
     name = "parameter_191"
+    original_name = "batch_norm2d_90.w_1"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -2028,6 +2220,7 @@ class Program_weight_tensor_parameter_191:
 
 class Program_weight_tensor_parameter_192:
     name = "parameter_192"
+    original_name = "conv2d_102.w_0"
     shape = [1, 160, 5, 5]
     dtype = "float32"
     min_val = float("-0.343268")
@@ -2039,6 +2232,7 @@ class Program_weight_tensor_parameter_192:
 
 class Program_weight_tensor_parameter_193:
     name = "parameter_193"
+    original_name = "conv2d_101.b_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -2048,6 +2242,7 @@ class Program_weight_tensor_parameter_193:
 
 class Program_weight_tensor_parameter_194:
     name = "parameter_194"
+    original_name = "conv2d_101.w_0"
     shape = [32, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.501342")
@@ -2059,6 +2254,7 @@ class Program_weight_tensor_parameter_194:
 
 class Program_weight_tensor_parameter_195:
     name = "parameter_195"
+    original_name = "conv2d_100.b_0"
     shape = [4]
     dtype = "float32"
     min_val = float("0")
@@ -2068,6 +2264,7 @@ class Program_weight_tensor_parameter_195:
 
 class Program_weight_tensor_parameter_196:
     name = "parameter_196"
+    original_name = "conv2d_100.w_0"
     shape = [4, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.0284732")
@@ -2079,6 +2276,7 @@ class Program_weight_tensor_parameter_196:
 
 class Program_weight_tensor_parameter_197:
     name = "parameter_197"
+    original_name = "batch_norm2d_62.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.175123")
@@ -2090,6 +2288,7 @@ class Program_weight_tensor_parameter_197:
 
 class Program_weight_tensor_parameter_198:
     name = "parameter_198"
+    original_name = "batch_norm2d_62.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.394877")
@@ -2101,6 +2300,7 @@ class Program_weight_tensor_parameter_198:
 
 class Program_weight_tensor_parameter_199:
     name = "parameter_199"
+    original_name = "batch_norm2d_62.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.0156991")
@@ -2112,6 +2312,7 @@ class Program_weight_tensor_parameter_199:
 
 class Program_weight_tensor_parameter_200:
     name = "parameter_200"
+    original_name = "batch_norm2d_62.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.37927")
@@ -2123,6 +2324,7 @@ class Program_weight_tensor_parameter_200:
 
 class Program_weight_tensor_parameter_201:
     name = "parameter_201"
+    original_name = "conv2d_67.w_0"
     shape = [160, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.486278")
@@ -2134,6 +2336,7 @@ class Program_weight_tensor_parameter_201:
 
 class Program_weight_tensor_parameter_202:
     name = "parameter_202"
+    original_name = "conv2d_66.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.051179")
@@ -2145,6 +2348,7 @@ class Program_weight_tensor_parameter_202:
 
 class Program_weight_tensor_parameter_203:
     name = "parameter_203"
+    original_name = "conv2d_66.w_0"
     shape = [160, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.314122")
@@ -2156,6 +2360,7 @@ class Program_weight_tensor_parameter_203:
 
 class Program_weight_tensor_parameter_204:
     name = "parameter_204"
+    original_name = "batch_norm2d_61.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.824726")
@@ -2167,6 +2372,7 @@ class Program_weight_tensor_parameter_204:
 
 class Program_weight_tensor_parameter_205:
     name = "parameter_205"
+    original_name = "batch_norm2d_61.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.502036")
@@ -2178,6 +2384,7 @@ class Program_weight_tensor_parameter_205:
 
 class Program_weight_tensor_parameter_206:
     name = "parameter_206"
+    original_name = "batch_norm2d_61.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.0802909")
@@ -2189,6 +2396,7 @@ class Program_weight_tensor_parameter_206:
 
 class Program_weight_tensor_parameter_207:
     name = "parameter_207"
+    original_name = "batch_norm2d_61.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-1.28711")
@@ -2200,6 +2408,7 @@ class Program_weight_tensor_parameter_207:
 
 class Program_weight_tensor_parameter_208:
     name = "parameter_208"
+    original_name = "conv2d_65.w_0"
     shape = [160, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.576577")
@@ -2211,6 +2420,7 @@ class Program_weight_tensor_parameter_208:
 
 class Program_weight_tensor_parameter_209:
     name = "parameter_209"
+    original_name = "batch_norm2d_60.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.452386")
@@ -2222,6 +2432,7 @@ class Program_weight_tensor_parameter_209:
 
 class Program_weight_tensor_parameter_210:
     name = "parameter_210"
+    original_name = "batch_norm2d_60.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.494642")
@@ -2233,6 +2444,7 @@ class Program_weight_tensor_parameter_210:
 
 class Program_weight_tensor_parameter_211:
     name = "parameter_211"
+    original_name = "batch_norm2d_60.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.000336369")
@@ -2244,6 +2456,7 @@ class Program_weight_tensor_parameter_211:
 
 class Program_weight_tensor_parameter_212:
     name = "parameter_212"
+    original_name = "batch_norm2d_60.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.502753")
@@ -2255,6 +2468,7 @@ class Program_weight_tensor_parameter_212:
 
 class Program_weight_tensor_parameter_213:
     name = "parameter_213"
+    original_name = "conv2d_64.w_0"
     shape = [160, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.526089")
@@ -2266,6 +2480,7 @@ class Program_weight_tensor_parameter_213:
 
 class Program_weight_tensor_parameter_214:
     name = "parameter_214"
+    original_name = "batch_norm2d_59.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-1.34131")
@@ -2277,6 +2492,7 @@ class Program_weight_tensor_parameter_214:
 
 class Program_weight_tensor_parameter_215:
     name = "parameter_215"
+    original_name = "batch_norm2d_59.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.0732341")
@@ -2288,6 +2504,7 @@ class Program_weight_tensor_parameter_215:
 
 class Program_weight_tensor_parameter_216:
     name = "parameter_216"
+    original_name = "batch_norm2d_59.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.0498151")
@@ -2299,6 +2516,7 @@ class Program_weight_tensor_parameter_216:
 
 class Program_weight_tensor_parameter_217:
     name = "parameter_217"
+    original_name = "batch_norm2d_59.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.898176")
@@ -2310,6 +2528,7 @@ class Program_weight_tensor_parameter_217:
 
 class Program_weight_tensor_parameter_218:
     name = "parameter_218"
+    original_name = "conv2d_63.w_0"
     shape = [160, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.474332")
@@ -2321,6 +2540,7 @@ class Program_weight_tensor_parameter_218:
 
 class Program_weight_tensor_parameter_219:
     name = "parameter_219"
+    original_name = "batch_norm2d_58.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.715361")
@@ -2332,6 +2552,7 @@ class Program_weight_tensor_parameter_219:
 
 class Program_weight_tensor_parameter_220:
     name = "parameter_220"
+    original_name = "batch_norm2d_58.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.480677")
@@ -2343,6 +2564,7 @@ class Program_weight_tensor_parameter_220:
 
 class Program_weight_tensor_parameter_221:
     name = "parameter_221"
+    original_name = "batch_norm2d_58.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.000591381")
@@ -2354,6 +2576,7 @@ class Program_weight_tensor_parameter_221:
 
 class Program_weight_tensor_parameter_222:
     name = "parameter_222"
+    original_name = "batch_norm2d_58.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.467052")
@@ -2365,6 +2588,7 @@ class Program_weight_tensor_parameter_222:
 
 class Program_weight_tensor_parameter_223:
     name = "parameter_223"
+    original_name = "conv2d_62.w_0"
     shape = [160, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.241131")
@@ -2376,6 +2600,7 @@ class Program_weight_tensor_parameter_223:
 
 class Program_weight_tensor_parameter_224:
     name = "parameter_224"
+    original_name = "batch_norm2d_57.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-1.10971")
@@ -2387,6 +2612,7 @@ class Program_weight_tensor_parameter_224:
 
 class Program_weight_tensor_parameter_225:
     name = "parameter_225"
+    original_name = "batch_norm2d_57.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.2268")
@@ -2398,6 +2624,7 @@ class Program_weight_tensor_parameter_225:
 
 class Program_weight_tensor_parameter_226:
     name = "parameter_226"
+    original_name = "batch_norm2d_57.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.0801081")
@@ -2409,6 +2636,7 @@ class Program_weight_tensor_parameter_226:
 
 class Program_weight_tensor_parameter_227:
     name = "parameter_227"
+    original_name = "batch_norm2d_57.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.701403")
@@ -2420,6 +2648,7 @@ class Program_weight_tensor_parameter_227:
 
 class Program_weight_tensor_parameter_228:
     name = "parameter_228"
+    original_name = "conv2d_61.w_0"
     shape = [160, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.347425")
@@ -2431,6 +2660,7 @@ class Program_weight_tensor_parameter_228:
 
 class Program_weight_tensor_parameter_229:
     name = "parameter_229"
+    original_name = "batch_norm2d_56.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.634156")
@@ -2442,6 +2672,7 @@ class Program_weight_tensor_parameter_229:
 
 class Program_weight_tensor_parameter_230:
     name = "parameter_230"
+    original_name = "batch_norm2d_56.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.516561")
@@ -2453,6 +2684,7 @@ class Program_weight_tensor_parameter_230:
 
 class Program_weight_tensor_parameter_231:
     name = "parameter_231"
+    original_name = "batch_norm2d_56.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.000687546")
@@ -2464,6 +2696,7 @@ class Program_weight_tensor_parameter_231:
 
 class Program_weight_tensor_parameter_232:
     name = "parameter_232"
+    original_name = "batch_norm2d_56.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.340192")
@@ -2475,6 +2708,7 @@ class Program_weight_tensor_parameter_232:
 
 class Program_weight_tensor_parameter_233:
     name = "parameter_233"
+    original_name = "conv2d_60.w_0"
     shape = [160, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.255104")
@@ -2486,6 +2720,7 @@ class Program_weight_tensor_parameter_233:
 
 class Program_weight_tensor_parameter_234:
     name = "parameter_234"
+    original_name = "batch_norm2d_55.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.814931")
@@ -2497,6 +2732,7 @@ class Program_weight_tensor_parameter_234:
 
 class Program_weight_tensor_parameter_235:
     name = "parameter_235"
+    original_name = "batch_norm2d_55.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.0857535")
@@ -2508,6 +2744,7 @@ class Program_weight_tensor_parameter_235:
 
 class Program_weight_tensor_parameter_236:
     name = "parameter_236"
+    original_name = "batch_norm2d_55.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.0784898")
@@ -2519,6 +2756,7 @@ class Program_weight_tensor_parameter_236:
 
 class Program_weight_tensor_parameter_237:
     name = "parameter_237"
+    original_name = "batch_norm2d_55.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.995845")
@@ -2530,6 +2768,7 @@ class Program_weight_tensor_parameter_237:
 
 class Program_weight_tensor_parameter_238:
     name = "parameter_238"
+    original_name = "conv2d_59.w_0"
     shape = [160, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.37022")
@@ -2541,6 +2780,7 @@ class Program_weight_tensor_parameter_238:
 
 class Program_weight_tensor_parameter_239:
     name = "parameter_239"
+    original_name = "batch_norm2d_54.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.297092")
@@ -2552,6 +2792,7 @@ class Program_weight_tensor_parameter_239:
 
 class Program_weight_tensor_parameter_240:
     name = "parameter_240"
+    original_name = "batch_norm2d_54.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.535509")
@@ -2563,6 +2804,7 @@ class Program_weight_tensor_parameter_240:
 
 class Program_weight_tensor_parameter_241:
     name = "parameter_241"
+    original_name = "batch_norm2d_54.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.00115202")
@@ -2574,6 +2816,7 @@ class Program_weight_tensor_parameter_241:
 
 class Program_weight_tensor_parameter_242:
     name = "parameter_242"
+    original_name = "batch_norm2d_54.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.297696")
@@ -2585,6 +2828,7 @@ class Program_weight_tensor_parameter_242:
 
 class Program_weight_tensor_parameter_243:
     name = "parameter_243"
+    original_name = "conv2d_58.w_0"
     shape = [160, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.371889")
@@ -2596,6 +2840,7 @@ class Program_weight_tensor_parameter_243:
 
 class Program_weight_tensor_parameter_244:
     name = "parameter_244"
+    original_name = "batch_norm2d_33.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.0776265")
@@ -2607,6 +2852,7 @@ class Program_weight_tensor_parameter_244:
 
 class Program_weight_tensor_parameter_245:
     name = "parameter_245"
+    original_name = "batch_norm2d_33.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.0222148")
@@ -2618,6 +2864,7 @@ class Program_weight_tensor_parameter_245:
 
 class Program_weight_tensor_parameter_246:
     name = "parameter_246"
+    original_name = "batch_norm2d_33.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.000385213")
@@ -2629,6 +2876,7 @@ class Program_weight_tensor_parameter_246:
 
 class Program_weight_tensor_parameter_247:
     name = "parameter_247"
+    original_name = "batch_norm2d_33.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.0235305")
@@ -2640,6 +2888,7 @@ class Program_weight_tensor_parameter_247:
 
 class Program_weight_tensor_parameter_248:
     name = "parameter_248"
+    original_name = "conv2d_37.w_0"
     shape = [160, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.275385")
@@ -2651,6 +2900,7 @@ class Program_weight_tensor_parameter_248:
 
 class Program_weight_tensor_parameter_249:
     name = "parameter_249"
+    original_name = "batch_norm2d_32.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.274203")
@@ -2662,6 +2912,7 @@ class Program_weight_tensor_parameter_249:
 
 class Program_weight_tensor_parameter_250:
     name = "parameter_250"
+    original_name = "batch_norm2d_32.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.0556746")
@@ -2673,6 +2924,7 @@ class Program_weight_tensor_parameter_250:
 
 class Program_weight_tensor_parameter_251:
     name = "parameter_251"
+    original_name = "batch_norm2d_32.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.00075499")
@@ -2684,6 +2936,7 @@ class Program_weight_tensor_parameter_251:
 
 class Program_weight_tensor_parameter_252:
     name = "parameter_252"
+    original_name = "batch_norm2d_32.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.294837")
@@ -2695,6 +2948,7 @@ class Program_weight_tensor_parameter_252:
 
 class Program_weight_tensor_parameter_253:
     name = "parameter_253"
+    original_name = "conv2d_36.w_0"
     shape = [160, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.160648")
@@ -2706,6 +2960,7 @@ class Program_weight_tensor_parameter_253:
 
 class Program_weight_tensor_parameter_254:
     name = "parameter_254"
+    original_name = "batch_norm2d_31.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.102693")
@@ -2717,6 +2972,7 @@ class Program_weight_tensor_parameter_254:
 
 class Program_weight_tensor_parameter_255:
     name = "parameter_255"
+    original_name = "batch_norm2d_31.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.00393406")
@@ -2728,6 +2984,7 @@ class Program_weight_tensor_parameter_255:
 
 class Program_weight_tensor_parameter_256:
     name = "parameter_256"
+    original_name = "batch_norm2d_31.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.000101782")
@@ -2739,6 +2996,7 @@ class Program_weight_tensor_parameter_256:
 
 class Program_weight_tensor_parameter_257:
     name = "parameter_257"
+    original_name = "batch_norm2d_31.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.0145582")
@@ -2750,6 +3008,7 @@ class Program_weight_tensor_parameter_257:
 
 class Program_weight_tensor_parameter_258:
     name = "parameter_258"
+    original_name = "conv2d_35.w_0"
     shape = [160, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.375548")
@@ -2761,6 +3020,7 @@ class Program_weight_tensor_parameter_258:
 
 class Program_weight_tensor_parameter_259:
     name = "parameter_259"
+    original_name = "batch_norm2d_30.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.257622")
@@ -2772,6 +3032,7 @@ class Program_weight_tensor_parameter_259:
 
 class Program_weight_tensor_parameter_260:
     name = "parameter_260"
+    original_name = "batch_norm2d_30.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.0455946")
@@ -2783,6 +3044,7 @@ class Program_weight_tensor_parameter_260:
 
 class Program_weight_tensor_parameter_261:
     name = "parameter_261"
+    original_name = "batch_norm2d_30.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("1.17939e-05")
@@ -2794,6 +3056,7 @@ class Program_weight_tensor_parameter_261:
 
 class Program_weight_tensor_parameter_262:
     name = "parameter_262"
+    original_name = "batch_norm2d_30.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.0426814")
@@ -2805,6 +3068,7 @@ class Program_weight_tensor_parameter_262:
 
 class Program_weight_tensor_parameter_263:
     name = "parameter_263"
+    original_name = "conv2d_34.w_0"
     shape = [160, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.108871")
@@ -2816,6 +3080,7 @@ class Program_weight_tensor_parameter_263:
 
 class Program_weight_tensor_parameter_264:
     name = "parameter_264"
+    original_name = "batch_norm2d_53.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-1.52748")
@@ -2827,6 +3092,7 @@ class Program_weight_tensor_parameter_264:
 
 class Program_weight_tensor_parameter_265:
     name = "parameter_265"
+    original_name = "batch_norm2d_53.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.111756")
@@ -2838,6 +3104,7 @@ class Program_weight_tensor_parameter_265:
 
 class Program_weight_tensor_parameter_266:
     name = "parameter_266"
+    original_name = "batch_norm2d_53.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.10883")
@@ -2849,6 +3116,7 @@ class Program_weight_tensor_parameter_266:
 
 class Program_weight_tensor_parameter_267:
     name = "parameter_267"
+    original_name = "batch_norm2d_53.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.482996")
@@ -2860,6 +3128,7 @@ class Program_weight_tensor_parameter_267:
 
 class Program_weight_tensor_parameter_268:
     name = "parameter_268"
+    original_name = "conv2d_57.w_0"
     shape = [160, 320, 1, 1]
     dtype = "float32"
     min_val = float("-0.346795")
@@ -2871,6 +3140,7 @@ class Program_weight_tensor_parameter_268:
 
 class Program_weight_tensor_parameter_269:
     name = "parameter_269"
+    original_name = "batch_norm2d_52.b_0"
     shape = [320]
     dtype = "float32"
     min_val = float("-0.675587")
@@ -2882,6 +3152,7 @@ class Program_weight_tensor_parameter_269:
 
 class Program_weight_tensor_parameter_270:
     name = "parameter_270"
+    original_name = "batch_norm2d_52.w_0"
     shape = [320]
     dtype = "float32"
     min_val = float("0.703312")
@@ -2893,6 +3164,7 @@ class Program_weight_tensor_parameter_270:
 
 class Program_weight_tensor_parameter_271:
     name = "parameter_271"
+    original_name = "batch_norm2d_52.w_2"
     shape = [320]
     dtype = "float32"
     min_val = float("0.00646339")
@@ -2904,6 +3176,7 @@ class Program_weight_tensor_parameter_271:
 
 class Program_weight_tensor_parameter_272:
     name = "parameter_272"
+    original_name = "batch_norm2d_52.w_1"
     shape = [320]
     dtype = "float32"
     min_val = float("-0.237389")
@@ -2915,6 +3188,7 @@ class Program_weight_tensor_parameter_272:
 
 class Program_weight_tensor_parameter_273:
     name = "parameter_273"
+    original_name = "conv2d_56.w_0"
     shape = [320, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.21215")
@@ -2926,6 +3200,7 @@ class Program_weight_tensor_parameter_273:
 
 class Program_weight_tensor_parameter_274:
     name = "parameter_274"
+    original_name = "batch_norm2d_51.b_0"
     shape = [320]
     dtype = "float32"
     min_val = float("-1.02069")
@@ -2937,6 +3212,7 @@ class Program_weight_tensor_parameter_274:
 
 class Program_weight_tensor_parameter_275:
     name = "parameter_275"
+    original_name = "batch_norm2d_51.w_0"
     shape = [320]
     dtype = "float32"
     min_val = float("0.581052")
@@ -2948,6 +3224,7 @@ class Program_weight_tensor_parameter_275:
 
 class Program_weight_tensor_parameter_276:
     name = "parameter_276"
+    original_name = "batch_norm2d_51.w_2"
     shape = [320]
     dtype = "float32"
     min_val = float("0.0969674")
@@ -2959,6 +3236,7 @@ class Program_weight_tensor_parameter_276:
 
 class Program_weight_tensor_parameter_277:
     name = "parameter_277"
+    original_name = "batch_norm2d_51.w_1"
     shape = [320]
     dtype = "float32"
     min_val = float("-0.799869")
@@ -2970,6 +3248,7 @@ class Program_weight_tensor_parameter_277:
 
 class Program_weight_tensor_parameter_278:
     name = "parameter_278"
+    original_name = "conv2d_55.w_0"
     shape = [320, 320, 1, 1]
     dtype = "float32"
     min_val = float("-0.372282")
@@ -2981,6 +3260,7 @@ class Program_weight_tensor_parameter_278:
 
 class Program_weight_tensor_parameter_279:
     name = "parameter_279"
+    original_name = "batch_norm2d_50.b_0"
     shape = [320]
     dtype = "float32"
     min_val = float("-1.061")
@@ -2992,6 +3272,7 @@ class Program_weight_tensor_parameter_279:
 
 class Program_weight_tensor_parameter_280:
     name = "parameter_280"
+    original_name = "batch_norm2d_50.w_0"
     shape = [320]
     dtype = "float32"
     min_val = float("0.573956")
@@ -3003,6 +3284,7 @@ class Program_weight_tensor_parameter_280:
 
 class Program_weight_tensor_parameter_281:
     name = "parameter_281"
+    original_name = "batch_norm2d_50.w_2"
     shape = [320]
     dtype = "float32"
     min_val = float("4.67192e-05")
@@ -3014,6 +3296,7 @@ class Program_weight_tensor_parameter_281:
 
 class Program_weight_tensor_parameter_282:
     name = "parameter_282"
+    original_name = "batch_norm2d_50.w_1"
     shape = [320]
     dtype = "float32"
     min_val = float("-0.0566461")
@@ -3025,6 +3308,7 @@ class Program_weight_tensor_parameter_282:
 
 class Program_weight_tensor_parameter_283:
     name = "parameter_283"
+    original_name = "conv2d_54.w_0"
     shape = [320, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.307488")
@@ -3036,6 +3320,7 @@ class Program_weight_tensor_parameter_283:
 
 class Program_weight_tensor_parameter_284:
     name = "parameter_284"
+    original_name = "batch_norm2d_49.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.0797254")
@@ -3047,6 +3332,7 @@ class Program_weight_tensor_parameter_284:
 
 class Program_weight_tensor_parameter_285:
     name = "parameter_285"
+    original_name = "batch_norm2d_49.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.052028")
@@ -3058,6 +3344,7 @@ class Program_weight_tensor_parameter_285:
 
 class Program_weight_tensor_parameter_286:
     name = "parameter_286"
+    original_name = "batch_norm2d_49.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.000861177")
@@ -3069,6 +3356,7 @@ class Program_weight_tensor_parameter_286:
 
 class Program_weight_tensor_parameter_287:
     name = "parameter_287"
+    original_name = "batch_norm2d_49.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.0262198")
@@ -3080,6 +3368,7 @@ class Program_weight_tensor_parameter_287:
 
 class Program_weight_tensor_parameter_288:
     name = "parameter_288"
+    original_name = "conv2d_53.w_0"
     shape = [160, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.317078")
@@ -3091,6 +3380,7 @@ class Program_weight_tensor_parameter_288:
 
 class Program_weight_tensor_parameter_289:
     name = "parameter_289"
+    original_name = "batch_norm2d_48.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.219784")
@@ -3102,6 +3392,7 @@ class Program_weight_tensor_parameter_289:
 
 class Program_weight_tensor_parameter_290:
     name = "parameter_290"
+    original_name = "batch_norm2d_48.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.0410927")
@@ -3113,6 +3404,7 @@ class Program_weight_tensor_parameter_290:
 
 class Program_weight_tensor_parameter_291:
     name = "parameter_291"
+    original_name = "batch_norm2d_48.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.000551279")
@@ -3124,6 +3416,7 @@ class Program_weight_tensor_parameter_291:
 
 class Program_weight_tensor_parameter_292:
     name = "parameter_292"
+    original_name = "batch_norm2d_48.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.49396")
@@ -3135,6 +3428,7 @@ class Program_weight_tensor_parameter_292:
 
 class Program_weight_tensor_parameter_293:
     name = "parameter_293"
+    original_name = "conv2d_52.w_0"
     shape = [160, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.204997")
@@ -3146,6 +3440,7 @@ class Program_weight_tensor_parameter_293:
 
 class Program_weight_tensor_parameter_294:
     name = "parameter_294"
+    original_name = "batch_norm2d_47.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-1.34916")
@@ -3157,6 +3452,7 @@ class Program_weight_tensor_parameter_294:
 
 class Program_weight_tensor_parameter_295:
     name = "parameter_295"
+    original_name = "batch_norm2d_47.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.128985")
@@ -3168,6 +3464,7 @@ class Program_weight_tensor_parameter_295:
 
 class Program_weight_tensor_parameter_296:
     name = "parameter_296"
+    original_name = "batch_norm2d_47.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.1482")
@@ -3179,6 +3476,7 @@ class Program_weight_tensor_parameter_296:
 
 class Program_weight_tensor_parameter_297:
     name = "parameter_297"
+    original_name = "batch_norm2d_47.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.630289")
@@ -3190,6 +3488,7 @@ class Program_weight_tensor_parameter_297:
 
 class Program_weight_tensor_parameter_298:
     name = "parameter_298"
+    original_name = "conv2d_51.w_0"
     shape = [160, 320, 1, 1]
     dtype = "float32"
     min_val = float("-0.355557")
@@ -3201,6 +3500,7 @@ class Program_weight_tensor_parameter_298:
 
 class Program_weight_tensor_parameter_299:
     name = "parameter_299"
+    original_name = "batch_norm2d_46.b_0"
     shape = [320]
     dtype = "float32"
     min_val = float("-0.52523")
@@ -3212,6 +3512,7 @@ class Program_weight_tensor_parameter_299:
 
 class Program_weight_tensor_parameter_300:
     name = "parameter_300"
+    original_name = "batch_norm2d_46.w_0"
     shape = [320]
     dtype = "float32"
     min_val = float("0.621527")
@@ -3223,6 +3524,7 @@ class Program_weight_tensor_parameter_300:
 
 class Program_weight_tensor_parameter_301:
     name = "parameter_301"
+    original_name = "batch_norm2d_46.w_2"
     shape = [320]
     dtype = "float32"
     min_val = float("0.00597836")
@@ -3234,6 +3536,7 @@ class Program_weight_tensor_parameter_301:
 
 class Program_weight_tensor_parameter_302:
     name = "parameter_302"
+    original_name = "batch_norm2d_46.w_1"
     shape = [320]
     dtype = "float32"
     min_val = float("-0.275771")
@@ -3245,6 +3548,7 @@ class Program_weight_tensor_parameter_302:
 
 class Program_weight_tensor_parameter_303:
     name = "parameter_303"
+    original_name = "conv2d_50.w_0"
     shape = [320, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.265974")
@@ -3256,6 +3560,7 @@ class Program_weight_tensor_parameter_303:
 
 class Program_weight_tensor_parameter_304:
     name = "parameter_304"
+    original_name = "batch_norm2d_45.b_0"
     shape = [320]
     dtype = "float32"
     min_val = float("-0.969353")
@@ -3267,6 +3572,7 @@ class Program_weight_tensor_parameter_304:
 
 class Program_weight_tensor_parameter_305:
     name = "parameter_305"
+    original_name = "batch_norm2d_45.w_0"
     shape = [320]
     dtype = "float32"
     min_val = float("0.69884")
@@ -3278,6 +3584,7 @@ class Program_weight_tensor_parameter_305:
 
 class Program_weight_tensor_parameter_306:
     name = "parameter_306"
+    original_name = "batch_norm2d_45.w_2"
     shape = [320]
     dtype = "float32"
     min_val = float("0.139343")
@@ -3289,6 +3596,7 @@ class Program_weight_tensor_parameter_306:
 
 class Program_weight_tensor_parameter_307:
     name = "parameter_307"
+    original_name = "batch_norm2d_45.w_1"
     shape = [320]
     dtype = "float32"
     min_val = float("-0.629862")
@@ -3300,6 +3608,7 @@ class Program_weight_tensor_parameter_307:
 
 class Program_weight_tensor_parameter_308:
     name = "parameter_308"
+    original_name = "conv2d_49.w_0"
     shape = [320, 320, 1, 1]
     dtype = "float32"
     min_val = float("-0.326183")
@@ -3311,6 +3620,7 @@ class Program_weight_tensor_parameter_308:
 
 class Program_weight_tensor_parameter_309:
     name = "parameter_309"
+    original_name = "batch_norm2d_44.b_0"
     shape = [320]
     dtype = "float32"
     min_val = float("-0.888972")
@@ -3322,6 +3632,7 @@ class Program_weight_tensor_parameter_309:
 
 class Program_weight_tensor_parameter_310:
     name = "parameter_310"
+    original_name = "batch_norm2d_44.w_0"
     shape = [320]
     dtype = "float32"
     min_val = float("0.591744")
@@ -3333,6 +3644,7 @@ class Program_weight_tensor_parameter_310:
 
 class Program_weight_tensor_parameter_311:
     name = "parameter_311"
+    original_name = "batch_norm2d_44.w_2"
     shape = [320]
     dtype = "float32"
     min_val = float("6.31744e-05")
@@ -3344,6 +3656,7 @@ class Program_weight_tensor_parameter_311:
 
 class Program_weight_tensor_parameter_312:
     name = "parameter_312"
+    original_name = "batch_norm2d_44.w_1"
     shape = [320]
     dtype = "float32"
     min_val = float("-0.317887")
@@ -3355,6 +3668,7 @@ class Program_weight_tensor_parameter_312:
 
 class Program_weight_tensor_parameter_313:
     name = "parameter_313"
+    original_name = "conv2d_48.w_0"
     shape = [320, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.431323")
@@ -3366,6 +3680,7 @@ class Program_weight_tensor_parameter_313:
 
 class Program_weight_tensor_parameter_314:
     name = "parameter_314"
+    original_name = "batch_norm2d_43.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.232932")
@@ -3377,6 +3692,7 @@ class Program_weight_tensor_parameter_314:
 
 class Program_weight_tensor_parameter_315:
     name = "parameter_315"
+    original_name = "batch_norm2d_43.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.0392113")
@@ -3388,6 +3704,7 @@ class Program_weight_tensor_parameter_315:
 
 class Program_weight_tensor_parameter_316:
     name = "parameter_316"
+    original_name = "batch_norm2d_43.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.00111325")
@@ -3399,6 +3716,7 @@ class Program_weight_tensor_parameter_316:
 
 class Program_weight_tensor_parameter_317:
     name = "parameter_317"
+    original_name = "batch_norm2d_43.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.0513811")
@@ -3410,6 +3728,7 @@ class Program_weight_tensor_parameter_317:
 
 class Program_weight_tensor_parameter_318:
     name = "parameter_318"
+    original_name = "conv2d_47.w_0"
     shape = [160, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.398657")
@@ -3421,6 +3740,7 @@ class Program_weight_tensor_parameter_318:
 
 class Program_weight_tensor_parameter_319:
     name = "parameter_319"
+    original_name = "batch_norm2d_42.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.459831")
@@ -3432,6 +3752,7 @@ class Program_weight_tensor_parameter_319:
 
 class Program_weight_tensor_parameter_320:
     name = "parameter_320"
+    original_name = "batch_norm2d_42.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.0745871")
@@ -3443,6 +3764,7 @@ class Program_weight_tensor_parameter_320:
 
 class Program_weight_tensor_parameter_321:
     name = "parameter_321"
+    original_name = "batch_norm2d_42.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.00108402")
@@ -3454,6 +3776,7 @@ class Program_weight_tensor_parameter_321:
 
 class Program_weight_tensor_parameter_322:
     name = "parameter_322"
+    original_name = "batch_norm2d_42.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.545314")
@@ -3465,6 +3788,7 @@ class Program_weight_tensor_parameter_322:
 
 class Program_weight_tensor_parameter_323:
     name = "parameter_323"
+    original_name = "conv2d_46.w_0"
     shape = [160, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.264093")
@@ -3476,6 +3800,7 @@ class Program_weight_tensor_parameter_323:
 
 class Program_weight_tensor_parameter_324:
     name = "parameter_324"
+    original_name = "batch_norm2d_41.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-1.50544")
@@ -3487,6 +3812,7 @@ class Program_weight_tensor_parameter_324:
 
 class Program_weight_tensor_parameter_325:
     name = "parameter_325"
+    original_name = "batch_norm2d_41.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.170202")
@@ -3498,6 +3824,7 @@ class Program_weight_tensor_parameter_325:
 
 class Program_weight_tensor_parameter_326:
     name = "parameter_326"
+    original_name = "batch_norm2d_41.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.153327")
@@ -3509,6 +3836,7 @@ class Program_weight_tensor_parameter_326:
 
 class Program_weight_tensor_parameter_327:
     name = "parameter_327"
+    original_name = "batch_norm2d_41.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.858114")
@@ -3520,6 +3848,7 @@ class Program_weight_tensor_parameter_327:
 
 class Program_weight_tensor_parameter_328:
     name = "parameter_328"
+    original_name = "conv2d_45.w_0"
     shape = [160, 320, 1, 1]
     dtype = "float32"
     min_val = float("-0.491857")
@@ -3531,6 +3860,7 @@ class Program_weight_tensor_parameter_328:
 
 class Program_weight_tensor_parameter_329:
     name = "parameter_329"
+    original_name = "batch_norm2d_40.b_0"
     shape = [320]
     dtype = "float32"
     min_val = float("-1.20321")
@@ -3542,6 +3872,7 @@ class Program_weight_tensor_parameter_329:
 
 class Program_weight_tensor_parameter_330:
     name = "parameter_330"
+    original_name = "batch_norm2d_40.w_0"
     shape = [320]
     dtype = "float32"
     min_val = float("0.504584")
@@ -3553,6 +3884,7 @@ class Program_weight_tensor_parameter_330:
 
 class Program_weight_tensor_parameter_331:
     name = "parameter_331"
+    original_name = "batch_norm2d_40.w_2"
     shape = [320]
     dtype = "float32"
     min_val = float("0.000653724")
@@ -3564,6 +3896,7 @@ class Program_weight_tensor_parameter_331:
 
 class Program_weight_tensor_parameter_332:
     name = "parameter_332"
+    original_name = "batch_norm2d_40.w_1"
     shape = [320]
     dtype = "float32"
     min_val = float("-0.410034")
@@ -3575,6 +3908,7 @@ class Program_weight_tensor_parameter_332:
 
 class Program_weight_tensor_parameter_333:
     name = "parameter_333"
+    original_name = "conv2d_44.w_0"
     shape = [320, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.40731")
@@ -3586,6 +3920,7 @@ class Program_weight_tensor_parameter_333:
 
 class Program_weight_tensor_parameter_334:
     name = "parameter_334"
+    original_name = "batch_norm2d_39.b_0"
     shape = [320]
     dtype = "float32"
     min_val = float("-1.51559")
@@ -3597,6 +3932,7 @@ class Program_weight_tensor_parameter_334:
 
 class Program_weight_tensor_parameter_335:
     name = "parameter_335"
+    original_name = "batch_norm2d_39.w_0"
     shape = [320]
     dtype = "float32"
     min_val = float("0.198973")
@@ -3608,6 +3944,7 @@ class Program_weight_tensor_parameter_335:
 
 class Program_weight_tensor_parameter_336:
     name = "parameter_336"
+    original_name = "batch_norm2d_39.w_2"
     shape = [320]
     dtype = "float32"
     min_val = float("0.17924")
@@ -3619,6 +3956,7 @@ class Program_weight_tensor_parameter_336:
 
 class Program_weight_tensor_parameter_337:
     name = "parameter_337"
+    original_name = "batch_norm2d_39.w_1"
     shape = [320]
     dtype = "float32"
     min_val = float("-1.36412")
@@ -3630,6 +3968,7 @@ class Program_weight_tensor_parameter_337:
 
 class Program_weight_tensor_parameter_338:
     name = "parameter_338"
+    original_name = "conv2d_43.w_0"
     shape = [320, 320, 1, 1]
     dtype = "float32"
     min_val = float("-0.433226")
@@ -3641,6 +3980,7 @@ class Program_weight_tensor_parameter_338:
 
 class Program_weight_tensor_parameter_339:
     name = "parameter_339"
+    original_name = "batch_norm2d_38.b_0"
     shape = [320]
     dtype = "float32"
     min_val = float("-0.701718")
@@ -3652,6 +3992,7 @@ class Program_weight_tensor_parameter_339:
 
 class Program_weight_tensor_parameter_340:
     name = "parameter_340"
+    original_name = "batch_norm2d_38.w_0"
     shape = [320]
     dtype = "float32"
     min_val = float("0.524093")
@@ -3663,6 +4004,7 @@ class Program_weight_tensor_parameter_340:
 
 class Program_weight_tensor_parameter_341:
     name = "parameter_341"
+    original_name = "batch_norm2d_38.w_2"
     shape = [320]
     dtype = "float32"
     min_val = float("6.54846e-05")
@@ -3674,6 +4016,7 @@ class Program_weight_tensor_parameter_341:
 
 class Program_weight_tensor_parameter_342:
     name = "parameter_342"
+    original_name = "batch_norm2d_38.w_1"
     shape = [320]
     dtype = "float32"
     min_val = float("-0.657219")
@@ -3685,6 +4028,7 @@ class Program_weight_tensor_parameter_342:
 
 class Program_weight_tensor_parameter_343:
     name = "parameter_343"
+    original_name = "conv2d_42.w_0"
     shape = [320, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.464143")
@@ -3696,6 +4040,7 @@ class Program_weight_tensor_parameter_343:
 
 class Program_weight_tensor_parameter_344:
     name = "parameter_344"
+    original_name = "batch_norm2d_37.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.608445")
@@ -3707,6 +4052,7 @@ class Program_weight_tensor_parameter_344:
 
 class Program_weight_tensor_parameter_345:
     name = "parameter_345"
+    original_name = "batch_norm2d_37.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.206023")
@@ -3718,6 +4064,7 @@ class Program_weight_tensor_parameter_345:
 
 class Program_weight_tensor_parameter_346:
     name = "parameter_346"
+    original_name = "batch_norm2d_37.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.29916")
@@ -3729,6 +4076,7 @@ class Program_weight_tensor_parameter_346:
 
 class Program_weight_tensor_parameter_347:
     name = "parameter_347"
+    original_name = "batch_norm2d_37.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.880782")
@@ -3740,6 +4088,7 @@ class Program_weight_tensor_parameter_347:
 
 class Program_weight_tensor_parameter_348:
     name = "parameter_348"
+    original_name = "conv2d_41.w_0"
     shape = [160, 320, 1, 1]
     dtype = "float32"
     min_val = float("-0.360981")
@@ -3751,6 +4100,7 @@ class Program_weight_tensor_parameter_348:
 
 class Program_weight_tensor_parameter_349:
     name = "parameter_349"
+    original_name = "batch_norm2d_36.b_0"
     shape = [320]
     dtype = "float32"
     min_val = float("-0.737954")
@@ -3762,6 +4112,7 @@ class Program_weight_tensor_parameter_349:
 
 class Program_weight_tensor_parameter_350:
     name = "parameter_350"
+    original_name = "batch_norm2d_36.w_0"
     shape = [320]
     dtype = "float32"
     min_val = float("0.633432")
@@ -3773,6 +4124,7 @@ class Program_weight_tensor_parameter_350:
 
 class Program_weight_tensor_parameter_351:
     name = "parameter_351"
+    original_name = "batch_norm2d_36.w_2"
     shape = [320]
     dtype = "float32"
     min_val = float("0.0044455")
@@ -3784,6 +4136,7 @@ class Program_weight_tensor_parameter_351:
 
 class Program_weight_tensor_parameter_352:
     name = "parameter_352"
+    original_name = "batch_norm2d_36.w_1"
     shape = [320]
     dtype = "float32"
     min_val = float("-0.253354")
@@ -3795,6 +4148,7 @@ class Program_weight_tensor_parameter_352:
 
 class Program_weight_tensor_parameter_353:
     name = "parameter_353"
+    original_name = "conv2d_40.w_0"
     shape = [320, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.457842")
@@ -3806,6 +4160,7 @@ class Program_weight_tensor_parameter_353:
 
 class Program_weight_tensor_parameter_354:
     name = "parameter_354"
+    original_name = "batch_norm2d_35.b_0"
     shape = [320]
     dtype = "float32"
     min_val = float("-1.02394")
@@ -3817,6 +4172,7 @@ class Program_weight_tensor_parameter_354:
 
 class Program_weight_tensor_parameter_355:
     name = "parameter_355"
+    original_name = "batch_norm2d_35.w_0"
     shape = [320]
     dtype = "float32"
     min_val = float("0.375157")
@@ -3828,6 +4184,7 @@ class Program_weight_tensor_parameter_355:
 
 class Program_weight_tensor_parameter_356:
     name = "parameter_356"
+    original_name = "batch_norm2d_35.w_2"
     shape = [320]
     dtype = "float32"
     min_val = float("0.208465")
@@ -3839,6 +4196,7 @@ class Program_weight_tensor_parameter_356:
 
 class Program_weight_tensor_parameter_357:
     name = "parameter_357"
+    original_name = "batch_norm2d_35.w_1"
     shape = [320]
     dtype = "float32"
     min_val = float("-2.02841")
@@ -3850,6 +4208,7 @@ class Program_weight_tensor_parameter_357:
 
 class Program_weight_tensor_parameter_358:
     name = "parameter_358"
+    original_name = "conv2d_39.w_0"
     shape = [320, 320, 1, 1]
     dtype = "float32"
     min_val = float("-0.326319")
@@ -3861,6 +4220,7 @@ class Program_weight_tensor_parameter_358:
 
 class Program_weight_tensor_parameter_359:
     name = "parameter_359"
+    original_name = "batch_norm2d_34.b_0"
     shape = [320]
     dtype = "float32"
     min_val = float("-1.12875")
@@ -3872,6 +4232,7 @@ class Program_weight_tensor_parameter_359:
 
 class Program_weight_tensor_parameter_360:
     name = "parameter_360"
+    original_name = "batch_norm2d_34.w_0"
     shape = [320]
     dtype = "float32"
     min_val = float("0.708274")
@@ -3883,6 +4244,7 @@ class Program_weight_tensor_parameter_360:
 
 class Program_weight_tensor_parameter_361:
     name = "parameter_361"
+    original_name = "batch_norm2d_34.w_2"
     shape = [320]
     dtype = "float32"
     min_val = float("6.84383e-05")
@@ -3894,6 +4256,7 @@ class Program_weight_tensor_parameter_361:
 
 class Program_weight_tensor_parameter_362:
     name = "parameter_362"
+    original_name = "batch_norm2d_34.w_1"
     shape = [320]
     dtype = "float32"
     min_val = float("-0.0596305")
@@ -3905,6 +4268,7 @@ class Program_weight_tensor_parameter_362:
 
 class Program_weight_tensor_parameter_363:
     name = "parameter_363"
+    original_name = "conv2d_38.w_0"
     shape = [320, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.51661")
@@ -3916,6 +4280,7 @@ class Program_weight_tensor_parameter_363:
 
 class Program_weight_tensor_parameter_364:
     name = "parameter_364"
+    original_name = "batch_norm2d_29.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.264581")
@@ -3927,6 +4292,7 @@ class Program_weight_tensor_parameter_364:
 
 class Program_weight_tensor_parameter_365:
     name = "parameter_365"
+    original_name = "batch_norm2d_29.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.0624614")
@@ -3938,6 +4304,7 @@ class Program_weight_tensor_parameter_365:
 
 class Program_weight_tensor_parameter_366:
     name = "parameter_366"
+    original_name = "batch_norm2d_29.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("1.44429")
@@ -3949,6 +4316,7 @@ class Program_weight_tensor_parameter_366:
 
 class Program_weight_tensor_parameter_367:
     name = "parameter_367"
+    original_name = "batch_norm2d_29.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-1.33424")
@@ -3960,6 +4328,7 @@ class Program_weight_tensor_parameter_367:
 
 class Program_weight_tensor_parameter_368:
     name = "parameter_368"
+    original_name = "conv2d_33.w_0"
     shape = [160, 1024, 1, 1]
     dtype = "float32"
     min_val = float("-0.362239")
@@ -3971,6 +4340,7 @@ class Program_weight_tensor_parameter_368:
 
 class Program_weight_tensor_parameter_369:
     name = "parameter_369"
+    original_name = "batch_norm2d_28.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.106552")
@@ -3982,6 +4352,7 @@ class Program_weight_tensor_parameter_369:
 
 class Program_weight_tensor_parameter_370:
     name = "parameter_370"
+    original_name = "batch_norm2d_28.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.04519")
@@ -3993,6 +4364,7 @@ class Program_weight_tensor_parameter_370:
 
 class Program_weight_tensor_parameter_371:
     name = "parameter_371"
+    original_name = "batch_norm2d_28.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.0401099")
@@ -4004,6 +4376,7 @@ class Program_weight_tensor_parameter_371:
 
 class Program_weight_tensor_parameter_372:
     name = "parameter_372"
+    original_name = "batch_norm2d_28.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.693841")
@@ -4015,6 +4388,7 @@ class Program_weight_tensor_parameter_372:
 
 class Program_weight_tensor_parameter_373:
     name = "parameter_373"
+    original_name = "conv2d_32.w_0"
     shape = [160, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.166586")
@@ -4026,6 +4400,7 @@ class Program_weight_tensor_parameter_373:
 
 class Program_weight_tensor_parameter_374:
     name = "parameter_374"
+    original_name = "batch_norm2d_27.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.153379")
@@ -4037,6 +4412,7 @@ class Program_weight_tensor_parameter_374:
 
 class Program_weight_tensor_parameter_375:
     name = "parameter_375"
+    original_name = "batch_norm2d_27.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.0574355")
@@ -4048,6 +4424,7 @@ class Program_weight_tensor_parameter_375:
 
 class Program_weight_tensor_parameter_376:
     name = "parameter_376"
+    original_name = "batch_norm2d_27.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.0275042")
@@ -4059,6 +4436,7 @@ class Program_weight_tensor_parameter_376:
 
 class Program_weight_tensor_parameter_377:
     name = "parameter_377"
+    original_name = "batch_norm2d_27.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.947276")
@@ -4070,6 +4448,7 @@ class Program_weight_tensor_parameter_377:
 
 class Program_weight_tensor_parameter_378:
     name = "parameter_378"
+    original_name = "conv2d_31.w_0"
     shape = [160, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.270755")
@@ -4081,6 +4460,7 @@ class Program_weight_tensor_parameter_378:
 
 class Program_weight_tensor_parameter_379:
     name = "parameter_379"
+    original_name = "batch_norm2d_26.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-4.59365")
@@ -4092,6 +4472,7 @@ class Program_weight_tensor_parameter_379:
 
 class Program_weight_tensor_parameter_380:
     name = "parameter_380"
+    original_name = "batch_norm2d_26.w_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("1.80103")
@@ -4103,6 +4484,7 @@ class Program_weight_tensor_parameter_380:
 
 class Program_weight_tensor_parameter_381:
     name = "parameter_381"
+    original_name = "batch_norm2d_26.w_2"
     shape = [1024]
     dtype = "float32"
     min_val = float("0.0507408")
@@ -4114,6 +4496,7 @@ class Program_weight_tensor_parameter_381:
 
 class Program_weight_tensor_parameter_382:
     name = "parameter_382"
+    original_name = "batch_norm2d_26.w_1"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.544802")
@@ -4125,6 +4508,7 @@ class Program_weight_tensor_parameter_382:
 
 class Program_weight_tensor_parameter_383:
     name = "parameter_383"
+    original_name = "conv2d_30.w_0"
     shape = [1024, 1024, 1, 1]
     dtype = "float32"
     min_val = float("-0.267156")
@@ -4136,6 +4520,7 @@ class Program_weight_tensor_parameter_383:
 
 class Program_weight_tensor_parameter_384:
     name = "parameter_384"
+    original_name = "conv2d_29.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.0733212")
@@ -4147,6 +4532,7 @@ class Program_weight_tensor_parameter_384:
 
 class Program_weight_tensor_parameter_385:
     name = "parameter_385"
+    original_name = "conv2d_29.w_0"
     shape = [1024, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.352913")
@@ -4158,6 +4544,7 @@ class Program_weight_tensor_parameter_385:
 
 class Program_weight_tensor_parameter_386:
     name = "parameter_386"
+    original_name = "conv2d_28.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.011965")
@@ -4169,6 +4556,7 @@ class Program_weight_tensor_parameter_386:
 
 class Program_weight_tensor_parameter_387:
     name = "parameter_387"
+    original_name = "conv2d_28.w_0"
     shape = [256, 1024, 1, 1]
     dtype = "float32"
     min_val = float("-0.319736")
@@ -4180,6 +4568,7 @@ class Program_weight_tensor_parameter_387:
 
 class Program_weight_tensor_parameter_388:
     name = "parameter_388"
+    original_name = "batch_norm2d_25.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-4.03939")
@@ -4191,6 +4580,7 @@ class Program_weight_tensor_parameter_388:
 
 class Program_weight_tensor_parameter_389:
     name = "parameter_389"
+    original_name = "batch_norm2d_25.w_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("0.251479")
@@ -4202,6 +4592,7 @@ class Program_weight_tensor_parameter_389:
 
 class Program_weight_tensor_parameter_390:
     name = "parameter_390"
+    original_name = "batch_norm2d_25.w_2"
     shape = [1024]
     dtype = "float32"
     min_val = float("0.000143616")
@@ -4213,6 +4604,7 @@ class Program_weight_tensor_parameter_390:
 
 class Program_weight_tensor_parameter_391:
     name = "parameter_391"
+    original_name = "batch_norm2d_25.w_1"
     shape = [1024]
     dtype = "float32"
     min_val = float("-1.99176")
@@ -4224,6 +4616,7 @@ class Program_weight_tensor_parameter_391:
 
 class Program_weight_tensor_parameter_392:
     name = "parameter_392"
+    original_name = "conv2d_27.w_0"
     shape = [1024, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.512854")
@@ -4235,6 +4628,7 @@ class Program_weight_tensor_parameter_392:
 
 class Program_weight_tensor_parameter_393:
     name = "parameter_393"
+    original_name = "batch_norm2d_24.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-3.08876")
@@ -4246,6 +4640,7 @@ class Program_weight_tensor_parameter_393:
 
 class Program_weight_tensor_parameter_394:
     name = "parameter_394"
+    original_name = "batch_norm2d_24.w_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.0915386")
@@ -4257,6 +4652,7 @@ class Program_weight_tensor_parameter_394:
 
 class Program_weight_tensor_parameter_395:
     name = "parameter_395"
+    original_name = "batch_norm2d_24.w_2"
     shape = [1024]
     dtype = "float32"
     min_val = float("0.0737215")
@@ -4268,6 +4664,7 @@ class Program_weight_tensor_parameter_395:
 
 class Program_weight_tensor_parameter_396:
     name = "parameter_396"
+    original_name = "batch_norm2d_24.w_1"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.978417")
@@ -4279,6 +4676,7 @@ class Program_weight_tensor_parameter_396:
 
 class Program_weight_tensor_parameter_397:
     name = "parameter_397"
+    original_name = "conv2d_26.w_0"
     shape = [1024, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.346647")
@@ -4290,6 +4688,7 @@ class Program_weight_tensor_parameter_397:
 
 class Program_weight_tensor_parameter_398:
     name = "parameter_398"
+    original_name = "conv2d_25.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.112261")
@@ -4301,6 +4700,7 @@ class Program_weight_tensor_parameter_398:
 
 class Program_weight_tensor_parameter_399:
     name = "parameter_399"
+    original_name = "conv2d_25.w_0"
     shape = [512, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.294697")
@@ -4312,6 +4712,7 @@ class Program_weight_tensor_parameter_399:
 
 class Program_weight_tensor_parameter_400:
     name = "parameter_400"
+    original_name = "conv2d_24.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.00249438")
@@ -4323,6 +4724,7 @@ class Program_weight_tensor_parameter_400:
 
 class Program_weight_tensor_parameter_401:
     name = "parameter_401"
+    original_name = "conv2d_24.w_0"
     shape = [128, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.358139")
@@ -4334,6 +4736,7 @@ class Program_weight_tensor_parameter_401:
 
 class Program_weight_tensor_parameter_402:
     name = "parameter_402"
+    original_name = "batch_norm2d_23.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-1.41417")
@@ -4345,6 +4748,7 @@ class Program_weight_tensor_parameter_402:
 
 class Program_weight_tensor_parameter_403:
     name = "parameter_403"
+    original_name = "batch_norm2d_23.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("0.636134")
@@ -4356,6 +4760,7 @@ class Program_weight_tensor_parameter_403:
 
 class Program_weight_tensor_parameter_404:
     name = "parameter_404"
+    original_name = "batch_norm2d_23.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("0.000240487")
@@ -4367,6 +4772,7 @@ class Program_weight_tensor_parameter_404:
 
 class Program_weight_tensor_parameter_405:
     name = "parameter_405"
+    original_name = "batch_norm2d_23.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-1.44789")
@@ -4378,6 +4784,7 @@ class Program_weight_tensor_parameter_405:
 
 class Program_weight_tensor_parameter_406:
     name = "parameter_406"
+    original_name = "conv2d_23.w_0"
     shape = [512, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.244106")
@@ -4389,6 +4796,7 @@ class Program_weight_tensor_parameter_406:
 
 class Program_weight_tensor_parameter_407:
     name = "parameter_407"
+    original_name = "batch_norm2d_22.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-2.49342")
@@ -4400,6 +4808,7 @@ class Program_weight_tensor_parameter_407:
 
 class Program_weight_tensor_parameter_408:
     name = "parameter_408"
+    original_name = "batch_norm2d_22.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-1.02861")
@@ -4411,6 +4820,7 @@ class Program_weight_tensor_parameter_408:
 
 class Program_weight_tensor_parameter_409:
     name = "parameter_409"
+    original_name = "batch_norm2d_22.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("0.624996")
@@ -4422,6 +4832,7 @@ class Program_weight_tensor_parameter_409:
 
 class Program_weight_tensor_parameter_410:
     name = "parameter_410"
+    original_name = "batch_norm2d_22.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-4.31712")
@@ -4433,6 +4844,7 @@ class Program_weight_tensor_parameter_410:
 
 class Program_weight_tensor_parameter_411:
     name = "parameter_411"
+    original_name = "conv2d_22.w_0"
     shape = [512, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.506002")
@@ -4444,6 +4856,7 @@ class Program_weight_tensor_parameter_411:
 
 class Program_weight_tensor_parameter_412:
     name = "parameter_412"
+    original_name = "batch_norm2d_21.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-4.50513")
@@ -4455,6 +4868,7 @@ class Program_weight_tensor_parameter_412:
 
 class Program_weight_tensor_parameter_413:
     name = "parameter_413"
+    original_name = "batch_norm2d_21.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("0.536682")
@@ -4466,6 +4880,7 @@ class Program_weight_tensor_parameter_413:
 
 class Program_weight_tensor_parameter_414:
     name = "parameter_414"
+    original_name = "batch_norm2d_21.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("0.000220032")
@@ -4477,6 +4892,7 @@ class Program_weight_tensor_parameter_414:
 
 class Program_weight_tensor_parameter_415:
     name = "parameter_415"
+    original_name = "batch_norm2d_21.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-1.75606")
@@ -4488,6 +4904,7 @@ class Program_weight_tensor_parameter_415:
 
 class Program_weight_tensor_parameter_416:
     name = "parameter_416"
+    original_name = "conv2d_21.w_0"
     shape = [512, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.604931")
@@ -4499,6 +4916,7 @@ class Program_weight_tensor_parameter_416:
 
 class Program_weight_tensor_parameter_417:
     name = "parameter_417"
+    original_name = "batch_norm2d_20.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-3.05432")
@@ -4510,6 +4928,7 @@ class Program_weight_tensor_parameter_417:
 
 class Program_weight_tensor_parameter_418:
     name = "parameter_418"
+    original_name = "batch_norm2d_20.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.0930345")
@@ -4521,6 +4940,7 @@ class Program_weight_tensor_parameter_418:
 
 class Program_weight_tensor_parameter_419:
     name = "parameter_419"
+    original_name = "batch_norm2d_20.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("0.424618")
@@ -4532,6 +4952,7 @@ class Program_weight_tensor_parameter_419:
 
 class Program_weight_tensor_parameter_420:
     name = "parameter_420"
+    original_name = "batch_norm2d_20.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-4.57231")
@@ -4543,6 +4964,7 @@ class Program_weight_tensor_parameter_420:
 
 class Program_weight_tensor_parameter_421:
     name = "parameter_421"
+    original_name = "conv2d_20.w_0"
     shape = [512, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.628397")
@@ -4554,6 +4976,7 @@ class Program_weight_tensor_parameter_421:
 
 class Program_weight_tensor_parameter_422:
     name = "parameter_422"
+    original_name = "batch_norm2d_19.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-3.62744")
@@ -4565,6 +4988,7 @@ class Program_weight_tensor_parameter_422:
 
 class Program_weight_tensor_parameter_423:
     name = "parameter_423"
+    original_name = "batch_norm2d_19.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("0.452706")
@@ -4576,6 +5000,7 @@ class Program_weight_tensor_parameter_423:
 
 class Program_weight_tensor_parameter_424:
     name = "parameter_424"
+    original_name = "batch_norm2d_19.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("0.000284192")
@@ -4587,6 +5012,7 @@ class Program_weight_tensor_parameter_424:
 
 class Program_weight_tensor_parameter_425:
     name = "parameter_425"
+    original_name = "batch_norm2d_19.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-6.571")
@@ -4598,6 +5024,7 @@ class Program_weight_tensor_parameter_425:
 
 class Program_weight_tensor_parameter_426:
     name = "parameter_426"
+    original_name = "conv2d_19.w_0"
     shape = [512, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.625063")
@@ -4609,6 +5036,7 @@ class Program_weight_tensor_parameter_426:
 
 class Program_weight_tensor_parameter_427:
     name = "parameter_427"
+    original_name = "batch_norm2d_18.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-3.62172")
@@ -4620,6 +5048,7 @@ class Program_weight_tensor_parameter_427:
 
 class Program_weight_tensor_parameter_428:
     name = "parameter_428"
+    original_name = "batch_norm2d_18.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("0.0580161")
@@ -4631,6 +5060,7 @@ class Program_weight_tensor_parameter_428:
 
 class Program_weight_tensor_parameter_429:
     name = "parameter_429"
+    original_name = "batch_norm2d_18.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("0.43543")
@@ -4642,6 +5072,7 @@ class Program_weight_tensor_parameter_429:
 
 class Program_weight_tensor_parameter_430:
     name = "parameter_430"
+    original_name = "batch_norm2d_18.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-3.60351")
@@ -4653,6 +5084,7 @@ class Program_weight_tensor_parameter_430:
 
 class Program_weight_tensor_parameter_431:
     name = "parameter_431"
+    original_name = "conv2d_18.w_0"
     shape = [512, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.468574")
@@ -4664,6 +5096,7 @@ class Program_weight_tensor_parameter_431:
 
 class Program_weight_tensor_parameter_432:
     name = "parameter_432"
+    original_name = "batch_norm2d_17.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-2.59304")
@@ -4675,6 +5108,7 @@ class Program_weight_tensor_parameter_432:
 
 class Program_weight_tensor_parameter_433:
     name = "parameter_433"
+    original_name = "batch_norm2d_17.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("0.439846")
@@ -4686,6 +5120,7 @@ class Program_weight_tensor_parameter_433:
 
 class Program_weight_tensor_parameter_434:
     name = "parameter_434"
+    original_name = "batch_norm2d_17.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("0.000185541")
@@ -4697,6 +5132,7 @@ class Program_weight_tensor_parameter_434:
 
 class Program_weight_tensor_parameter_435:
     name = "parameter_435"
+    original_name = "batch_norm2d_17.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-4.14991")
@@ -4708,6 +5144,7 @@ class Program_weight_tensor_parameter_435:
 
 class Program_weight_tensor_parameter_436:
     name = "parameter_436"
+    original_name = "conv2d_17.w_0"
     shape = [512, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.632903")
@@ -4719,6 +5156,7 @@ class Program_weight_tensor_parameter_436:
 
 class Program_weight_tensor_parameter_437:
     name = "parameter_437"
+    original_name = "batch_norm2d_16.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-2.83441")
@@ -4730,6 +5168,7 @@ class Program_weight_tensor_parameter_437:
 
 class Program_weight_tensor_parameter_438:
     name = "parameter_438"
+    original_name = "batch_norm2d_16.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("0.0560199")
@@ -4741,6 +5180,7 @@ class Program_weight_tensor_parameter_438:
 
 class Program_weight_tensor_parameter_439:
     name = "parameter_439"
+    original_name = "batch_norm2d_16.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("0.477085")
@@ -4752,6 +5192,7 @@ class Program_weight_tensor_parameter_439:
 
 class Program_weight_tensor_parameter_440:
     name = "parameter_440"
+    original_name = "batch_norm2d_16.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-4.34208")
@@ -4763,6 +5204,7 @@ class Program_weight_tensor_parameter_440:
 
 class Program_weight_tensor_parameter_441:
     name = "parameter_441"
+    original_name = "conv2d_16.w_0"
     shape = [512, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.560703")
@@ -4774,6 +5216,7 @@ class Program_weight_tensor_parameter_441:
 
 class Program_weight_tensor_parameter_442:
     name = "parameter_442"
+    original_name = "batch_norm2d_15.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-3.39034")
@@ -4785,6 +5228,7 @@ class Program_weight_tensor_parameter_442:
 
 class Program_weight_tensor_parameter_443:
     name = "parameter_443"
+    original_name = "batch_norm2d_15.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("0.473573")
@@ -4796,6 +5240,7 @@ class Program_weight_tensor_parameter_443:
 
 class Program_weight_tensor_parameter_444:
     name = "parameter_444"
+    original_name = "batch_norm2d_15.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("0.000181706")
@@ -4807,6 +5252,7 @@ class Program_weight_tensor_parameter_444:
 
 class Program_weight_tensor_parameter_445:
     name = "parameter_445"
+    original_name = "batch_norm2d_15.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-2.40472")
@@ -4818,6 +5264,7 @@ class Program_weight_tensor_parameter_445:
 
 class Program_weight_tensor_parameter_446:
     name = "parameter_446"
+    original_name = "conv2d_15.w_0"
     shape = [512, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.635629")
@@ -4829,6 +5276,7 @@ class Program_weight_tensor_parameter_446:
 
 class Program_weight_tensor_parameter_447:
     name = "parameter_447"
+    original_name = "batch_norm2d_14.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-2.94189")
@@ -4840,6 +5288,7 @@ class Program_weight_tensor_parameter_447:
 
 class Program_weight_tensor_parameter_448:
     name = "parameter_448"
+    original_name = "batch_norm2d_14.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.0809755")
@@ -4851,6 +5300,7 @@ class Program_weight_tensor_parameter_448:
 
 class Program_weight_tensor_parameter_449:
     name = "parameter_449"
+    original_name = "batch_norm2d_14.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("0.238356")
@@ -4862,6 +5312,7 @@ class Program_weight_tensor_parameter_449:
 
 class Program_weight_tensor_parameter_450:
     name = "parameter_450"
+    original_name = "batch_norm2d_14.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-2.90686")
@@ -4873,6 +5324,7 @@ class Program_weight_tensor_parameter_450:
 
 class Program_weight_tensor_parameter_451:
     name = "parameter_451"
+    original_name = "conv2d_14.w_0"
     shape = [512, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.593518")
@@ -4884,6 +5336,7 @@ class Program_weight_tensor_parameter_451:
 
 class Program_weight_tensor_parameter_452:
     name = "parameter_452"
+    original_name = "batch_norm2d_13.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-5.74784")
@@ -4895,6 +5348,7 @@ class Program_weight_tensor_parameter_452:
 
 class Program_weight_tensor_parameter_453:
     name = "parameter_453"
+    original_name = "batch_norm2d_13.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("0.434059")
@@ -4906,6 +5360,7 @@ class Program_weight_tensor_parameter_453:
 
 class Program_weight_tensor_parameter_454:
     name = "parameter_454"
+    original_name = "batch_norm2d_13.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("0.000167347")
@@ -4917,6 +5372,7 @@ class Program_weight_tensor_parameter_454:
 
 class Program_weight_tensor_parameter_455:
     name = "parameter_455"
+    original_name = "batch_norm2d_13.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-3.60431")
@@ -4928,6 +5384,7 @@ class Program_weight_tensor_parameter_455:
 
 class Program_weight_tensor_parameter_456:
     name = "parameter_456"
+    original_name = "conv2d_13.w_0"
     shape = [512, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.640492")
@@ -4939,6 +5396,7 @@ class Program_weight_tensor_parameter_456:
 
 class Program_weight_tensor_parameter_457:
     name = "parameter_457"
+    original_name = "batch_norm2d_12.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-1.8037")
@@ -4950,6 +5408,7 @@ class Program_weight_tensor_parameter_457:
 
 class Program_weight_tensor_parameter_458:
     name = "parameter_458"
+    original_name = "batch_norm2d_12.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.320595")
@@ -4961,6 +5420,7 @@ class Program_weight_tensor_parameter_458:
 
 class Program_weight_tensor_parameter_459:
     name = "parameter_459"
+    original_name = "batch_norm2d_12.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("0.253849")
@@ -4972,6 +5432,7 @@ class Program_weight_tensor_parameter_459:
 
 class Program_weight_tensor_parameter_460:
     name = "parameter_460"
+    original_name = "batch_norm2d_12.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-4.89159")
@@ -4983,6 +5444,7 @@ class Program_weight_tensor_parameter_460:
 
 class Program_weight_tensor_parameter_461:
     name = "parameter_461"
+    original_name = "conv2d_12.w_0"
     shape = [512, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.610816")
@@ -4994,6 +5456,7 @@ class Program_weight_tensor_parameter_461:
 
 class Program_weight_tensor_parameter_462:
     name = "parameter_462"
+    original_name = "batch_norm2d_11.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-2.50714")
@@ -5005,6 +5468,7 @@ class Program_weight_tensor_parameter_462:
 
 class Program_weight_tensor_parameter_463:
     name = "parameter_463"
+    original_name = "batch_norm2d_11.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.314736")
@@ -5016,6 +5480,7 @@ class Program_weight_tensor_parameter_463:
 
 class Program_weight_tensor_parameter_464:
     name = "parameter_464"
+    original_name = "batch_norm2d_11.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.000171071")
@@ -5027,6 +5492,7 @@ class Program_weight_tensor_parameter_464:
 
 class Program_weight_tensor_parameter_465:
     name = "parameter_465"
+    original_name = "batch_norm2d_11.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.27212")
@@ -5038,6 +5504,7 @@ class Program_weight_tensor_parameter_465:
 
 class Program_weight_tensor_parameter_466:
     name = "parameter_466"
+    original_name = "conv2d_11.w_0"
     shape = [256, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.27563")
@@ -5049,6 +5516,7 @@ class Program_weight_tensor_parameter_466:
 
 class Program_weight_tensor_parameter_467:
     name = "parameter_467"
+    original_name = "batch_norm2d_10.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-2.74923")
@@ -5060,6 +5528,7 @@ class Program_weight_tensor_parameter_467:
 
 class Program_weight_tensor_parameter_468:
     name = "parameter_468"
+    original_name = "batch_norm2d_10.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.0711412")
@@ -5071,6 +5540,7 @@ class Program_weight_tensor_parameter_468:
 
 class Program_weight_tensor_parameter_469:
     name = "parameter_469"
+    original_name = "batch_norm2d_10.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.153933")
@@ -5082,6 +5552,7 @@ class Program_weight_tensor_parameter_469:
 
 class Program_weight_tensor_parameter_470:
     name = "parameter_470"
+    original_name = "batch_norm2d_10.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-3.9339")
@@ -5093,6 +5564,7 @@ class Program_weight_tensor_parameter_470:
 
 class Program_weight_tensor_parameter_471:
     name = "parameter_471"
+    original_name = "conv2d_10.w_0"
     shape = [256, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.642075")
@@ -5104,6 +5576,7 @@ class Program_weight_tensor_parameter_471:
 
 class Program_weight_tensor_parameter_472:
     name = "parameter_472"
+    original_name = "batch_norm2d_9.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.91748")
@@ -5115,6 +5588,7 @@ class Program_weight_tensor_parameter_472:
 
 class Program_weight_tensor_parameter_473:
     name = "parameter_473"
+    original_name = "batch_norm2d_9.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.306298")
@@ -5126,6 +5600,7 @@ class Program_weight_tensor_parameter_473:
 
 class Program_weight_tensor_parameter_474:
     name = "parameter_474"
+    original_name = "batch_norm2d_9.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("5.65524e-05")
@@ -5137,6 +5612,7 @@ class Program_weight_tensor_parameter_474:
 
 class Program_weight_tensor_parameter_475:
     name = "parameter_475"
+    original_name = "batch_norm2d_9.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-3.10033")
@@ -5148,6 +5624,7 @@ class Program_weight_tensor_parameter_475:
 
 class Program_weight_tensor_parameter_476:
     name = "parameter_476"
+    original_name = "conv2d_9.w_0"
     shape = [256, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.83698")
@@ -5159,6 +5636,7 @@ class Program_weight_tensor_parameter_476:
 
 class Program_weight_tensor_parameter_477:
     name = "parameter_477"
+    original_name = "batch_norm2d_8.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.8338")
@@ -5170,6 +5648,7 @@ class Program_weight_tensor_parameter_477:
 
 class Program_weight_tensor_parameter_478:
     name = "parameter_478"
+    original_name = "batch_norm2d_8.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.391939")
@@ -5181,6 +5660,7 @@ class Program_weight_tensor_parameter_478:
 
 class Program_weight_tensor_parameter_479:
     name = "parameter_479"
+    original_name = "batch_norm2d_8.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.202733")
@@ -5192,6 +5672,7 @@ class Program_weight_tensor_parameter_479:
 
 class Program_weight_tensor_parameter_480:
     name = "parameter_480"
+    original_name = "batch_norm2d_8.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-6.49469")
@@ -5203,6 +5684,7 @@ class Program_weight_tensor_parameter_480:
 
 class Program_weight_tensor_parameter_481:
     name = "parameter_481"
+    original_name = "conv2d_8.w_0"
     shape = [256, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.780703")
@@ -5214,6 +5696,7 @@ class Program_weight_tensor_parameter_481:
 
 class Program_weight_tensor_parameter_482:
     name = "parameter_482"
+    original_name = "batch_norm2d_7.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-3.47534")
@@ -5225,6 +5708,7 @@ class Program_weight_tensor_parameter_482:
 
 class Program_weight_tensor_parameter_483:
     name = "parameter_483"
+    original_name = "batch_norm2d_7.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.693513")
@@ -5236,6 +5720,7 @@ class Program_weight_tensor_parameter_483:
 
 class Program_weight_tensor_parameter_484:
     name = "parameter_484"
+    original_name = "batch_norm2d_7.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.000138215")
@@ -5247,6 +5732,7 @@ class Program_weight_tensor_parameter_484:
 
 class Program_weight_tensor_parameter_485:
     name = "parameter_485"
+    original_name = "batch_norm2d_7.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.83852")
@@ -5258,6 +5744,7 @@ class Program_weight_tensor_parameter_485:
 
 class Program_weight_tensor_parameter_486:
     name = "parameter_486"
+    original_name = "conv2d_7.w_0"
     shape = [128, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.423952")
@@ -5269,6 +5756,7 @@ class Program_weight_tensor_parameter_486:
 
 class Program_weight_tensor_parameter_487:
     name = "parameter_487"
+    original_name = "batch_norm2d_6.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-2.39073")
@@ -5280,6 +5768,7 @@ class Program_weight_tensor_parameter_487:
 
 class Program_weight_tensor_parameter_488:
     name = "parameter_488"
+    original_name = "batch_norm2d_6.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.617568")
@@ -5291,6 +5780,7 @@ class Program_weight_tensor_parameter_488:
 
 class Program_weight_tensor_parameter_489:
     name = "parameter_489"
+    original_name = "batch_norm2d_6.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("2.12861")
@@ -5302,6 +5792,7 @@ class Program_weight_tensor_parameter_489:
 
 class Program_weight_tensor_parameter_490:
     name = "parameter_490"
+    original_name = "batch_norm2d_6.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-8.12315")
@@ -5313,6 +5804,7 @@ class Program_weight_tensor_parameter_490:
 
 class Program_weight_tensor_parameter_491:
     name = "parameter_491"
+    original_name = "conv2d_6.w_0"
     shape = [128, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.700269")
@@ -5324,6 +5816,7 @@ class Program_weight_tensor_parameter_491:
 
 class Program_weight_tensor_parameter_492:
     name = "parameter_492"
+    original_name = "batch_norm2d_5.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.46237")
@@ -5335,6 +5828,7 @@ class Program_weight_tensor_parameter_492:
 
 class Program_weight_tensor_parameter_493:
     name = "parameter_493"
+    original_name = "batch_norm2d_5.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.952433")
@@ -5346,6 +5840,7 @@ class Program_weight_tensor_parameter_493:
 
 class Program_weight_tensor_parameter_494:
     name = "parameter_494"
+    original_name = "batch_norm2d_5.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.000122605")
@@ -5357,6 +5852,7 @@ class Program_weight_tensor_parameter_494:
 
 class Program_weight_tensor_parameter_495:
     name = "parameter_495"
+    original_name = "batch_norm2d_5.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-2.76921")
@@ -5368,6 +5864,7 @@ class Program_weight_tensor_parameter_495:
 
 class Program_weight_tensor_parameter_496:
     name = "parameter_496"
+    original_name = "conv2d_5.w_0"
     shape = [128, 1, 3, 3]
     dtype = "float32"
     min_val = float("-1.57968")
@@ -5379,6 +5876,7 @@ class Program_weight_tensor_parameter_496:
 
 class Program_weight_tensor_parameter_497:
     name = "parameter_497"
+    original_name = "batch_norm2d_4.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-3.63339")
@@ -5390,6 +5888,7 @@ class Program_weight_tensor_parameter_497:
 
 class Program_weight_tensor_parameter_498:
     name = "parameter_498"
+    original_name = "batch_norm2d_4.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.281156")
@@ -5401,6 +5900,7 @@ class Program_weight_tensor_parameter_498:
 
 class Program_weight_tensor_parameter_499:
     name = "parameter_499"
+    original_name = "batch_norm2d_4.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.90586")
@@ -5412,6 +5912,7 @@ class Program_weight_tensor_parameter_499:
 
 class Program_weight_tensor_parameter_500:
     name = "parameter_500"
+    original_name = "batch_norm2d_4.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-12.4785")
@@ -5423,6 +5924,7 @@ class Program_weight_tensor_parameter_500:
 
 class Program_weight_tensor_parameter_501:
     name = "parameter_501"
+    original_name = "conv2d_4.w_0"
     shape = [128, 64, 1, 1]
     dtype = "float32"
     min_val = float("-0.824516")
@@ -5434,6 +5936,7 @@ class Program_weight_tensor_parameter_501:
 
 class Program_weight_tensor_parameter_502:
     name = "parameter_502"
+    original_name = "batch_norm2d_3.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -5443,6 +5946,7 @@ class Program_weight_tensor_parameter_502:
 
 class Program_weight_tensor_parameter_503:
     name = "parameter_503"
+    original_name = "batch_norm2d_3.w_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -5452,6 +5956,7 @@ class Program_weight_tensor_parameter_503:
 
 class Program_weight_tensor_parameter_504:
     name = "parameter_504"
+    original_name = "batch_norm2d_3.w_2"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -5461,6 +5966,7 @@ class Program_weight_tensor_parameter_504:
 
 class Program_weight_tensor_parameter_505:
     name = "parameter_505"
+    original_name = "batch_norm2d_3.w_1"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -5470,6 +5976,7 @@ class Program_weight_tensor_parameter_505:
 
 class Program_weight_tensor_parameter_506:
     name = "parameter_506"
+    original_name = "conv2d_3.w_0"
     shape = [64, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.380395")
@@ -5481,6 +5988,7 @@ class Program_weight_tensor_parameter_506:
 
 class Program_weight_tensor_parameter_507:
     name = "parameter_507"
+    original_name = "batch_norm2d_2.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -5490,6 +5998,7 @@ class Program_weight_tensor_parameter_507:
 
 class Program_weight_tensor_parameter_508:
     name = "parameter_508"
+    original_name = "batch_norm2d_2.w_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -5499,6 +6008,7 @@ class Program_weight_tensor_parameter_508:
 
 class Program_weight_tensor_parameter_509:
     name = "parameter_509"
+    original_name = "batch_norm2d_2.w_2"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -5508,6 +6018,7 @@ class Program_weight_tensor_parameter_509:
 
 class Program_weight_tensor_parameter_510:
     name = "parameter_510"
+    original_name = "batch_norm2d_2.w_1"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -5517,6 +6028,7 @@ class Program_weight_tensor_parameter_510:
 
 class Program_weight_tensor_parameter_511:
     name = "parameter_511"
+    original_name = "conv2d_2.w_0"
     shape = [64, 32, 1, 1]
     dtype = "float32"
     min_val = float("-1.24187")
@@ -5528,6 +6040,7 @@ class Program_weight_tensor_parameter_511:
 
 class Program_weight_tensor_parameter_512:
     name = "parameter_512"
+    original_name = "batch_norm2d_1.b_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -5537,6 +6050,7 @@ class Program_weight_tensor_parameter_512:
 
 class Program_weight_tensor_parameter_513:
     name = "parameter_513"
+    original_name = "batch_norm2d_1.w_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -5546,6 +6060,7 @@ class Program_weight_tensor_parameter_513:
 
 class Program_weight_tensor_parameter_514:
     name = "parameter_514"
+    original_name = "batch_norm2d_1.w_2"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -5555,6 +6070,7 @@ class Program_weight_tensor_parameter_514:
 
 class Program_weight_tensor_parameter_515:
     name = "parameter_515"
+    original_name = "batch_norm2d_1.w_1"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -5564,6 +6080,7 @@ class Program_weight_tensor_parameter_515:
 
 class Program_weight_tensor_parameter_516:
     name = "parameter_516"
+    original_name = "conv2d_1.w_0"
     shape = [32, 1, 3, 3]
     dtype = "float32"
     min_val = float("-1.89874")
@@ -5575,6 +6092,7 @@ class Program_weight_tensor_parameter_516:
 
 class Program_weight_tensor_parameter_517:
     name = "parameter_517"
+    original_name = "batch_norm2d_0.b_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -5584,6 +6102,7 @@ class Program_weight_tensor_parameter_517:
 
 class Program_weight_tensor_parameter_518:
     name = "parameter_518"
+    original_name = "batch_norm2d_0.w_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -5593,6 +6112,7 @@ class Program_weight_tensor_parameter_518:
 
 class Program_weight_tensor_parameter_519:
     name = "parameter_519"
+    original_name = "batch_norm2d_0.w_2"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -5602,6 +6122,7 @@ class Program_weight_tensor_parameter_519:
 
 class Program_weight_tensor_parameter_520:
     name = "parameter_520"
+    original_name = "batch_norm2d_0.w_1"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -5611,6 +6132,7 @@ class Program_weight_tensor_parameter_520:
 
 class Program_weight_tensor_parameter_521:
     name = "parameter_521"
+    original_name = "conv2d_0.w_0"
     shape = [32, 3, 3, 3]
     dtype = "float32"
     min_val = float("-0.652931")

--- a/paddle_samples/PaddleX/PicoDet-M/subgraph_1/input_meta.py
+++ b/paddle_samples/PaddleX/PicoDet-M/subgraph_1/input_meta.py
@@ -1,5 +1,6 @@
 class Program_weight_tensor_data_0:
     name = "data_0"
+    original_name = "var_1804"
     shape = [4, 3, 352, 352]
     dtype = "float32"
     min_val = float("-2.1179")
@@ -11,6 +12,7 @@ class Program_weight_tensor_data_0:
 
 class Program_weight_tensor_data_1:
     name = "data_1"
+    original_name = "var_2057"
     shape = [8]
     dtype = "float32"
     data = [0.0, 1.0, 2.0, 3.0003, 4.0, 5.0, 6.0006, 7.0]

--- a/paddle_samples/PaddleX/PicoDet-M/subgraph_1/weight_meta.py
+++ b/paddle_samples/PaddleX/PicoDet-M/subgraph_1/weight_meta.py
@@ -1,5 +1,6 @@
 class Program_weight_tensor_parameter_0:
     name = "parameter_0"
+    original_name = "batch_norm2d_97.b_0"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -9,6 +10,7 @@ class Program_weight_tensor_parameter_0:
 
 class Program_weight_tensor_parameter_1:
     name = "parameter_1"
+    original_name = "batch_norm2d_97.w_0"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -18,6 +20,7 @@ class Program_weight_tensor_parameter_1:
 
 class Program_weight_tensor_parameter_2:
     name = "parameter_2"
+    original_name = "batch_norm2d_97.w_2"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -27,6 +30,7 @@ class Program_weight_tensor_parameter_2:
 
 class Program_weight_tensor_parameter_3:
     name = "parameter_3"
+    original_name = "batch_norm2d_97.w_1"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -36,6 +40,7 @@ class Program_weight_tensor_parameter_3:
 
 class Program_weight_tensor_parameter_4:
     name = "parameter_4"
+    original_name = "conv2d_115.w_0"
     shape = [1, 1, 1, 1]
     dtype = "float32"
     min_val = float("0")
@@ -45,6 +50,7 @@ class Program_weight_tensor_parameter_4:
 
 class Program_weight_tensor_parameter_5:
     name = "parameter_5"
+    original_name = "batch_norm2d_96.b_0"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -54,6 +60,7 @@ class Program_weight_tensor_parameter_5:
 
 class Program_weight_tensor_parameter_6:
     name = "parameter_6"
+    original_name = "batch_norm2d_96.w_0"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -63,6 +70,7 @@ class Program_weight_tensor_parameter_6:
 
 class Program_weight_tensor_parameter_7:
     name = "parameter_7"
+    original_name = "batch_norm2d_96.w_2"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -72,6 +80,7 @@ class Program_weight_tensor_parameter_7:
 
 class Program_weight_tensor_parameter_8:
     name = "parameter_8"
+    original_name = "batch_norm2d_96.w_1"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -81,6 +90,7 @@ class Program_weight_tensor_parameter_8:
 
 class Program_weight_tensor_parameter_9:
     name = "parameter_9"
+    original_name = "conv2d_114.w_0"
     shape = [1, 128, 5, 5]
     dtype = "float32"
     min_val = float("-0.299565")
@@ -92,6 +102,7 @@ class Program_weight_tensor_parameter_9:
 
 class Program_weight_tensor_parameter_10:
     name = "parameter_10"
+    original_name = "conv2d_113.b_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -101,6 +112,7 @@ class Program_weight_tensor_parameter_10:
 
 class Program_weight_tensor_parameter_11:
     name = "parameter_11"
+    original_name = "conv2d_113.w_0"
     shape = [32, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.454145")
@@ -112,6 +124,7 @@ class Program_weight_tensor_parameter_11:
 
 class Program_weight_tensor_parameter_12:
     name = "parameter_12"
+    original_name = "conv2d_112.b_0"
     shape = [4]
     dtype = "float32"
     min_val = float("0")
@@ -121,6 +134,7 @@ class Program_weight_tensor_parameter_12:
 
 class Program_weight_tensor_parameter_13:
     name = "parameter_13"
+    original_name = "conv2d_112.w_0"
     shape = [4, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.0293642")
@@ -132,6 +146,7 @@ class Program_weight_tensor_parameter_13:
 
 class Program_weight_tensor_parameter_14:
     name = "parameter_14"
+    original_name = "batch_norm2d_89.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.00436877")
@@ -143,6 +158,7 @@ class Program_weight_tensor_parameter_14:
 
 class Program_weight_tensor_parameter_15:
     name = "parameter_15"
+    original_name = "batch_norm2d_89.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.848057")
@@ -154,6 +170,7 @@ class Program_weight_tensor_parameter_15:
 
 class Program_weight_tensor_parameter_16:
     name = "parameter_16"
+    original_name = "batch_norm2d_89.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.00628139")
@@ -165,6 +182,7 @@ class Program_weight_tensor_parameter_16:
 
 class Program_weight_tensor_parameter_17:
     name = "parameter_17"
+    original_name = "batch_norm2d_89.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.163325")
@@ -176,6 +194,7 @@ class Program_weight_tensor_parameter_17:
 
 class Program_weight_tensor_parameter_18:
     name = "parameter_18"
+    original_name = "conv2d_97.w_0"
     shape = [128, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.239995")
@@ -187,6 +206,7 @@ class Program_weight_tensor_parameter_18:
 
 class Program_weight_tensor_parameter_19:
     name = "parameter_19"
+    original_name = "conv2d_96.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.0513742")
@@ -198,6 +218,7 @@ class Program_weight_tensor_parameter_19:
 
 class Program_weight_tensor_parameter_20:
     name = "parameter_20"
+    original_name = "conv2d_96.w_0"
     shape = [128, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.105123")
@@ -209,6 +230,7 @@ class Program_weight_tensor_parameter_20:
 
 class Program_weight_tensor_parameter_21:
     name = "parameter_21"
+    original_name = "batch_norm2d_88.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.29575")
@@ -220,6 +242,7 @@ class Program_weight_tensor_parameter_21:
 
 class Program_weight_tensor_parameter_22:
     name = "parameter_22"
+    original_name = "batch_norm2d_88.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.738786")
@@ -231,6 +254,7 @@ class Program_weight_tensor_parameter_22:
 
 class Program_weight_tensor_parameter_23:
     name = "parameter_23"
+    original_name = "batch_norm2d_88.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.0252795")
@@ -242,6 +266,7 @@ class Program_weight_tensor_parameter_23:
 
 class Program_weight_tensor_parameter_24:
     name = "parameter_24"
+    original_name = "batch_norm2d_88.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.526768")
@@ -253,6 +278,7 @@ class Program_weight_tensor_parameter_24:
 
 class Program_weight_tensor_parameter_25:
     name = "parameter_25"
+    original_name = "conv2d_95.w_0"
     shape = [128, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.312924")
@@ -264,6 +290,7 @@ class Program_weight_tensor_parameter_25:
 
 class Program_weight_tensor_parameter_26:
     name = "parameter_26"
+    original_name = "batch_norm2d_87.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.12697")
@@ -275,6 +302,7 @@ class Program_weight_tensor_parameter_26:
 
 class Program_weight_tensor_parameter_27:
     name = "parameter_27"
+    original_name = "batch_norm2d_87.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.449743")
@@ -286,6 +314,7 @@ class Program_weight_tensor_parameter_27:
 
 class Program_weight_tensor_parameter_28:
     name = "parameter_28"
+    original_name = "batch_norm2d_87.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.00172347")
@@ -297,6 +326,7 @@ class Program_weight_tensor_parameter_28:
 
 class Program_weight_tensor_parameter_29:
     name = "parameter_29"
+    original_name = "batch_norm2d_87.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.260473")
@@ -308,6 +338,7 @@ class Program_weight_tensor_parameter_29:
 
 class Program_weight_tensor_parameter_30:
     name = "parameter_30"
+    original_name = "conv2d_94.w_0"
     shape = [128, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.229629")
@@ -319,6 +350,7 @@ class Program_weight_tensor_parameter_30:
 
 class Program_weight_tensor_parameter_31:
     name = "parameter_31"
+    original_name = "batch_norm2d_86.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.802679")
@@ -330,6 +362,7 @@ class Program_weight_tensor_parameter_31:
 
 class Program_weight_tensor_parameter_32:
     name = "parameter_32"
+    original_name = "batch_norm2d_86.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.405641")
@@ -341,6 +374,7 @@ class Program_weight_tensor_parameter_32:
 
 class Program_weight_tensor_parameter_33:
     name = "parameter_33"
+    original_name = "batch_norm2d_86.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.0362135")
@@ -352,6 +386,7 @@ class Program_weight_tensor_parameter_33:
 
 class Program_weight_tensor_parameter_34:
     name = "parameter_34"
+    original_name = "batch_norm2d_86.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.486258")
@@ -363,6 +398,7 @@ class Program_weight_tensor_parameter_34:
 
 class Program_weight_tensor_parameter_35:
     name = "parameter_35"
+    original_name = "conv2d_93.w_0"
     shape = [128, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.284462")
@@ -374,6 +410,7 @@ class Program_weight_tensor_parameter_35:
 
 class Program_weight_tensor_parameter_36:
     name = "parameter_36"
+    original_name = "batch_norm2d_85.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.545573")
@@ -385,6 +422,7 @@ class Program_weight_tensor_parameter_36:
 
 class Program_weight_tensor_parameter_37:
     name = "parameter_37"
+    original_name = "batch_norm2d_85.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.579825")
@@ -396,6 +434,7 @@ class Program_weight_tensor_parameter_37:
 
 class Program_weight_tensor_parameter_38:
     name = "parameter_38"
+    original_name = "batch_norm2d_85.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.00277581")
@@ -407,6 +446,7 @@ class Program_weight_tensor_parameter_38:
 
 class Program_weight_tensor_parameter_39:
     name = "parameter_39"
+    original_name = "batch_norm2d_85.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.287199")
@@ -418,6 +458,7 @@ class Program_weight_tensor_parameter_39:
 
 class Program_weight_tensor_parameter_40:
     name = "parameter_40"
+    original_name = "conv2d_92.w_0"
     shape = [128, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.175352")
@@ -429,6 +470,7 @@ class Program_weight_tensor_parameter_40:
 
 class Program_weight_tensor_parameter_41:
     name = "parameter_41"
+    original_name = "batch_norm2d_84.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.370593")
@@ -440,6 +482,7 @@ class Program_weight_tensor_parameter_41:
 
 class Program_weight_tensor_parameter_42:
     name = "parameter_42"
+    original_name = "batch_norm2d_84.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.291239")
@@ -451,6 +494,7 @@ class Program_weight_tensor_parameter_42:
 
 class Program_weight_tensor_parameter_43:
     name = "parameter_43"
+    original_name = "batch_norm2d_84.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.0341439")
@@ -462,6 +506,7 @@ class Program_weight_tensor_parameter_43:
 
 class Program_weight_tensor_parameter_44:
     name = "parameter_44"
+    original_name = "batch_norm2d_84.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.465874")
@@ -473,6 +518,7 @@ class Program_weight_tensor_parameter_44:
 
 class Program_weight_tensor_parameter_45:
     name = "parameter_45"
+    original_name = "conv2d_91.w_0"
     shape = [128, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.239295")
@@ -484,6 +530,7 @@ class Program_weight_tensor_parameter_45:
 
 class Program_weight_tensor_parameter_46:
     name = "parameter_46"
+    original_name = "batch_norm2d_83.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.675736")
@@ -495,6 +542,7 @@ class Program_weight_tensor_parameter_46:
 
 class Program_weight_tensor_parameter_47:
     name = "parameter_47"
+    original_name = "batch_norm2d_83.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.647311")
@@ -506,6 +554,7 @@ class Program_weight_tensor_parameter_47:
 
 class Program_weight_tensor_parameter_48:
     name = "parameter_48"
+    original_name = "batch_norm2d_83.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.00125544")
@@ -517,6 +566,7 @@ class Program_weight_tensor_parameter_48:
 
 class Program_weight_tensor_parameter_49:
     name = "parameter_49"
+    original_name = "batch_norm2d_83.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.213415")
@@ -528,6 +578,7 @@ class Program_weight_tensor_parameter_49:
 
 class Program_weight_tensor_parameter_50:
     name = "parameter_50"
+    original_name = "conv2d_90.w_0"
     shape = [128, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.225853")
@@ -539,6 +590,7 @@ class Program_weight_tensor_parameter_50:
 
 class Program_weight_tensor_parameter_51:
     name = "parameter_51"
+    original_name = "batch_norm2d_82.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.741283")
@@ -550,6 +602,7 @@ class Program_weight_tensor_parameter_51:
 
 class Program_weight_tensor_parameter_52:
     name = "parameter_52"
+    original_name = "batch_norm2d_82.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.25945")
@@ -561,6 +614,7 @@ class Program_weight_tensor_parameter_52:
 
 class Program_weight_tensor_parameter_53:
     name = "parameter_53"
+    original_name = "batch_norm2d_82.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.0497916")
@@ -572,6 +626,7 @@ class Program_weight_tensor_parameter_53:
 
 class Program_weight_tensor_parameter_54:
     name = "parameter_54"
+    original_name = "batch_norm2d_82.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.255087")
@@ -583,6 +638,7 @@ class Program_weight_tensor_parameter_54:
 
 class Program_weight_tensor_parameter_55:
     name = "parameter_55"
+    original_name = "conv2d_89.w_0"
     shape = [128, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.30253")
@@ -594,6 +650,7 @@ class Program_weight_tensor_parameter_55:
 
 class Program_weight_tensor_parameter_56:
     name = "parameter_56"
+    original_name = "batch_norm2d_81.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.449391")
@@ -605,6 +662,7 @@ class Program_weight_tensor_parameter_56:
 
 class Program_weight_tensor_parameter_57:
     name = "parameter_57"
+    original_name = "batch_norm2d_81.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.926733")
@@ -616,6 +674,7 @@ class Program_weight_tensor_parameter_57:
 
 class Program_weight_tensor_parameter_58:
     name = "parameter_58"
+    original_name = "batch_norm2d_81.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.000145412")
@@ -627,6 +686,7 @@ class Program_weight_tensor_parameter_58:
 
 class Program_weight_tensor_parameter_59:
     name = "parameter_59"
+    original_name = "batch_norm2d_81.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.0628302")
@@ -638,6 +698,7 @@ class Program_weight_tensor_parameter_59:
 
 class Program_weight_tensor_parameter_60:
     name = "parameter_60"
+    original_name = "conv2d_88.w_0"
     shape = [128, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.261723")
@@ -649,6 +710,7 @@ class Program_weight_tensor_parameter_60:
 
 class Program_weight_tensor_parameter_61:
     name = "parameter_61"
+    original_name = "batch_norm2d_95.b_0"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -658,6 +720,7 @@ class Program_weight_tensor_parameter_61:
 
 class Program_weight_tensor_parameter_62:
     name = "parameter_62"
+    original_name = "batch_norm2d_95.w_0"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -667,6 +730,7 @@ class Program_weight_tensor_parameter_62:
 
 class Program_weight_tensor_parameter_63:
     name = "parameter_63"
+    original_name = "batch_norm2d_95.w_2"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -676,6 +740,7 @@ class Program_weight_tensor_parameter_63:
 
 class Program_weight_tensor_parameter_64:
     name = "parameter_64"
+    original_name = "batch_norm2d_95.w_1"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -685,6 +750,7 @@ class Program_weight_tensor_parameter_64:
 
 class Program_weight_tensor_parameter_65:
     name = "parameter_65"
+    original_name = "conv2d_111.w_0"
     shape = [1, 1, 1, 1]
     dtype = "float32"
     min_val = float("0")
@@ -694,6 +760,7 @@ class Program_weight_tensor_parameter_65:
 
 class Program_weight_tensor_parameter_66:
     name = "parameter_66"
+    original_name = "batch_norm2d_94.b_0"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -703,6 +770,7 @@ class Program_weight_tensor_parameter_66:
 
 class Program_weight_tensor_parameter_67:
     name = "parameter_67"
+    original_name = "batch_norm2d_94.w_0"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -712,6 +780,7 @@ class Program_weight_tensor_parameter_67:
 
 class Program_weight_tensor_parameter_68:
     name = "parameter_68"
+    original_name = "batch_norm2d_94.w_2"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -721,6 +790,7 @@ class Program_weight_tensor_parameter_68:
 
 class Program_weight_tensor_parameter_69:
     name = "parameter_69"
+    original_name = "batch_norm2d_94.w_1"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -730,6 +800,7 @@ class Program_weight_tensor_parameter_69:
 
 class Program_weight_tensor_parameter_70:
     name = "parameter_70"
+    original_name = "conv2d_110.w_0"
     shape = [1, 128, 5, 5]
     dtype = "float32"
     min_val = float("-0.363502")
@@ -741,6 +812,7 @@ class Program_weight_tensor_parameter_70:
 
 class Program_weight_tensor_parameter_71:
     name = "parameter_71"
+    original_name = "conv2d_109.b_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -750,6 +822,7 @@ class Program_weight_tensor_parameter_71:
 
 class Program_weight_tensor_parameter_72:
     name = "parameter_72"
+    original_name = "conv2d_109.w_0"
     shape = [32, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.467742")
@@ -761,6 +834,7 @@ class Program_weight_tensor_parameter_72:
 
 class Program_weight_tensor_parameter_73:
     name = "parameter_73"
+    original_name = "conv2d_108.b_0"
     shape = [4]
     dtype = "float32"
     min_val = float("0")
@@ -770,6 +844,7 @@ class Program_weight_tensor_parameter_73:
 
 class Program_weight_tensor_parameter_74:
     name = "parameter_74"
+    original_name = "conv2d_108.w_0"
     shape = [4, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.0297158")
@@ -781,6 +856,7 @@ class Program_weight_tensor_parameter_74:
 
 class Program_weight_tensor_parameter_75:
     name = "parameter_75"
+    original_name = "batch_norm2d_80.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.0599435")
@@ -792,6 +868,7 @@ class Program_weight_tensor_parameter_75:
 
 class Program_weight_tensor_parameter_76:
     name = "parameter_76"
+    original_name = "batch_norm2d_80.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.599368")
@@ -803,6 +880,7 @@ class Program_weight_tensor_parameter_76:
 
 class Program_weight_tensor_parameter_77:
     name = "parameter_77"
+    original_name = "batch_norm2d_80.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.00783025")
@@ -814,6 +892,7 @@ class Program_weight_tensor_parameter_77:
 
 class Program_weight_tensor_parameter_78:
     name = "parameter_78"
+    original_name = "batch_norm2d_80.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.342643")
@@ -825,6 +904,7 @@ class Program_weight_tensor_parameter_78:
 
 class Program_weight_tensor_parameter_79:
     name = "parameter_79"
+    original_name = "conv2d_87.w_0"
     shape = [128, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.436353")
@@ -836,6 +916,7 @@ class Program_weight_tensor_parameter_79:
 
 class Program_weight_tensor_parameter_80:
     name = "parameter_80"
+    original_name = "conv2d_86.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.0488427")
@@ -847,6 +928,7 @@ class Program_weight_tensor_parameter_80:
 
 class Program_weight_tensor_parameter_81:
     name = "parameter_81"
+    original_name = "conv2d_86.w_0"
     shape = [128, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.158454")
@@ -858,6 +940,7 @@ class Program_weight_tensor_parameter_81:
 
 class Program_weight_tensor_parameter_82:
     name = "parameter_82"
+    original_name = "batch_norm2d_79.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.29969")
@@ -869,6 +952,7 @@ class Program_weight_tensor_parameter_82:
 
 class Program_weight_tensor_parameter_83:
     name = "parameter_83"
+    original_name = "batch_norm2d_79.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.439862")
@@ -880,6 +964,7 @@ class Program_weight_tensor_parameter_83:
 
 class Program_weight_tensor_parameter_84:
     name = "parameter_84"
+    original_name = "batch_norm2d_79.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.0355918")
@@ -891,6 +976,7 @@ class Program_weight_tensor_parameter_84:
 
 class Program_weight_tensor_parameter_85:
     name = "parameter_85"
+    original_name = "batch_norm2d_79.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.43105")
@@ -902,6 +988,7 @@ class Program_weight_tensor_parameter_85:
 
 class Program_weight_tensor_parameter_86:
     name = "parameter_86"
+    original_name = "conv2d_85.w_0"
     shape = [128, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.406578")
@@ -913,6 +1000,7 @@ class Program_weight_tensor_parameter_86:
 
 class Program_weight_tensor_parameter_87:
     name = "parameter_87"
+    original_name = "batch_norm2d_78.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.24861")
@@ -924,6 +1012,7 @@ class Program_weight_tensor_parameter_87:
 
 class Program_weight_tensor_parameter_88:
     name = "parameter_88"
+    original_name = "batch_norm2d_78.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.46203")
@@ -935,6 +1024,7 @@ class Program_weight_tensor_parameter_88:
 
 class Program_weight_tensor_parameter_89:
     name = "parameter_89"
+    original_name = "batch_norm2d_78.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.000829372")
@@ -946,6 +1036,7 @@ class Program_weight_tensor_parameter_89:
 
 class Program_weight_tensor_parameter_90:
     name = "parameter_90"
+    original_name = "batch_norm2d_78.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.303179")
@@ -957,6 +1048,7 @@ class Program_weight_tensor_parameter_90:
 
 class Program_weight_tensor_parameter_91:
     name = "parameter_91"
+    original_name = "conv2d_84.w_0"
     shape = [128, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.36541")
@@ -968,6 +1060,7 @@ class Program_weight_tensor_parameter_91:
 
 class Program_weight_tensor_parameter_92:
     name = "parameter_92"
+    original_name = "batch_norm2d_77.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.866103")
@@ -979,6 +1072,7 @@ class Program_weight_tensor_parameter_92:
 
 class Program_weight_tensor_parameter_93:
     name = "parameter_93"
+    original_name = "batch_norm2d_77.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.198274")
@@ -990,6 +1084,7 @@ class Program_weight_tensor_parameter_93:
 
 class Program_weight_tensor_parameter_94:
     name = "parameter_94"
+    original_name = "batch_norm2d_77.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.0371733")
@@ -1001,6 +1096,7 @@ class Program_weight_tensor_parameter_94:
 
 class Program_weight_tensor_parameter_95:
     name = "parameter_95"
+    original_name = "batch_norm2d_77.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.651786")
@@ -1012,6 +1108,7 @@ class Program_weight_tensor_parameter_95:
 
 class Program_weight_tensor_parameter_96:
     name = "parameter_96"
+    original_name = "conv2d_83.w_0"
     shape = [128, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.363373")
@@ -1023,6 +1120,7 @@ class Program_weight_tensor_parameter_96:
 
 class Program_weight_tensor_parameter_97:
     name = "parameter_97"
+    original_name = "batch_norm2d_76.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.539485")
@@ -1034,6 +1132,7 @@ class Program_weight_tensor_parameter_97:
 
 class Program_weight_tensor_parameter_98:
     name = "parameter_98"
+    original_name = "batch_norm2d_76.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.531155")
@@ -1045,6 +1144,7 @@ class Program_weight_tensor_parameter_98:
 
 class Program_weight_tensor_parameter_99:
     name = "parameter_99"
+    original_name = "batch_norm2d_76.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.00498508")
@@ -1056,6 +1156,7 @@ class Program_weight_tensor_parameter_99:
 
 class Program_weight_tensor_parameter_100:
     name = "parameter_100"
+    original_name = "batch_norm2d_76.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.27029")
@@ -1067,6 +1168,7 @@ class Program_weight_tensor_parameter_100:
 
 class Program_weight_tensor_parameter_101:
     name = "parameter_101"
+    original_name = "conv2d_82.w_0"
     shape = [128, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.206759")
@@ -1078,6 +1180,7 @@ class Program_weight_tensor_parameter_101:
 
 class Program_weight_tensor_parameter_102:
     name = "parameter_102"
+    original_name = "batch_norm2d_75.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.703047")
@@ -1089,6 +1192,7 @@ class Program_weight_tensor_parameter_102:
 
 class Program_weight_tensor_parameter_103:
     name = "parameter_103"
+    original_name = "batch_norm2d_75.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.317356")
@@ -1100,6 +1204,7 @@ class Program_weight_tensor_parameter_103:
 
 class Program_weight_tensor_parameter_104:
     name = "parameter_104"
+    original_name = "batch_norm2d_75.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.0359817")
@@ -1111,6 +1216,7 @@ class Program_weight_tensor_parameter_104:
 
 class Program_weight_tensor_parameter_105:
     name = "parameter_105"
+    original_name = "batch_norm2d_75.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.59565")
@@ -1122,6 +1228,7 @@ class Program_weight_tensor_parameter_105:
 
 class Program_weight_tensor_parameter_106:
     name = "parameter_106"
+    original_name = "conv2d_81.w_0"
     shape = [128, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.429161")
@@ -1133,6 +1240,7 @@ class Program_weight_tensor_parameter_106:
 
 class Program_weight_tensor_parameter_107:
     name = "parameter_107"
+    original_name = "batch_norm2d_74.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.791388")
@@ -1144,6 +1252,7 @@ class Program_weight_tensor_parameter_107:
 
 class Program_weight_tensor_parameter_108:
     name = "parameter_108"
+    original_name = "batch_norm2d_74.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.568991")
@@ -1155,6 +1264,7 @@ class Program_weight_tensor_parameter_108:
 
 class Program_weight_tensor_parameter_109:
     name = "parameter_109"
+    original_name = "batch_norm2d_74.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.000461131")
@@ -1166,6 +1276,7 @@ class Program_weight_tensor_parameter_109:
 
 class Program_weight_tensor_parameter_110:
     name = "parameter_110"
+    original_name = "batch_norm2d_74.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.511549")
@@ -1177,6 +1288,7 @@ class Program_weight_tensor_parameter_110:
 
 class Program_weight_tensor_parameter_111:
     name = "parameter_111"
+    original_name = "conv2d_80.w_0"
     shape = [128, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.292513")
@@ -1188,6 +1300,7 @@ class Program_weight_tensor_parameter_111:
 
 class Program_weight_tensor_parameter_112:
     name = "parameter_112"
+    original_name = "batch_norm2d_73.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.587232")
@@ -1199,6 +1312,7 @@ class Program_weight_tensor_parameter_112:
 
 class Program_weight_tensor_parameter_113:
     name = "parameter_113"
+    original_name = "batch_norm2d_73.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.109909")
@@ -1210,6 +1324,7 @@ class Program_weight_tensor_parameter_113:
 
 class Program_weight_tensor_parameter_114:
     name = "parameter_114"
+    original_name = "batch_norm2d_73.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.0444412")
@@ -1221,6 +1336,7 @@ class Program_weight_tensor_parameter_114:
 
 class Program_weight_tensor_parameter_115:
     name = "parameter_115"
+    original_name = "batch_norm2d_73.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.742942")
@@ -1232,6 +1348,7 @@ class Program_weight_tensor_parameter_115:
 
 class Program_weight_tensor_parameter_116:
     name = "parameter_116"
+    original_name = "conv2d_79.w_0"
     shape = [128, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.499866")
@@ -1243,6 +1360,7 @@ class Program_weight_tensor_parameter_116:
 
 class Program_weight_tensor_parameter_117:
     name = "parameter_117"
+    original_name = "batch_norm2d_72.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.344714")
@@ -1254,6 +1372,7 @@ class Program_weight_tensor_parameter_117:
 
 class Program_weight_tensor_parameter_118:
     name = "parameter_118"
+    original_name = "batch_norm2d_72.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.462789")
@@ -1265,6 +1384,7 @@ class Program_weight_tensor_parameter_118:
 
 class Program_weight_tensor_parameter_119:
     name = "parameter_119"
+    original_name = "batch_norm2d_72.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.00307899")
@@ -1276,6 +1396,7 @@ class Program_weight_tensor_parameter_119:
 
 class Program_weight_tensor_parameter_120:
     name = "parameter_120"
+    original_name = "batch_norm2d_72.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.425254")
@@ -1287,6 +1408,7 @@ class Program_weight_tensor_parameter_120:
 
 class Program_weight_tensor_parameter_121:
     name = "parameter_121"
+    original_name = "conv2d_78.w_0"
     shape = [128, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.297374")
@@ -1298,6 +1420,7 @@ class Program_weight_tensor_parameter_121:
 
 class Program_weight_tensor_parameter_122:
     name = "parameter_122"
+    original_name = "batch_norm2d_93.b_0"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -1307,6 +1430,7 @@ class Program_weight_tensor_parameter_122:
 
 class Program_weight_tensor_parameter_123:
     name = "parameter_123"
+    original_name = "batch_norm2d_93.w_0"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -1316,6 +1440,7 @@ class Program_weight_tensor_parameter_123:
 
 class Program_weight_tensor_parameter_124:
     name = "parameter_124"
+    original_name = "batch_norm2d_93.w_2"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -1325,6 +1450,7 @@ class Program_weight_tensor_parameter_124:
 
 class Program_weight_tensor_parameter_125:
     name = "parameter_125"
+    original_name = "batch_norm2d_93.w_1"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -1334,6 +1460,7 @@ class Program_weight_tensor_parameter_125:
 
 class Program_weight_tensor_parameter_126:
     name = "parameter_126"
+    original_name = "conv2d_107.w_0"
     shape = [1, 1, 1, 1]
     dtype = "float32"
     min_val = float("0")
@@ -1343,6 +1470,7 @@ class Program_weight_tensor_parameter_126:
 
 class Program_weight_tensor_parameter_127:
     name = "parameter_127"
+    original_name = "batch_norm2d_92.b_0"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -1352,6 +1480,7 @@ class Program_weight_tensor_parameter_127:
 
 class Program_weight_tensor_parameter_128:
     name = "parameter_128"
+    original_name = "batch_norm2d_92.w_0"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -1361,6 +1490,7 @@ class Program_weight_tensor_parameter_128:
 
 class Program_weight_tensor_parameter_129:
     name = "parameter_129"
+    original_name = "batch_norm2d_92.w_2"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -1370,6 +1500,7 @@ class Program_weight_tensor_parameter_129:
 
 class Program_weight_tensor_parameter_130:
     name = "parameter_130"
+    original_name = "batch_norm2d_92.w_1"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -1379,6 +1510,7 @@ class Program_weight_tensor_parameter_130:
 
 class Program_weight_tensor_parameter_131:
     name = "parameter_131"
+    original_name = "conv2d_106.w_0"
     shape = [1, 128, 5, 5]
     dtype = "float32"
     min_val = float("-0.357095")
@@ -1390,6 +1522,7 @@ class Program_weight_tensor_parameter_131:
 
 class Program_weight_tensor_parameter_132:
     name = "parameter_132"
+    original_name = "conv2d_105.b_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -1399,6 +1532,7 @@ class Program_weight_tensor_parameter_132:
 
 class Program_weight_tensor_parameter_133:
     name = "parameter_133"
+    original_name = "conv2d_105.w_0"
     shape = [32, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.460762")
@@ -1410,6 +1544,7 @@ class Program_weight_tensor_parameter_133:
 
 class Program_weight_tensor_parameter_134:
     name = "parameter_134"
+    original_name = "conv2d_104.b_0"
     shape = [4]
     dtype = "float32"
     min_val = float("0")
@@ -1419,6 +1554,7 @@ class Program_weight_tensor_parameter_134:
 
 class Program_weight_tensor_parameter_135:
     name = "parameter_135"
+    original_name = "conv2d_104.w_0"
     shape = [4, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.0314999")
@@ -1430,6 +1566,7 @@ class Program_weight_tensor_parameter_135:
 
 class Program_weight_tensor_parameter_136:
     name = "parameter_136"
+    original_name = "batch_norm2d_71.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.000153021")
@@ -1441,6 +1578,7 @@ class Program_weight_tensor_parameter_136:
 
 class Program_weight_tensor_parameter_137:
     name = "parameter_137"
+    original_name = "batch_norm2d_71.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.581301")
@@ -1452,6 +1590,7 @@ class Program_weight_tensor_parameter_137:
 
 class Program_weight_tensor_parameter_138:
     name = "parameter_138"
+    original_name = "batch_norm2d_71.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.011277")
@@ -1463,6 +1602,7 @@ class Program_weight_tensor_parameter_138:
 
 class Program_weight_tensor_parameter_139:
     name = "parameter_139"
+    original_name = "batch_norm2d_71.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.436509")
@@ -1474,6 +1614,7 @@ class Program_weight_tensor_parameter_139:
 
 class Program_weight_tensor_parameter_140:
     name = "parameter_140"
+    original_name = "conv2d_77.w_0"
     shape = [128, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.430623")
@@ -1485,6 +1626,7 @@ class Program_weight_tensor_parameter_140:
 
 class Program_weight_tensor_parameter_141:
     name = "parameter_141"
+    original_name = "conv2d_76.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.0442838")
@@ -1496,6 +1638,7 @@ class Program_weight_tensor_parameter_141:
 
 class Program_weight_tensor_parameter_142:
     name = "parameter_142"
+    original_name = "conv2d_76.w_0"
     shape = [128, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.28396")
@@ -1507,6 +1650,7 @@ class Program_weight_tensor_parameter_142:
 
 class Program_weight_tensor_parameter_143:
     name = "parameter_143"
+    original_name = "batch_norm2d_70.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.0377")
@@ -1518,6 +1662,7 @@ class Program_weight_tensor_parameter_143:
 
 class Program_weight_tensor_parameter_144:
     name = "parameter_144"
+    original_name = "batch_norm2d_70.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.36302")
@@ -1529,6 +1674,7 @@ class Program_weight_tensor_parameter_144:
 
 class Program_weight_tensor_parameter_145:
     name = "parameter_145"
+    original_name = "batch_norm2d_70.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.0639928")
@@ -1540,6 +1686,7 @@ class Program_weight_tensor_parameter_145:
 
 class Program_weight_tensor_parameter_146:
     name = "parameter_146"
+    original_name = "batch_norm2d_70.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.53298")
@@ -1551,6 +1698,7 @@ class Program_weight_tensor_parameter_146:
 
 class Program_weight_tensor_parameter_147:
     name = "parameter_147"
+    original_name = "conv2d_75.w_0"
     shape = [128, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.377901")
@@ -1562,6 +1710,7 @@ class Program_weight_tensor_parameter_147:
 
 class Program_weight_tensor_parameter_148:
     name = "parameter_148"
+    original_name = "batch_norm2d_69.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.44107")
@@ -1573,6 +1722,7 @@ class Program_weight_tensor_parameter_148:
 
 class Program_weight_tensor_parameter_149:
     name = "parameter_149"
+    original_name = "batch_norm2d_69.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.438879")
@@ -1584,6 +1734,7 @@ class Program_weight_tensor_parameter_149:
 
 class Program_weight_tensor_parameter_150:
     name = "parameter_150"
+    original_name = "batch_norm2d_69.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("9.97297e-05")
@@ -1595,6 +1746,7 @@ class Program_weight_tensor_parameter_150:
 
 class Program_weight_tensor_parameter_151:
     name = "parameter_151"
+    original_name = "batch_norm2d_69.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.374796")
@@ -1606,6 +1758,7 @@ class Program_weight_tensor_parameter_151:
 
 class Program_weight_tensor_parameter_152:
     name = "parameter_152"
+    original_name = "conv2d_74.w_0"
     shape = [128, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.4643")
@@ -1617,6 +1770,7 @@ class Program_weight_tensor_parameter_152:
 
 class Program_weight_tensor_parameter_153:
     name = "parameter_153"
+    original_name = "batch_norm2d_68.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.32816")
@@ -1628,6 +1782,7 @@ class Program_weight_tensor_parameter_153:
 
 class Program_weight_tensor_parameter_154:
     name = "parameter_154"
+    original_name = "batch_norm2d_68.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.0439716")
@@ -1639,6 +1794,7 @@ class Program_weight_tensor_parameter_154:
 
 class Program_weight_tensor_parameter_155:
     name = "parameter_155"
+    original_name = "batch_norm2d_68.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.0441345")
@@ -1650,6 +1806,7 @@ class Program_weight_tensor_parameter_155:
 
 class Program_weight_tensor_parameter_156:
     name = "parameter_156"
+    original_name = "batch_norm2d_68.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.604378")
@@ -1661,6 +1818,7 @@ class Program_weight_tensor_parameter_156:
 
 class Program_weight_tensor_parameter_157:
     name = "parameter_157"
+    original_name = "conv2d_73.w_0"
     shape = [128, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.343683")
@@ -1672,6 +1830,7 @@ class Program_weight_tensor_parameter_157:
 
 class Program_weight_tensor_parameter_158:
     name = "parameter_158"
+    original_name = "batch_norm2d_67.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.543288")
@@ -1683,6 +1842,7 @@ class Program_weight_tensor_parameter_158:
 
 class Program_weight_tensor_parameter_159:
     name = "parameter_159"
+    original_name = "batch_norm2d_67.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.533197")
@@ -1694,6 +1854,7 @@ class Program_weight_tensor_parameter_159:
 
 class Program_weight_tensor_parameter_160:
     name = "parameter_160"
+    original_name = "batch_norm2d_67.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.000433345")
@@ -1705,6 +1866,7 @@ class Program_weight_tensor_parameter_160:
 
 class Program_weight_tensor_parameter_161:
     name = "parameter_161"
+    original_name = "batch_norm2d_67.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.275069")
@@ -1716,6 +1878,7 @@ class Program_weight_tensor_parameter_161:
 
 class Program_weight_tensor_parameter_162:
     name = "parameter_162"
+    original_name = "conv2d_72.w_0"
     shape = [128, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.268468")
@@ -1727,6 +1890,7 @@ class Program_weight_tensor_parameter_162:
 
 class Program_weight_tensor_parameter_163:
     name = "parameter_163"
+    original_name = "batch_norm2d_66.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.539032")
@@ -1738,6 +1902,7 @@ class Program_weight_tensor_parameter_163:
 
 class Program_weight_tensor_parameter_164:
     name = "parameter_164"
+    original_name = "batch_norm2d_66.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.143475")
@@ -1749,6 +1914,7 @@ class Program_weight_tensor_parameter_164:
 
 class Program_weight_tensor_parameter_165:
     name = "parameter_165"
+    original_name = "batch_norm2d_66.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.0715116")
@@ -1760,6 +1926,7 @@ class Program_weight_tensor_parameter_165:
 
 class Program_weight_tensor_parameter_166:
     name = "parameter_166"
+    original_name = "batch_norm2d_66.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.704876")
@@ -1771,6 +1938,7 @@ class Program_weight_tensor_parameter_166:
 
 class Program_weight_tensor_parameter_167:
     name = "parameter_167"
+    original_name = "conv2d_71.w_0"
     shape = [128, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.384326")
@@ -1782,6 +1950,7 @@ class Program_weight_tensor_parameter_167:
 
 class Program_weight_tensor_parameter_168:
     name = "parameter_168"
+    original_name = "batch_norm2d_65.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.756363")
@@ -1793,6 +1962,7 @@ class Program_weight_tensor_parameter_168:
 
 class Program_weight_tensor_parameter_169:
     name = "parameter_169"
+    original_name = "batch_norm2d_65.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.490566")
@@ -1804,6 +1974,7 @@ class Program_weight_tensor_parameter_169:
 
 class Program_weight_tensor_parameter_170:
     name = "parameter_170"
+    original_name = "batch_norm2d_65.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.000915794")
@@ -1815,6 +1986,7 @@ class Program_weight_tensor_parameter_170:
 
 class Program_weight_tensor_parameter_171:
     name = "parameter_171"
+    original_name = "batch_norm2d_65.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.428133")
@@ -1826,6 +1998,7 @@ class Program_weight_tensor_parameter_171:
 
 class Program_weight_tensor_parameter_172:
     name = "parameter_172"
+    original_name = "conv2d_70.w_0"
     shape = [128, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.260975")
@@ -1837,6 +2010,7 @@ class Program_weight_tensor_parameter_172:
 
 class Program_weight_tensor_parameter_173:
     name = "parameter_173"
+    original_name = "batch_norm2d_64.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.759552")
@@ -1848,6 +2022,7 @@ class Program_weight_tensor_parameter_173:
 
 class Program_weight_tensor_parameter_174:
     name = "parameter_174"
+    original_name = "batch_norm2d_64.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.103413")
@@ -1859,6 +2034,7 @@ class Program_weight_tensor_parameter_174:
 
 class Program_weight_tensor_parameter_175:
     name = "parameter_175"
+    original_name = "batch_norm2d_64.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.0519159")
@@ -1870,6 +2046,7 @@ class Program_weight_tensor_parameter_175:
 
 class Program_weight_tensor_parameter_176:
     name = "parameter_176"
+    original_name = "batch_norm2d_64.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.625449")
@@ -1881,6 +2058,7 @@ class Program_weight_tensor_parameter_176:
 
 class Program_weight_tensor_parameter_177:
     name = "parameter_177"
+    original_name = "conv2d_69.w_0"
     shape = [128, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.344386")
@@ -1892,6 +2070,7 @@ class Program_weight_tensor_parameter_177:
 
 class Program_weight_tensor_parameter_178:
     name = "parameter_178"
+    original_name = "batch_norm2d_63.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.0497877")
@@ -1903,6 +2082,7 @@ class Program_weight_tensor_parameter_178:
 
 class Program_weight_tensor_parameter_179:
     name = "parameter_179"
+    original_name = "batch_norm2d_63.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.499711")
@@ -1914,6 +2094,7 @@ class Program_weight_tensor_parameter_179:
 
 class Program_weight_tensor_parameter_180:
     name = "parameter_180"
+    original_name = "batch_norm2d_63.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.00299741")
@@ -1925,6 +2106,7 @@ class Program_weight_tensor_parameter_180:
 
 class Program_weight_tensor_parameter_181:
     name = "parameter_181"
+    original_name = "batch_norm2d_63.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.631537")
@@ -1936,6 +2118,7 @@ class Program_weight_tensor_parameter_181:
 
 class Program_weight_tensor_parameter_182:
     name = "parameter_182"
+    original_name = "conv2d_68.w_0"
     shape = [128, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.332613")
@@ -1947,6 +2130,7 @@ class Program_weight_tensor_parameter_182:
 
 class Program_weight_tensor_parameter_183:
     name = "parameter_183"
+    original_name = "batch_norm2d_91.b_0"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -1956,6 +2140,7 @@ class Program_weight_tensor_parameter_183:
 
 class Program_weight_tensor_parameter_184:
     name = "parameter_184"
+    original_name = "batch_norm2d_91.w_0"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -1965,6 +2150,7 @@ class Program_weight_tensor_parameter_184:
 
 class Program_weight_tensor_parameter_185:
     name = "parameter_185"
+    original_name = "batch_norm2d_91.w_2"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -1974,6 +2160,7 @@ class Program_weight_tensor_parameter_185:
 
 class Program_weight_tensor_parameter_186:
     name = "parameter_186"
+    original_name = "batch_norm2d_91.w_1"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -1983,6 +2170,7 @@ class Program_weight_tensor_parameter_186:
 
 class Program_weight_tensor_parameter_187:
     name = "parameter_187"
+    original_name = "conv2d_103.w_0"
     shape = [1, 1, 1, 1]
     dtype = "float32"
     min_val = float("0")
@@ -1992,6 +2180,7 @@ class Program_weight_tensor_parameter_187:
 
 class Program_weight_tensor_parameter_188:
     name = "parameter_188"
+    original_name = "batch_norm2d_90.b_0"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -2001,6 +2190,7 @@ class Program_weight_tensor_parameter_188:
 
 class Program_weight_tensor_parameter_189:
     name = "parameter_189"
+    original_name = "batch_norm2d_90.w_0"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -2010,6 +2200,7 @@ class Program_weight_tensor_parameter_189:
 
 class Program_weight_tensor_parameter_190:
     name = "parameter_190"
+    original_name = "batch_norm2d_90.w_2"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -2019,6 +2210,7 @@ class Program_weight_tensor_parameter_190:
 
 class Program_weight_tensor_parameter_191:
     name = "parameter_191"
+    original_name = "batch_norm2d_90.w_1"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -2028,6 +2220,7 @@ class Program_weight_tensor_parameter_191:
 
 class Program_weight_tensor_parameter_192:
     name = "parameter_192"
+    original_name = "conv2d_102.w_0"
     shape = [1, 128, 5, 5]
     dtype = "float32"
     min_val = float("-0.517362")
@@ -2039,6 +2232,7 @@ class Program_weight_tensor_parameter_192:
 
 class Program_weight_tensor_parameter_193:
     name = "parameter_193"
+    original_name = "conv2d_101.b_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -2048,6 +2242,7 @@ class Program_weight_tensor_parameter_193:
 
 class Program_weight_tensor_parameter_194:
     name = "parameter_194"
+    original_name = "conv2d_101.w_0"
     shape = [32, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.548081")
@@ -2059,6 +2254,7 @@ class Program_weight_tensor_parameter_194:
 
 class Program_weight_tensor_parameter_195:
     name = "parameter_195"
+    original_name = "conv2d_100.b_0"
     shape = [4]
     dtype = "float32"
     min_val = float("0")
@@ -2068,6 +2264,7 @@ class Program_weight_tensor_parameter_195:
 
 class Program_weight_tensor_parameter_196:
     name = "parameter_196"
+    original_name = "conv2d_100.w_0"
     shape = [4, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.0280774")
@@ -2079,6 +2276,7 @@ class Program_weight_tensor_parameter_196:
 
 class Program_weight_tensor_parameter_197:
     name = "parameter_197"
+    original_name = "batch_norm2d_62.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.767284")
@@ -2090,6 +2288,7 @@ class Program_weight_tensor_parameter_197:
 
 class Program_weight_tensor_parameter_198:
     name = "parameter_198"
+    original_name = "batch_norm2d_62.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.428088")
@@ -2101,6 +2300,7 @@ class Program_weight_tensor_parameter_198:
 
 class Program_weight_tensor_parameter_199:
     name = "parameter_199"
+    original_name = "batch_norm2d_62.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.0142679")
@@ -2112,6 +2312,7 @@ class Program_weight_tensor_parameter_199:
 
 class Program_weight_tensor_parameter_200:
     name = "parameter_200"
+    original_name = "batch_norm2d_62.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.497378")
@@ -2123,6 +2324,7 @@ class Program_weight_tensor_parameter_200:
 
 class Program_weight_tensor_parameter_201:
     name = "parameter_201"
+    original_name = "conv2d_67.w_0"
     shape = [128, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.622406")
@@ -2134,6 +2336,7 @@ class Program_weight_tensor_parameter_201:
 
 class Program_weight_tensor_parameter_202:
     name = "parameter_202"
+    original_name = "conv2d_66.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.042073")
@@ -2145,6 +2348,7 @@ class Program_weight_tensor_parameter_202:
 
 class Program_weight_tensor_parameter_203:
     name = "parameter_203"
+    original_name = "conv2d_66.w_0"
     shape = [128, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.459779")
@@ -2156,6 +2360,7 @@ class Program_weight_tensor_parameter_203:
 
 class Program_weight_tensor_parameter_204:
     name = "parameter_204"
+    original_name = "batch_norm2d_61.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.14623")
@@ -2167,6 +2372,7 @@ class Program_weight_tensor_parameter_204:
 
 class Program_weight_tensor_parameter_205:
     name = "parameter_205"
+    original_name = "batch_norm2d_61.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.369668")
@@ -2178,6 +2384,7 @@ class Program_weight_tensor_parameter_205:
 
 class Program_weight_tensor_parameter_206:
     name = "parameter_206"
+    original_name = "batch_norm2d_61.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.082293")
@@ -2189,6 +2396,7 @@ class Program_weight_tensor_parameter_206:
 
 class Program_weight_tensor_parameter_207:
     name = "parameter_207"
+    original_name = "batch_norm2d_61.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.41668")
@@ -2200,6 +2408,7 @@ class Program_weight_tensor_parameter_207:
 
 class Program_weight_tensor_parameter_208:
     name = "parameter_208"
+    original_name = "conv2d_65.w_0"
     shape = [128, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.617549")
@@ -2211,6 +2420,7 @@ class Program_weight_tensor_parameter_208:
 
 class Program_weight_tensor_parameter_209:
     name = "parameter_209"
+    original_name = "batch_norm2d_60.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.22479")
@@ -2222,6 +2432,7 @@ class Program_weight_tensor_parameter_209:
 
 class Program_weight_tensor_parameter_210:
     name = "parameter_210"
+    original_name = "batch_norm2d_60.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.41972")
@@ -2233,6 +2444,7 @@ class Program_weight_tensor_parameter_210:
 
 class Program_weight_tensor_parameter_211:
     name = "parameter_211"
+    original_name = "batch_norm2d_60.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.000126157")
@@ -2244,6 +2456,7 @@ class Program_weight_tensor_parameter_211:
 
 class Program_weight_tensor_parameter_212:
     name = "parameter_212"
+    original_name = "batch_norm2d_60.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.452427")
@@ -2255,6 +2468,7 @@ class Program_weight_tensor_parameter_212:
 
 class Program_weight_tensor_parameter_213:
     name = "parameter_213"
+    original_name = "conv2d_64.w_0"
     shape = [128, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.615459")
@@ -2266,6 +2480,7 @@ class Program_weight_tensor_parameter_213:
 
 class Program_weight_tensor_parameter_214:
     name = "parameter_214"
+    original_name = "batch_norm2d_59.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.18132")
@@ -2277,6 +2492,7 @@ class Program_weight_tensor_parameter_214:
 
 class Program_weight_tensor_parameter_215:
     name = "parameter_215"
+    original_name = "batch_norm2d_59.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.0395595")
@@ -2288,6 +2504,7 @@ class Program_weight_tensor_parameter_215:
 
 class Program_weight_tensor_parameter_216:
     name = "parameter_216"
+    original_name = "batch_norm2d_59.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.0573328")
@@ -2299,6 +2516,7 @@ class Program_weight_tensor_parameter_216:
 
 class Program_weight_tensor_parameter_217:
     name = "parameter_217"
+    original_name = "batch_norm2d_59.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.932972")
@@ -2310,6 +2528,7 @@ class Program_weight_tensor_parameter_217:
 
 class Program_weight_tensor_parameter_218:
     name = "parameter_218"
+    original_name = "conv2d_63.w_0"
     shape = [128, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.581771")
@@ -2321,6 +2540,7 @@ class Program_weight_tensor_parameter_218:
 
 class Program_weight_tensor_parameter_219:
     name = "parameter_219"
+    original_name = "batch_norm2d_58.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.993674")
@@ -2332,6 +2552,7 @@ class Program_weight_tensor_parameter_219:
 
 class Program_weight_tensor_parameter_220:
     name = "parameter_220"
+    original_name = "batch_norm2d_58.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.496146")
@@ -2343,6 +2564,7 @@ class Program_weight_tensor_parameter_220:
 
 class Program_weight_tensor_parameter_221:
     name = "parameter_221"
+    original_name = "batch_norm2d_58.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("8.81465e-05")
@@ -2354,6 +2576,7 @@ class Program_weight_tensor_parameter_221:
 
 class Program_weight_tensor_parameter_222:
     name = "parameter_222"
+    original_name = "batch_norm2d_58.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.352038")
@@ -2365,6 +2588,7 @@ class Program_weight_tensor_parameter_222:
 
 class Program_weight_tensor_parameter_223:
     name = "parameter_223"
+    original_name = "conv2d_62.w_0"
     shape = [128, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.350438")
@@ -2376,6 +2600,7 @@ class Program_weight_tensor_parameter_223:
 
 class Program_weight_tensor_parameter_224:
     name = "parameter_224"
+    original_name = "batch_norm2d_57.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.39768")
@@ -2387,6 +2612,7 @@ class Program_weight_tensor_parameter_224:
 
 class Program_weight_tensor_parameter_225:
     name = "parameter_225"
+    original_name = "batch_norm2d_57.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.0608506")
@@ -2398,6 +2624,7 @@ class Program_weight_tensor_parameter_225:
 
 class Program_weight_tensor_parameter_226:
     name = "parameter_226"
+    original_name = "batch_norm2d_57.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.0870411")
@@ -2409,6 +2636,7 @@ class Program_weight_tensor_parameter_226:
 
 class Program_weight_tensor_parameter_227:
     name = "parameter_227"
+    original_name = "batch_norm2d_57.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.91949")
@@ -2420,6 +2648,7 @@ class Program_weight_tensor_parameter_227:
 
 class Program_weight_tensor_parameter_228:
     name = "parameter_228"
+    original_name = "conv2d_61.w_0"
     shape = [128, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.476188")
@@ -2431,6 +2660,7 @@ class Program_weight_tensor_parameter_228:
 
 class Program_weight_tensor_parameter_229:
     name = "parameter_229"
+    original_name = "batch_norm2d_56.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.831886")
@@ -2442,6 +2672,7 @@ class Program_weight_tensor_parameter_229:
 
 class Program_weight_tensor_parameter_230:
     name = "parameter_230"
+    original_name = "batch_norm2d_56.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.447848")
@@ -2453,6 +2684,7 @@ class Program_weight_tensor_parameter_230:
 
 class Program_weight_tensor_parameter_231:
     name = "parameter_231"
+    original_name = "batch_norm2d_56.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.000320532")
@@ -2464,6 +2696,7 @@ class Program_weight_tensor_parameter_231:
 
 class Program_weight_tensor_parameter_232:
     name = "parameter_232"
+    original_name = "batch_norm2d_56.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.484525")
@@ -2475,6 +2708,7 @@ class Program_weight_tensor_parameter_232:
 
 class Program_weight_tensor_parameter_233:
     name = "parameter_233"
+    original_name = "conv2d_60.w_0"
     shape = [128, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.355469")
@@ -2486,6 +2720,7 @@ class Program_weight_tensor_parameter_233:
 
 class Program_weight_tensor_parameter_234:
     name = "parameter_234"
+    original_name = "batch_norm2d_55.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.992895")
@@ -2497,6 +2732,7 @@ class Program_weight_tensor_parameter_234:
 
 class Program_weight_tensor_parameter_235:
     name = "parameter_235"
+    original_name = "batch_norm2d_55.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.0912093")
@@ -2508,6 +2744,7 @@ class Program_weight_tensor_parameter_235:
 
 class Program_weight_tensor_parameter_236:
     name = "parameter_236"
+    original_name = "batch_norm2d_55.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.0687013")
@@ -2519,6 +2756,7 @@ class Program_weight_tensor_parameter_236:
 
 class Program_weight_tensor_parameter_237:
     name = "parameter_237"
+    original_name = "batch_norm2d_55.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.37571")
@@ -2530,6 +2768,7 @@ class Program_weight_tensor_parameter_237:
 
 class Program_weight_tensor_parameter_238:
     name = "parameter_238"
+    original_name = "conv2d_59.w_0"
     shape = [128, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.59794")
@@ -2541,6 +2780,7 @@ class Program_weight_tensor_parameter_238:
 
 class Program_weight_tensor_parameter_239:
     name = "parameter_239"
+    original_name = "batch_norm2d_54.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.117188")
@@ -2552,6 +2792,7 @@ class Program_weight_tensor_parameter_239:
 
 class Program_weight_tensor_parameter_240:
     name = "parameter_240"
+    original_name = "batch_norm2d_54.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.404575")
@@ -2563,6 +2804,7 @@ class Program_weight_tensor_parameter_240:
 
 class Program_weight_tensor_parameter_241:
     name = "parameter_241"
+    original_name = "batch_norm2d_54.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.00137661")
@@ -2574,6 +2816,7 @@ class Program_weight_tensor_parameter_241:
 
 class Program_weight_tensor_parameter_242:
     name = "parameter_242"
+    original_name = "batch_norm2d_54.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.372183")
@@ -2585,6 +2828,7 @@ class Program_weight_tensor_parameter_242:
 
 class Program_weight_tensor_parameter_243:
     name = "parameter_243"
+    original_name = "conv2d_58.w_0"
     shape = [128, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.401948")
@@ -2596,6 +2840,7 @@ class Program_weight_tensor_parameter_243:
 
 class Program_weight_tensor_parameter_244:
     name = "parameter_244"
+    original_name = "batch_norm2d_33.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.0777025")
@@ -2607,6 +2852,7 @@ class Program_weight_tensor_parameter_244:
 
 class Program_weight_tensor_parameter_245:
     name = "parameter_245"
+    original_name = "batch_norm2d_33.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.00626794")
@@ -2618,6 +2864,7 @@ class Program_weight_tensor_parameter_245:
 
 class Program_weight_tensor_parameter_246:
     name = "parameter_246"
+    original_name = "batch_norm2d_33.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("5.38267e-05")
@@ -2629,6 +2876,7 @@ class Program_weight_tensor_parameter_246:
 
 class Program_weight_tensor_parameter_247:
     name = "parameter_247"
+    original_name = "batch_norm2d_33.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.0111934")
@@ -2640,6 +2888,7 @@ class Program_weight_tensor_parameter_247:
 
 class Program_weight_tensor_parameter_248:
     name = "parameter_248"
+    original_name = "conv2d_37.w_0"
     shape = [128, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.263587")
@@ -2651,6 +2900,7 @@ class Program_weight_tensor_parameter_248:
 
 class Program_weight_tensor_parameter_249:
     name = "parameter_249"
+    original_name = "batch_norm2d_32.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.166459")
@@ -2662,6 +2912,7 @@ class Program_weight_tensor_parameter_249:
 
 class Program_weight_tensor_parameter_250:
     name = "parameter_250"
+    original_name = "batch_norm2d_32.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.0592484")
@@ -2673,6 +2924,7 @@ class Program_weight_tensor_parameter_250:
 
 class Program_weight_tensor_parameter_251:
     name = "parameter_251"
+    original_name = "batch_norm2d_32.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.000291746")
@@ -2684,6 +2936,7 @@ class Program_weight_tensor_parameter_251:
 
 class Program_weight_tensor_parameter_252:
     name = "parameter_252"
+    original_name = "batch_norm2d_32.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.375115")
@@ -2695,6 +2948,7 @@ class Program_weight_tensor_parameter_252:
 
 class Program_weight_tensor_parameter_253:
     name = "parameter_253"
+    original_name = "conv2d_36.w_0"
     shape = [128, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.157171")
@@ -2706,6 +2960,7 @@ class Program_weight_tensor_parameter_253:
 
 class Program_weight_tensor_parameter_254:
     name = "parameter_254"
+    original_name = "batch_norm2d_31.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.0813256")
@@ -2717,6 +2972,7 @@ class Program_weight_tensor_parameter_254:
 
 class Program_weight_tensor_parameter_255:
     name = "parameter_255"
+    original_name = "batch_norm2d_31.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.00354969")
@@ -2728,6 +2984,7 @@ class Program_weight_tensor_parameter_255:
 
 class Program_weight_tensor_parameter_256:
     name = "parameter_256"
+    original_name = "batch_norm2d_31.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("3.73611e-05")
@@ -2739,6 +2996,7 @@ class Program_weight_tensor_parameter_256:
 
 class Program_weight_tensor_parameter_257:
     name = "parameter_257"
+    original_name = "batch_norm2d_31.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.00637771")
@@ -2750,6 +3008,7 @@ class Program_weight_tensor_parameter_257:
 
 class Program_weight_tensor_parameter_258:
     name = "parameter_258"
+    original_name = "conv2d_35.w_0"
     shape = [128, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.229532")
@@ -2761,6 +3020,7 @@ class Program_weight_tensor_parameter_258:
 
 class Program_weight_tensor_parameter_259:
     name = "parameter_259"
+    original_name = "batch_norm2d_30.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.0510405")
@@ -2772,6 +3032,7 @@ class Program_weight_tensor_parameter_259:
 
 class Program_weight_tensor_parameter_260:
     name = "parameter_260"
+    original_name = "batch_norm2d_30.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.0169983")
@@ -2783,6 +3044,7 @@ class Program_weight_tensor_parameter_260:
 
 class Program_weight_tensor_parameter_261:
     name = "parameter_261"
+    original_name = "batch_norm2d_30.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("4.54972e-06")
@@ -2794,6 +3056,7 @@ class Program_weight_tensor_parameter_261:
 
 class Program_weight_tensor_parameter_262:
     name = "parameter_262"
+    original_name = "batch_norm2d_30.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.0365659")
@@ -2805,6 +3068,7 @@ class Program_weight_tensor_parameter_262:
 
 class Program_weight_tensor_parameter_263:
     name = "parameter_263"
+    original_name = "conv2d_34.w_0"
     shape = [128, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.133984")
@@ -2816,6 +3080,7 @@ class Program_weight_tensor_parameter_263:
 
 class Program_weight_tensor_parameter_264:
     name = "parameter_264"
+    original_name = "batch_norm2d_53.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.12844")
@@ -2827,6 +3092,7 @@ class Program_weight_tensor_parameter_264:
 
 class Program_weight_tensor_parameter_265:
     name = "parameter_265"
+    original_name = "batch_norm2d_53.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.153161")
@@ -2838,6 +3104,7 @@ class Program_weight_tensor_parameter_265:
 
 class Program_weight_tensor_parameter_266:
     name = "parameter_266"
+    original_name = "batch_norm2d_53.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.105695")
@@ -2849,6 +3116,7 @@ class Program_weight_tensor_parameter_266:
 
 class Program_weight_tensor_parameter_267:
     name = "parameter_267"
+    original_name = "batch_norm2d_53.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.501924")
@@ -2860,6 +3128,7 @@ class Program_weight_tensor_parameter_267:
 
 class Program_weight_tensor_parameter_268:
     name = "parameter_268"
+    original_name = "conv2d_57.w_0"
     shape = [128, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.303875")
@@ -2871,6 +3140,7 @@ class Program_weight_tensor_parameter_268:
 
 class Program_weight_tensor_parameter_269:
     name = "parameter_269"
+    original_name = "batch_norm2d_52.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.561948")
@@ -2882,6 +3152,7 @@ class Program_weight_tensor_parameter_269:
 
 class Program_weight_tensor_parameter_270:
     name = "parameter_270"
+    original_name = "batch_norm2d_52.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.654182")
@@ -2893,6 +3164,7 @@ class Program_weight_tensor_parameter_270:
 
 class Program_weight_tensor_parameter_271:
     name = "parameter_271"
+    original_name = "batch_norm2d_52.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.00550309")
@@ -2904,6 +3176,7 @@ class Program_weight_tensor_parameter_271:
 
 class Program_weight_tensor_parameter_272:
     name = "parameter_272"
+    original_name = "batch_norm2d_52.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.239817")
@@ -2915,6 +3188,7 @@ class Program_weight_tensor_parameter_272:
 
 class Program_weight_tensor_parameter_273:
     name = "parameter_273"
+    original_name = "conv2d_56.w_0"
     shape = [256, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.21924")
@@ -2926,6 +3200,7 @@ class Program_weight_tensor_parameter_273:
 
 class Program_weight_tensor_parameter_274:
     name = "parameter_274"
+    original_name = "batch_norm2d_51.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.837643")
@@ -2937,6 +3212,7 @@ class Program_weight_tensor_parameter_274:
 
 class Program_weight_tensor_parameter_275:
     name = "parameter_275"
+    original_name = "batch_norm2d_51.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.502986")
@@ -2948,6 +3224,7 @@ class Program_weight_tensor_parameter_275:
 
 class Program_weight_tensor_parameter_276:
     name = "parameter_276"
+    original_name = "batch_norm2d_51.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.0740257")
@@ -2959,6 +3236,7 @@ class Program_weight_tensor_parameter_276:
 
 class Program_weight_tensor_parameter_277:
     name = "parameter_277"
+    original_name = "batch_norm2d_51.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.751619")
@@ -2970,6 +3248,7 @@ class Program_weight_tensor_parameter_277:
 
 class Program_weight_tensor_parameter_278:
     name = "parameter_278"
+    original_name = "conv2d_55.w_0"
     shape = [256, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.30347")
@@ -2981,6 +3260,7 @@ class Program_weight_tensor_parameter_278:
 
 class Program_weight_tensor_parameter_279:
     name = "parameter_279"
+    original_name = "batch_norm2d_50.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.926956")
@@ -2992,6 +3272,7 @@ class Program_weight_tensor_parameter_279:
 
 class Program_weight_tensor_parameter_280:
     name = "parameter_280"
+    original_name = "batch_norm2d_50.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.539759")
@@ -3003,6 +3284,7 @@ class Program_weight_tensor_parameter_280:
 
 class Program_weight_tensor_parameter_281:
     name = "parameter_281"
+    original_name = "batch_norm2d_50.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("4.20977e-05")
@@ -3014,6 +3296,7 @@ class Program_weight_tensor_parameter_281:
 
 class Program_weight_tensor_parameter_282:
     name = "parameter_282"
+    original_name = "batch_norm2d_50.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.0316001")
@@ -3025,6 +3308,7 @@ class Program_weight_tensor_parameter_282:
 
 class Program_weight_tensor_parameter_283:
     name = "parameter_283"
+    original_name = "conv2d_54.w_0"
     shape = [256, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.306925")
@@ -3036,6 +3320,7 @@ class Program_weight_tensor_parameter_283:
 
 class Program_weight_tensor_parameter_284:
     name = "parameter_284"
+    original_name = "batch_norm2d_49.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.101457")
@@ -3047,6 +3332,7 @@ class Program_weight_tensor_parameter_284:
 
 class Program_weight_tensor_parameter_285:
     name = "parameter_285"
+    original_name = "batch_norm2d_49.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.048759")
@@ -3058,6 +3344,7 @@ class Program_weight_tensor_parameter_285:
 
 class Program_weight_tensor_parameter_286:
     name = "parameter_286"
+    original_name = "batch_norm2d_49.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.000581237")
@@ -3069,6 +3356,7 @@ class Program_weight_tensor_parameter_286:
 
 class Program_weight_tensor_parameter_287:
     name = "parameter_287"
+    original_name = "batch_norm2d_49.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.0289962")
@@ -3080,6 +3368,7 @@ class Program_weight_tensor_parameter_287:
 
 class Program_weight_tensor_parameter_288:
     name = "parameter_288"
+    original_name = "conv2d_53.w_0"
     shape = [128, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.265892")
@@ -3091,6 +3380,7 @@ class Program_weight_tensor_parameter_288:
 
 class Program_weight_tensor_parameter_289:
     name = "parameter_289"
+    original_name = "batch_norm2d_48.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.387828")
@@ -3102,6 +3392,7 @@ class Program_weight_tensor_parameter_289:
 
 class Program_weight_tensor_parameter_290:
     name = "parameter_290"
+    original_name = "batch_norm2d_48.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.0396281")
@@ -3113,6 +3404,7 @@ class Program_weight_tensor_parameter_290:
 
 class Program_weight_tensor_parameter_291:
     name = "parameter_291"
+    original_name = "batch_norm2d_48.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.000760377")
@@ -3124,6 +3416,7 @@ class Program_weight_tensor_parameter_291:
 
 class Program_weight_tensor_parameter_292:
     name = "parameter_292"
+    original_name = "batch_norm2d_48.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.36")
@@ -3135,6 +3428,7 @@ class Program_weight_tensor_parameter_292:
 
 class Program_weight_tensor_parameter_293:
     name = "parameter_293"
+    original_name = "conv2d_52.w_0"
     shape = [128, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.206093")
@@ -3146,6 +3440,7 @@ class Program_weight_tensor_parameter_293:
 
 class Program_weight_tensor_parameter_294:
     name = "parameter_294"
+    original_name = "batch_norm2d_47.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.06378")
@@ -3157,6 +3452,7 @@ class Program_weight_tensor_parameter_294:
 
 class Program_weight_tensor_parameter_295:
     name = "parameter_295"
+    original_name = "batch_norm2d_47.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.165644")
@@ -3168,6 +3464,7 @@ class Program_weight_tensor_parameter_295:
 
 class Program_weight_tensor_parameter_296:
     name = "parameter_296"
+    original_name = "batch_norm2d_47.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.146812")
@@ -3179,6 +3476,7 @@ class Program_weight_tensor_parameter_296:
 
 class Program_weight_tensor_parameter_297:
     name = "parameter_297"
+    original_name = "batch_norm2d_47.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.720655")
@@ -3190,6 +3488,7 @@ class Program_weight_tensor_parameter_297:
 
 class Program_weight_tensor_parameter_298:
     name = "parameter_298"
+    original_name = "conv2d_51.w_0"
     shape = [128, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.369382")
@@ -3201,6 +3500,7 @@ class Program_weight_tensor_parameter_298:
 
 class Program_weight_tensor_parameter_299:
     name = "parameter_299"
+    original_name = "batch_norm2d_46.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.556533")
@@ -3212,6 +3512,7 @@ class Program_weight_tensor_parameter_299:
 
 class Program_weight_tensor_parameter_300:
     name = "parameter_300"
+    original_name = "batch_norm2d_46.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.585282")
@@ -3223,6 +3524,7 @@ class Program_weight_tensor_parameter_300:
 
 class Program_weight_tensor_parameter_301:
     name = "parameter_301"
+    original_name = "batch_norm2d_46.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.00557888")
@@ -3234,6 +3536,7 @@ class Program_weight_tensor_parameter_301:
 
 class Program_weight_tensor_parameter_302:
     name = "parameter_302"
+    original_name = "batch_norm2d_46.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.389026")
@@ -3245,6 +3548,7 @@ class Program_weight_tensor_parameter_302:
 
 class Program_weight_tensor_parameter_303:
     name = "parameter_303"
+    original_name = "conv2d_50.w_0"
     shape = [256, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.2867")
@@ -3256,6 +3560,7 @@ class Program_weight_tensor_parameter_303:
 
 class Program_weight_tensor_parameter_304:
     name = "parameter_304"
+    original_name = "batch_norm2d_45.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.23732")
@@ -3267,6 +3572,7 @@ class Program_weight_tensor_parameter_304:
 
 class Program_weight_tensor_parameter_305:
     name = "parameter_305"
+    original_name = "batch_norm2d_45.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.578294")
@@ -3278,6 +3584,7 @@ class Program_weight_tensor_parameter_305:
 
 class Program_weight_tensor_parameter_306:
     name = "parameter_306"
+    original_name = "batch_norm2d_45.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.0987963")
@@ -3289,6 +3596,7 @@ class Program_weight_tensor_parameter_306:
 
 class Program_weight_tensor_parameter_307:
     name = "parameter_307"
+    original_name = "batch_norm2d_45.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.906536")
@@ -3300,6 +3608,7 @@ class Program_weight_tensor_parameter_307:
 
 class Program_weight_tensor_parameter_308:
     name = "parameter_308"
+    original_name = "conv2d_49.w_0"
     shape = [256, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.347947")
@@ -3311,6 +3620,7 @@ class Program_weight_tensor_parameter_308:
 
 class Program_weight_tensor_parameter_309:
     name = "parameter_309"
+    original_name = "batch_norm2d_44.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.855421")
@@ -3322,6 +3632,7 @@ class Program_weight_tensor_parameter_309:
 
 class Program_weight_tensor_parameter_310:
     name = "parameter_310"
+    original_name = "batch_norm2d_44.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.595153")
@@ -3333,6 +3644,7 @@ class Program_weight_tensor_parameter_310:
 
 class Program_weight_tensor_parameter_311:
     name = "parameter_311"
+    original_name = "batch_norm2d_44.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("5.10925e-05")
@@ -3344,6 +3656,7 @@ class Program_weight_tensor_parameter_311:
 
 class Program_weight_tensor_parameter_312:
     name = "parameter_312"
+    original_name = "batch_norm2d_44.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.466439")
@@ -3355,6 +3668,7 @@ class Program_weight_tensor_parameter_312:
 
 class Program_weight_tensor_parameter_313:
     name = "parameter_313"
+    original_name = "conv2d_48.w_0"
     shape = [256, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.419147")
@@ -3366,6 +3680,7 @@ class Program_weight_tensor_parameter_313:
 
 class Program_weight_tensor_parameter_314:
     name = "parameter_314"
+    original_name = "batch_norm2d_43.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.149595")
@@ -3377,6 +3692,7 @@ class Program_weight_tensor_parameter_314:
 
 class Program_weight_tensor_parameter_315:
     name = "parameter_315"
+    original_name = "batch_norm2d_43.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.0493305")
@@ -3388,6 +3704,7 @@ class Program_weight_tensor_parameter_315:
 
 class Program_weight_tensor_parameter_316:
     name = "parameter_316"
+    original_name = "batch_norm2d_43.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.00118933")
@@ -3399,6 +3716,7 @@ class Program_weight_tensor_parameter_316:
 
 class Program_weight_tensor_parameter_317:
     name = "parameter_317"
+    original_name = "batch_norm2d_43.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.0603067")
@@ -3410,6 +3728,7 @@ class Program_weight_tensor_parameter_317:
 
 class Program_weight_tensor_parameter_318:
     name = "parameter_318"
+    original_name = "conv2d_47.w_0"
     shape = [128, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.308637")
@@ -3421,6 +3740,7 @@ class Program_weight_tensor_parameter_318:
 
 class Program_weight_tensor_parameter_319:
     name = "parameter_319"
+    original_name = "batch_norm2d_42.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.314457")
@@ -3432,6 +3752,7 @@ class Program_weight_tensor_parameter_319:
 
 class Program_weight_tensor_parameter_320:
     name = "parameter_320"
+    original_name = "batch_norm2d_42.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.0746202")
@@ -3443,6 +3764,7 @@ class Program_weight_tensor_parameter_320:
 
 class Program_weight_tensor_parameter_321:
     name = "parameter_321"
+    original_name = "batch_norm2d_42.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.000178662")
@@ -3454,6 +3776,7 @@ class Program_weight_tensor_parameter_321:
 
 class Program_weight_tensor_parameter_322:
     name = "parameter_322"
+    original_name = "batch_norm2d_42.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.328531")
@@ -3465,6 +3788,7 @@ class Program_weight_tensor_parameter_322:
 
 class Program_weight_tensor_parameter_323:
     name = "parameter_323"
+    original_name = "conv2d_46.w_0"
     shape = [128, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.291615")
@@ -3476,6 +3800,7 @@ class Program_weight_tensor_parameter_323:
 
 class Program_weight_tensor_parameter_324:
     name = "parameter_324"
+    original_name = "batch_norm2d_41.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.67147")
@@ -3487,6 +3812,7 @@ class Program_weight_tensor_parameter_324:
 
 class Program_weight_tensor_parameter_325:
     name = "parameter_325"
+    original_name = "batch_norm2d_41.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.12253")
@@ -3498,6 +3824,7 @@ class Program_weight_tensor_parameter_325:
 
 class Program_weight_tensor_parameter_326:
     name = "parameter_326"
+    original_name = "batch_norm2d_41.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.126036")
@@ -3509,6 +3836,7 @@ class Program_weight_tensor_parameter_326:
 
 class Program_weight_tensor_parameter_327:
     name = "parameter_327"
+    original_name = "batch_norm2d_41.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.933596")
@@ -3520,6 +3848,7 @@ class Program_weight_tensor_parameter_327:
 
 class Program_weight_tensor_parameter_328:
     name = "parameter_328"
+    original_name = "conv2d_45.w_0"
     shape = [128, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.493592")
@@ -3531,6 +3860,7 @@ class Program_weight_tensor_parameter_328:
 
 class Program_weight_tensor_parameter_329:
     name = "parameter_329"
+    original_name = "batch_norm2d_40.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.13748")
@@ -3542,6 +3872,7 @@ class Program_weight_tensor_parameter_329:
 
 class Program_weight_tensor_parameter_330:
     name = "parameter_330"
+    original_name = "batch_norm2d_40.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.407562")
@@ -3553,6 +3884,7 @@ class Program_weight_tensor_parameter_330:
 
 class Program_weight_tensor_parameter_331:
     name = "parameter_331"
+    original_name = "batch_norm2d_40.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.000169855")
@@ -3564,6 +3896,7 @@ class Program_weight_tensor_parameter_331:
 
 class Program_weight_tensor_parameter_332:
     name = "parameter_332"
+    original_name = "batch_norm2d_40.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.493498")
@@ -3575,6 +3908,7 @@ class Program_weight_tensor_parameter_332:
 
 class Program_weight_tensor_parameter_333:
     name = "parameter_333"
+    original_name = "conv2d_44.w_0"
     shape = [256, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.452621")
@@ -3586,6 +3920,7 @@ class Program_weight_tensor_parameter_333:
 
 class Program_weight_tensor_parameter_334:
     name = "parameter_334"
+    original_name = "batch_norm2d_39.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.74296")
@@ -3597,6 +3932,7 @@ class Program_weight_tensor_parameter_334:
 
 class Program_weight_tensor_parameter_335:
     name = "parameter_335"
+    original_name = "batch_norm2d_39.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.040558")
@@ -3608,6 +3944,7 @@ class Program_weight_tensor_parameter_335:
 
 class Program_weight_tensor_parameter_336:
     name = "parameter_336"
+    original_name = "batch_norm2d_39.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.204251")
@@ -3619,6 +3956,7 @@ class Program_weight_tensor_parameter_336:
 
 class Program_weight_tensor_parameter_337:
     name = "parameter_337"
+    original_name = "batch_norm2d_39.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.76357")
@@ -3630,6 +3968,7 @@ class Program_weight_tensor_parameter_337:
 
 class Program_weight_tensor_parameter_338:
     name = "parameter_338"
+    original_name = "conv2d_43.w_0"
     shape = [256, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.384675")
@@ -3641,6 +3980,7 @@ class Program_weight_tensor_parameter_338:
 
 class Program_weight_tensor_parameter_339:
     name = "parameter_339"
+    original_name = "batch_norm2d_38.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.783542")
@@ -3652,6 +3992,7 @@ class Program_weight_tensor_parameter_339:
 
 class Program_weight_tensor_parameter_340:
     name = "parameter_340"
+    original_name = "batch_norm2d_38.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.558462")
@@ -3663,6 +4004,7 @@ class Program_weight_tensor_parameter_340:
 
 class Program_weight_tensor_parameter_341:
     name = "parameter_341"
+    original_name = "batch_norm2d_38.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("8.68331e-05")
@@ -3674,6 +4016,7 @@ class Program_weight_tensor_parameter_341:
 
 class Program_weight_tensor_parameter_342:
     name = "parameter_342"
+    original_name = "batch_norm2d_38.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.761635")
@@ -3685,6 +4028,7 @@ class Program_weight_tensor_parameter_342:
 
 class Program_weight_tensor_parameter_343:
     name = "parameter_343"
+    original_name = "conv2d_42.w_0"
     shape = [256, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.593284")
@@ -3696,6 +4040,7 @@ class Program_weight_tensor_parameter_343:
 
 class Program_weight_tensor_parameter_344:
     name = "parameter_344"
+    original_name = "batch_norm2d_37.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.679396")
@@ -3707,6 +4052,7 @@ class Program_weight_tensor_parameter_344:
 
 class Program_weight_tensor_parameter_345:
     name = "parameter_345"
+    original_name = "batch_norm2d_37.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.177368")
@@ -3718,6 +4064,7 @@ class Program_weight_tensor_parameter_345:
 
 class Program_weight_tensor_parameter_346:
     name = "parameter_346"
+    original_name = "batch_norm2d_37.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.320587")
@@ -3729,6 +4076,7 @@ class Program_weight_tensor_parameter_346:
 
 class Program_weight_tensor_parameter_347:
     name = "parameter_347"
+    original_name = "batch_norm2d_37.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.23404")
@@ -3740,6 +4088,7 @@ class Program_weight_tensor_parameter_347:
 
 class Program_weight_tensor_parameter_348:
     name = "parameter_348"
+    original_name = "conv2d_41.w_0"
     shape = [128, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.388015")
@@ -3751,6 +4100,7 @@ class Program_weight_tensor_parameter_348:
 
 class Program_weight_tensor_parameter_349:
     name = "parameter_349"
+    original_name = "batch_norm2d_36.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.00127")
@@ -3762,6 +4112,7 @@ class Program_weight_tensor_parameter_349:
 
 class Program_weight_tensor_parameter_350:
     name = "parameter_350"
+    original_name = "batch_norm2d_36.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.604187")
@@ -3773,6 +4124,7 @@ class Program_weight_tensor_parameter_350:
 
 class Program_weight_tensor_parameter_351:
     name = "parameter_351"
+    original_name = "batch_norm2d_36.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.00210374")
@@ -3784,6 +4136,7 @@ class Program_weight_tensor_parameter_351:
 
 class Program_weight_tensor_parameter_352:
     name = "parameter_352"
+    original_name = "batch_norm2d_36.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.296665")
@@ -3795,6 +4148,7 @@ class Program_weight_tensor_parameter_352:
 
 class Program_weight_tensor_parameter_353:
     name = "parameter_353"
+    original_name = "conv2d_40.w_0"
     shape = [256, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.45905")
@@ -3806,6 +4160,7 @@ class Program_weight_tensor_parameter_353:
 
 class Program_weight_tensor_parameter_354:
     name = "parameter_354"
+    original_name = "batch_norm2d_35.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.22219")
@@ -3817,6 +4172,7 @@ class Program_weight_tensor_parameter_354:
 
 class Program_weight_tensor_parameter_355:
     name = "parameter_355"
+    original_name = "batch_norm2d_35.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.203283")
@@ -3828,6 +4184,7 @@ class Program_weight_tensor_parameter_355:
 
 class Program_weight_tensor_parameter_356:
     name = "parameter_356"
+    original_name = "batch_norm2d_35.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.26026")
@@ -3839,6 +4196,7 @@ class Program_weight_tensor_parameter_356:
 
 class Program_weight_tensor_parameter_357:
     name = "parameter_357"
+    original_name = "batch_norm2d_35.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-2.28725")
@@ -3850,6 +4208,7 @@ class Program_weight_tensor_parameter_357:
 
 class Program_weight_tensor_parameter_358:
     name = "parameter_358"
+    original_name = "conv2d_39.w_0"
     shape = [256, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.509708")
@@ -3861,6 +4220,7 @@ class Program_weight_tensor_parameter_358:
 
 class Program_weight_tensor_parameter_359:
     name = "parameter_359"
+    original_name = "batch_norm2d_34.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.963954")
@@ -3872,6 +4232,7 @@ class Program_weight_tensor_parameter_359:
 
 class Program_weight_tensor_parameter_360:
     name = "parameter_360"
+    original_name = "batch_norm2d_34.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.803262")
@@ -3883,6 +4244,7 @@ class Program_weight_tensor_parameter_360:
 
 class Program_weight_tensor_parameter_361:
     name = "parameter_361"
+    original_name = "batch_norm2d_34.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("8.93593e-05")
@@ -3894,6 +4256,7 @@ class Program_weight_tensor_parameter_361:
 
 class Program_weight_tensor_parameter_362:
     name = "parameter_362"
+    original_name = "batch_norm2d_34.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.0583011")
@@ -3905,6 +4268,7 @@ class Program_weight_tensor_parameter_362:
 
 class Program_weight_tensor_parameter_363:
     name = "parameter_363"
+    original_name = "conv2d_38.w_0"
     shape = [256, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.450699")
@@ -3916,6 +4280,7 @@ class Program_weight_tensor_parameter_363:
 
 class Program_weight_tensor_parameter_364:
     name = "parameter_364"
+    original_name = "batch_norm2d_29.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.192636")
@@ -3927,6 +4292,7 @@ class Program_weight_tensor_parameter_364:
 
 class Program_weight_tensor_parameter_365:
     name = "parameter_365"
+    original_name = "batch_norm2d_29.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.060181")
@@ -3938,6 +4304,7 @@ class Program_weight_tensor_parameter_365:
 
 class Program_weight_tensor_parameter_366:
     name = "parameter_366"
+    original_name = "batch_norm2d_29.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("1.8765")
@@ -3949,6 +4316,7 @@ class Program_weight_tensor_parameter_366:
 
 class Program_weight_tensor_parameter_367:
     name = "parameter_367"
+    original_name = "batch_norm2d_29.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.94517")
@@ -3960,6 +4328,7 @@ class Program_weight_tensor_parameter_367:
 
 class Program_weight_tensor_parameter_368:
     name = "parameter_368"
+    original_name = "conv2d_33.w_0"
     shape = [128, 768, 1, 1]
     dtype = "float32"
     min_val = float("-0.210464")
@@ -3971,6 +4340,7 @@ class Program_weight_tensor_parameter_368:
 
 class Program_weight_tensor_parameter_369:
     name = "parameter_369"
+    original_name = "batch_norm2d_28.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.0634701")
@@ -3982,6 +4352,7 @@ class Program_weight_tensor_parameter_369:
 
 class Program_weight_tensor_parameter_370:
     name = "parameter_370"
+    original_name = "batch_norm2d_28.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.0483199")
@@ -3993,6 +4364,7 @@ class Program_weight_tensor_parameter_370:
 
 class Program_weight_tensor_parameter_371:
     name = "parameter_371"
+    original_name = "batch_norm2d_28.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.0425474")
@@ -4004,6 +4376,7 @@ class Program_weight_tensor_parameter_371:
 
 class Program_weight_tensor_parameter_372:
     name = "parameter_372"
+    original_name = "batch_norm2d_28.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.532804")
@@ -4015,6 +4388,7 @@ class Program_weight_tensor_parameter_372:
 
 class Program_weight_tensor_parameter_373:
     name = "parameter_373"
+    original_name = "conv2d_32.w_0"
     shape = [128, 384, 1, 1]
     dtype = "float32"
     min_val = float("-0.168444")
@@ -4026,6 +4400,7 @@ class Program_weight_tensor_parameter_373:
 
 class Program_weight_tensor_parameter_374:
     name = "parameter_374"
+    original_name = "batch_norm2d_27.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.120262")
@@ -4037,6 +4412,7 @@ class Program_weight_tensor_parameter_374:
 
 class Program_weight_tensor_parameter_375:
     name = "parameter_375"
+    original_name = "batch_norm2d_27.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.0448105")
@@ -4048,6 +4424,7 @@ class Program_weight_tensor_parameter_375:
 
 class Program_weight_tensor_parameter_376:
     name = "parameter_376"
+    original_name = "batch_norm2d_27.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.0301731")
@@ -4059,6 +4436,7 @@ class Program_weight_tensor_parameter_376:
 
 class Program_weight_tensor_parameter_377:
     name = "parameter_377"
+    original_name = "batch_norm2d_27.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.720043")
@@ -4070,6 +4448,7 @@ class Program_weight_tensor_parameter_377:
 
 class Program_weight_tensor_parameter_378:
     name = "parameter_378"
+    original_name = "conv2d_31.w_0"
     shape = [128, 192, 1, 1]
     dtype = "float32"
     min_val = float("-0.554542")
@@ -4081,6 +4460,7 @@ class Program_weight_tensor_parameter_378:
 
 class Program_weight_tensor_parameter_379:
     name = "parameter_379"
+    original_name = "batch_norm2d_26.b_0"
     shape = [768]
     dtype = "float32"
     min_val = float("-5.13561")
@@ -4092,6 +4472,7 @@ class Program_weight_tensor_parameter_379:
 
 class Program_weight_tensor_parameter_380:
     name = "parameter_380"
+    original_name = "batch_norm2d_26.w_0"
     shape = [768]
     dtype = "float32"
     min_val = float("1.95066")
@@ -4103,6 +4484,7 @@ class Program_weight_tensor_parameter_380:
 
 class Program_weight_tensor_parameter_381:
     name = "parameter_381"
+    original_name = "batch_norm2d_26.w_2"
     shape = [768]
     dtype = "float32"
     min_val = float("0.0690177")
@@ -4114,6 +4496,7 @@ class Program_weight_tensor_parameter_381:
 
 class Program_weight_tensor_parameter_382:
     name = "parameter_382"
+    original_name = "batch_norm2d_26.w_1"
     shape = [768]
     dtype = "float32"
     min_val = float("-0.651178")
@@ -4125,6 +4508,7 @@ class Program_weight_tensor_parameter_382:
 
 class Program_weight_tensor_parameter_383:
     name = "parameter_383"
+    original_name = "conv2d_30.w_0"
     shape = [768, 768, 1, 1]
     dtype = "float32"
     min_val = float("-0.253387")
@@ -4136,6 +4520,7 @@ class Program_weight_tensor_parameter_383:
 
 class Program_weight_tensor_parameter_384:
     name = "parameter_384"
+    original_name = "conv2d_29.b_0"
     shape = [768]
     dtype = "float32"
     min_val = float("-0.0918306")
@@ -4147,6 +4532,7 @@ class Program_weight_tensor_parameter_384:
 
 class Program_weight_tensor_parameter_385:
     name = "parameter_385"
+    original_name = "conv2d_29.w_0"
     shape = [768, 192, 1, 1]
     dtype = "float32"
     min_val = float("-0.327356")
@@ -4158,6 +4544,7 @@ class Program_weight_tensor_parameter_385:
 
 class Program_weight_tensor_parameter_386:
     name = "parameter_386"
+    original_name = "conv2d_28.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.013977")
@@ -4169,6 +4556,7 @@ class Program_weight_tensor_parameter_386:
 
 class Program_weight_tensor_parameter_387:
     name = "parameter_387"
+    original_name = "conv2d_28.w_0"
     shape = [192, 768, 1, 1]
     dtype = "float32"
     min_val = float("-0.312124")
@@ -4180,6 +4568,7 @@ class Program_weight_tensor_parameter_387:
 
 class Program_weight_tensor_parameter_388:
     name = "parameter_388"
+    original_name = "batch_norm2d_25.b_0"
     shape = [768]
     dtype = "float32"
     min_val = float("-5.55245")
@@ -4191,6 +4580,7 @@ class Program_weight_tensor_parameter_388:
 
 class Program_weight_tensor_parameter_389:
     name = "parameter_389"
+    original_name = "batch_norm2d_25.w_0"
     shape = [768]
     dtype = "float32"
     min_val = float("0.407266")
@@ -4202,6 +4592,7 @@ class Program_weight_tensor_parameter_389:
 
 class Program_weight_tensor_parameter_390:
     name = "parameter_390"
+    original_name = "batch_norm2d_25.w_2"
     shape = [768]
     dtype = "float32"
     min_val = float("0.00013713")
@@ -4213,6 +4604,7 @@ class Program_weight_tensor_parameter_390:
 
 class Program_weight_tensor_parameter_391:
     name = "parameter_391"
+    original_name = "batch_norm2d_25.w_1"
     shape = [768]
     dtype = "float32"
     min_val = float("-0.951064")
@@ -4224,6 +4616,7 @@ class Program_weight_tensor_parameter_391:
 
 class Program_weight_tensor_parameter_392:
     name = "parameter_392"
+    original_name = "conv2d_27.w_0"
     shape = [768, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.524188")
@@ -4235,6 +4628,7 @@ class Program_weight_tensor_parameter_392:
 
 class Program_weight_tensor_parameter_393:
     name = "parameter_393"
+    original_name = "batch_norm2d_24.b_0"
     shape = [768]
     dtype = "float32"
     min_val = float("-2.53083")
@@ -4246,6 +4640,7 @@ class Program_weight_tensor_parameter_393:
 
 class Program_weight_tensor_parameter_394:
     name = "parameter_394"
+    original_name = "batch_norm2d_24.w_0"
     shape = [768]
     dtype = "float32"
     min_val = float("-1.30232")
@@ -4257,6 +4652,7 @@ class Program_weight_tensor_parameter_394:
 
 class Program_weight_tensor_parameter_395:
     name = "parameter_395"
+    original_name = "batch_norm2d_24.w_2"
     shape = [768]
     dtype = "float32"
     min_val = float("0.0813818")
@@ -4268,6 +4664,7 @@ class Program_weight_tensor_parameter_395:
 
 class Program_weight_tensor_parameter_396:
     name = "parameter_396"
+    original_name = "batch_norm2d_24.w_1"
     shape = [768]
     dtype = "float32"
     min_val = float("-1.14437")
@@ -4279,6 +4676,7 @@ class Program_weight_tensor_parameter_396:
 
 class Program_weight_tensor_parameter_397:
     name = "parameter_397"
+    original_name = "conv2d_26.w_0"
     shape = [768, 384, 1, 1]
     dtype = "float32"
     min_val = float("-0.72743")
@@ -4290,6 +4688,7 @@ class Program_weight_tensor_parameter_397:
 
 class Program_weight_tensor_parameter_398:
     name = "parameter_398"
+    original_name = "conv2d_25.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-0.109989")
@@ -4301,6 +4700,7 @@ class Program_weight_tensor_parameter_398:
 
 class Program_weight_tensor_parameter_399:
     name = "parameter_399"
+    original_name = "conv2d_25.w_0"
     shape = [384, 96, 1, 1]
     dtype = "float32"
     min_val = float("-0.305786")
@@ -4312,6 +4712,7 @@ class Program_weight_tensor_parameter_399:
 
 class Program_weight_tensor_parameter_400:
     name = "parameter_400"
+    original_name = "conv2d_24.b_0"
     shape = [96]
     dtype = "float32"
     min_val = float("-0.00395807")
@@ -4323,6 +4724,7 @@ class Program_weight_tensor_parameter_400:
 
 class Program_weight_tensor_parameter_401:
     name = "parameter_401"
+    original_name = "conv2d_24.w_0"
     shape = [96, 384, 1, 1]
     dtype = "float32"
     min_val = float("-0.311654")
@@ -4334,6 +4736,7 @@ class Program_weight_tensor_parameter_401:
 
 class Program_weight_tensor_parameter_402:
     name = "parameter_402"
+    original_name = "batch_norm2d_23.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-1.65104")
@@ -4345,6 +4748,7 @@ class Program_weight_tensor_parameter_402:
 
 class Program_weight_tensor_parameter_403:
     name = "parameter_403"
+    original_name = "batch_norm2d_23.w_0"
     shape = [384]
     dtype = "float32"
     min_val = float("0.685313")
@@ -4356,6 +4760,7 @@ class Program_weight_tensor_parameter_403:
 
 class Program_weight_tensor_parameter_404:
     name = "parameter_404"
+    original_name = "batch_norm2d_23.w_2"
     shape = [384]
     dtype = "float32"
     min_val = float("0.000181826")
@@ -4367,6 +4772,7 @@ class Program_weight_tensor_parameter_404:
 
 class Program_weight_tensor_parameter_405:
     name = "parameter_405"
+    original_name = "batch_norm2d_23.w_1"
     shape = [384]
     dtype = "float32"
     min_val = float("-1.43704")
@@ -4378,6 +4784,7 @@ class Program_weight_tensor_parameter_405:
 
 class Program_weight_tensor_parameter_406:
     name = "parameter_406"
+    original_name = "conv2d_23.w_0"
     shape = [384, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.242674")
@@ -4389,6 +4796,7 @@ class Program_weight_tensor_parameter_406:
 
 class Program_weight_tensor_parameter_407:
     name = "parameter_407"
+    original_name = "batch_norm2d_22.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-2.76083")
@@ -4400,6 +4808,7 @@ class Program_weight_tensor_parameter_407:
 
 class Program_weight_tensor_parameter_408:
     name = "parameter_408"
+    original_name = "batch_norm2d_22.w_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-0.965135")
@@ -4411,6 +4820,7 @@ class Program_weight_tensor_parameter_408:
 
 class Program_weight_tensor_parameter_409:
     name = "parameter_409"
+    original_name = "batch_norm2d_22.w_2"
     shape = [384]
     dtype = "float32"
     min_val = float("0.542674")
@@ -4422,6 +4832,7 @@ class Program_weight_tensor_parameter_409:
 
 class Program_weight_tensor_parameter_410:
     name = "parameter_410"
+    original_name = "batch_norm2d_22.w_1"
     shape = [384]
     dtype = "float32"
     min_val = float("-5.88851")
@@ -4433,6 +4844,7 @@ class Program_weight_tensor_parameter_410:
 
 class Program_weight_tensor_parameter_411:
     name = "parameter_411"
+    original_name = "conv2d_22.w_0"
     shape = [384, 384, 1, 1]
     dtype = "float32"
     min_val = float("-0.873735")
@@ -4444,6 +4856,7 @@ class Program_weight_tensor_parameter_411:
 
 class Program_weight_tensor_parameter_412:
     name = "parameter_412"
+    original_name = "batch_norm2d_21.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-3.48933")
@@ -4455,6 +4868,7 @@ class Program_weight_tensor_parameter_412:
 
 class Program_weight_tensor_parameter_413:
     name = "parameter_413"
+    original_name = "batch_norm2d_21.w_0"
     shape = [384]
     dtype = "float32"
     min_val = float("0.492313")
@@ -4466,6 +4880,7 @@ class Program_weight_tensor_parameter_413:
 
 class Program_weight_tensor_parameter_414:
     name = "parameter_414"
+    original_name = "batch_norm2d_21.w_2"
     shape = [384]
     dtype = "float32"
     min_val = float("0.000326599")
@@ -4477,6 +4892,7 @@ class Program_weight_tensor_parameter_414:
 
 class Program_weight_tensor_parameter_415:
     name = "parameter_415"
+    original_name = "batch_norm2d_21.w_1"
     shape = [384]
     dtype = "float32"
     min_val = float("-1.5994")
@@ -4488,6 +4904,7 @@ class Program_weight_tensor_parameter_415:
 
 class Program_weight_tensor_parameter_416:
     name = "parameter_416"
+    original_name = "conv2d_21.w_0"
     shape = [384, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.669036")
@@ -4499,6 +4916,7 @@ class Program_weight_tensor_parameter_416:
 
 class Program_weight_tensor_parameter_417:
     name = "parameter_417"
+    original_name = "batch_norm2d_20.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-2.19367")
@@ -4510,6 +4928,7 @@ class Program_weight_tensor_parameter_417:
 
 class Program_weight_tensor_parameter_418:
     name = "parameter_418"
+    original_name = "batch_norm2d_20.w_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-0.223466")
@@ -4521,6 +4940,7 @@ class Program_weight_tensor_parameter_418:
 
 class Program_weight_tensor_parameter_419:
     name = "parameter_419"
+    original_name = "batch_norm2d_20.w_2"
     shape = [384]
     dtype = "float32"
     min_val = float("0.478777")
@@ -4532,6 +4952,7 @@ class Program_weight_tensor_parameter_419:
 
 class Program_weight_tensor_parameter_420:
     name = "parameter_420"
+    original_name = "batch_norm2d_20.w_1"
     shape = [384]
     dtype = "float32"
     min_val = float("-3.83182")
@@ -4543,6 +4964,7 @@ class Program_weight_tensor_parameter_420:
 
 class Program_weight_tensor_parameter_421:
     name = "parameter_421"
+    original_name = "conv2d_20.w_0"
     shape = [384, 384, 1, 1]
     dtype = "float32"
     min_val = float("-0.456909")
@@ -4554,6 +4976,7 @@ class Program_weight_tensor_parameter_421:
 
 class Program_weight_tensor_parameter_422:
     name = "parameter_422"
+    original_name = "batch_norm2d_19.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-4.16418")
@@ -4565,6 +4988,7 @@ class Program_weight_tensor_parameter_422:
 
 class Program_weight_tensor_parameter_423:
     name = "parameter_423"
+    original_name = "batch_norm2d_19.w_0"
     shape = [384]
     dtype = "float32"
     min_val = float("0.466019")
@@ -4576,6 +5000,7 @@ class Program_weight_tensor_parameter_423:
 
 class Program_weight_tensor_parameter_424:
     name = "parameter_424"
+    original_name = "batch_norm2d_19.w_2"
     shape = [384]
     dtype = "float32"
     min_val = float("0.000229177")
@@ -4587,6 +5012,7 @@ class Program_weight_tensor_parameter_424:
 
 class Program_weight_tensor_parameter_425:
     name = "parameter_425"
+    original_name = "batch_norm2d_19.w_1"
     shape = [384]
     dtype = "float32"
     min_val = float("-5.06425")
@@ -4598,6 +5024,7 @@ class Program_weight_tensor_parameter_425:
 
 class Program_weight_tensor_parameter_426:
     name = "parameter_426"
+    original_name = "conv2d_19.w_0"
     shape = [384, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.735929")
@@ -4609,6 +5036,7 @@ class Program_weight_tensor_parameter_426:
 
 class Program_weight_tensor_parameter_427:
     name = "parameter_427"
+    original_name = "batch_norm2d_18.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-2.46526")
@@ -4620,6 +5048,7 @@ class Program_weight_tensor_parameter_427:
 
 class Program_weight_tensor_parameter_428:
     name = "parameter_428"
+    original_name = "batch_norm2d_18.w_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-0.415039")
@@ -4631,6 +5060,7 @@ class Program_weight_tensor_parameter_428:
 
 class Program_weight_tensor_parameter_429:
     name = "parameter_429"
+    original_name = "batch_norm2d_18.w_2"
     shape = [384]
     dtype = "float32"
     min_val = float("0.326317")
@@ -4642,6 +5072,7 @@ class Program_weight_tensor_parameter_429:
 
 class Program_weight_tensor_parameter_430:
     name = "parameter_430"
+    original_name = "batch_norm2d_18.w_1"
     shape = [384]
     dtype = "float32"
     min_val = float("-3.24703")
@@ -4653,6 +5084,7 @@ class Program_weight_tensor_parameter_430:
 
 class Program_weight_tensor_parameter_431:
     name = "parameter_431"
+    original_name = "conv2d_18.w_0"
     shape = [384, 384, 1, 1]
     dtype = "float32"
     min_val = float("-0.635164")
@@ -4664,6 +5096,7 @@ class Program_weight_tensor_parameter_431:
 
 class Program_weight_tensor_parameter_432:
     name = "parameter_432"
+    original_name = "batch_norm2d_17.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-4.52697")
@@ -4675,6 +5108,7 @@ class Program_weight_tensor_parameter_432:
 
 class Program_weight_tensor_parameter_433:
     name = "parameter_433"
+    original_name = "batch_norm2d_17.w_0"
     shape = [384]
     dtype = "float32"
     min_val = float("0.474749")
@@ -4686,6 +5120,7 @@ class Program_weight_tensor_parameter_433:
 
 class Program_weight_tensor_parameter_434:
     name = "parameter_434"
+    original_name = "batch_norm2d_17.w_2"
     shape = [384]
     dtype = "float32"
     min_val = float("0.000205092")
@@ -4697,6 +5132,7 @@ class Program_weight_tensor_parameter_434:
 
 class Program_weight_tensor_parameter_435:
     name = "parameter_435"
+    original_name = "batch_norm2d_17.w_1"
     shape = [384]
     dtype = "float32"
     min_val = float("-3.99655")
@@ -4708,6 +5144,7 @@ class Program_weight_tensor_parameter_435:
 
 class Program_weight_tensor_parameter_436:
     name = "parameter_436"
+    original_name = "conv2d_17.w_0"
     shape = [384, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.621985")
@@ -4719,6 +5156,7 @@ class Program_weight_tensor_parameter_436:
 
 class Program_weight_tensor_parameter_437:
     name = "parameter_437"
+    original_name = "batch_norm2d_16.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-2.92299")
@@ -4730,6 +5168,7 @@ class Program_weight_tensor_parameter_437:
 
 class Program_weight_tensor_parameter_438:
     name = "parameter_438"
+    original_name = "batch_norm2d_16.w_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-0.0961144")
@@ -4741,6 +5180,7 @@ class Program_weight_tensor_parameter_438:
 
 class Program_weight_tensor_parameter_439:
     name = "parameter_439"
+    original_name = "batch_norm2d_16.w_2"
     shape = [384]
     dtype = "float32"
     min_val = float("0.369175")
@@ -4752,6 +5192,7 @@ class Program_weight_tensor_parameter_439:
 
 class Program_weight_tensor_parameter_440:
     name = "parameter_440"
+    original_name = "batch_norm2d_16.w_1"
     shape = [384]
     dtype = "float32"
     min_val = float("-4.31326")
@@ -4763,6 +5204,7 @@ class Program_weight_tensor_parameter_440:
 
 class Program_weight_tensor_parameter_441:
     name = "parameter_441"
+    original_name = "conv2d_16.w_0"
     shape = [384, 384, 1, 1]
     dtype = "float32"
     min_val = float("-0.564105")
@@ -4774,6 +5216,7 @@ class Program_weight_tensor_parameter_441:
 
 class Program_weight_tensor_parameter_442:
     name = "parameter_442"
+    original_name = "batch_norm2d_15.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-2.74603")
@@ -4785,6 +5228,7 @@ class Program_weight_tensor_parameter_442:
 
 class Program_weight_tensor_parameter_443:
     name = "parameter_443"
+    original_name = "batch_norm2d_15.w_0"
     shape = [384]
     dtype = "float32"
     min_val = float("0.475871")
@@ -4796,6 +5240,7 @@ class Program_weight_tensor_parameter_443:
 
 class Program_weight_tensor_parameter_444:
     name = "parameter_444"
+    original_name = "batch_norm2d_15.w_2"
     shape = [384]
     dtype = "float32"
     min_val = float("0.000193793")
@@ -4807,6 +5252,7 @@ class Program_weight_tensor_parameter_444:
 
 class Program_weight_tensor_parameter_445:
     name = "parameter_445"
+    original_name = "batch_norm2d_15.w_1"
     shape = [384]
     dtype = "float32"
     min_val = float("-4.40316")
@@ -4818,6 +5264,7 @@ class Program_weight_tensor_parameter_445:
 
 class Program_weight_tensor_parameter_446:
     name = "parameter_446"
+    original_name = "conv2d_15.w_0"
     shape = [384, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.663219")
@@ -4829,6 +5276,7 @@ class Program_weight_tensor_parameter_446:
 
 class Program_weight_tensor_parameter_447:
     name = "parameter_447"
+    original_name = "batch_norm2d_14.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-3.23988")
@@ -4840,6 +5288,7 @@ class Program_weight_tensor_parameter_447:
 
 class Program_weight_tensor_parameter_448:
     name = "parameter_448"
+    original_name = "batch_norm2d_14.w_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-0.197722")
@@ -4851,6 +5300,7 @@ class Program_weight_tensor_parameter_448:
 
 class Program_weight_tensor_parameter_449:
     name = "parameter_449"
+    original_name = "batch_norm2d_14.w_2"
     shape = [384]
     dtype = "float32"
     min_val = float("0.376202")
@@ -4862,6 +5312,7 @@ class Program_weight_tensor_parameter_449:
 
 class Program_weight_tensor_parameter_450:
     name = "parameter_450"
+    original_name = "batch_norm2d_14.w_1"
     shape = [384]
     dtype = "float32"
     min_val = float("-3.28288")
@@ -4873,6 +5324,7 @@ class Program_weight_tensor_parameter_450:
 
 class Program_weight_tensor_parameter_451:
     name = "parameter_451"
+    original_name = "conv2d_14.w_0"
     shape = [384, 384, 1, 1]
     dtype = "float32"
     min_val = float("-0.680346")
@@ -4884,6 +5336,7 @@ class Program_weight_tensor_parameter_451:
 
 class Program_weight_tensor_parameter_452:
     name = "parameter_452"
+    original_name = "batch_norm2d_13.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-4.65751")
@@ -4895,6 +5348,7 @@ class Program_weight_tensor_parameter_452:
 
 class Program_weight_tensor_parameter_453:
     name = "parameter_453"
+    original_name = "batch_norm2d_13.w_0"
     shape = [384]
     dtype = "float32"
     min_val = float("0.46584")
@@ -4906,6 +5360,7 @@ class Program_weight_tensor_parameter_453:
 
 class Program_weight_tensor_parameter_454:
     name = "parameter_454"
+    original_name = "batch_norm2d_13.w_2"
     shape = [384]
     dtype = "float32"
     min_val = float("0.000169244")
@@ -4917,6 +5372,7 @@ class Program_weight_tensor_parameter_454:
 
 class Program_weight_tensor_parameter_455:
     name = "parameter_455"
+    original_name = "batch_norm2d_13.w_1"
     shape = [384]
     dtype = "float32"
     min_val = float("-4.67121")
@@ -4928,6 +5384,7 @@ class Program_weight_tensor_parameter_455:
 
 class Program_weight_tensor_parameter_456:
     name = "parameter_456"
+    original_name = "conv2d_13.w_0"
     shape = [384, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.801552")
@@ -4939,6 +5396,7 @@ class Program_weight_tensor_parameter_456:
 
 class Program_weight_tensor_parameter_457:
     name = "parameter_457"
+    original_name = "batch_norm2d_12.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-2.36156")
@@ -4950,6 +5408,7 @@ class Program_weight_tensor_parameter_457:
 
 class Program_weight_tensor_parameter_458:
     name = "parameter_458"
+    original_name = "batch_norm2d_12.w_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-0.121955")
@@ -4961,6 +5420,7 @@ class Program_weight_tensor_parameter_458:
 
 class Program_weight_tensor_parameter_459:
     name = "parameter_459"
+    original_name = "batch_norm2d_12.w_2"
     shape = [384]
     dtype = "float32"
     min_val = float("0.174903")
@@ -4972,6 +5432,7 @@ class Program_weight_tensor_parameter_459:
 
 class Program_weight_tensor_parameter_460:
     name = "parameter_460"
+    original_name = "batch_norm2d_12.w_1"
     shape = [384]
     dtype = "float32"
     min_val = float("-6.05523")
@@ -4983,6 +5444,7 @@ class Program_weight_tensor_parameter_460:
 
 class Program_weight_tensor_parameter_461:
     name = "parameter_461"
+    original_name = "conv2d_12.w_0"
     shape = [384, 192, 1, 1]
     dtype = "float32"
     min_val = float("-0.723385")
@@ -4994,6 +5456,7 @@ class Program_weight_tensor_parameter_461:
 
 class Program_weight_tensor_parameter_462:
     name = "parameter_462"
+    original_name = "batch_norm2d_11.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-4.38947")
@@ -5005,6 +5468,7 @@ class Program_weight_tensor_parameter_462:
 
 class Program_weight_tensor_parameter_463:
     name = "parameter_463"
+    original_name = "batch_norm2d_11.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("0.376211")
@@ -5016,6 +5480,7 @@ class Program_weight_tensor_parameter_463:
 
 class Program_weight_tensor_parameter_464:
     name = "parameter_464"
+    original_name = "batch_norm2d_11.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("0.000825027")
@@ -5027,6 +5492,7 @@ class Program_weight_tensor_parameter_464:
 
 class Program_weight_tensor_parameter_465:
     name = "parameter_465"
+    original_name = "batch_norm2d_11.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-1.82069")
@@ -5038,6 +5504,7 @@ class Program_weight_tensor_parameter_465:
 
 class Program_weight_tensor_parameter_466:
     name = "parameter_466"
+    original_name = "conv2d_11.w_0"
     shape = [192, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.273891")
@@ -5049,6 +5516,7 @@ class Program_weight_tensor_parameter_466:
 
 class Program_weight_tensor_parameter_467:
     name = "parameter_467"
+    original_name = "batch_norm2d_10.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-2.4084")
@@ -5060,6 +5528,7 @@ class Program_weight_tensor_parameter_467:
 
 class Program_weight_tensor_parameter_468:
     name = "parameter_468"
+    original_name = "batch_norm2d_10.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("0.213863")
@@ -5071,6 +5540,7 @@ class Program_weight_tensor_parameter_468:
 
 class Program_weight_tensor_parameter_469:
     name = "parameter_469"
+    original_name = "batch_norm2d_10.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("0.449528")
@@ -5082,6 +5552,7 @@ class Program_weight_tensor_parameter_469:
 
 class Program_weight_tensor_parameter_470:
     name = "parameter_470"
+    original_name = "batch_norm2d_10.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-6.67535")
@@ -5093,6 +5564,7 @@ class Program_weight_tensor_parameter_470:
 
 class Program_weight_tensor_parameter_471:
     name = "parameter_471"
+    original_name = "conv2d_10.w_0"
     shape = [192, 192, 1, 1]
     dtype = "float32"
     min_val = float("-0.689997")
@@ -5104,6 +5576,7 @@ class Program_weight_tensor_parameter_471:
 
 class Program_weight_tensor_parameter_472:
     name = "parameter_472"
+    original_name = "batch_norm2d_9.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-1.40563")
@@ -5115,6 +5588,7 @@ class Program_weight_tensor_parameter_472:
 
 class Program_weight_tensor_parameter_473:
     name = "parameter_473"
+    original_name = "batch_norm2d_9.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("0.506077")
@@ -5126,6 +5600,7 @@ class Program_weight_tensor_parameter_473:
 
 class Program_weight_tensor_parameter_474:
     name = "parameter_474"
+    original_name = "batch_norm2d_9.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("0.000114995")
@@ -5137,6 +5612,7 @@ class Program_weight_tensor_parameter_474:
 
 class Program_weight_tensor_parameter_475:
     name = "parameter_475"
+    original_name = "batch_norm2d_9.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-6.82445")
@@ -5148,6 +5624,7 @@ class Program_weight_tensor_parameter_475:
 
 class Program_weight_tensor_parameter_476:
     name = "parameter_476"
+    original_name = "conv2d_9.w_0"
     shape = [192, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.968288")
@@ -5159,6 +5636,7 @@ class Program_weight_tensor_parameter_476:
 
 class Program_weight_tensor_parameter_477:
     name = "parameter_477"
+    original_name = "batch_norm2d_8.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-1.49872")
@@ -5170,6 +5648,7 @@ class Program_weight_tensor_parameter_477:
 
 class Program_weight_tensor_parameter_478:
     name = "parameter_478"
+    original_name = "batch_norm2d_8.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-1.09514")
@@ -5181,6 +5660,7 @@ class Program_weight_tensor_parameter_478:
 
 class Program_weight_tensor_parameter_479:
     name = "parameter_479"
+    original_name = "batch_norm2d_8.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("0.188232")
@@ -5192,6 +5672,7 @@ class Program_weight_tensor_parameter_479:
 
 class Program_weight_tensor_parameter_480:
     name = "parameter_480"
+    original_name = "batch_norm2d_8.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-6.26824")
@@ -5203,6 +5684,7 @@ class Program_weight_tensor_parameter_480:
 
 class Program_weight_tensor_parameter_481:
     name = "parameter_481"
+    original_name = "conv2d_8.w_0"
     shape = [192, 96, 1, 1]
     dtype = "float32"
     min_val = float("-1.05058")
@@ -5214,6 +5696,7 @@ class Program_weight_tensor_parameter_481:
 
 class Program_weight_tensor_parameter_482:
     name = "parameter_482"
+    original_name = "batch_norm2d_7.b_0"
     shape = [96]
     dtype = "float32"
     min_val = float("-0.61244")
@@ -5225,6 +5708,7 @@ class Program_weight_tensor_parameter_482:
 
 class Program_weight_tensor_parameter_483:
     name = "parameter_483"
+    original_name = "batch_norm2d_7.w_0"
     shape = [96]
     dtype = "float32"
     min_val = float("-0.648764")
@@ -5236,6 +5720,7 @@ class Program_weight_tensor_parameter_483:
 
 class Program_weight_tensor_parameter_484:
     name = "parameter_484"
+    original_name = "batch_norm2d_7.w_2"
     shape = [96]
     dtype = "float32"
     min_val = float("0.000213704")
@@ -5247,6 +5732,7 @@ class Program_weight_tensor_parameter_484:
 
 class Program_weight_tensor_parameter_485:
     name = "parameter_485"
+    original_name = "batch_norm2d_7.w_1"
     shape = [96]
     dtype = "float32"
     min_val = float("-4.04669")
@@ -5258,6 +5744,7 @@ class Program_weight_tensor_parameter_485:
 
 class Program_weight_tensor_parameter_486:
     name = "parameter_486"
+    original_name = "conv2d_7.w_0"
     shape = [96, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.492791")
@@ -5269,6 +5756,7 @@ class Program_weight_tensor_parameter_486:
 
 class Program_weight_tensor_parameter_487:
     name = "parameter_487"
+    original_name = "batch_norm2d_6.b_0"
     shape = [96]
     dtype = "float32"
     min_val = float("-3.06421")
@@ -5280,6 +5768,7 @@ class Program_weight_tensor_parameter_487:
 
 class Program_weight_tensor_parameter_488:
     name = "parameter_488"
+    original_name = "batch_norm2d_6.w_0"
     shape = [96]
     dtype = "float32"
     min_val = float("-0.294473")
@@ -5291,6 +5780,7 @@ class Program_weight_tensor_parameter_488:
 
 class Program_weight_tensor_parameter_489:
     name = "parameter_489"
+    original_name = "batch_norm2d_6.w_2"
     shape = [96]
     dtype = "float32"
     min_val = float("2.154")
@@ -5302,6 +5792,7 @@ class Program_weight_tensor_parameter_489:
 
 class Program_weight_tensor_parameter_490:
     name = "parameter_490"
+    original_name = "batch_norm2d_6.w_1"
     shape = [96]
     dtype = "float32"
     min_val = float("-10.6735")
@@ -5313,6 +5804,7 @@ class Program_weight_tensor_parameter_490:
 
 class Program_weight_tensor_parameter_491:
     name = "parameter_491"
+    original_name = "conv2d_6.w_0"
     shape = [96, 96, 1, 1]
     dtype = "float32"
     min_val = float("-0.814401")
@@ -5324,6 +5816,7 @@ class Program_weight_tensor_parameter_491:
 
 class Program_weight_tensor_parameter_492:
     name = "parameter_492"
+    original_name = "batch_norm2d_5.b_0"
     shape = [96]
     dtype = "float32"
     min_val = float("-1.81003")
@@ -5335,6 +5828,7 @@ class Program_weight_tensor_parameter_492:
 
 class Program_weight_tensor_parameter_493:
     name = "parameter_493"
+    original_name = "batch_norm2d_5.w_0"
     shape = [96]
     dtype = "float32"
     min_val = float("1.19183")
@@ -5346,6 +5840,7 @@ class Program_weight_tensor_parameter_493:
 
 class Program_weight_tensor_parameter_494:
     name = "parameter_494"
+    original_name = "batch_norm2d_5.w_2"
     shape = [96]
     dtype = "float32"
     min_val = float("0.00024778")
@@ -5357,6 +5852,7 @@ class Program_weight_tensor_parameter_494:
 
 class Program_weight_tensor_parameter_495:
     name = "parameter_495"
+    original_name = "batch_norm2d_5.w_1"
     shape = [96]
     dtype = "float32"
     min_val = float("-4.24423")
@@ -5368,6 +5864,7 @@ class Program_weight_tensor_parameter_495:
 
 class Program_weight_tensor_parameter_496:
     name = "parameter_496"
+    original_name = "conv2d_5.w_0"
     shape = [96, 1, 3, 3]
     dtype = "float32"
     min_val = float("-1.10028")
@@ -5379,6 +5876,7 @@ class Program_weight_tensor_parameter_496:
 
 class Program_weight_tensor_parameter_497:
     name = "parameter_497"
+    original_name = "batch_norm2d_4.b_0"
     shape = [96]
     dtype = "float32"
     min_val = float("-3.62766")
@@ -5390,6 +5888,7 @@ class Program_weight_tensor_parameter_497:
 
 class Program_weight_tensor_parameter_498:
     name = "parameter_498"
+    original_name = "batch_norm2d_4.w_0"
     shape = [96]
     dtype = "float32"
     min_val = float("-1.37036")
@@ -5401,6 +5900,7 @@ class Program_weight_tensor_parameter_498:
 
 class Program_weight_tensor_parameter_499:
     name = "parameter_499"
+    original_name = "batch_norm2d_4.w_2"
     shape = [96]
     dtype = "float32"
     min_val = float("1.93604")
@@ -5412,6 +5912,7 @@ class Program_weight_tensor_parameter_499:
 
 class Program_weight_tensor_parameter_500:
     name = "parameter_500"
+    original_name = "batch_norm2d_4.w_1"
     shape = [96]
     dtype = "float32"
     min_val = float("-11.6782")
@@ -5423,6 +5924,7 @@ class Program_weight_tensor_parameter_500:
 
 class Program_weight_tensor_parameter_501:
     name = "parameter_501"
+    original_name = "conv2d_4.w_0"
     shape = [96, 48, 1, 1]
     dtype = "float32"
     min_val = float("-1.19086")
@@ -5434,6 +5936,7 @@ class Program_weight_tensor_parameter_501:
 
 class Program_weight_tensor_parameter_502:
     name = "parameter_502"
+    original_name = "batch_norm2d_3.b_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -5443,6 +5946,7 @@ class Program_weight_tensor_parameter_502:
 
 class Program_weight_tensor_parameter_503:
     name = "parameter_503"
+    original_name = "batch_norm2d_3.w_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -5452,6 +5956,7 @@ class Program_weight_tensor_parameter_503:
 
 class Program_weight_tensor_parameter_504:
     name = "parameter_504"
+    original_name = "batch_norm2d_3.w_2"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -5461,6 +5966,7 @@ class Program_weight_tensor_parameter_504:
 
 class Program_weight_tensor_parameter_505:
     name = "parameter_505"
+    original_name = "batch_norm2d_3.w_1"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -5470,6 +5976,7 @@ class Program_weight_tensor_parameter_505:
 
 class Program_weight_tensor_parameter_506:
     name = "parameter_506"
+    original_name = "conv2d_3.w_0"
     shape = [48, 1, 3, 3]
     dtype = "float32"
     min_val = float("-1.38528")
@@ -5481,6 +5988,7 @@ class Program_weight_tensor_parameter_506:
 
 class Program_weight_tensor_parameter_507:
     name = "parameter_507"
+    original_name = "batch_norm2d_2.b_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -5490,6 +5998,7 @@ class Program_weight_tensor_parameter_507:
 
 class Program_weight_tensor_parameter_508:
     name = "parameter_508"
+    original_name = "batch_norm2d_2.w_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -5499,6 +6008,7 @@ class Program_weight_tensor_parameter_508:
 
 class Program_weight_tensor_parameter_509:
     name = "parameter_509"
+    original_name = "batch_norm2d_2.w_2"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -5508,6 +6018,7 @@ class Program_weight_tensor_parameter_509:
 
 class Program_weight_tensor_parameter_510:
     name = "parameter_510"
+    original_name = "batch_norm2d_2.w_1"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -5517,6 +6028,7 @@ class Program_weight_tensor_parameter_510:
 
 class Program_weight_tensor_parameter_511:
     name = "parameter_511"
+    original_name = "conv2d_2.w_0"
     shape = [48, 24, 1, 1]
     dtype = "float32"
     min_val = float("-1.06142")
@@ -5528,6 +6040,7 @@ class Program_weight_tensor_parameter_511:
 
 class Program_weight_tensor_parameter_512:
     name = "parameter_512"
+    original_name = "batch_norm2d_1.b_0"
     shape = [24]
     dtype = "float32"
     min_val = float("0")
@@ -5537,6 +6050,7 @@ class Program_weight_tensor_parameter_512:
 
 class Program_weight_tensor_parameter_513:
     name = "parameter_513"
+    original_name = "batch_norm2d_1.w_0"
     shape = [24]
     dtype = "float32"
     min_val = float("0")
@@ -5546,6 +6060,7 @@ class Program_weight_tensor_parameter_513:
 
 class Program_weight_tensor_parameter_514:
     name = "parameter_514"
+    original_name = "batch_norm2d_1.w_2"
     shape = [24]
     dtype = "float32"
     min_val = float("0")
@@ -5555,6 +6070,7 @@ class Program_weight_tensor_parameter_514:
 
 class Program_weight_tensor_parameter_515:
     name = "parameter_515"
+    original_name = "batch_norm2d_1.w_1"
     shape = [24]
     dtype = "float32"
     min_val = float("0")
@@ -5564,6 +6080,7 @@ class Program_weight_tensor_parameter_515:
 
 class Program_weight_tensor_parameter_516:
     name = "parameter_516"
+    original_name = "conv2d_1.w_0"
     shape = [24, 1, 3, 3]
     dtype = "float32"
     min_val = float("-1.27735")
@@ -5575,6 +6092,7 @@ class Program_weight_tensor_parameter_516:
 
 class Program_weight_tensor_parameter_517:
     name = "parameter_517"
+    original_name = "batch_norm2d_0.b_0"
     shape = [24]
     dtype = "float32"
     min_val = float("0")
@@ -5584,6 +6102,7 @@ class Program_weight_tensor_parameter_517:
 
 class Program_weight_tensor_parameter_518:
     name = "parameter_518"
+    original_name = "batch_norm2d_0.w_0"
     shape = [24]
     dtype = "float32"
     min_val = float("0")
@@ -5593,6 +6112,7 @@ class Program_weight_tensor_parameter_518:
 
 class Program_weight_tensor_parameter_519:
     name = "parameter_519"
+    original_name = "batch_norm2d_0.w_2"
     shape = [24]
     dtype = "float32"
     min_val = float("0")
@@ -5602,6 +6122,7 @@ class Program_weight_tensor_parameter_519:
 
 class Program_weight_tensor_parameter_520:
     name = "parameter_520"
+    original_name = "batch_norm2d_0.w_1"
     shape = [24]
     dtype = "float32"
     min_val = float("0")
@@ -5611,6 +6132,7 @@ class Program_weight_tensor_parameter_520:
 
 class Program_weight_tensor_parameter_521:
     name = "parameter_521"
+    original_name = "conv2d_0.w_0"
     shape = [24, 3, 3, 3]
     dtype = "float32"
     min_val = float("-0.791344")

--- a/paddle_samples/PaddleX/PicoDet-M/subgraph_13/input_meta.py
+++ b/paddle_samples/PaddleX/PicoDet-M/subgraph_13/input_meta.py
@@ -1,5 +1,6 @@
 class Program_weight_tensor_data_0:
     name = "data_0"
+    original_name = "var_658"
     shape = [4, 3, 480, 480]
     dtype = "float32"
     min_val = float("-2.09515")
@@ -11,6 +12,7 @@ class Program_weight_tensor_data_0:
 
 class Program_weight_tensor_data_1:
     name = "data_1"
+    original_name = "var_907"
     shape = [8]
     dtype = "float32"
     data = [0.0, 1.0, 2.0, 3.0003, 4.0, 5.0, 6.0006, 7.0]

--- a/paddle_samples/PaddleX/PicoDet-M/subgraph_13/weight_meta.py
+++ b/paddle_samples/PaddleX/PicoDet-M/subgraph_13/weight_meta.py
@@ -1,5 +1,6 @@
 class Program_weight_tensor_parameter_0:
     name = "parameter_0"
+    original_name = "batch_norm2d_97.b_0"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -9,6 +10,7 @@ class Program_weight_tensor_parameter_0:
 
 class Program_weight_tensor_parameter_1:
     name = "parameter_1"
+    original_name = "batch_norm2d_97.w_0"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -18,6 +20,7 @@ class Program_weight_tensor_parameter_1:
 
 class Program_weight_tensor_parameter_2:
     name = "parameter_2"
+    original_name = "batch_norm2d_97.w_2"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -27,6 +30,7 @@ class Program_weight_tensor_parameter_2:
 
 class Program_weight_tensor_parameter_3:
     name = "parameter_3"
+    original_name = "batch_norm2d_97.w_1"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -36,6 +40,7 @@ class Program_weight_tensor_parameter_3:
 
 class Program_weight_tensor_parameter_4:
     name = "parameter_4"
+    original_name = "conv2d_115.w_0"
     shape = [1, 1, 1, 1]
     dtype = "float32"
     min_val = float("0")
@@ -45,6 +50,7 @@ class Program_weight_tensor_parameter_4:
 
 class Program_weight_tensor_parameter_5:
     name = "parameter_5"
+    original_name = "batch_norm2d_96.b_0"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -54,6 +60,7 @@ class Program_weight_tensor_parameter_5:
 
 class Program_weight_tensor_parameter_6:
     name = "parameter_6"
+    original_name = "batch_norm2d_96.w_0"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -63,6 +70,7 @@ class Program_weight_tensor_parameter_6:
 
 class Program_weight_tensor_parameter_7:
     name = "parameter_7"
+    original_name = "batch_norm2d_96.w_2"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -72,6 +80,7 @@ class Program_weight_tensor_parameter_7:
 
 class Program_weight_tensor_parameter_8:
     name = "parameter_8"
+    original_name = "batch_norm2d_96.w_1"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -81,6 +90,7 @@ class Program_weight_tensor_parameter_8:
 
 class Program_weight_tensor_parameter_9:
     name = "parameter_9"
+    original_name = "conv2d_114.w_0"
     shape = [1, 128, 5, 5]
     dtype = "float32"
     min_val = float("-0.29957")
@@ -92,6 +102,7 @@ class Program_weight_tensor_parameter_9:
 
 class Program_weight_tensor_parameter_10:
     name = "parameter_10"
+    original_name = "conv2d_113.b_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -101,6 +112,7 @@ class Program_weight_tensor_parameter_10:
 
 class Program_weight_tensor_parameter_11:
     name = "parameter_11"
+    original_name = "conv2d_113.w_0"
     shape = [32, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.454145")
@@ -112,6 +124,7 @@ class Program_weight_tensor_parameter_11:
 
 class Program_weight_tensor_parameter_12:
     name = "parameter_12"
+    original_name = "conv2d_112.b_0"
     shape = [4]
     dtype = "float32"
     min_val = float("0")
@@ -121,6 +134,7 @@ class Program_weight_tensor_parameter_12:
 
 class Program_weight_tensor_parameter_13:
     name = "parameter_13"
+    original_name = "conv2d_112.w_0"
     shape = [4, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.0293174")
@@ -132,6 +146,7 @@ class Program_weight_tensor_parameter_13:
 
 class Program_weight_tensor_parameter_14:
     name = "parameter_14"
+    original_name = "batch_norm2d_89.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.00436834")
@@ -143,6 +158,7 @@ class Program_weight_tensor_parameter_14:
 
 class Program_weight_tensor_parameter_15:
     name = "parameter_15"
+    original_name = "batch_norm2d_89.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.848057")
@@ -154,6 +170,7 @@ class Program_weight_tensor_parameter_15:
 
 class Program_weight_tensor_parameter_16:
     name = "parameter_16"
+    original_name = "batch_norm2d_89.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.00620491")
@@ -165,6 +182,7 @@ class Program_weight_tensor_parameter_16:
 
 class Program_weight_tensor_parameter_17:
     name = "parameter_17"
+    original_name = "batch_norm2d_89.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.162688")
@@ -176,6 +194,7 @@ class Program_weight_tensor_parameter_17:
 
 class Program_weight_tensor_parameter_18:
     name = "parameter_18"
+    original_name = "conv2d_97.w_0"
     shape = [128, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.239996")
@@ -187,6 +206,7 @@ class Program_weight_tensor_parameter_18:
 
 class Program_weight_tensor_parameter_19:
     name = "parameter_19"
+    original_name = "conv2d_96.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.0513742")
@@ -198,6 +218,7 @@ class Program_weight_tensor_parameter_19:
 
 class Program_weight_tensor_parameter_20:
     name = "parameter_20"
+    original_name = "conv2d_96.w_0"
     shape = [128, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.105123")
@@ -209,6 +230,7 @@ class Program_weight_tensor_parameter_20:
 
 class Program_weight_tensor_parameter_21:
     name = "parameter_21"
+    original_name = "batch_norm2d_88.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.29575")
@@ -220,6 +242,7 @@ class Program_weight_tensor_parameter_21:
 
 class Program_weight_tensor_parameter_22:
     name = "parameter_22"
+    original_name = "batch_norm2d_88.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.738786")
@@ -231,6 +254,7 @@ class Program_weight_tensor_parameter_22:
 
 class Program_weight_tensor_parameter_23:
     name = "parameter_23"
+    original_name = "batch_norm2d_88.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.025205")
@@ -242,6 +266,7 @@ class Program_weight_tensor_parameter_23:
 
 class Program_weight_tensor_parameter_24:
     name = "parameter_24"
+    original_name = "batch_norm2d_88.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.526073")
@@ -253,6 +278,7 @@ class Program_weight_tensor_parameter_24:
 
 class Program_weight_tensor_parameter_25:
     name = "parameter_25"
+    original_name = "conv2d_95.w_0"
     shape = [128, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.312924")
@@ -264,6 +290,7 @@ class Program_weight_tensor_parameter_25:
 
 class Program_weight_tensor_parameter_26:
     name = "parameter_26"
+    original_name = "batch_norm2d_87.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.12697")
@@ -275,6 +302,7 @@ class Program_weight_tensor_parameter_26:
 
 class Program_weight_tensor_parameter_27:
     name = "parameter_27"
+    original_name = "batch_norm2d_87.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.449744")
@@ -286,6 +314,7 @@ class Program_weight_tensor_parameter_27:
 
 class Program_weight_tensor_parameter_28:
     name = "parameter_28"
+    original_name = "batch_norm2d_87.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.0017443")
@@ -297,6 +326,7 @@ class Program_weight_tensor_parameter_28:
 
 class Program_weight_tensor_parameter_29:
     name = "parameter_29"
+    original_name = "batch_norm2d_87.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.259559")
@@ -308,6 +338,7 @@ class Program_weight_tensor_parameter_29:
 
 class Program_weight_tensor_parameter_30:
     name = "parameter_30"
+    original_name = "conv2d_94.w_0"
     shape = [128, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.229629")
@@ -319,6 +350,7 @@ class Program_weight_tensor_parameter_30:
 
 class Program_weight_tensor_parameter_31:
     name = "parameter_31"
+    original_name = "batch_norm2d_86.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.802679")
@@ -330,6 +362,7 @@ class Program_weight_tensor_parameter_31:
 
 class Program_weight_tensor_parameter_32:
     name = "parameter_32"
+    original_name = "batch_norm2d_86.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.405641")
@@ -341,6 +374,7 @@ class Program_weight_tensor_parameter_32:
 
 class Program_weight_tensor_parameter_33:
     name = "parameter_33"
+    original_name = "batch_norm2d_86.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.0362595")
@@ -352,6 +386,7 @@ class Program_weight_tensor_parameter_33:
 
 class Program_weight_tensor_parameter_34:
     name = "parameter_34"
+    original_name = "batch_norm2d_86.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.485018")
@@ -363,6 +398,7 @@ class Program_weight_tensor_parameter_34:
 
 class Program_weight_tensor_parameter_35:
     name = "parameter_35"
+    original_name = "conv2d_93.w_0"
     shape = [128, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.284462")
@@ -374,6 +410,7 @@ class Program_weight_tensor_parameter_35:
 
 class Program_weight_tensor_parameter_36:
     name = "parameter_36"
+    original_name = "batch_norm2d_85.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.545573")
@@ -385,6 +422,7 @@ class Program_weight_tensor_parameter_36:
 
 class Program_weight_tensor_parameter_37:
     name = "parameter_37"
+    original_name = "batch_norm2d_85.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.579824")
@@ -396,6 +434,7 @@ class Program_weight_tensor_parameter_37:
 
 class Program_weight_tensor_parameter_38:
     name = "parameter_38"
+    original_name = "batch_norm2d_85.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.00284824")
@@ -407,6 +446,7 @@ class Program_weight_tensor_parameter_38:
 
 class Program_weight_tensor_parameter_39:
     name = "parameter_39"
+    original_name = "batch_norm2d_85.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.286476")
@@ -418,6 +458,7 @@ class Program_weight_tensor_parameter_39:
 
 class Program_weight_tensor_parameter_40:
     name = "parameter_40"
+    original_name = "conv2d_92.w_0"
     shape = [128, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.175353")
@@ -429,6 +470,7 @@ class Program_weight_tensor_parameter_40:
 
 class Program_weight_tensor_parameter_41:
     name = "parameter_41"
+    original_name = "batch_norm2d_84.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.370593")
@@ -440,6 +482,7 @@ class Program_weight_tensor_parameter_41:
 
 class Program_weight_tensor_parameter_42:
     name = "parameter_42"
+    original_name = "batch_norm2d_84.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.291239")
@@ -451,6 +494,7 @@ class Program_weight_tensor_parameter_42:
 
 class Program_weight_tensor_parameter_43:
     name = "parameter_43"
+    original_name = "batch_norm2d_84.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.035065")
@@ -462,6 +506,7 @@ class Program_weight_tensor_parameter_43:
 
 class Program_weight_tensor_parameter_44:
     name = "parameter_44"
+    original_name = "batch_norm2d_84.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.464825")
@@ -473,6 +518,7 @@ class Program_weight_tensor_parameter_44:
 
 class Program_weight_tensor_parameter_45:
     name = "parameter_45"
+    original_name = "conv2d_91.w_0"
     shape = [128, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.239295")
@@ -484,6 +530,7 @@ class Program_weight_tensor_parameter_45:
 
 class Program_weight_tensor_parameter_46:
     name = "parameter_46"
+    original_name = "batch_norm2d_83.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.675736")
@@ -495,6 +542,7 @@ class Program_weight_tensor_parameter_46:
 
 class Program_weight_tensor_parameter_47:
     name = "parameter_47"
+    original_name = "batch_norm2d_83.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.647312")
@@ -506,6 +554,7 @@ class Program_weight_tensor_parameter_47:
 
 class Program_weight_tensor_parameter_48:
     name = "parameter_48"
+    original_name = "batch_norm2d_83.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.00125696")
@@ -517,6 +566,7 @@ class Program_weight_tensor_parameter_48:
 
 class Program_weight_tensor_parameter_49:
     name = "parameter_49"
+    original_name = "batch_norm2d_83.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.21336")
@@ -528,6 +578,7 @@ class Program_weight_tensor_parameter_49:
 
 class Program_weight_tensor_parameter_50:
     name = "parameter_50"
+    original_name = "conv2d_90.w_0"
     shape = [128, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.225854")
@@ -539,6 +590,7 @@ class Program_weight_tensor_parameter_50:
 
 class Program_weight_tensor_parameter_51:
     name = "parameter_51"
+    original_name = "batch_norm2d_82.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.741283")
@@ -550,6 +602,7 @@ class Program_weight_tensor_parameter_51:
 
 class Program_weight_tensor_parameter_52:
     name = "parameter_52"
+    original_name = "batch_norm2d_82.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.259452")
@@ -561,6 +614,7 @@ class Program_weight_tensor_parameter_52:
 
 class Program_weight_tensor_parameter_53:
     name = "parameter_53"
+    original_name = "batch_norm2d_82.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.0504553")
@@ -572,6 +626,7 @@ class Program_weight_tensor_parameter_53:
 
 class Program_weight_tensor_parameter_54:
     name = "parameter_54"
+    original_name = "batch_norm2d_82.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.254248")
@@ -583,6 +638,7 @@ class Program_weight_tensor_parameter_54:
 
 class Program_weight_tensor_parameter_55:
     name = "parameter_55"
+    original_name = "conv2d_89.w_0"
     shape = [128, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.302531")
@@ -594,6 +650,7 @@ class Program_weight_tensor_parameter_55:
 
 class Program_weight_tensor_parameter_56:
     name = "parameter_56"
+    original_name = "batch_norm2d_81.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.449391")
@@ -605,6 +662,7 @@ class Program_weight_tensor_parameter_56:
 
 class Program_weight_tensor_parameter_57:
     name = "parameter_57"
+    original_name = "batch_norm2d_81.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.926733")
@@ -616,6 +674,7 @@ class Program_weight_tensor_parameter_57:
 
 class Program_weight_tensor_parameter_58:
     name = "parameter_58"
+    original_name = "batch_norm2d_81.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.00014557")
@@ -627,6 +686,7 @@ class Program_weight_tensor_parameter_58:
 
 class Program_weight_tensor_parameter_59:
     name = "parameter_59"
+    original_name = "batch_norm2d_81.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.0620925")
@@ -638,6 +698,7 @@ class Program_weight_tensor_parameter_59:
 
 class Program_weight_tensor_parameter_60:
     name = "parameter_60"
+    original_name = "conv2d_88.w_0"
     shape = [128, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.261723")
@@ -649,6 +710,7 @@ class Program_weight_tensor_parameter_60:
 
 class Program_weight_tensor_parameter_61:
     name = "parameter_61"
+    original_name = "batch_norm2d_95.b_0"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -658,6 +720,7 @@ class Program_weight_tensor_parameter_61:
 
 class Program_weight_tensor_parameter_62:
     name = "parameter_62"
+    original_name = "batch_norm2d_95.w_0"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -667,6 +730,7 @@ class Program_weight_tensor_parameter_62:
 
 class Program_weight_tensor_parameter_63:
     name = "parameter_63"
+    original_name = "batch_norm2d_95.w_2"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -676,6 +740,7 @@ class Program_weight_tensor_parameter_63:
 
 class Program_weight_tensor_parameter_64:
     name = "parameter_64"
+    original_name = "batch_norm2d_95.w_1"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -685,6 +750,7 @@ class Program_weight_tensor_parameter_64:
 
 class Program_weight_tensor_parameter_65:
     name = "parameter_65"
+    original_name = "conv2d_111.w_0"
     shape = [1, 1, 1, 1]
     dtype = "float32"
     min_val = float("0")
@@ -694,6 +760,7 @@ class Program_weight_tensor_parameter_65:
 
 class Program_weight_tensor_parameter_66:
     name = "parameter_66"
+    original_name = "batch_norm2d_94.b_0"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -703,6 +770,7 @@ class Program_weight_tensor_parameter_66:
 
 class Program_weight_tensor_parameter_67:
     name = "parameter_67"
+    original_name = "batch_norm2d_94.w_0"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -712,6 +780,7 @@ class Program_weight_tensor_parameter_67:
 
 class Program_weight_tensor_parameter_68:
     name = "parameter_68"
+    original_name = "batch_norm2d_94.w_2"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -721,6 +790,7 @@ class Program_weight_tensor_parameter_68:
 
 class Program_weight_tensor_parameter_69:
     name = "parameter_69"
+    original_name = "batch_norm2d_94.w_1"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -730,6 +800,7 @@ class Program_weight_tensor_parameter_69:
 
 class Program_weight_tensor_parameter_70:
     name = "parameter_70"
+    original_name = "conv2d_110.w_0"
     shape = [1, 128, 5, 5]
     dtype = "float32"
     min_val = float("-0.363149")
@@ -741,6 +812,7 @@ class Program_weight_tensor_parameter_70:
 
 class Program_weight_tensor_parameter_71:
     name = "parameter_71"
+    original_name = "conv2d_109.b_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -750,6 +822,7 @@ class Program_weight_tensor_parameter_71:
 
 class Program_weight_tensor_parameter_72:
     name = "parameter_72"
+    original_name = "conv2d_109.w_0"
     shape = [32, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.467737")
@@ -761,6 +834,7 @@ class Program_weight_tensor_parameter_72:
 
 class Program_weight_tensor_parameter_73:
     name = "parameter_73"
+    original_name = "conv2d_108.b_0"
     shape = [4]
     dtype = "float32"
     min_val = float("0")
@@ -770,6 +844,7 @@ class Program_weight_tensor_parameter_73:
 
 class Program_weight_tensor_parameter_74:
     name = "parameter_74"
+    original_name = "conv2d_108.w_0"
     shape = [4, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.0296727")
@@ -781,6 +856,7 @@ class Program_weight_tensor_parameter_74:
 
 class Program_weight_tensor_parameter_75:
     name = "parameter_75"
+    original_name = "batch_norm2d_80.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.0599833")
@@ -792,6 +868,7 @@ class Program_weight_tensor_parameter_75:
 
 class Program_weight_tensor_parameter_76:
     name = "parameter_76"
+    original_name = "batch_norm2d_80.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.599343")
@@ -803,6 +880,7 @@ class Program_weight_tensor_parameter_76:
 
 class Program_weight_tensor_parameter_77:
     name = "parameter_77"
+    original_name = "batch_norm2d_80.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.00766621")
@@ -814,6 +892,7 @@ class Program_weight_tensor_parameter_77:
 
 class Program_weight_tensor_parameter_78:
     name = "parameter_78"
+    original_name = "batch_norm2d_80.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.342413")
@@ -825,6 +904,7 @@ class Program_weight_tensor_parameter_78:
 
 class Program_weight_tensor_parameter_79:
     name = "parameter_79"
+    original_name = "conv2d_87.w_0"
     shape = [128, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.436356")
@@ -836,6 +916,7 @@ class Program_weight_tensor_parameter_79:
 
 class Program_weight_tensor_parameter_80:
     name = "parameter_80"
+    original_name = "conv2d_86.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.0486745")
@@ -847,6 +928,7 @@ class Program_weight_tensor_parameter_80:
 
 class Program_weight_tensor_parameter_81:
     name = "parameter_81"
+    original_name = "conv2d_86.w_0"
     shape = [128, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.158288")
@@ -858,6 +940,7 @@ class Program_weight_tensor_parameter_81:
 
 class Program_weight_tensor_parameter_82:
     name = "parameter_82"
+    original_name = "batch_norm2d_79.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.29968")
@@ -869,6 +952,7 @@ class Program_weight_tensor_parameter_82:
 
 class Program_weight_tensor_parameter_83:
     name = "parameter_83"
+    original_name = "batch_norm2d_79.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.439816")
@@ -880,6 +964,7 @@ class Program_weight_tensor_parameter_83:
 
 class Program_weight_tensor_parameter_84:
     name = "parameter_84"
+    original_name = "batch_norm2d_79.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.0360969")
@@ -891,6 +976,7 @@ class Program_weight_tensor_parameter_84:
 
 class Program_weight_tensor_parameter_85:
     name = "parameter_85"
+    original_name = "batch_norm2d_79.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.43005")
@@ -902,6 +988,7 @@ class Program_weight_tensor_parameter_85:
 
 class Program_weight_tensor_parameter_86:
     name = "parameter_86"
+    original_name = "conv2d_85.w_0"
     shape = [128, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.406601")
@@ -913,6 +1000,7 @@ class Program_weight_tensor_parameter_86:
 
 class Program_weight_tensor_parameter_87:
     name = "parameter_87"
+    original_name = "batch_norm2d_78.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.24859")
@@ -924,6 +1012,7 @@ class Program_weight_tensor_parameter_87:
 
 class Program_weight_tensor_parameter_88:
     name = "parameter_88"
+    original_name = "batch_norm2d_78.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.461882")
@@ -935,6 +1024,7 @@ class Program_weight_tensor_parameter_88:
 
 class Program_weight_tensor_parameter_89:
     name = "parameter_89"
+    original_name = "batch_norm2d_78.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.000826609")
@@ -946,6 +1036,7 @@ class Program_weight_tensor_parameter_89:
 
 class Program_weight_tensor_parameter_90:
     name = "parameter_90"
+    original_name = "batch_norm2d_78.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.302339")
@@ -957,6 +1048,7 @@ class Program_weight_tensor_parameter_90:
 
 class Program_weight_tensor_parameter_91:
     name = "parameter_91"
+    original_name = "conv2d_84.w_0"
     shape = [128, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.365547")
@@ -968,6 +1060,7 @@ class Program_weight_tensor_parameter_91:
 
 class Program_weight_tensor_parameter_92:
     name = "parameter_92"
+    original_name = "batch_norm2d_77.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.865864")
@@ -979,6 +1072,7 @@ class Program_weight_tensor_parameter_92:
 
 class Program_weight_tensor_parameter_93:
     name = "parameter_93"
+    original_name = "batch_norm2d_77.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.198408")
@@ -990,6 +1084,7 @@ class Program_weight_tensor_parameter_93:
 
 class Program_weight_tensor_parameter_94:
     name = "parameter_94"
+    original_name = "batch_norm2d_77.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.0378139")
@@ -1001,6 +1096,7 @@ class Program_weight_tensor_parameter_94:
 
 class Program_weight_tensor_parameter_95:
     name = "parameter_95"
+    original_name = "batch_norm2d_77.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.651349")
@@ -1012,6 +1108,7 @@ class Program_weight_tensor_parameter_95:
 
 class Program_weight_tensor_parameter_96:
     name = "parameter_96"
+    original_name = "conv2d_83.w_0"
     shape = [128, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.363452")
@@ -1023,6 +1120,7 @@ class Program_weight_tensor_parameter_96:
 
 class Program_weight_tensor_parameter_97:
     name = "parameter_97"
+    original_name = "batch_norm2d_76.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.539994")
@@ -1034,6 +1132,7 @@ class Program_weight_tensor_parameter_97:
 
 class Program_weight_tensor_parameter_98:
     name = "parameter_98"
+    original_name = "batch_norm2d_76.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.531144")
@@ -1045,6 +1144,7 @@ class Program_weight_tensor_parameter_98:
 
 class Program_weight_tensor_parameter_99:
     name = "parameter_99"
+    original_name = "batch_norm2d_76.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.00501941")
@@ -1056,6 +1156,7 @@ class Program_weight_tensor_parameter_99:
 
 class Program_weight_tensor_parameter_100:
     name = "parameter_100"
+    original_name = "batch_norm2d_76.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.269546")
@@ -1067,6 +1168,7 @@ class Program_weight_tensor_parameter_100:
 
 class Program_weight_tensor_parameter_101:
     name = "parameter_101"
+    original_name = "conv2d_82.w_0"
     shape = [128, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.206791")
@@ -1078,6 +1180,7 @@ class Program_weight_tensor_parameter_101:
 
 class Program_weight_tensor_parameter_102:
     name = "parameter_102"
+    original_name = "batch_norm2d_75.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.703013")
@@ -1089,6 +1192,7 @@ class Program_weight_tensor_parameter_102:
 
 class Program_weight_tensor_parameter_103:
     name = "parameter_103"
+    original_name = "batch_norm2d_75.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.317357")
@@ -1100,6 +1204,7 @@ class Program_weight_tensor_parameter_103:
 
 class Program_weight_tensor_parameter_104:
     name = "parameter_104"
+    original_name = "batch_norm2d_75.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.0357772")
@@ -1111,6 +1216,7 @@ class Program_weight_tensor_parameter_104:
 
 class Program_weight_tensor_parameter_105:
     name = "parameter_105"
+    original_name = "batch_norm2d_75.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.594563")
@@ -1122,6 +1228,7 @@ class Program_weight_tensor_parameter_105:
 
 class Program_weight_tensor_parameter_106:
     name = "parameter_106"
+    original_name = "conv2d_81.w_0"
     shape = [128, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.429123")
@@ -1133,6 +1240,7 @@ class Program_weight_tensor_parameter_106:
 
 class Program_weight_tensor_parameter_107:
     name = "parameter_107"
+    original_name = "batch_norm2d_74.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.791314")
@@ -1144,6 +1252,7 @@ class Program_weight_tensor_parameter_107:
 
 class Program_weight_tensor_parameter_108:
     name = "parameter_108"
+    original_name = "batch_norm2d_74.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.567183")
@@ -1155,6 +1264,7 @@ class Program_weight_tensor_parameter_108:
 
 class Program_weight_tensor_parameter_109:
     name = "parameter_109"
+    original_name = "batch_norm2d_74.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.000460676")
@@ -1166,6 +1276,7 @@ class Program_weight_tensor_parameter_109:
 
 class Program_weight_tensor_parameter_110:
     name = "parameter_110"
+    original_name = "batch_norm2d_74.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.51014")
@@ -1177,6 +1288,7 @@ class Program_weight_tensor_parameter_110:
 
 class Program_weight_tensor_parameter_111:
     name = "parameter_111"
+    original_name = "conv2d_80.w_0"
     shape = [128, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.292761")
@@ -1188,6 +1300,7 @@ class Program_weight_tensor_parameter_111:
 
 class Program_weight_tensor_parameter_112:
     name = "parameter_112"
+    original_name = "batch_norm2d_73.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.587185")
@@ -1199,6 +1312,7 @@ class Program_weight_tensor_parameter_112:
 
 class Program_weight_tensor_parameter_113:
     name = "parameter_113"
+    original_name = "batch_norm2d_73.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.109887")
@@ -1210,6 +1324,7 @@ class Program_weight_tensor_parameter_113:
 
 class Program_weight_tensor_parameter_114:
     name = "parameter_114"
+    original_name = "batch_norm2d_73.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.0443951")
@@ -1221,6 +1336,7 @@ class Program_weight_tensor_parameter_114:
 
 class Program_weight_tensor_parameter_115:
     name = "parameter_115"
+    original_name = "batch_norm2d_73.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.742795")
@@ -1232,6 +1348,7 @@ class Program_weight_tensor_parameter_115:
 
 class Program_weight_tensor_parameter_116:
     name = "parameter_116"
+    original_name = "conv2d_79.w_0"
     shape = [128, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.50042")
@@ -1243,6 +1360,7 @@ class Program_weight_tensor_parameter_116:
 
 class Program_weight_tensor_parameter_117:
     name = "parameter_117"
+    original_name = "batch_norm2d_72.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.344465")
@@ -1254,6 +1372,7 @@ class Program_weight_tensor_parameter_117:
 
 class Program_weight_tensor_parameter_118:
     name = "parameter_118"
+    original_name = "batch_norm2d_72.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.462949")
@@ -1265,6 +1384,7 @@ class Program_weight_tensor_parameter_118:
 
 class Program_weight_tensor_parameter_119:
     name = "parameter_119"
+    original_name = "batch_norm2d_72.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.00305671")
@@ -1276,6 +1396,7 @@ class Program_weight_tensor_parameter_119:
 
 class Program_weight_tensor_parameter_120:
     name = "parameter_120"
+    original_name = "batch_norm2d_72.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.42283")
@@ -1287,6 +1408,7 @@ class Program_weight_tensor_parameter_120:
 
 class Program_weight_tensor_parameter_121:
     name = "parameter_121"
+    original_name = "conv2d_78.w_0"
     shape = [128, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.297676")
@@ -1298,6 +1420,7 @@ class Program_weight_tensor_parameter_121:
 
 class Program_weight_tensor_parameter_122:
     name = "parameter_122"
+    original_name = "batch_norm2d_93.b_0"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -1307,6 +1430,7 @@ class Program_weight_tensor_parameter_122:
 
 class Program_weight_tensor_parameter_123:
     name = "parameter_123"
+    original_name = "batch_norm2d_93.w_0"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -1316,6 +1440,7 @@ class Program_weight_tensor_parameter_123:
 
 class Program_weight_tensor_parameter_124:
     name = "parameter_124"
+    original_name = "batch_norm2d_93.w_2"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -1325,6 +1450,7 @@ class Program_weight_tensor_parameter_124:
 
 class Program_weight_tensor_parameter_125:
     name = "parameter_125"
+    original_name = "batch_norm2d_93.w_1"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -1334,6 +1460,7 @@ class Program_weight_tensor_parameter_125:
 
 class Program_weight_tensor_parameter_126:
     name = "parameter_126"
+    original_name = "conv2d_107.w_0"
     shape = [1, 1, 1, 1]
     dtype = "float32"
     min_val = float("0")
@@ -1343,6 +1470,7 @@ class Program_weight_tensor_parameter_126:
 
 class Program_weight_tensor_parameter_127:
     name = "parameter_127"
+    original_name = "batch_norm2d_92.b_0"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -1352,6 +1480,7 @@ class Program_weight_tensor_parameter_127:
 
 class Program_weight_tensor_parameter_128:
     name = "parameter_128"
+    original_name = "batch_norm2d_92.w_0"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -1361,6 +1490,7 @@ class Program_weight_tensor_parameter_128:
 
 class Program_weight_tensor_parameter_129:
     name = "parameter_129"
+    original_name = "batch_norm2d_92.w_2"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -1370,6 +1500,7 @@ class Program_weight_tensor_parameter_129:
 
 class Program_weight_tensor_parameter_130:
     name = "parameter_130"
+    original_name = "batch_norm2d_92.w_1"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -1379,6 +1510,7 @@ class Program_weight_tensor_parameter_130:
 
 class Program_weight_tensor_parameter_131:
     name = "parameter_131"
+    original_name = "conv2d_106.w_0"
     shape = [1, 128, 5, 5]
     dtype = "float32"
     min_val = float("-0.357091")
@@ -1390,6 +1522,7 @@ class Program_weight_tensor_parameter_131:
 
 class Program_weight_tensor_parameter_132:
     name = "parameter_132"
+    original_name = "conv2d_105.b_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -1399,6 +1532,7 @@ class Program_weight_tensor_parameter_132:
 
 class Program_weight_tensor_parameter_133:
     name = "parameter_133"
+    original_name = "conv2d_105.w_0"
     shape = [32, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.460762")
@@ -1410,6 +1544,7 @@ class Program_weight_tensor_parameter_133:
 
 class Program_weight_tensor_parameter_134:
     name = "parameter_134"
+    original_name = "conv2d_104.b_0"
     shape = [4]
     dtype = "float32"
     min_val = float("0")
@@ -1419,6 +1554,7 @@ class Program_weight_tensor_parameter_134:
 
 class Program_weight_tensor_parameter_135:
     name = "parameter_135"
+    original_name = "conv2d_104.w_0"
     shape = [4, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.031269")
@@ -1430,6 +1566,7 @@ class Program_weight_tensor_parameter_135:
 
 class Program_weight_tensor_parameter_136:
     name = "parameter_136"
+    original_name = "batch_norm2d_71.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.000154596")
@@ -1441,6 +1578,7 @@ class Program_weight_tensor_parameter_136:
 
 class Program_weight_tensor_parameter_137:
     name = "parameter_137"
+    original_name = "batch_norm2d_71.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.581305")
@@ -1452,6 +1590,7 @@ class Program_weight_tensor_parameter_137:
 
 class Program_weight_tensor_parameter_138:
     name = "parameter_138"
+    original_name = "batch_norm2d_71.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.0113732")
@@ -1463,6 +1602,7 @@ class Program_weight_tensor_parameter_138:
 
 class Program_weight_tensor_parameter_139:
     name = "parameter_139"
+    original_name = "batch_norm2d_71.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.436365")
@@ -1474,6 +1614,7 @@ class Program_weight_tensor_parameter_139:
 
 class Program_weight_tensor_parameter_140:
     name = "parameter_140"
+    original_name = "conv2d_77.w_0"
     shape = [128, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.43062")
@@ -1485,6 +1626,7 @@ class Program_weight_tensor_parameter_140:
 
 class Program_weight_tensor_parameter_141:
     name = "parameter_141"
+    original_name = "conv2d_76.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.0442835")
@@ -1496,6 +1638,7 @@ class Program_weight_tensor_parameter_141:
 
 class Program_weight_tensor_parameter_142:
     name = "parameter_142"
+    original_name = "conv2d_76.w_0"
     shape = [128, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.283959")
@@ -1507,6 +1650,7 @@ class Program_weight_tensor_parameter_142:
 
 class Program_weight_tensor_parameter_143:
     name = "parameter_143"
+    original_name = "batch_norm2d_70.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.0377")
@@ -1518,6 +1662,7 @@ class Program_weight_tensor_parameter_143:
 
 class Program_weight_tensor_parameter_144:
     name = "parameter_144"
+    original_name = "batch_norm2d_70.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.363024")
@@ -1529,6 +1674,7 @@ class Program_weight_tensor_parameter_144:
 
 class Program_weight_tensor_parameter_145:
     name = "parameter_145"
+    original_name = "batch_norm2d_70.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.0651401")
@@ -1540,6 +1686,7 @@ class Program_weight_tensor_parameter_145:
 
 class Program_weight_tensor_parameter_146:
     name = "parameter_146"
+    original_name = "batch_norm2d_70.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.53252")
@@ -1551,6 +1698,7 @@ class Program_weight_tensor_parameter_146:
 
 class Program_weight_tensor_parameter_147:
     name = "parameter_147"
+    original_name = "conv2d_75.w_0"
     shape = [128, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.377902")
@@ -1562,6 +1710,7 @@ class Program_weight_tensor_parameter_147:
 
 class Program_weight_tensor_parameter_148:
     name = "parameter_148"
+    original_name = "batch_norm2d_69.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.44107")
@@ -1573,6 +1722,7 @@ class Program_weight_tensor_parameter_148:
 
 class Program_weight_tensor_parameter_149:
     name = "parameter_149"
+    original_name = "batch_norm2d_69.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.438856")
@@ -1584,6 +1734,7 @@ class Program_weight_tensor_parameter_149:
 
 class Program_weight_tensor_parameter_150:
     name = "parameter_150"
+    original_name = "batch_norm2d_69.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.000100845")
@@ -1595,6 +1746,7 @@ class Program_weight_tensor_parameter_150:
 
 class Program_weight_tensor_parameter_151:
     name = "parameter_151"
+    original_name = "batch_norm2d_69.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.374015")
@@ -1606,6 +1758,7 @@ class Program_weight_tensor_parameter_151:
 
 class Program_weight_tensor_parameter_152:
     name = "parameter_152"
+    original_name = "conv2d_74.w_0"
     shape = [128, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.464301")
@@ -1617,6 +1770,7 @@ class Program_weight_tensor_parameter_152:
 
 class Program_weight_tensor_parameter_153:
     name = "parameter_153"
+    original_name = "batch_norm2d_68.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.32816")
@@ -1628,6 +1782,7 @@ class Program_weight_tensor_parameter_153:
 
 class Program_weight_tensor_parameter_154:
     name = "parameter_154"
+    original_name = "batch_norm2d_68.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.0439727")
@@ -1639,6 +1794,7 @@ class Program_weight_tensor_parameter_154:
 
 class Program_weight_tensor_parameter_155:
     name = "parameter_155"
+    original_name = "batch_norm2d_68.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.0445632")
@@ -1650,6 +1806,7 @@ class Program_weight_tensor_parameter_155:
 
 class Program_weight_tensor_parameter_156:
     name = "parameter_156"
+    original_name = "batch_norm2d_68.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.604038")
@@ -1661,6 +1818,7 @@ class Program_weight_tensor_parameter_156:
 
 class Program_weight_tensor_parameter_157:
     name = "parameter_157"
+    original_name = "conv2d_73.w_0"
     shape = [128, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.343683")
@@ -1672,6 +1830,7 @@ class Program_weight_tensor_parameter_157:
 
 class Program_weight_tensor_parameter_158:
     name = "parameter_158"
+    original_name = "batch_norm2d_67.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.543288")
@@ -1683,6 +1842,7 @@ class Program_weight_tensor_parameter_158:
 
 class Program_weight_tensor_parameter_159:
     name = "parameter_159"
+    original_name = "batch_norm2d_67.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.533199")
@@ -1694,6 +1854,7 @@ class Program_weight_tensor_parameter_159:
 
 class Program_weight_tensor_parameter_160:
     name = "parameter_160"
+    original_name = "batch_norm2d_67.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.000433059")
@@ -1705,6 +1866,7 @@ class Program_weight_tensor_parameter_160:
 
 class Program_weight_tensor_parameter_161:
     name = "parameter_161"
+    original_name = "batch_norm2d_67.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.274309")
@@ -1716,6 +1878,7 @@ class Program_weight_tensor_parameter_161:
 
 class Program_weight_tensor_parameter_162:
     name = "parameter_162"
+    original_name = "conv2d_72.w_0"
     shape = [128, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.26847")
@@ -1727,6 +1890,7 @@ class Program_weight_tensor_parameter_162:
 
 class Program_weight_tensor_parameter_163:
     name = "parameter_163"
+    original_name = "batch_norm2d_66.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.539036")
@@ -1738,6 +1902,7 @@ class Program_weight_tensor_parameter_163:
 
 class Program_weight_tensor_parameter_164:
     name = "parameter_164"
+    original_name = "batch_norm2d_66.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.143475")
@@ -1749,6 +1914,7 @@ class Program_weight_tensor_parameter_164:
 
 class Program_weight_tensor_parameter_165:
     name = "parameter_165"
+    original_name = "batch_norm2d_66.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.0722798")
@@ -1760,6 +1926,7 @@ class Program_weight_tensor_parameter_165:
 
 class Program_weight_tensor_parameter_166:
     name = "parameter_166"
+    original_name = "batch_norm2d_66.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.704521")
@@ -1771,6 +1938,7 @@ class Program_weight_tensor_parameter_166:
 
 class Program_weight_tensor_parameter_167:
     name = "parameter_167"
+    original_name = "conv2d_71.w_0"
     shape = [128, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.384294")
@@ -1782,6 +1950,7 @@ class Program_weight_tensor_parameter_167:
 
 class Program_weight_tensor_parameter_168:
     name = "parameter_168"
+    original_name = "batch_norm2d_65.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.756363")
@@ -1793,6 +1962,7 @@ class Program_weight_tensor_parameter_168:
 
 class Program_weight_tensor_parameter_169:
     name = "parameter_169"
+    original_name = "batch_norm2d_65.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.490567")
@@ -1804,6 +1974,7 @@ class Program_weight_tensor_parameter_169:
 
 class Program_weight_tensor_parameter_170:
     name = "parameter_170"
+    original_name = "batch_norm2d_65.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.000918087")
@@ -1815,6 +1986,7 @@ class Program_weight_tensor_parameter_170:
 
 class Program_weight_tensor_parameter_171:
     name = "parameter_171"
+    original_name = "batch_norm2d_65.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.427421")
@@ -1826,6 +1998,7 @@ class Program_weight_tensor_parameter_171:
 
 class Program_weight_tensor_parameter_172:
     name = "parameter_172"
+    original_name = "conv2d_70.w_0"
     shape = [128, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.260976")
@@ -1837,6 +2010,7 @@ class Program_weight_tensor_parameter_172:
 
 class Program_weight_tensor_parameter_173:
     name = "parameter_173"
+    original_name = "batch_norm2d_64.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.759551")
@@ -1848,6 +2022,7 @@ class Program_weight_tensor_parameter_173:
 
 class Program_weight_tensor_parameter_174:
     name = "parameter_174"
+    original_name = "batch_norm2d_64.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.103419")
@@ -1859,6 +2034,7 @@ class Program_weight_tensor_parameter_174:
 
 class Program_weight_tensor_parameter_175:
     name = "parameter_175"
+    original_name = "batch_norm2d_64.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.0516592")
@@ -1870,6 +2046,7 @@ class Program_weight_tensor_parameter_175:
 
 class Program_weight_tensor_parameter_176:
     name = "parameter_176"
+    original_name = "batch_norm2d_64.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.625461")
@@ -1881,6 +2058,7 @@ class Program_weight_tensor_parameter_176:
 
 class Program_weight_tensor_parameter_177:
     name = "parameter_177"
+    original_name = "conv2d_69.w_0"
     shape = [128, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.344399")
@@ -1892,6 +2070,7 @@ class Program_weight_tensor_parameter_177:
 
 class Program_weight_tensor_parameter_178:
     name = "parameter_178"
+    original_name = "batch_norm2d_63.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.0497875")
@@ -1903,6 +2082,7 @@ class Program_weight_tensor_parameter_178:
 
 class Program_weight_tensor_parameter_179:
     name = "parameter_179"
+    original_name = "batch_norm2d_63.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.49971")
@@ -1914,6 +2094,7 @@ class Program_weight_tensor_parameter_179:
 
 class Program_weight_tensor_parameter_180:
     name = "parameter_180"
+    original_name = "batch_norm2d_63.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.00294445")
@@ -1925,6 +2106,7 @@ class Program_weight_tensor_parameter_180:
 
 class Program_weight_tensor_parameter_181:
     name = "parameter_181"
+    original_name = "batch_norm2d_63.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.630782")
@@ -1936,6 +2118,7 @@ class Program_weight_tensor_parameter_181:
 
 class Program_weight_tensor_parameter_182:
     name = "parameter_182"
+    original_name = "conv2d_68.w_0"
     shape = [128, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.332609")
@@ -1947,6 +2130,7 @@ class Program_weight_tensor_parameter_182:
 
 class Program_weight_tensor_parameter_183:
     name = "parameter_183"
+    original_name = "batch_norm2d_91.b_0"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -1956,6 +2140,7 @@ class Program_weight_tensor_parameter_183:
 
 class Program_weight_tensor_parameter_184:
     name = "parameter_184"
+    original_name = "batch_norm2d_91.w_0"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -1965,6 +2150,7 @@ class Program_weight_tensor_parameter_184:
 
 class Program_weight_tensor_parameter_185:
     name = "parameter_185"
+    original_name = "batch_norm2d_91.w_2"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -1974,6 +2160,7 @@ class Program_weight_tensor_parameter_185:
 
 class Program_weight_tensor_parameter_186:
     name = "parameter_186"
+    original_name = "batch_norm2d_91.w_1"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -1983,6 +2170,7 @@ class Program_weight_tensor_parameter_186:
 
 class Program_weight_tensor_parameter_187:
     name = "parameter_187"
+    original_name = "conv2d_103.w_0"
     shape = [1, 1, 1, 1]
     dtype = "float32"
     min_val = float("0")
@@ -1992,6 +2180,7 @@ class Program_weight_tensor_parameter_187:
 
 class Program_weight_tensor_parameter_188:
     name = "parameter_188"
+    original_name = "batch_norm2d_90.b_0"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -2001,6 +2190,7 @@ class Program_weight_tensor_parameter_188:
 
 class Program_weight_tensor_parameter_189:
     name = "parameter_189"
+    original_name = "batch_norm2d_90.w_0"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -2010,6 +2200,7 @@ class Program_weight_tensor_parameter_189:
 
 class Program_weight_tensor_parameter_190:
     name = "parameter_190"
+    original_name = "batch_norm2d_90.w_2"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -2019,6 +2210,7 @@ class Program_weight_tensor_parameter_190:
 
 class Program_weight_tensor_parameter_191:
     name = "parameter_191"
+    original_name = "batch_norm2d_90.w_1"
     shape = [1]
     dtype = "float32"
     min_val = float("0")
@@ -2028,6 +2220,7 @@ class Program_weight_tensor_parameter_191:
 
 class Program_weight_tensor_parameter_192:
     name = "parameter_192"
+    original_name = "conv2d_102.w_0"
     shape = [1, 128, 5, 5]
     dtype = "float32"
     min_val = float("-0.51734")
@@ -2039,6 +2232,7 @@ class Program_weight_tensor_parameter_192:
 
 class Program_weight_tensor_parameter_193:
     name = "parameter_193"
+    original_name = "conv2d_101.b_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -2048,6 +2242,7 @@ class Program_weight_tensor_parameter_193:
 
 class Program_weight_tensor_parameter_194:
     name = "parameter_194"
+    original_name = "conv2d_101.w_0"
     shape = [32, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.548082")
@@ -2059,6 +2254,7 @@ class Program_weight_tensor_parameter_194:
 
 class Program_weight_tensor_parameter_195:
     name = "parameter_195"
+    original_name = "conv2d_100.b_0"
     shape = [4]
     dtype = "float32"
     min_val = float("0")
@@ -2068,6 +2264,7 @@ class Program_weight_tensor_parameter_195:
 
 class Program_weight_tensor_parameter_196:
     name = "parameter_196"
+    original_name = "conv2d_100.w_0"
     shape = [4, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.0269545")
@@ -2079,6 +2276,7 @@ class Program_weight_tensor_parameter_196:
 
 class Program_weight_tensor_parameter_197:
     name = "parameter_197"
+    original_name = "batch_norm2d_62.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.767282")
@@ -2090,6 +2288,7 @@ class Program_weight_tensor_parameter_197:
 
 class Program_weight_tensor_parameter_198:
     name = "parameter_198"
+    original_name = "batch_norm2d_62.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.428027")
@@ -2101,6 +2300,7 @@ class Program_weight_tensor_parameter_198:
 
 class Program_weight_tensor_parameter_199:
     name = "parameter_199"
+    original_name = "batch_norm2d_62.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.0145267")
@@ -2112,6 +2312,7 @@ class Program_weight_tensor_parameter_199:
 
 class Program_weight_tensor_parameter_200:
     name = "parameter_200"
+    original_name = "batch_norm2d_62.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.49817")
@@ -2123,6 +2324,7 @@ class Program_weight_tensor_parameter_200:
 
 class Program_weight_tensor_parameter_201:
     name = "parameter_201"
+    original_name = "conv2d_67.w_0"
     shape = [128, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.622399")
@@ -2134,6 +2336,7 @@ class Program_weight_tensor_parameter_201:
 
 class Program_weight_tensor_parameter_202:
     name = "parameter_202"
+    original_name = "conv2d_66.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.0420704")
@@ -2145,6 +2348,7 @@ class Program_weight_tensor_parameter_202:
 
 class Program_weight_tensor_parameter_203:
     name = "parameter_203"
+    original_name = "conv2d_66.w_0"
     shape = [128, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.459781")
@@ -2156,6 +2360,7 @@ class Program_weight_tensor_parameter_203:
 
 class Program_weight_tensor_parameter_204:
     name = "parameter_204"
+    original_name = "batch_norm2d_61.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.14625")
@@ -2167,6 +2372,7 @@ class Program_weight_tensor_parameter_204:
 
 class Program_weight_tensor_parameter_205:
     name = "parameter_205"
+    original_name = "batch_norm2d_61.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.369436")
@@ -2178,6 +2384,7 @@ class Program_weight_tensor_parameter_205:
 
 class Program_weight_tensor_parameter_206:
     name = "parameter_206"
+    original_name = "batch_norm2d_61.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.0818767")
@@ -2189,6 +2396,7 @@ class Program_weight_tensor_parameter_206:
 
 class Program_weight_tensor_parameter_207:
     name = "parameter_207"
+    original_name = "batch_norm2d_61.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.41623")
@@ -2200,6 +2408,7 @@ class Program_weight_tensor_parameter_207:
 
 class Program_weight_tensor_parameter_208:
     name = "parameter_208"
+    original_name = "conv2d_65.w_0"
     shape = [128, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.617533")
@@ -2211,6 +2420,7 @@ class Program_weight_tensor_parameter_208:
 
 class Program_weight_tensor_parameter_209:
     name = "parameter_209"
+    original_name = "batch_norm2d_60.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.22479")
@@ -2222,6 +2432,7 @@ class Program_weight_tensor_parameter_209:
 
 class Program_weight_tensor_parameter_210:
     name = "parameter_210"
+    original_name = "batch_norm2d_60.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.419721")
@@ -2233,6 +2444,7 @@ class Program_weight_tensor_parameter_210:
 
 class Program_weight_tensor_parameter_211:
     name = "parameter_211"
+    original_name = "batch_norm2d_60.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.000125305")
@@ -2244,6 +2456,7 @@ class Program_weight_tensor_parameter_211:
 
 class Program_weight_tensor_parameter_212:
     name = "parameter_212"
+    original_name = "batch_norm2d_60.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.451911")
@@ -2255,6 +2468,7 @@ class Program_weight_tensor_parameter_212:
 
 class Program_weight_tensor_parameter_213:
     name = "parameter_213"
+    original_name = "conv2d_64.w_0"
     shape = [128, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.61546")
@@ -2266,6 +2480,7 @@ class Program_weight_tensor_parameter_213:
 
 class Program_weight_tensor_parameter_214:
     name = "parameter_214"
+    original_name = "batch_norm2d_59.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.18127")
@@ -2277,6 +2492,7 @@ class Program_weight_tensor_parameter_214:
 
 class Program_weight_tensor_parameter_215:
     name = "parameter_215"
+    original_name = "batch_norm2d_59.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.0395585")
@@ -2288,6 +2504,7 @@ class Program_weight_tensor_parameter_215:
 
 class Program_weight_tensor_parameter_216:
     name = "parameter_216"
+    original_name = "batch_norm2d_59.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.0573107")
@@ -2299,6 +2516,7 @@ class Program_weight_tensor_parameter_216:
 
 class Program_weight_tensor_parameter_217:
     name = "parameter_217"
+    original_name = "batch_norm2d_59.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.932786")
@@ -2310,6 +2528,7 @@ class Program_weight_tensor_parameter_217:
 
 class Program_weight_tensor_parameter_218:
     name = "parameter_218"
+    original_name = "conv2d_63.w_0"
     shape = [128, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.581829")
@@ -2321,6 +2540,7 @@ class Program_weight_tensor_parameter_218:
 
 class Program_weight_tensor_parameter_219:
     name = "parameter_219"
+    original_name = "batch_norm2d_58.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.993675")
@@ -2332,6 +2552,7 @@ class Program_weight_tensor_parameter_219:
 
 class Program_weight_tensor_parameter_220:
     name = "parameter_220"
+    original_name = "batch_norm2d_58.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.496144")
@@ -2343,6 +2564,7 @@ class Program_weight_tensor_parameter_220:
 
 class Program_weight_tensor_parameter_221:
     name = "parameter_221"
+    original_name = "batch_norm2d_58.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("9.11579e-05")
@@ -2354,6 +2576,7 @@ class Program_weight_tensor_parameter_221:
 
 class Program_weight_tensor_parameter_222:
     name = "parameter_222"
+    original_name = "batch_norm2d_58.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.351794")
@@ -2365,6 +2588,7 @@ class Program_weight_tensor_parameter_222:
 
 class Program_weight_tensor_parameter_223:
     name = "parameter_223"
+    original_name = "conv2d_62.w_0"
     shape = [128, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.350437")
@@ -2376,6 +2600,7 @@ class Program_weight_tensor_parameter_223:
 
 class Program_weight_tensor_parameter_224:
     name = "parameter_224"
+    original_name = "batch_norm2d_57.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.39768")
@@ -2387,6 +2612,7 @@ class Program_weight_tensor_parameter_224:
 
 class Program_weight_tensor_parameter_225:
     name = "parameter_225"
+    original_name = "batch_norm2d_57.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.0608444")
@@ -2398,6 +2624,7 @@ class Program_weight_tensor_parameter_225:
 
 class Program_weight_tensor_parameter_226:
     name = "parameter_226"
+    original_name = "batch_norm2d_57.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.0874452")
@@ -2409,6 +2636,7 @@ class Program_weight_tensor_parameter_226:
 
 class Program_weight_tensor_parameter_227:
     name = "parameter_227"
+    original_name = "batch_norm2d_57.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.91907")
@@ -2420,6 +2648,7 @@ class Program_weight_tensor_parameter_227:
 
 class Program_weight_tensor_parameter_228:
     name = "parameter_228"
+    original_name = "conv2d_61.w_0"
     shape = [128, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.476129")
@@ -2431,6 +2660,7 @@ class Program_weight_tensor_parameter_228:
 
 class Program_weight_tensor_parameter_229:
     name = "parameter_229"
+    original_name = "batch_norm2d_56.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.831886")
@@ -2442,6 +2672,7 @@ class Program_weight_tensor_parameter_229:
 
 class Program_weight_tensor_parameter_230:
     name = "parameter_230"
+    original_name = "batch_norm2d_56.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.447895")
@@ -2453,6 +2684,7 @@ class Program_weight_tensor_parameter_230:
 
 class Program_weight_tensor_parameter_231:
     name = "parameter_231"
+    original_name = "batch_norm2d_56.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.000318756")
@@ -2464,6 +2696,7 @@ class Program_weight_tensor_parameter_231:
 
 class Program_weight_tensor_parameter_232:
     name = "parameter_232"
+    original_name = "batch_norm2d_56.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.484044")
@@ -2475,6 +2708,7 @@ class Program_weight_tensor_parameter_232:
 
 class Program_weight_tensor_parameter_233:
     name = "parameter_233"
+    original_name = "conv2d_60.w_0"
     shape = [128, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.355479")
@@ -2486,6 +2720,7 @@ class Program_weight_tensor_parameter_233:
 
 class Program_weight_tensor_parameter_234:
     name = "parameter_234"
+    original_name = "batch_norm2d_55.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.992898")
@@ -2497,6 +2732,7 @@ class Program_weight_tensor_parameter_234:
 
 class Program_weight_tensor_parameter_235:
     name = "parameter_235"
+    original_name = "batch_norm2d_55.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.0912636")
@@ -2508,6 +2744,7 @@ class Program_weight_tensor_parameter_235:
 
 class Program_weight_tensor_parameter_236:
     name = "parameter_236"
+    original_name = "batch_norm2d_55.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.0691461")
@@ -2519,6 +2756,7 @@ class Program_weight_tensor_parameter_236:
 
 class Program_weight_tensor_parameter_237:
     name = "parameter_237"
+    original_name = "batch_norm2d_55.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.37572")
@@ -2530,6 +2768,7 @@ class Program_weight_tensor_parameter_237:
 
 class Program_weight_tensor_parameter_238:
     name = "parameter_238"
+    original_name = "conv2d_59.w_0"
     shape = [128, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.597936")
@@ -2541,6 +2780,7 @@ class Program_weight_tensor_parameter_238:
 
 class Program_weight_tensor_parameter_239:
     name = "parameter_239"
+    original_name = "batch_norm2d_54.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.117188")
@@ -2552,6 +2792,7 @@ class Program_weight_tensor_parameter_239:
 
 class Program_weight_tensor_parameter_240:
     name = "parameter_240"
+    original_name = "batch_norm2d_54.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.404567")
@@ -2563,6 +2804,7 @@ class Program_weight_tensor_parameter_240:
 
 class Program_weight_tensor_parameter_241:
     name = "parameter_241"
+    original_name = "batch_norm2d_54.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.00138066")
@@ -2574,6 +2816,7 @@ class Program_weight_tensor_parameter_241:
 
 class Program_weight_tensor_parameter_242:
     name = "parameter_242"
+    original_name = "batch_norm2d_54.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.37167")
@@ -2585,6 +2828,7 @@ class Program_weight_tensor_parameter_242:
 
 class Program_weight_tensor_parameter_243:
     name = "parameter_243"
+    original_name = "conv2d_58.w_0"
     shape = [128, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.401946")
@@ -2596,6 +2840,7 @@ class Program_weight_tensor_parameter_243:
 
 class Program_weight_tensor_parameter_244:
     name = "parameter_244"
+    original_name = "batch_norm2d_33.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.0777038")
@@ -2607,6 +2852,7 @@ class Program_weight_tensor_parameter_244:
 
 class Program_weight_tensor_parameter_245:
     name = "parameter_245"
+    original_name = "batch_norm2d_33.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.00626663")
@@ -2618,6 +2864,7 @@ class Program_weight_tensor_parameter_245:
 
 class Program_weight_tensor_parameter_246:
     name = "parameter_246"
+    original_name = "batch_norm2d_33.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("5.51813e-05")
@@ -2629,6 +2876,7 @@ class Program_weight_tensor_parameter_246:
 
 class Program_weight_tensor_parameter_247:
     name = "parameter_247"
+    original_name = "batch_norm2d_33.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.0111929")
@@ -2640,6 +2888,7 @@ class Program_weight_tensor_parameter_247:
 
 class Program_weight_tensor_parameter_248:
     name = "parameter_248"
+    original_name = "conv2d_37.w_0"
     shape = [128, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.263587")
@@ -2651,6 +2900,7 @@ class Program_weight_tensor_parameter_248:
 
 class Program_weight_tensor_parameter_249:
     name = "parameter_249"
+    original_name = "batch_norm2d_32.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.166459")
@@ -2662,6 +2912,7 @@ class Program_weight_tensor_parameter_249:
 
 class Program_weight_tensor_parameter_250:
     name = "parameter_250"
+    original_name = "batch_norm2d_32.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.05925")
@@ -2673,6 +2924,7 @@ class Program_weight_tensor_parameter_250:
 
 class Program_weight_tensor_parameter_251:
     name = "parameter_251"
+    original_name = "batch_norm2d_32.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.000291072")
@@ -2684,6 +2936,7 @@ class Program_weight_tensor_parameter_251:
 
 class Program_weight_tensor_parameter_252:
     name = "parameter_252"
+    original_name = "batch_norm2d_32.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.37507")
@@ -2695,6 +2948,7 @@ class Program_weight_tensor_parameter_252:
 
 class Program_weight_tensor_parameter_253:
     name = "parameter_253"
+    original_name = "conv2d_36.w_0"
     shape = [128, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.157172")
@@ -2706,6 +2960,7 @@ class Program_weight_tensor_parameter_253:
 
 class Program_weight_tensor_parameter_254:
     name = "parameter_254"
+    original_name = "batch_norm2d_31.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.0813255")
@@ -2717,6 +2972,7 @@ class Program_weight_tensor_parameter_254:
 
 class Program_weight_tensor_parameter_255:
     name = "parameter_255"
+    original_name = "batch_norm2d_31.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.00354688")
@@ -2728,6 +2984,7 @@ class Program_weight_tensor_parameter_255:
 
 class Program_weight_tensor_parameter_256:
     name = "parameter_256"
+    original_name = "batch_norm2d_31.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("3.84388e-05")
@@ -2739,6 +2996,7 @@ class Program_weight_tensor_parameter_256:
 
 class Program_weight_tensor_parameter_257:
     name = "parameter_257"
+    original_name = "batch_norm2d_31.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.00637622")
@@ -2750,6 +3008,7 @@ class Program_weight_tensor_parameter_257:
 
 class Program_weight_tensor_parameter_258:
     name = "parameter_258"
+    original_name = "conv2d_35.w_0"
     shape = [128, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.229532")
@@ -2761,6 +3020,7 @@ class Program_weight_tensor_parameter_258:
 
 class Program_weight_tensor_parameter_259:
     name = "parameter_259"
+    original_name = "batch_norm2d_30.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.0510407")
@@ -2772,6 +3032,7 @@ class Program_weight_tensor_parameter_259:
 
 class Program_weight_tensor_parameter_260:
     name = "parameter_260"
+    original_name = "batch_norm2d_30.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.0169985")
@@ -2783,6 +3044,7 @@ class Program_weight_tensor_parameter_260:
 
 class Program_weight_tensor_parameter_261:
     name = "parameter_261"
+    original_name = "batch_norm2d_30.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("4.63938e-06")
@@ -2794,6 +3056,7 @@ class Program_weight_tensor_parameter_261:
 
 class Program_weight_tensor_parameter_262:
     name = "parameter_262"
+    original_name = "batch_norm2d_30.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.036702")
@@ -2805,6 +3068,7 @@ class Program_weight_tensor_parameter_262:
 
 class Program_weight_tensor_parameter_263:
     name = "parameter_263"
+    original_name = "conv2d_34.w_0"
     shape = [128, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.133986")
@@ -2816,6 +3080,7 @@ class Program_weight_tensor_parameter_263:
 
 class Program_weight_tensor_parameter_264:
     name = "parameter_264"
+    original_name = "batch_norm2d_53.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.12847")
@@ -2827,6 +3092,7 @@ class Program_weight_tensor_parameter_264:
 
 class Program_weight_tensor_parameter_265:
     name = "parameter_265"
+    original_name = "batch_norm2d_53.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.15137")
@@ -2838,6 +3104,7 @@ class Program_weight_tensor_parameter_265:
 
 class Program_weight_tensor_parameter_266:
     name = "parameter_266"
+    original_name = "batch_norm2d_53.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.104951")
@@ -2849,6 +3116,7 @@ class Program_weight_tensor_parameter_266:
 
 class Program_weight_tensor_parameter_267:
     name = "parameter_267"
+    original_name = "batch_norm2d_53.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.500605")
@@ -2860,6 +3128,7 @@ class Program_weight_tensor_parameter_267:
 
 class Program_weight_tensor_parameter_268:
     name = "parameter_268"
+    original_name = "conv2d_57.w_0"
     shape = [128, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.303907")
@@ -2871,6 +3140,7 @@ class Program_weight_tensor_parameter_268:
 
 class Program_weight_tensor_parameter_269:
     name = "parameter_269"
+    original_name = "batch_norm2d_52.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.561868")
@@ -2882,6 +3152,7 @@ class Program_weight_tensor_parameter_269:
 
 class Program_weight_tensor_parameter_270:
     name = "parameter_270"
+    original_name = "batch_norm2d_52.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.652484")
@@ -2893,6 +3164,7 @@ class Program_weight_tensor_parameter_270:
 
 class Program_weight_tensor_parameter_271:
     name = "parameter_271"
+    original_name = "batch_norm2d_52.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.00559421")
@@ -2904,6 +3176,7 @@ class Program_weight_tensor_parameter_271:
 
 class Program_weight_tensor_parameter_272:
     name = "parameter_272"
+    original_name = "batch_norm2d_52.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.236839")
@@ -2915,6 +3188,7 @@ class Program_weight_tensor_parameter_272:
 
 class Program_weight_tensor_parameter_273:
     name = "parameter_273"
+    original_name = "conv2d_56.w_0"
     shape = [256, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.219092")
@@ -2926,6 +3200,7 @@ class Program_weight_tensor_parameter_273:
 
 class Program_weight_tensor_parameter_274:
     name = "parameter_274"
+    original_name = "batch_norm2d_51.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.837547")
@@ -2937,6 +3212,7 @@ class Program_weight_tensor_parameter_274:
 
 class Program_weight_tensor_parameter_275:
     name = "parameter_275"
+    original_name = "batch_norm2d_51.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.503062")
@@ -2948,6 +3224,7 @@ class Program_weight_tensor_parameter_275:
 
 class Program_weight_tensor_parameter_276:
     name = "parameter_276"
+    original_name = "batch_norm2d_51.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.0745182")
@@ -2959,6 +3236,7 @@ class Program_weight_tensor_parameter_276:
 
 class Program_weight_tensor_parameter_277:
     name = "parameter_277"
+    original_name = "batch_norm2d_51.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.75029")
@@ -2970,6 +3248,7 @@ class Program_weight_tensor_parameter_277:
 
 class Program_weight_tensor_parameter_278:
     name = "parameter_278"
+    original_name = "conv2d_55.w_0"
     shape = [256, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.30295")
@@ -2981,6 +3260,7 @@ class Program_weight_tensor_parameter_278:
 
 class Program_weight_tensor_parameter_279:
     name = "parameter_279"
+    original_name = "batch_norm2d_50.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.926851")
@@ -2992,6 +3272,7 @@ class Program_weight_tensor_parameter_279:
 
 class Program_weight_tensor_parameter_280:
     name = "parameter_280"
+    original_name = "batch_norm2d_50.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.539634")
@@ -3003,6 +3284,7 @@ class Program_weight_tensor_parameter_280:
 
 class Program_weight_tensor_parameter_281:
     name = "parameter_281"
+    original_name = "batch_norm2d_50.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("4.20165e-05")
@@ -3014,6 +3296,7 @@ class Program_weight_tensor_parameter_281:
 
 class Program_weight_tensor_parameter_282:
     name = "parameter_282"
+    original_name = "batch_norm2d_50.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.0315107")
@@ -3025,6 +3308,7 @@ class Program_weight_tensor_parameter_282:
 
 class Program_weight_tensor_parameter_283:
     name = "parameter_283"
+    original_name = "conv2d_54.w_0"
     shape = [256, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.306677")
@@ -3036,6 +3320,7 @@ class Program_weight_tensor_parameter_283:
 
 class Program_weight_tensor_parameter_284:
     name = "parameter_284"
+    original_name = "batch_norm2d_49.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.100957")
@@ -3047,6 +3332,7 @@ class Program_weight_tensor_parameter_284:
 
 class Program_weight_tensor_parameter_285:
     name = "parameter_285"
+    original_name = "batch_norm2d_49.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.0486604")
@@ -3058,6 +3344,7 @@ class Program_weight_tensor_parameter_285:
 
 class Program_weight_tensor_parameter_286:
     name = "parameter_286"
+    original_name = "batch_norm2d_49.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.00058498")
@@ -3069,6 +3356,7 @@ class Program_weight_tensor_parameter_286:
 
 class Program_weight_tensor_parameter_287:
     name = "parameter_287"
+    original_name = "batch_norm2d_49.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.028994")
@@ -3080,6 +3368,7 @@ class Program_weight_tensor_parameter_287:
 
 class Program_weight_tensor_parameter_288:
     name = "parameter_288"
+    original_name = "conv2d_53.w_0"
     shape = [128, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.265981")
@@ -3091,6 +3380,7 @@ class Program_weight_tensor_parameter_288:
 
 class Program_weight_tensor_parameter_289:
     name = "parameter_289"
+    original_name = "batch_norm2d_48.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.386906")
@@ -3102,6 +3392,7 @@ class Program_weight_tensor_parameter_289:
 
 class Program_weight_tensor_parameter_290:
     name = "parameter_290"
+    original_name = "batch_norm2d_48.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.0397707")
@@ -3113,6 +3404,7 @@ class Program_weight_tensor_parameter_290:
 
 class Program_weight_tensor_parameter_291:
     name = "parameter_291"
+    original_name = "batch_norm2d_48.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.000750297")
@@ -3124,6 +3416,7 @@ class Program_weight_tensor_parameter_291:
 
 class Program_weight_tensor_parameter_292:
     name = "parameter_292"
+    original_name = "batch_norm2d_48.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.360292")
@@ -3135,6 +3428,7 @@ class Program_weight_tensor_parameter_292:
 
 class Program_weight_tensor_parameter_293:
     name = "parameter_293"
+    original_name = "conv2d_52.w_0"
     shape = [128, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.207082")
@@ -3146,6 +3440,7 @@ class Program_weight_tensor_parameter_293:
 
 class Program_weight_tensor_parameter_294:
     name = "parameter_294"
+    original_name = "batch_norm2d_47.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.06345")
@@ -3157,6 +3452,7 @@ class Program_weight_tensor_parameter_294:
 
 class Program_weight_tensor_parameter_295:
     name = "parameter_295"
+    original_name = "batch_norm2d_47.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.166203")
@@ -3168,6 +3464,7 @@ class Program_weight_tensor_parameter_295:
 
 class Program_weight_tensor_parameter_296:
     name = "parameter_296"
+    original_name = "batch_norm2d_47.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.147874")
@@ -3179,6 +3476,7 @@ class Program_weight_tensor_parameter_296:
 
 class Program_weight_tensor_parameter_297:
     name = "parameter_297"
+    original_name = "batch_norm2d_47.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.71976")
@@ -3190,6 +3488,7 @@ class Program_weight_tensor_parameter_297:
 
 class Program_weight_tensor_parameter_298:
     name = "parameter_298"
+    original_name = "conv2d_51.w_0"
     shape = [128, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.369323")
@@ -3201,6 +3500,7 @@ class Program_weight_tensor_parameter_298:
 
 class Program_weight_tensor_parameter_299:
     name = "parameter_299"
+    original_name = "batch_norm2d_46.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.556539")
@@ -3212,6 +3512,7 @@ class Program_weight_tensor_parameter_299:
 
 class Program_weight_tensor_parameter_300:
     name = "parameter_300"
+    original_name = "batch_norm2d_46.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.585263")
@@ -3223,6 +3524,7 @@ class Program_weight_tensor_parameter_300:
 
 class Program_weight_tensor_parameter_301:
     name = "parameter_301"
+    original_name = "batch_norm2d_46.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.00556262")
@@ -3234,6 +3536,7 @@ class Program_weight_tensor_parameter_301:
 
 class Program_weight_tensor_parameter_302:
     name = "parameter_302"
+    original_name = "batch_norm2d_46.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.388697")
@@ -3245,6 +3548,7 @@ class Program_weight_tensor_parameter_302:
 
 class Program_weight_tensor_parameter_303:
     name = "parameter_303"
+    original_name = "conv2d_50.w_0"
     shape = [256, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.286656")
@@ -3256,6 +3560,7 @@ class Program_weight_tensor_parameter_303:
 
 class Program_weight_tensor_parameter_304:
     name = "parameter_304"
+    original_name = "batch_norm2d_45.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.23728")
@@ -3267,6 +3572,7 @@ class Program_weight_tensor_parameter_304:
 
 class Program_weight_tensor_parameter_305:
     name = "parameter_305"
+    original_name = "batch_norm2d_45.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.578222")
@@ -3278,6 +3584,7 @@ class Program_weight_tensor_parameter_305:
 
 class Program_weight_tensor_parameter_306:
     name = "parameter_306"
+    original_name = "batch_norm2d_45.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.100125")
@@ -3289,6 +3596,7 @@ class Program_weight_tensor_parameter_306:
 
 class Program_weight_tensor_parameter_307:
     name = "parameter_307"
+    original_name = "batch_norm2d_45.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.905829")
@@ -3300,6 +3608,7 @@ class Program_weight_tensor_parameter_307:
 
 class Program_weight_tensor_parameter_308:
     name = "parameter_308"
+    original_name = "conv2d_49.w_0"
     shape = [256, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.348573")
@@ -3311,6 +3620,7 @@ class Program_weight_tensor_parameter_308:
 
 class Program_weight_tensor_parameter_309:
     name = "parameter_309"
+    original_name = "batch_norm2d_44.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.855361")
@@ -3322,6 +3632,7 @@ class Program_weight_tensor_parameter_309:
 
 class Program_weight_tensor_parameter_310:
     name = "parameter_310"
+    original_name = "batch_norm2d_44.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.595033")
@@ -3333,6 +3644,7 @@ class Program_weight_tensor_parameter_310:
 
 class Program_weight_tensor_parameter_311:
     name = "parameter_311"
+    original_name = "batch_norm2d_44.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("5.23877e-05")
@@ -3344,6 +3656,7 @@ class Program_weight_tensor_parameter_311:
 
 class Program_weight_tensor_parameter_312:
     name = "parameter_312"
+    original_name = "batch_norm2d_44.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.4645")
@@ -3355,6 +3668,7 @@ class Program_weight_tensor_parameter_312:
 
 class Program_weight_tensor_parameter_313:
     name = "parameter_313"
+    original_name = "conv2d_48.w_0"
     shape = [256, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.419157")
@@ -3366,6 +3680,7 @@ class Program_weight_tensor_parameter_313:
 
 class Program_weight_tensor_parameter_314:
     name = "parameter_314"
+    original_name = "batch_norm2d_43.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.149677")
@@ -3377,6 +3692,7 @@ class Program_weight_tensor_parameter_314:
 
 class Program_weight_tensor_parameter_315:
     name = "parameter_315"
+    original_name = "batch_norm2d_43.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.0493259")
@@ -3388,6 +3704,7 @@ class Program_weight_tensor_parameter_315:
 
 class Program_weight_tensor_parameter_316:
     name = "parameter_316"
+    original_name = "batch_norm2d_43.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.00120153")
@@ -3399,6 +3716,7 @@ class Program_weight_tensor_parameter_316:
 
 class Program_weight_tensor_parameter_317:
     name = "parameter_317"
+    original_name = "batch_norm2d_43.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.0603152")
@@ -3410,6 +3728,7 @@ class Program_weight_tensor_parameter_317:
 
 class Program_weight_tensor_parameter_318:
     name = "parameter_318"
+    original_name = "conv2d_47.w_0"
     shape = [128, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.30867")
@@ -3421,6 +3740,7 @@ class Program_weight_tensor_parameter_318:
 
 class Program_weight_tensor_parameter_319:
     name = "parameter_319"
+    original_name = "batch_norm2d_42.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.315068")
@@ -3432,6 +3752,7 @@ class Program_weight_tensor_parameter_319:
 
 class Program_weight_tensor_parameter_320:
     name = "parameter_320"
+    original_name = "batch_norm2d_42.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.0739719")
@@ -3443,6 +3764,7 @@ class Program_weight_tensor_parameter_320:
 
 class Program_weight_tensor_parameter_321:
     name = "parameter_321"
+    original_name = "batch_norm2d_42.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.000181854")
@@ -3454,6 +3776,7 @@ class Program_weight_tensor_parameter_321:
 
 class Program_weight_tensor_parameter_322:
     name = "parameter_322"
+    original_name = "batch_norm2d_42.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.328587")
@@ -3465,6 +3788,7 @@ class Program_weight_tensor_parameter_322:
 
 class Program_weight_tensor_parameter_323:
     name = "parameter_323"
+    original_name = "conv2d_46.w_0"
     shape = [128, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.291963")
@@ -3476,6 +3800,7 @@ class Program_weight_tensor_parameter_323:
 
 class Program_weight_tensor_parameter_324:
     name = "parameter_324"
+    original_name = "batch_norm2d_41.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.67201")
@@ -3487,6 +3812,7 @@ class Program_weight_tensor_parameter_324:
 
 class Program_weight_tensor_parameter_325:
     name = "parameter_325"
+    original_name = "batch_norm2d_41.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.122652")
@@ -3498,6 +3824,7 @@ class Program_weight_tensor_parameter_325:
 
 class Program_weight_tensor_parameter_326:
     name = "parameter_326"
+    original_name = "batch_norm2d_41.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.126209")
@@ -3509,6 +3836,7 @@ class Program_weight_tensor_parameter_326:
 
 class Program_weight_tensor_parameter_327:
     name = "parameter_327"
+    original_name = "batch_norm2d_41.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.932374")
@@ -3520,6 +3848,7 @@ class Program_weight_tensor_parameter_327:
 
 class Program_weight_tensor_parameter_328:
     name = "parameter_328"
+    original_name = "conv2d_45.w_0"
     shape = [128, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.493607")
@@ -3531,6 +3860,7 @@ class Program_weight_tensor_parameter_328:
 
 class Program_weight_tensor_parameter_329:
     name = "parameter_329"
+    original_name = "batch_norm2d_40.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.13752")
@@ -3542,6 +3872,7 @@ class Program_weight_tensor_parameter_329:
 
 class Program_weight_tensor_parameter_330:
     name = "parameter_330"
+    original_name = "batch_norm2d_40.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.407395")
@@ -3553,6 +3884,7 @@ class Program_weight_tensor_parameter_330:
 
 class Program_weight_tensor_parameter_331:
     name = "parameter_331"
+    original_name = "batch_norm2d_40.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.000171895")
@@ -3564,6 +3896,7 @@ class Program_weight_tensor_parameter_331:
 
 class Program_weight_tensor_parameter_332:
     name = "parameter_332"
+    original_name = "batch_norm2d_40.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.492815")
@@ -3575,6 +3908,7 @@ class Program_weight_tensor_parameter_332:
 
 class Program_weight_tensor_parameter_333:
     name = "parameter_333"
+    original_name = "conv2d_44.w_0"
     shape = [256, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.452579")
@@ -3586,6 +3920,7 @@ class Program_weight_tensor_parameter_333:
 
 class Program_weight_tensor_parameter_334:
     name = "parameter_334"
+    original_name = "batch_norm2d_39.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.74295")
@@ -3597,6 +3932,7 @@ class Program_weight_tensor_parameter_334:
 
 class Program_weight_tensor_parameter_335:
     name = "parameter_335"
+    original_name = "batch_norm2d_39.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.0400784")
@@ -3608,6 +3944,7 @@ class Program_weight_tensor_parameter_335:
 
 class Program_weight_tensor_parameter_336:
     name = "parameter_336"
+    original_name = "batch_norm2d_39.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.205377")
@@ -3619,6 +3956,7 @@ class Program_weight_tensor_parameter_336:
 
 class Program_weight_tensor_parameter_337:
     name = "parameter_337"
+    original_name = "batch_norm2d_39.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.76364")
@@ -3630,6 +3968,7 @@ class Program_weight_tensor_parameter_337:
 
 class Program_weight_tensor_parameter_338:
     name = "parameter_338"
+    original_name = "conv2d_43.w_0"
     shape = [256, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.384741")
@@ -3641,6 +3980,7 @@ class Program_weight_tensor_parameter_338:
 
 class Program_weight_tensor_parameter_339:
     name = "parameter_339"
+    original_name = "batch_norm2d_38.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.783536")
@@ -3652,6 +3992,7 @@ class Program_weight_tensor_parameter_339:
 
 class Program_weight_tensor_parameter_340:
     name = "parameter_340"
+    original_name = "batch_norm2d_38.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.558621")
@@ -3663,6 +4004,7 @@ class Program_weight_tensor_parameter_340:
 
 class Program_weight_tensor_parameter_341:
     name = "parameter_341"
+    original_name = "batch_norm2d_38.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("8.7599e-05")
@@ -3674,6 +4016,7 @@ class Program_weight_tensor_parameter_341:
 
 class Program_weight_tensor_parameter_342:
     name = "parameter_342"
+    original_name = "batch_norm2d_38.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.759114")
@@ -3685,6 +4028,7 @@ class Program_weight_tensor_parameter_342:
 
 class Program_weight_tensor_parameter_343:
     name = "parameter_343"
+    original_name = "conv2d_42.w_0"
     shape = [256, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.593109")
@@ -3696,6 +4040,7 @@ class Program_weight_tensor_parameter_343:
 
 class Program_weight_tensor_parameter_344:
     name = "parameter_344"
+    original_name = "batch_norm2d_37.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.679424")
@@ -3707,6 +4052,7 @@ class Program_weight_tensor_parameter_344:
 
 class Program_weight_tensor_parameter_345:
     name = "parameter_345"
+    original_name = "batch_norm2d_37.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.177261")
@@ -3718,6 +4064,7 @@ class Program_weight_tensor_parameter_345:
 
 class Program_weight_tensor_parameter_346:
     name = "parameter_346"
+    original_name = "batch_norm2d_37.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.312262")
@@ -3729,6 +4076,7 @@ class Program_weight_tensor_parameter_346:
 
 class Program_weight_tensor_parameter_347:
     name = "parameter_347"
+    original_name = "batch_norm2d_37.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.23097")
@@ -3740,6 +4088,7 @@ class Program_weight_tensor_parameter_347:
 
 class Program_weight_tensor_parameter_348:
     name = "parameter_348"
+    original_name = "conv2d_41.w_0"
     shape = [128, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.388094")
@@ -3751,6 +4100,7 @@ class Program_weight_tensor_parameter_348:
 
 class Program_weight_tensor_parameter_349:
     name = "parameter_349"
+    original_name = "batch_norm2d_36.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.00128")
@@ -3762,6 +4112,7 @@ class Program_weight_tensor_parameter_349:
 
 class Program_weight_tensor_parameter_350:
     name = "parameter_350"
+    original_name = "batch_norm2d_36.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.604189")
@@ -3773,6 +4124,7 @@ class Program_weight_tensor_parameter_350:
 
 class Program_weight_tensor_parameter_351:
     name = "parameter_351"
+    original_name = "batch_norm2d_36.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.00206914")
@@ -3784,6 +4136,7 @@ class Program_weight_tensor_parameter_351:
 
 class Program_weight_tensor_parameter_352:
     name = "parameter_352"
+    original_name = "batch_norm2d_36.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.296579")
@@ -3795,6 +4148,7 @@ class Program_weight_tensor_parameter_352:
 
 class Program_weight_tensor_parameter_353:
     name = "parameter_353"
+    original_name = "conv2d_40.w_0"
     shape = [256, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.45824")
@@ -3806,6 +4160,7 @@ class Program_weight_tensor_parameter_353:
 
 class Program_weight_tensor_parameter_354:
     name = "parameter_354"
+    original_name = "batch_norm2d_35.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.22215")
@@ -3817,6 +4172,7 @@ class Program_weight_tensor_parameter_354:
 
 class Program_weight_tensor_parameter_355:
     name = "parameter_355"
+    original_name = "batch_norm2d_35.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.203543")
@@ -3828,6 +4184,7 @@ class Program_weight_tensor_parameter_355:
 
 class Program_weight_tensor_parameter_356:
     name = "parameter_356"
+    original_name = "batch_norm2d_35.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.25957")
@@ -3839,6 +4196,7 @@ class Program_weight_tensor_parameter_356:
 
 class Program_weight_tensor_parameter_357:
     name = "parameter_357"
+    original_name = "batch_norm2d_35.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-2.28364")
@@ -3850,6 +4208,7 @@ class Program_weight_tensor_parameter_357:
 
 class Program_weight_tensor_parameter_358:
     name = "parameter_358"
+    original_name = "conv2d_39.w_0"
     shape = [256, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.50966")
@@ -3861,6 +4220,7 @@ class Program_weight_tensor_parameter_358:
 
 class Program_weight_tensor_parameter_359:
     name = "parameter_359"
+    original_name = "batch_norm2d_34.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.963958")
@@ -3872,6 +4232,7 @@ class Program_weight_tensor_parameter_359:
 
 class Program_weight_tensor_parameter_360:
     name = "parameter_360"
+    original_name = "batch_norm2d_34.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.803165")
@@ -3883,6 +4244,7 @@ class Program_weight_tensor_parameter_360:
 
 class Program_weight_tensor_parameter_361:
     name = "parameter_361"
+    original_name = "batch_norm2d_34.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("8.96439e-05")
@@ -3894,6 +4256,7 @@ class Program_weight_tensor_parameter_361:
 
 class Program_weight_tensor_parameter_362:
     name = "parameter_362"
+    original_name = "batch_norm2d_34.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.0580273")
@@ -3905,6 +4268,7 @@ class Program_weight_tensor_parameter_362:
 
 class Program_weight_tensor_parameter_363:
     name = "parameter_363"
+    original_name = "conv2d_38.w_0"
     shape = [256, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.450586")
@@ -3916,6 +4280,7 @@ class Program_weight_tensor_parameter_363:
 
 class Program_weight_tensor_parameter_364:
     name = "parameter_364"
+    original_name = "batch_norm2d_29.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.192956")
@@ -3927,6 +4292,7 @@ class Program_weight_tensor_parameter_364:
 
 class Program_weight_tensor_parameter_365:
     name = "parameter_365"
+    original_name = "batch_norm2d_29.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.0601437")
@@ -3938,6 +4304,7 @@ class Program_weight_tensor_parameter_365:
 
 class Program_weight_tensor_parameter_366:
     name = "parameter_366"
+    original_name = "batch_norm2d_29.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("1.97282")
@@ -3949,6 +4316,7 @@ class Program_weight_tensor_parameter_366:
 
 class Program_weight_tensor_parameter_367:
     name = "parameter_367"
+    original_name = "batch_norm2d_29.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.95254")
@@ -3960,6 +4328,7 @@ class Program_weight_tensor_parameter_367:
 
 class Program_weight_tensor_parameter_368:
     name = "parameter_368"
+    original_name = "conv2d_33.w_0"
     shape = [128, 768, 1, 1]
     dtype = "float32"
     min_val = float("-0.210411")
@@ -3971,6 +4340,7 @@ class Program_weight_tensor_parameter_368:
 
 class Program_weight_tensor_parameter_369:
     name = "parameter_369"
+    original_name = "batch_norm2d_28.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.0635894")
@@ -3982,6 +4352,7 @@ class Program_weight_tensor_parameter_369:
 
 class Program_weight_tensor_parameter_370:
     name = "parameter_370"
+    original_name = "batch_norm2d_28.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.0480673")
@@ -3993,6 +4364,7 @@ class Program_weight_tensor_parameter_370:
 
 class Program_weight_tensor_parameter_371:
     name = "parameter_371"
+    original_name = "batch_norm2d_28.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.0430946")
@@ -4004,6 +4376,7 @@ class Program_weight_tensor_parameter_371:
 
 class Program_weight_tensor_parameter_372:
     name = "parameter_372"
+    original_name = "batch_norm2d_28.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.532616")
@@ -4015,6 +4388,7 @@ class Program_weight_tensor_parameter_372:
 
 class Program_weight_tensor_parameter_373:
     name = "parameter_373"
+    original_name = "conv2d_32.w_0"
     shape = [128, 384, 1, 1]
     dtype = "float32"
     min_val = float("-0.168313")
@@ -4026,6 +4400,7 @@ class Program_weight_tensor_parameter_373:
 
 class Program_weight_tensor_parameter_374:
     name = "parameter_374"
+    original_name = "batch_norm2d_27.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.120563")
@@ -4037,6 +4412,7 @@ class Program_weight_tensor_parameter_374:
 
 class Program_weight_tensor_parameter_375:
     name = "parameter_375"
+    original_name = "batch_norm2d_27.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.0449625")
@@ -4048,6 +4424,7 @@ class Program_weight_tensor_parameter_375:
 
 class Program_weight_tensor_parameter_376:
     name = "parameter_376"
+    original_name = "batch_norm2d_27.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.0302137")
@@ -4059,6 +4436,7 @@ class Program_weight_tensor_parameter_376:
 
 class Program_weight_tensor_parameter_377:
     name = "parameter_377"
+    original_name = "batch_norm2d_27.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.720491")
@@ -4070,6 +4448,7 @@ class Program_weight_tensor_parameter_377:
 
 class Program_weight_tensor_parameter_378:
     name = "parameter_378"
+    original_name = "conv2d_31.w_0"
     shape = [128, 192, 1, 1]
     dtype = "float32"
     min_val = float("-0.554446")
@@ -4081,6 +4460,7 @@ class Program_weight_tensor_parameter_378:
 
 class Program_weight_tensor_parameter_379:
     name = "parameter_379"
+    original_name = "batch_norm2d_26.b_0"
     shape = [768]
     dtype = "float32"
     min_val = float("-5.13552")
@@ -4092,6 +4472,7 @@ class Program_weight_tensor_parameter_379:
 
 class Program_weight_tensor_parameter_380:
     name = "parameter_380"
+    original_name = "batch_norm2d_26.w_0"
     shape = [768]
     dtype = "float32"
     min_val = float("1.95051")
@@ -4103,6 +4484,7 @@ class Program_weight_tensor_parameter_380:
 
 class Program_weight_tensor_parameter_381:
     name = "parameter_381"
+    original_name = "batch_norm2d_26.w_2"
     shape = [768]
     dtype = "float32"
     min_val = float("0.0674532")
@@ -4114,6 +4496,7 @@ class Program_weight_tensor_parameter_381:
 
 class Program_weight_tensor_parameter_382:
     name = "parameter_382"
+    original_name = "batch_norm2d_26.w_1"
     shape = [768]
     dtype = "float32"
     min_val = float("-0.641825")
@@ -4125,6 +4508,7 @@ class Program_weight_tensor_parameter_382:
 
 class Program_weight_tensor_parameter_383:
     name = "parameter_383"
+    original_name = "conv2d_30.w_0"
     shape = [768, 768, 1, 1]
     dtype = "float32"
     min_val = float("-0.253374")
@@ -4136,6 +4520,7 @@ class Program_weight_tensor_parameter_383:
 
 class Program_weight_tensor_parameter_384:
     name = "parameter_384"
+    original_name = "conv2d_29.b_0"
     shape = [768]
     dtype = "float32"
     min_val = float("-0.0917331")
@@ -4147,6 +4532,7 @@ class Program_weight_tensor_parameter_384:
 
 class Program_weight_tensor_parameter_385:
     name = "parameter_385"
+    original_name = "conv2d_29.w_0"
     shape = [768, 192, 1, 1]
     dtype = "float32"
     min_val = float("-0.326777")
@@ -4158,6 +4544,7 @@ class Program_weight_tensor_parameter_385:
 
 class Program_weight_tensor_parameter_386:
     name = "parameter_386"
+    original_name = "conv2d_28.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.013977")
@@ -4169,6 +4556,7 @@ class Program_weight_tensor_parameter_386:
 
 class Program_weight_tensor_parameter_387:
     name = "parameter_387"
+    original_name = "conv2d_28.w_0"
     shape = [192, 768, 1, 1]
     dtype = "float32"
     min_val = float("-0.312492")
@@ -4180,6 +4568,7 @@ class Program_weight_tensor_parameter_387:
 
 class Program_weight_tensor_parameter_388:
     name = "parameter_388"
+    original_name = "batch_norm2d_25.b_0"
     shape = [768]
     dtype = "float32"
     min_val = float("-5.55032")
@@ -4191,6 +4580,7 @@ class Program_weight_tensor_parameter_388:
 
 class Program_weight_tensor_parameter_389:
     name = "parameter_389"
+    original_name = "batch_norm2d_25.w_0"
     shape = [768]
     dtype = "float32"
     min_val = float("0.406812")
@@ -4202,6 +4592,7 @@ class Program_weight_tensor_parameter_389:
 
 class Program_weight_tensor_parameter_390:
     name = "parameter_390"
+    original_name = "batch_norm2d_25.w_2"
     shape = [768]
     dtype = "float32"
     min_val = float("0.000137316")
@@ -4213,6 +4604,7 @@ class Program_weight_tensor_parameter_390:
 
 class Program_weight_tensor_parameter_391:
     name = "parameter_391"
+    original_name = "batch_norm2d_25.w_1"
     shape = [768]
     dtype = "float32"
     min_val = float("-0.950195")
@@ -4224,6 +4616,7 @@ class Program_weight_tensor_parameter_391:
 
 class Program_weight_tensor_parameter_392:
     name = "parameter_392"
+    original_name = "conv2d_27.w_0"
     shape = [768, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.524245")
@@ -4235,6 +4628,7 @@ class Program_weight_tensor_parameter_392:
 
 class Program_weight_tensor_parameter_393:
     name = "parameter_393"
+    original_name = "batch_norm2d_24.b_0"
     shape = [768]
     dtype = "float32"
     min_val = float("-2.53075")
@@ -4246,6 +4640,7 @@ class Program_weight_tensor_parameter_393:
 
 class Program_weight_tensor_parameter_394:
     name = "parameter_394"
+    original_name = "batch_norm2d_24.w_0"
     shape = [768]
     dtype = "float32"
     min_val = float("-1.30233")
@@ -4257,6 +4652,7 @@ class Program_weight_tensor_parameter_394:
 
 class Program_weight_tensor_parameter_395:
     name = "parameter_395"
+    original_name = "batch_norm2d_24.w_2"
     shape = [768]
     dtype = "float32"
     min_val = float("0.0818677")
@@ -4268,6 +4664,7 @@ class Program_weight_tensor_parameter_395:
 
 class Program_weight_tensor_parameter_396:
     name = "parameter_396"
+    original_name = "batch_norm2d_24.w_1"
     shape = [768]
     dtype = "float32"
     min_val = float("-1.14124")
@@ -4279,6 +4676,7 @@ class Program_weight_tensor_parameter_396:
 
 class Program_weight_tensor_parameter_397:
     name = "parameter_397"
+    original_name = "conv2d_26.w_0"
     shape = [768, 384, 1, 1]
     dtype = "float32"
     min_val = float("-0.727307")
@@ -4290,6 +4688,7 @@ class Program_weight_tensor_parameter_397:
 
 class Program_weight_tensor_parameter_398:
     name = "parameter_398"
+    original_name = "conv2d_25.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-0.110125")
@@ -4301,6 +4700,7 @@ class Program_weight_tensor_parameter_398:
 
 class Program_weight_tensor_parameter_399:
     name = "parameter_399"
+    original_name = "conv2d_25.w_0"
     shape = [384, 96, 1, 1]
     dtype = "float32"
     min_val = float("-0.306098")
@@ -4312,6 +4712,7 @@ class Program_weight_tensor_parameter_399:
 
 class Program_weight_tensor_parameter_400:
     name = "parameter_400"
+    original_name = "conv2d_24.b_0"
     shape = [96]
     dtype = "float32"
     min_val = float("-0.0037569")
@@ -4323,6 +4724,7 @@ class Program_weight_tensor_parameter_400:
 
 class Program_weight_tensor_parameter_401:
     name = "parameter_401"
+    original_name = "conv2d_24.w_0"
     shape = [96, 384, 1, 1]
     dtype = "float32"
     min_val = float("-0.311782")
@@ -4334,6 +4736,7 @@ class Program_weight_tensor_parameter_401:
 
 class Program_weight_tensor_parameter_402:
     name = "parameter_402"
+    original_name = "batch_norm2d_23.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-1.65094")
@@ -4345,6 +4748,7 @@ class Program_weight_tensor_parameter_402:
 
 class Program_weight_tensor_parameter_403:
     name = "parameter_403"
+    original_name = "batch_norm2d_23.w_0"
     shape = [384]
     dtype = "float32"
     min_val = float("0.686309")
@@ -4356,6 +4760,7 @@ class Program_weight_tensor_parameter_403:
 
 class Program_weight_tensor_parameter_404:
     name = "parameter_404"
+    original_name = "batch_norm2d_23.w_2"
     shape = [384]
     dtype = "float32"
     min_val = float("0.000181782")
@@ -4367,6 +4772,7 @@ class Program_weight_tensor_parameter_404:
 
 class Program_weight_tensor_parameter_405:
     name = "parameter_405"
+    original_name = "batch_norm2d_23.w_1"
     shape = [384]
     dtype = "float32"
     min_val = float("-1.43705")
@@ -4378,6 +4784,7 @@ class Program_weight_tensor_parameter_405:
 
 class Program_weight_tensor_parameter_406:
     name = "parameter_406"
+    original_name = "conv2d_23.w_0"
     shape = [384, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.242781")
@@ -4389,6 +4796,7 @@ class Program_weight_tensor_parameter_406:
 
 class Program_weight_tensor_parameter_407:
     name = "parameter_407"
+    original_name = "batch_norm2d_22.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-2.76092")
@@ -4400,6 +4808,7 @@ class Program_weight_tensor_parameter_407:
 
 class Program_weight_tensor_parameter_408:
     name = "parameter_408"
+    original_name = "batch_norm2d_22.w_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-0.965177")
@@ -4411,6 +4820,7 @@ class Program_weight_tensor_parameter_408:
 
 class Program_weight_tensor_parameter_409:
     name = "parameter_409"
+    original_name = "batch_norm2d_22.w_2"
     shape = [384]
     dtype = "float32"
     min_val = float("0.545222")
@@ -4422,6 +4832,7 @@ class Program_weight_tensor_parameter_409:
 
 class Program_weight_tensor_parameter_410:
     name = "parameter_410"
+    original_name = "batch_norm2d_22.w_1"
     shape = [384]
     dtype = "float32"
     min_val = float("-5.88732")
@@ -4433,6 +4844,7 @@ class Program_weight_tensor_parameter_410:
 
 class Program_weight_tensor_parameter_411:
     name = "parameter_411"
+    original_name = "conv2d_22.w_0"
     shape = [384, 384, 1, 1]
     dtype = "float32"
     min_val = float("-0.873806")
@@ -4444,6 +4856,7 @@ class Program_weight_tensor_parameter_411:
 
 class Program_weight_tensor_parameter_412:
     name = "parameter_412"
+    original_name = "batch_norm2d_21.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-3.48952")
@@ -4455,6 +4868,7 @@ class Program_weight_tensor_parameter_412:
 
 class Program_weight_tensor_parameter_413:
     name = "parameter_413"
+    original_name = "batch_norm2d_21.w_0"
     shape = [384]
     dtype = "float32"
     min_val = float("0.492558")
@@ -4466,6 +4880,7 @@ class Program_weight_tensor_parameter_413:
 
 class Program_weight_tensor_parameter_414:
     name = "parameter_414"
+    original_name = "batch_norm2d_21.w_2"
     shape = [384]
     dtype = "float32"
     min_val = float("0.000326886")
@@ -4477,6 +4892,7 @@ class Program_weight_tensor_parameter_414:
 
 class Program_weight_tensor_parameter_415:
     name = "parameter_415"
+    original_name = "batch_norm2d_21.w_1"
     shape = [384]
     dtype = "float32"
     min_val = float("-1.59459")
@@ -4488,6 +4904,7 @@ class Program_weight_tensor_parameter_415:
 
 class Program_weight_tensor_parameter_416:
     name = "parameter_416"
+    original_name = "conv2d_21.w_0"
     shape = [384, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.669919")
@@ -4499,6 +4916,7 @@ class Program_weight_tensor_parameter_416:
 
 class Program_weight_tensor_parameter_417:
     name = "parameter_417"
+    original_name = "batch_norm2d_20.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-2.19373")
@@ -4510,6 +4928,7 @@ class Program_weight_tensor_parameter_417:
 
 class Program_weight_tensor_parameter_418:
     name = "parameter_418"
+    original_name = "batch_norm2d_20.w_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-0.223286")
@@ -4521,6 +4940,7 @@ class Program_weight_tensor_parameter_418:
 
 class Program_weight_tensor_parameter_419:
     name = "parameter_419"
+    original_name = "batch_norm2d_20.w_2"
     shape = [384]
     dtype = "float32"
     min_val = float("0.47444")
@@ -4532,6 +4952,7 @@ class Program_weight_tensor_parameter_419:
 
 class Program_weight_tensor_parameter_420:
     name = "parameter_420"
+    original_name = "batch_norm2d_20.w_1"
     shape = [384]
     dtype = "float32"
     min_val = float("-3.8311")
@@ -4543,6 +4964,7 @@ class Program_weight_tensor_parameter_420:
 
 class Program_weight_tensor_parameter_421:
     name = "parameter_421"
+    original_name = "conv2d_20.w_0"
     shape = [384, 384, 1, 1]
     dtype = "float32"
     min_val = float("-0.456584")
@@ -4554,6 +4976,7 @@ class Program_weight_tensor_parameter_421:
 
 class Program_weight_tensor_parameter_422:
     name = "parameter_422"
+    original_name = "batch_norm2d_19.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-4.16434")
@@ -4565,6 +4988,7 @@ class Program_weight_tensor_parameter_422:
 
 class Program_weight_tensor_parameter_423:
     name = "parameter_423"
+    original_name = "batch_norm2d_19.w_0"
     shape = [384]
     dtype = "float32"
     min_val = float("0.466564")
@@ -4576,6 +5000,7 @@ class Program_weight_tensor_parameter_423:
 
 class Program_weight_tensor_parameter_424:
     name = "parameter_424"
+    original_name = "batch_norm2d_19.w_2"
     shape = [384]
     dtype = "float32"
     min_val = float("0.00022856")
@@ -4587,6 +5012,7 @@ class Program_weight_tensor_parameter_424:
 
 class Program_weight_tensor_parameter_425:
     name = "parameter_425"
+    original_name = "batch_norm2d_19.w_1"
     shape = [384]
     dtype = "float32"
     min_val = float("-5.05944")
@@ -4598,6 +5024,7 @@ class Program_weight_tensor_parameter_425:
 
 class Program_weight_tensor_parameter_426:
     name = "parameter_426"
+    original_name = "conv2d_19.w_0"
     shape = [384, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.735819")
@@ -4609,6 +5036,7 @@ class Program_weight_tensor_parameter_426:
 
 class Program_weight_tensor_parameter_427:
     name = "parameter_427"
+    original_name = "batch_norm2d_18.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-2.46506")
@@ -4620,6 +5048,7 @@ class Program_weight_tensor_parameter_427:
 
 class Program_weight_tensor_parameter_428:
     name = "parameter_428"
+    original_name = "batch_norm2d_18.w_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-0.415135")
@@ -4631,6 +5060,7 @@ class Program_weight_tensor_parameter_428:
 
 class Program_weight_tensor_parameter_429:
     name = "parameter_429"
+    original_name = "batch_norm2d_18.w_2"
     shape = [384]
     dtype = "float32"
     min_val = float("0.33377")
@@ -4642,6 +5072,7 @@ class Program_weight_tensor_parameter_429:
 
 class Program_weight_tensor_parameter_430:
     name = "parameter_430"
+    original_name = "batch_norm2d_18.w_1"
     shape = [384]
     dtype = "float32"
     min_val = float("-3.24626")
@@ -4653,6 +5084,7 @@ class Program_weight_tensor_parameter_430:
 
 class Program_weight_tensor_parameter_431:
     name = "parameter_431"
+    original_name = "conv2d_18.w_0"
     shape = [384, 384, 1, 1]
     dtype = "float32"
     min_val = float("-0.634735")
@@ -4664,6 +5096,7 @@ class Program_weight_tensor_parameter_431:
 
 class Program_weight_tensor_parameter_432:
     name = "parameter_432"
+    original_name = "batch_norm2d_17.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-4.52697")
@@ -4675,6 +5108,7 @@ class Program_weight_tensor_parameter_432:
 
 class Program_weight_tensor_parameter_433:
     name = "parameter_433"
+    original_name = "batch_norm2d_17.w_0"
     shape = [384]
     dtype = "float32"
     min_val = float("0.47464")
@@ -4686,6 +5120,7 @@ class Program_weight_tensor_parameter_433:
 
 class Program_weight_tensor_parameter_434:
     name = "parameter_434"
+    original_name = "batch_norm2d_17.w_2"
     shape = [384]
     dtype = "float32"
     min_val = float("0.000206609")
@@ -4697,6 +5132,7 @@ class Program_weight_tensor_parameter_434:
 
 class Program_weight_tensor_parameter_435:
     name = "parameter_435"
+    original_name = "batch_norm2d_17.w_1"
     shape = [384]
     dtype = "float32"
     min_val = float("-3.99282")
@@ -4708,6 +5144,7 @@ class Program_weight_tensor_parameter_435:
 
 class Program_weight_tensor_parameter_436:
     name = "parameter_436"
+    original_name = "conv2d_17.w_0"
     shape = [384, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.622473")
@@ -4719,6 +5156,7 @@ class Program_weight_tensor_parameter_436:
 
 class Program_weight_tensor_parameter_437:
     name = "parameter_437"
+    original_name = "batch_norm2d_16.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-2.92298")
@@ -4730,6 +5168,7 @@ class Program_weight_tensor_parameter_437:
 
 class Program_weight_tensor_parameter_438:
     name = "parameter_438"
+    original_name = "batch_norm2d_16.w_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-0.0963202")
@@ -4741,6 +5180,7 @@ class Program_weight_tensor_parameter_438:
 
 class Program_weight_tensor_parameter_439:
     name = "parameter_439"
+    original_name = "batch_norm2d_16.w_2"
     shape = [384]
     dtype = "float32"
     min_val = float("0.378212")
@@ -4752,6 +5192,7 @@ class Program_weight_tensor_parameter_439:
 
 class Program_weight_tensor_parameter_440:
     name = "parameter_440"
+    original_name = "batch_norm2d_16.w_1"
     shape = [384]
     dtype = "float32"
     min_val = float("-4.31477")
@@ -4763,6 +5204,7 @@ class Program_weight_tensor_parameter_440:
 
 class Program_weight_tensor_parameter_441:
     name = "parameter_441"
+    original_name = "conv2d_16.w_0"
     shape = [384, 384, 1, 1]
     dtype = "float32"
     min_val = float("-0.563475")
@@ -4774,6 +5216,7 @@ class Program_weight_tensor_parameter_441:
 
 class Program_weight_tensor_parameter_442:
     name = "parameter_442"
+    original_name = "batch_norm2d_15.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-2.7459")
@@ -4785,6 +5228,7 @@ class Program_weight_tensor_parameter_442:
 
 class Program_weight_tensor_parameter_443:
     name = "parameter_443"
+    original_name = "batch_norm2d_15.w_0"
     shape = [384]
     dtype = "float32"
     min_val = float("0.475796")
@@ -4796,6 +5240,7 @@ class Program_weight_tensor_parameter_443:
 
 class Program_weight_tensor_parameter_444:
     name = "parameter_444"
+    original_name = "batch_norm2d_15.w_2"
     shape = [384]
     dtype = "float32"
     min_val = float("0.000194028")
@@ -4807,6 +5252,7 @@ class Program_weight_tensor_parameter_444:
 
 class Program_weight_tensor_parameter_445:
     name = "parameter_445"
+    original_name = "batch_norm2d_15.w_1"
     shape = [384]
     dtype = "float32"
     min_val = float("-4.40324")
@@ -4818,6 +5264,7 @@ class Program_weight_tensor_parameter_445:
 
 class Program_weight_tensor_parameter_446:
     name = "parameter_446"
+    original_name = "conv2d_15.w_0"
     shape = [384, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.663897")
@@ -4829,6 +5276,7 @@ class Program_weight_tensor_parameter_446:
 
 class Program_weight_tensor_parameter_447:
     name = "parameter_447"
+    original_name = "batch_norm2d_14.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-3.23973")
@@ -4840,6 +5288,7 @@ class Program_weight_tensor_parameter_447:
 
 class Program_weight_tensor_parameter_448:
     name = "parameter_448"
+    original_name = "batch_norm2d_14.w_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-0.198052")
@@ -4851,6 +5300,7 @@ class Program_weight_tensor_parameter_448:
 
 class Program_weight_tensor_parameter_449:
     name = "parameter_449"
+    original_name = "batch_norm2d_14.w_2"
     shape = [384]
     dtype = "float32"
     min_val = float("0.382466")
@@ -4862,6 +5312,7 @@ class Program_weight_tensor_parameter_449:
 
 class Program_weight_tensor_parameter_450:
     name = "parameter_450"
+    original_name = "batch_norm2d_14.w_1"
     shape = [384]
     dtype = "float32"
     min_val = float("-3.28565")
@@ -4873,6 +5324,7 @@ class Program_weight_tensor_parameter_450:
 
 class Program_weight_tensor_parameter_451:
     name = "parameter_451"
+    original_name = "conv2d_14.w_0"
     shape = [384, 384, 1, 1]
     dtype = "float32"
     min_val = float("-0.680193")
@@ -4884,6 +5336,7 @@ class Program_weight_tensor_parameter_451:
 
 class Program_weight_tensor_parameter_452:
     name = "parameter_452"
+    original_name = "batch_norm2d_13.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-4.65754")
@@ -4895,6 +5348,7 @@ class Program_weight_tensor_parameter_452:
 
 class Program_weight_tensor_parameter_453:
     name = "parameter_453"
+    original_name = "batch_norm2d_13.w_0"
     shape = [384]
     dtype = "float32"
     min_val = float("0.466168")
@@ -4906,6 +5360,7 @@ class Program_weight_tensor_parameter_453:
 
 class Program_weight_tensor_parameter_454:
     name = "parameter_454"
+    original_name = "batch_norm2d_13.w_2"
     shape = [384]
     dtype = "float32"
     min_val = float("0.000171944")
@@ -4917,6 +5372,7 @@ class Program_weight_tensor_parameter_454:
 
 class Program_weight_tensor_parameter_455:
     name = "parameter_455"
+    original_name = "batch_norm2d_13.w_1"
     shape = [384]
     dtype = "float32"
     min_val = float("-4.6669")
@@ -4928,6 +5384,7 @@ class Program_weight_tensor_parameter_455:
 
 class Program_weight_tensor_parameter_456:
     name = "parameter_456"
+    original_name = "conv2d_13.w_0"
     shape = [384, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.80168")
@@ -4939,6 +5396,7 @@ class Program_weight_tensor_parameter_456:
 
 class Program_weight_tensor_parameter_457:
     name = "parameter_457"
+    original_name = "batch_norm2d_12.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-2.3612")
@@ -4950,6 +5408,7 @@ class Program_weight_tensor_parameter_457:
 
 class Program_weight_tensor_parameter_458:
     name = "parameter_458"
+    original_name = "batch_norm2d_12.w_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-0.122134")
@@ -4961,6 +5420,7 @@ class Program_weight_tensor_parameter_458:
 
 class Program_weight_tensor_parameter_459:
     name = "parameter_459"
+    original_name = "batch_norm2d_12.w_2"
     shape = [384]
     dtype = "float32"
     min_val = float("0.177016")
@@ -4972,6 +5432,7 @@ class Program_weight_tensor_parameter_459:
 
 class Program_weight_tensor_parameter_460:
     name = "parameter_460"
+    original_name = "batch_norm2d_12.w_1"
     shape = [384]
     dtype = "float32"
     min_val = float("-6.05383")
@@ -4983,6 +5444,7 @@ class Program_weight_tensor_parameter_460:
 
 class Program_weight_tensor_parameter_461:
     name = "parameter_461"
+    original_name = "conv2d_12.w_0"
     shape = [384, 192, 1, 1]
     dtype = "float32"
     min_val = float("-0.723431")
@@ -4994,6 +5456,7 @@ class Program_weight_tensor_parameter_461:
 
 class Program_weight_tensor_parameter_462:
     name = "parameter_462"
+    original_name = "batch_norm2d_11.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-4.38957")
@@ -5005,6 +5468,7 @@ class Program_weight_tensor_parameter_462:
 
 class Program_weight_tensor_parameter_463:
     name = "parameter_463"
+    original_name = "batch_norm2d_11.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("0.376604")
@@ -5016,6 +5480,7 @@ class Program_weight_tensor_parameter_463:
 
 class Program_weight_tensor_parameter_464:
     name = "parameter_464"
+    original_name = "batch_norm2d_11.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("0.000829851")
@@ -5027,6 +5492,7 @@ class Program_weight_tensor_parameter_464:
 
 class Program_weight_tensor_parameter_465:
     name = "parameter_465"
+    original_name = "batch_norm2d_11.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-1.82033")
@@ -5038,6 +5504,7 @@ class Program_weight_tensor_parameter_465:
 
 class Program_weight_tensor_parameter_466:
     name = "parameter_466"
+    original_name = "conv2d_11.w_0"
     shape = [192, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.273656")
@@ -5049,6 +5516,7 @@ class Program_weight_tensor_parameter_466:
 
 class Program_weight_tensor_parameter_467:
     name = "parameter_467"
+    original_name = "batch_norm2d_10.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-2.4084")
@@ -5060,6 +5528,7 @@ class Program_weight_tensor_parameter_467:
 
 class Program_weight_tensor_parameter_468:
     name = "parameter_468"
+    original_name = "batch_norm2d_10.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("0.213934")
@@ -5071,6 +5540,7 @@ class Program_weight_tensor_parameter_468:
 
 class Program_weight_tensor_parameter_469:
     name = "parameter_469"
+    original_name = "batch_norm2d_10.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("0.447297")
@@ -5082,6 +5552,7 @@ class Program_weight_tensor_parameter_469:
 
 class Program_weight_tensor_parameter_470:
     name = "parameter_470"
+    original_name = "batch_norm2d_10.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-6.67949")
@@ -5093,6 +5564,7 @@ class Program_weight_tensor_parameter_470:
 
 class Program_weight_tensor_parameter_471:
     name = "parameter_471"
+    original_name = "conv2d_10.w_0"
     shape = [192, 192, 1, 1]
     dtype = "float32"
     min_val = float("-0.69018")
@@ -5104,6 +5576,7 @@ class Program_weight_tensor_parameter_471:
 
 class Program_weight_tensor_parameter_472:
     name = "parameter_472"
+    original_name = "batch_norm2d_9.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-1.40565")
@@ -5115,6 +5588,7 @@ class Program_weight_tensor_parameter_472:
 
 class Program_weight_tensor_parameter_473:
     name = "parameter_473"
+    original_name = "batch_norm2d_9.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("0.505814")
@@ -5126,6 +5600,7 @@ class Program_weight_tensor_parameter_473:
 
 class Program_weight_tensor_parameter_474:
     name = "parameter_474"
+    original_name = "batch_norm2d_9.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("0.000115788")
@@ -5137,6 +5612,7 @@ class Program_weight_tensor_parameter_474:
 
 class Program_weight_tensor_parameter_475:
     name = "parameter_475"
+    original_name = "batch_norm2d_9.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-6.82118")
@@ -5148,6 +5624,7 @@ class Program_weight_tensor_parameter_475:
 
 class Program_weight_tensor_parameter_476:
     name = "parameter_476"
+    original_name = "conv2d_9.w_0"
     shape = [192, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.966841")
@@ -5159,6 +5636,7 @@ class Program_weight_tensor_parameter_476:
 
 class Program_weight_tensor_parameter_477:
     name = "parameter_477"
+    original_name = "batch_norm2d_8.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-1.49895")
@@ -5170,6 +5648,7 @@ class Program_weight_tensor_parameter_477:
 
 class Program_weight_tensor_parameter_478:
     name = "parameter_478"
+    original_name = "batch_norm2d_8.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-1.09512")
@@ -5181,6 +5660,7 @@ class Program_weight_tensor_parameter_478:
 
 class Program_weight_tensor_parameter_479:
     name = "parameter_479"
+    original_name = "batch_norm2d_8.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("0.186849")
@@ -5192,6 +5672,7 @@ class Program_weight_tensor_parameter_479:
 
 class Program_weight_tensor_parameter_480:
     name = "parameter_480"
+    original_name = "batch_norm2d_8.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-6.26769")
@@ -5203,6 +5684,7 @@ class Program_weight_tensor_parameter_480:
 
 class Program_weight_tensor_parameter_481:
     name = "parameter_481"
+    original_name = "conv2d_8.w_0"
     shape = [192, 96, 1, 1]
     dtype = "float32"
     min_val = float("-1.05107")
@@ -5214,6 +5696,7 @@ class Program_weight_tensor_parameter_481:
 
 class Program_weight_tensor_parameter_482:
     name = "parameter_482"
+    original_name = "batch_norm2d_7.b_0"
     shape = [96]
     dtype = "float32"
     min_val = float("-0.612535")
@@ -5225,6 +5708,7 @@ class Program_weight_tensor_parameter_482:
 
 class Program_weight_tensor_parameter_483:
     name = "parameter_483"
+    original_name = "batch_norm2d_7.w_0"
     shape = [96]
     dtype = "float32"
     min_val = float("-0.648831")
@@ -5236,6 +5720,7 @@ class Program_weight_tensor_parameter_483:
 
 class Program_weight_tensor_parameter_484:
     name = "parameter_484"
+    original_name = "batch_norm2d_7.w_2"
     shape = [96]
     dtype = "float32"
     min_val = float("0.00021319")
@@ -5247,6 +5732,7 @@ class Program_weight_tensor_parameter_484:
 
 class Program_weight_tensor_parameter_485:
     name = "parameter_485"
+    original_name = "batch_norm2d_7.w_1"
     shape = [96]
     dtype = "float32"
     min_val = float("-4.04569")
@@ -5258,6 +5744,7 @@ class Program_weight_tensor_parameter_485:
 
 class Program_weight_tensor_parameter_486:
     name = "parameter_486"
+    original_name = "conv2d_7.w_0"
     shape = [96, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.488915")
@@ -5269,6 +5756,7 @@ class Program_weight_tensor_parameter_486:
 
 class Program_weight_tensor_parameter_487:
     name = "parameter_487"
+    original_name = "batch_norm2d_6.b_0"
     shape = [96]
     dtype = "float32"
     min_val = float("-3.06425")
@@ -5280,6 +5768,7 @@ class Program_weight_tensor_parameter_487:
 
 class Program_weight_tensor_parameter_488:
     name = "parameter_488"
+    original_name = "batch_norm2d_6.w_0"
     shape = [96]
     dtype = "float32"
     min_val = float("-0.294203")
@@ -5291,6 +5780,7 @@ class Program_weight_tensor_parameter_488:
 
 class Program_weight_tensor_parameter_489:
     name = "parameter_489"
+    original_name = "batch_norm2d_6.w_2"
     shape = [96]
     dtype = "float32"
     min_val = float("2.19219")
@@ -5302,6 +5792,7 @@ class Program_weight_tensor_parameter_489:
 
 class Program_weight_tensor_parameter_490:
     name = "parameter_490"
+    original_name = "batch_norm2d_6.w_1"
     shape = [96]
     dtype = "float32"
     min_val = float("-10.71")
@@ -5313,6 +5804,7 @@ class Program_weight_tensor_parameter_490:
 
 class Program_weight_tensor_parameter_491:
     name = "parameter_491"
+    original_name = "conv2d_6.w_0"
     shape = [96, 96, 1, 1]
     dtype = "float32"
     min_val = float("-0.81451")
@@ -5324,6 +5816,7 @@ class Program_weight_tensor_parameter_491:
 
 class Program_weight_tensor_parameter_492:
     name = "parameter_492"
+    original_name = "batch_norm2d_5.b_0"
     shape = [96]
     dtype = "float32"
     min_val = float("-1.81008")
@@ -5335,6 +5828,7 @@ class Program_weight_tensor_parameter_492:
 
 class Program_weight_tensor_parameter_493:
     name = "parameter_493"
+    original_name = "batch_norm2d_5.w_0"
     shape = [96]
     dtype = "float32"
     min_val = float("1.19179")
@@ -5346,6 +5840,7 @@ class Program_weight_tensor_parameter_493:
 
 class Program_weight_tensor_parameter_494:
     name = "parameter_494"
+    original_name = "batch_norm2d_5.w_2"
     shape = [96]
     dtype = "float32"
     min_val = float("0.000253477")
@@ -5357,6 +5852,7 @@ class Program_weight_tensor_parameter_494:
 
 class Program_weight_tensor_parameter_495:
     name = "parameter_495"
+    original_name = "batch_norm2d_5.w_1"
     shape = [96]
     dtype = "float32"
     min_val = float("-4.28775")
@@ -5368,6 +5864,7 @@ class Program_weight_tensor_parameter_495:
 
 class Program_weight_tensor_parameter_496:
     name = "parameter_496"
+    original_name = "conv2d_5.w_0"
     shape = [96, 1, 3, 3]
     dtype = "float32"
     min_val = float("-1.10624")
@@ -5379,6 +5876,7 @@ class Program_weight_tensor_parameter_496:
 
 class Program_weight_tensor_parameter_497:
     name = "parameter_497"
+    original_name = "batch_norm2d_4.b_0"
     shape = [96]
     dtype = "float32"
     min_val = float("-3.62779")
@@ -5390,6 +5888,7 @@ class Program_weight_tensor_parameter_497:
 
 class Program_weight_tensor_parameter_498:
     name = "parameter_498"
+    original_name = "batch_norm2d_4.w_0"
     shape = [96]
     dtype = "float32"
     min_val = float("-1.37029")
@@ -5401,6 +5900,7 @@ class Program_weight_tensor_parameter_498:
 
 class Program_weight_tensor_parameter_499:
     name = "parameter_499"
+    original_name = "batch_norm2d_4.w_2"
     shape = [96]
     dtype = "float32"
     min_val = float("1.98428")
@@ -5412,6 +5912,7 @@ class Program_weight_tensor_parameter_499:
 
 class Program_weight_tensor_parameter_500:
     name = "parameter_500"
+    original_name = "batch_norm2d_4.w_1"
     shape = [96]
     dtype = "float32"
     min_val = float("-11.6768")
@@ -5423,6 +5924,7 @@ class Program_weight_tensor_parameter_500:
 
 class Program_weight_tensor_parameter_501:
     name = "parameter_501"
+    original_name = "conv2d_4.w_0"
     shape = [96, 48, 1, 1]
     dtype = "float32"
     min_val = float("-1.19138")
@@ -5434,6 +5936,7 @@ class Program_weight_tensor_parameter_501:
 
 class Program_weight_tensor_parameter_502:
     name = "parameter_502"
+    original_name = "batch_norm2d_3.b_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -5443,6 +5946,7 @@ class Program_weight_tensor_parameter_502:
 
 class Program_weight_tensor_parameter_503:
     name = "parameter_503"
+    original_name = "batch_norm2d_3.w_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -5452,6 +5956,7 @@ class Program_weight_tensor_parameter_503:
 
 class Program_weight_tensor_parameter_504:
     name = "parameter_504"
+    original_name = "batch_norm2d_3.w_2"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -5461,6 +5966,7 @@ class Program_weight_tensor_parameter_504:
 
 class Program_weight_tensor_parameter_505:
     name = "parameter_505"
+    original_name = "batch_norm2d_3.w_1"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -5470,6 +5976,7 @@ class Program_weight_tensor_parameter_505:
 
 class Program_weight_tensor_parameter_506:
     name = "parameter_506"
+    original_name = "conv2d_3.w_0"
     shape = [48, 1, 3, 3]
     dtype = "float32"
     min_val = float("-1.38278")
@@ -5481,6 +5988,7 @@ class Program_weight_tensor_parameter_506:
 
 class Program_weight_tensor_parameter_507:
     name = "parameter_507"
+    original_name = "batch_norm2d_2.b_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -5490,6 +5998,7 @@ class Program_weight_tensor_parameter_507:
 
 class Program_weight_tensor_parameter_508:
     name = "parameter_508"
+    original_name = "batch_norm2d_2.w_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -5499,6 +6008,7 @@ class Program_weight_tensor_parameter_508:
 
 class Program_weight_tensor_parameter_509:
     name = "parameter_509"
+    original_name = "batch_norm2d_2.w_2"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -5508,6 +6018,7 @@ class Program_weight_tensor_parameter_509:
 
 class Program_weight_tensor_parameter_510:
     name = "parameter_510"
+    original_name = "batch_norm2d_2.w_1"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -5517,6 +6028,7 @@ class Program_weight_tensor_parameter_510:
 
 class Program_weight_tensor_parameter_511:
     name = "parameter_511"
+    original_name = "conv2d_2.w_0"
     shape = [48, 24, 1, 1]
     dtype = "float32"
     min_val = float("-1.06154")
@@ -5528,6 +6040,7 @@ class Program_weight_tensor_parameter_511:
 
 class Program_weight_tensor_parameter_512:
     name = "parameter_512"
+    original_name = "batch_norm2d_1.b_0"
     shape = [24]
     dtype = "float32"
     min_val = float("0")
@@ -5537,6 +6050,7 @@ class Program_weight_tensor_parameter_512:
 
 class Program_weight_tensor_parameter_513:
     name = "parameter_513"
+    original_name = "batch_norm2d_1.w_0"
     shape = [24]
     dtype = "float32"
     min_val = float("0")
@@ -5546,6 +6060,7 @@ class Program_weight_tensor_parameter_513:
 
 class Program_weight_tensor_parameter_514:
     name = "parameter_514"
+    original_name = "batch_norm2d_1.w_2"
     shape = [24]
     dtype = "float32"
     min_val = float("0")
@@ -5555,6 +6070,7 @@ class Program_weight_tensor_parameter_514:
 
 class Program_weight_tensor_parameter_515:
     name = "parameter_515"
+    original_name = "batch_norm2d_1.w_1"
     shape = [24]
     dtype = "float32"
     min_val = float("0")
@@ -5564,6 +6080,7 @@ class Program_weight_tensor_parameter_515:
 
 class Program_weight_tensor_parameter_516:
     name = "parameter_516"
+    original_name = "conv2d_1.w_0"
     shape = [24, 1, 3, 3]
     dtype = "float32"
     min_val = float("-1.27887")
@@ -5575,6 +6092,7 @@ class Program_weight_tensor_parameter_516:
 
 class Program_weight_tensor_parameter_517:
     name = "parameter_517"
+    original_name = "batch_norm2d_0.b_0"
     shape = [24]
     dtype = "float32"
     min_val = float("0")
@@ -5584,6 +6102,7 @@ class Program_weight_tensor_parameter_517:
 
 class Program_weight_tensor_parameter_518:
     name = "parameter_518"
+    original_name = "batch_norm2d_0.w_0"
     shape = [24]
     dtype = "float32"
     min_val = float("0")
@@ -5593,6 +6112,7 @@ class Program_weight_tensor_parameter_518:
 
 class Program_weight_tensor_parameter_519:
     name = "parameter_519"
+    original_name = "batch_norm2d_0.w_2"
     shape = [24]
     dtype = "float32"
     min_val = float("0")
@@ -5602,6 +6122,7 @@ class Program_weight_tensor_parameter_519:
 
 class Program_weight_tensor_parameter_520:
     name = "parameter_520"
+    original_name = "batch_norm2d_0.w_1"
     shape = [24]
     dtype = "float32"
     min_val = float("0")
@@ -5611,6 +6132,7 @@ class Program_weight_tensor_parameter_520:
 
 class Program_weight_tensor_parameter_521:
     name = "parameter_521"
+    original_name = "conv2d_0.w_0"
     shape = [24, 3, 3, 3]
     dtype = "float32"
     min_val = float("-0.763684")

--- a/paddle_samples/PaddleX/ResNet18/input_meta.py
+++ b/paddle_samples/PaddleX/ResNet18/input_meta.py
@@ -1,5 +1,6 @@
 class Program_weight_tensor_data_0:
     name = "data_0"
+    original_name = "var_145"
     shape = [64, 3, 224, 224]
     dtype = "float32"
     min_val = float("-2.1179")

--- a/paddle_samples/PaddleX/ResNet18/weight_meta.py
+++ b/paddle_samples/PaddleX/ResNet18/weight_meta.py
@@ -1,5 +1,6 @@
 class Program_weight_tensor_parameter_0:
     name = "parameter_0"
+    original_name = "linear_0.b_0"
     shape = [102]
     dtype = "float32"
     min_val = float("-0.00917972")
@@ -11,6 +12,7 @@ class Program_weight_tensor_parameter_0:
 
 class Program_weight_tensor_parameter_1:
     name = "parameter_1"
+    original_name = "linear_0.w_0"
     shape = [512, 102]
     dtype = "float32"
     min_val = float("-0.0651744")
@@ -22,6 +24,7 @@ class Program_weight_tensor_parameter_1:
 
 class Program_weight_tensor_parameter_2:
     name = "parameter_2"
+    original_name = "batch_norm_20.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("0.0275836")
@@ -33,6 +36,7 @@ class Program_weight_tensor_parameter_2:
 
 class Program_weight_tensor_parameter_3:
     name = "parameter_3"
+    original_name = "batch_norm_20.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("1.52942")
@@ -44,6 +48,7 @@ class Program_weight_tensor_parameter_3:
 
 class Program_weight_tensor_parameter_4:
     name = "parameter_4"
+    original_name = "batch_norm_20.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("0.00931472")
@@ -55,6 +60,7 @@ class Program_weight_tensor_parameter_4:
 
 class Program_weight_tensor_parameter_5:
     name = "parameter_5"
+    original_name = "batch_norm_20.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.0467386")
@@ -66,6 +72,7 @@ class Program_weight_tensor_parameter_5:
 
 class Program_weight_tensor_parameter_6:
     name = "parameter_6"
+    original_name = "conv2d_20.w_0"
     shape = [512, 512, 3, 3]
     dtype = "float32"
     min_val = float("-0.113482")
@@ -77,6 +84,7 @@ class Program_weight_tensor_parameter_6:
 
 class Program_weight_tensor_parameter_7:
     name = "parameter_7"
+    original_name = "batch_norm_19.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.551929")
@@ -88,6 +96,7 @@ class Program_weight_tensor_parameter_7:
 
 class Program_weight_tensor_parameter_8:
     name = "parameter_8"
+    original_name = "batch_norm_19.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("0.0894387")
@@ -99,6 +108,7 @@ class Program_weight_tensor_parameter_8:
 
 class Program_weight_tensor_parameter_9:
     name = "parameter_9"
+    original_name = "batch_norm_19.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("0.0555482")
@@ -110,6 +120,7 @@ class Program_weight_tensor_parameter_9:
 
 class Program_weight_tensor_parameter_10:
     name = "parameter_10"
+    original_name = "batch_norm_19.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.749277")
@@ -121,6 +132,7 @@ class Program_weight_tensor_parameter_10:
 
 class Program_weight_tensor_parameter_11:
     name = "parameter_11"
+    original_name = "conv2d_19.w_0"
     shape = [512, 512, 3, 3]
     dtype = "float32"
     min_val = float("-0.319333")
@@ -132,6 +144,7 @@ class Program_weight_tensor_parameter_11:
 
 class Program_weight_tensor_parameter_12:
     name = "parameter_12"
+    original_name = "batch_norm_18.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.394103")
@@ -143,6 +156,7 @@ class Program_weight_tensor_parameter_12:
 
 class Program_weight_tensor_parameter_13:
     name = "parameter_13"
+    original_name = "batch_norm_18.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.0795484")
@@ -154,6 +168,7 @@ class Program_weight_tensor_parameter_13:
 
 class Program_weight_tensor_parameter_14:
     name = "parameter_14"
+    original_name = "batch_norm_18.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("0.00203374")
@@ -165,6 +180,7 @@ class Program_weight_tensor_parameter_14:
 
 class Program_weight_tensor_parameter_15:
     name = "parameter_15"
+    original_name = "batch_norm_18.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.252108")
@@ -176,6 +192,7 @@ class Program_weight_tensor_parameter_15:
 
 class Program_weight_tensor_parameter_16:
     name = "parameter_16"
+    original_name = "conv2d_18.w_0"
     shape = [512, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.908914")
@@ -187,6 +204,7 @@ class Program_weight_tensor_parameter_16:
 
 class Program_weight_tensor_parameter_17:
     name = "parameter_17"
+    original_name = "batch_norm_17.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.394103")
@@ -198,6 +216,7 @@ class Program_weight_tensor_parameter_17:
 
 class Program_weight_tensor_parameter_18:
     name = "parameter_18"
+    original_name = "batch_norm_17.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("0.0886931")
@@ -209,6 +228,7 @@ class Program_weight_tensor_parameter_18:
 
 class Program_weight_tensor_parameter_19:
     name = "parameter_19"
+    original_name = "batch_norm_17.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("0.00914284")
@@ -220,6 +240,7 @@ class Program_weight_tensor_parameter_19:
 
 class Program_weight_tensor_parameter_20:
     name = "parameter_20"
+    original_name = "batch_norm_17.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.314796")
@@ -231,6 +252,7 @@ class Program_weight_tensor_parameter_20:
 
 class Program_weight_tensor_parameter_21:
     name = "parameter_21"
+    original_name = "conv2d_17.w_0"
     shape = [512, 512, 3, 3]
     dtype = "float32"
     min_val = float("-0.275482")
@@ -242,6 +264,7 @@ class Program_weight_tensor_parameter_21:
 
 class Program_weight_tensor_parameter_22:
     name = "parameter_22"
+    original_name = "batch_norm_16.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.72348")
@@ -253,6 +276,7 @@ class Program_weight_tensor_parameter_22:
 
 class Program_weight_tensor_parameter_23:
     name = "parameter_23"
+    original_name = "batch_norm_16.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("0.119287")
@@ -264,6 +288,7 @@ class Program_weight_tensor_parameter_23:
 
 class Program_weight_tensor_parameter_24:
     name = "parameter_24"
+    original_name = "batch_norm_16.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("0.0593178")
@@ -275,6 +300,7 @@ class Program_weight_tensor_parameter_24:
 
 class Program_weight_tensor_parameter_25:
     name = "parameter_25"
+    original_name = "batch_norm_16.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-1.33638")
@@ -286,6 +312,7 @@ class Program_weight_tensor_parameter_25:
 
 class Program_weight_tensor_parameter_26:
     name = "parameter_26"
+    original_name = "conv2d_16.w_0"
     shape = [512, 256, 3, 3]
     dtype = "float32"
     min_val = float("-0.326124")
@@ -297,6 +324,7 @@ class Program_weight_tensor_parameter_26:
 
 class Program_weight_tensor_parameter_27:
     name = "parameter_27"
+    original_name = "batch_norm_15.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.664869")
@@ -308,6 +336,7 @@ class Program_weight_tensor_parameter_27:
 
 class Program_weight_tensor_parameter_28:
     name = "parameter_28"
+    original_name = "batch_norm_15.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.0259914")
@@ -319,6 +348,7 @@ class Program_weight_tensor_parameter_28:
 
 class Program_weight_tensor_parameter_29:
     name = "parameter_29"
+    original_name = "batch_norm_15.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.00549062")
@@ -330,6 +360,7 @@ class Program_weight_tensor_parameter_29:
 
 class Program_weight_tensor_parameter_30:
     name = "parameter_30"
+    original_name = "batch_norm_15.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.573859")
@@ -341,6 +372,7 @@ class Program_weight_tensor_parameter_30:
 
 class Program_weight_tensor_parameter_31:
     name = "parameter_31"
+    original_name = "conv2d_15.w_0"
     shape = [256, 256, 3, 3]
     dtype = "float32"
     min_val = float("-0.295601")
@@ -352,6 +384,7 @@ class Program_weight_tensor_parameter_31:
 
 class Program_weight_tensor_parameter_32:
     name = "parameter_32"
+    original_name = "batch_norm_14.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.701317")
@@ -363,6 +396,7 @@ class Program_weight_tensor_parameter_32:
 
 class Program_weight_tensor_parameter_33:
     name = "parameter_33"
+    original_name = "batch_norm_14.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.13944")
@@ -374,6 +408,7 @@ class Program_weight_tensor_parameter_33:
 
 class Program_weight_tensor_parameter_34:
     name = "parameter_34"
+    original_name = "batch_norm_14.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.0765543")
@@ -385,6 +420,7 @@ class Program_weight_tensor_parameter_34:
 
 class Program_weight_tensor_parameter_35:
     name = "parameter_35"
+    original_name = "batch_norm_14.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-2.66481")
@@ -396,6 +432,7 @@ class Program_weight_tensor_parameter_35:
 
 class Program_weight_tensor_parameter_36:
     name = "parameter_36"
+    original_name = "conv2d_14.w_0"
     shape = [256, 256, 3, 3]
     dtype = "float32"
     min_val = float("-0.290243")
@@ -407,6 +444,7 @@ class Program_weight_tensor_parameter_36:
 
 class Program_weight_tensor_parameter_37:
     name = "parameter_37"
+    original_name = "batch_norm_13.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.367234")
@@ -418,6 +456,7 @@ class Program_weight_tensor_parameter_37:
 
 class Program_weight_tensor_parameter_38:
     name = "parameter_38"
+    original_name = "batch_norm_13.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.0152404")
@@ -429,6 +468,7 @@ class Program_weight_tensor_parameter_38:
 
 class Program_weight_tensor_parameter_39:
     name = "parameter_39"
+    original_name = "batch_norm_13.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.00260952")
@@ -440,6 +480,7 @@ class Program_weight_tensor_parameter_39:
 
 class Program_weight_tensor_parameter_40:
     name = "parameter_40"
+    original_name = "batch_norm_13.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.24504")
@@ -451,6 +492,7 @@ class Program_weight_tensor_parameter_40:
 
 class Program_weight_tensor_parameter_41:
     name = "parameter_41"
+    original_name = "conv2d_13.w_0"
     shape = [256, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.263906")
@@ -462,6 +504,7 @@ class Program_weight_tensor_parameter_41:
 
 class Program_weight_tensor_parameter_42:
     name = "parameter_42"
+    original_name = "batch_norm_12.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.367234")
@@ -473,6 +516,7 @@ class Program_weight_tensor_parameter_42:
 
 class Program_weight_tensor_parameter_43:
     name = "parameter_43"
+    original_name = "batch_norm_12.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.170457")
@@ -484,6 +528,7 @@ class Program_weight_tensor_parameter_43:
 
 class Program_weight_tensor_parameter_44:
     name = "parameter_44"
+    original_name = "batch_norm_12.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.0423005")
@@ -495,6 +540,7 @@ class Program_weight_tensor_parameter_44:
 
 class Program_weight_tensor_parameter_45:
     name = "parameter_45"
+    original_name = "batch_norm_12.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.709179")
@@ -506,6 +552,7 @@ class Program_weight_tensor_parameter_45:
 
 class Program_weight_tensor_parameter_46:
     name = "parameter_46"
+    original_name = "conv2d_12.w_0"
     shape = [256, 256, 3, 3]
     dtype = "float32"
     min_val = float("-0.396432")
@@ -517,6 +564,7 @@ class Program_weight_tensor_parameter_46:
 
 class Program_weight_tensor_parameter_47:
     name = "parameter_47"
+    original_name = "batch_norm_11.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.421766")
@@ -528,6 +576,7 @@ class Program_weight_tensor_parameter_47:
 
 class Program_weight_tensor_parameter_48:
     name = "parameter_48"
+    original_name = "batch_norm_11.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.208535")
@@ -539,6 +588,7 @@ class Program_weight_tensor_parameter_48:
 
 class Program_weight_tensor_parameter_49:
     name = "parameter_49"
+    original_name = "batch_norm_11.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.086291")
@@ -550,6 +600,7 @@ class Program_weight_tensor_parameter_49:
 
 class Program_weight_tensor_parameter_50:
     name = "parameter_50"
+    original_name = "batch_norm_11.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.26515")
@@ -561,6 +612,7 @@ class Program_weight_tensor_parameter_50:
 
 class Program_weight_tensor_parameter_51:
     name = "parameter_51"
+    original_name = "conv2d_11.w_0"
     shape = [256, 128, 3, 3]
     dtype = "float32"
     min_val = float("-0.405646")
@@ -572,6 +624,7 @@ class Program_weight_tensor_parameter_51:
 
 class Program_weight_tensor_parameter_52:
     name = "parameter_52"
+    original_name = "batch_norm_10.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.532164")
@@ -583,6 +636,7 @@ class Program_weight_tensor_parameter_52:
 
 class Program_weight_tensor_parameter_53:
     name = "parameter_53"
+    original_name = "batch_norm_10.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.0387377")
@@ -594,6 +648,7 @@ class Program_weight_tensor_parameter_53:
 
 class Program_weight_tensor_parameter_54:
     name = "parameter_54"
+    original_name = "batch_norm_10.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.00614949")
@@ -605,6 +660,7 @@ class Program_weight_tensor_parameter_54:
 
 class Program_weight_tensor_parameter_55:
     name = "parameter_55"
+    original_name = "batch_norm_10.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.540636")
@@ -616,6 +672,7 @@ class Program_weight_tensor_parameter_55:
 
 class Program_weight_tensor_parameter_56:
     name = "parameter_56"
+    original_name = "conv2d_10.w_0"
     shape = [128, 128, 3, 3]
     dtype = "float32"
     min_val = float("-0.361143")
@@ -627,6 +684,7 @@ class Program_weight_tensor_parameter_56:
 
 class Program_weight_tensor_parameter_57:
     name = "parameter_57"
+    original_name = "batch_norm_9.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.658581")
@@ -638,6 +696,7 @@ class Program_weight_tensor_parameter_57:
 
 class Program_weight_tensor_parameter_58:
     name = "parameter_58"
+    original_name = "batch_norm_9.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.227461")
@@ -649,6 +708,7 @@ class Program_weight_tensor_parameter_58:
 
 class Program_weight_tensor_parameter_59:
     name = "parameter_59"
+    original_name = "batch_norm_9.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.0856519")
@@ -660,6 +720,7 @@ class Program_weight_tensor_parameter_59:
 
 class Program_weight_tensor_parameter_60:
     name = "parameter_60"
+    original_name = "batch_norm_9.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.50869")
@@ -671,6 +732,7 @@ class Program_weight_tensor_parameter_60:
 
 class Program_weight_tensor_parameter_61:
     name = "parameter_61"
+    original_name = "conv2d_9.w_0"
     shape = [128, 128, 3, 3]
     dtype = "float32"
     min_val = float("-0.338004")
@@ -682,6 +744,7 @@ class Program_weight_tensor_parameter_61:
 
 class Program_weight_tensor_parameter_62:
     name = "parameter_62"
+    original_name = "batch_norm_8.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.245089")
@@ -693,6 +756,7 @@ class Program_weight_tensor_parameter_62:
 
 class Program_weight_tensor_parameter_63:
     name = "parameter_63"
+    original_name = "batch_norm_8.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.0152137")
@@ -704,6 +768,7 @@ class Program_weight_tensor_parameter_63:
 
 class Program_weight_tensor_parameter_64:
     name = "parameter_64"
+    original_name = "batch_norm_8.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.00463106")
@@ -715,6 +780,7 @@ class Program_weight_tensor_parameter_64:
 
 class Program_weight_tensor_parameter_65:
     name = "parameter_65"
+    original_name = "batch_norm_8.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.384798")
@@ -726,6 +792,7 @@ class Program_weight_tensor_parameter_65:
 
 class Program_weight_tensor_parameter_66:
     name = "parameter_66"
+    original_name = "conv2d_8.w_0"
     shape = [128, 64, 1, 1]
     dtype = "float32"
     min_val = float("-0.658175")
@@ -737,6 +804,7 @@ class Program_weight_tensor_parameter_66:
 
 class Program_weight_tensor_parameter_67:
     name = "parameter_67"
+    original_name = "batch_norm_7.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.245089")
@@ -748,6 +816,7 @@ class Program_weight_tensor_parameter_67:
 
 class Program_weight_tensor_parameter_68:
     name = "parameter_68"
+    original_name = "batch_norm_7.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.0883116")
@@ -759,6 +828,7 @@ class Program_weight_tensor_parameter_68:
 
 class Program_weight_tensor_parameter_69:
     name = "parameter_69"
+    original_name = "batch_norm_7.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.026159")
@@ -770,6 +840,7 @@ class Program_weight_tensor_parameter_69:
 
 class Program_weight_tensor_parameter_70:
     name = "parameter_70"
+    original_name = "batch_norm_7.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.704322")
@@ -781,6 +852,7 @@ class Program_weight_tensor_parameter_70:
 
 class Program_weight_tensor_parameter_71:
     name = "parameter_71"
+    original_name = "conv2d_7.w_0"
     shape = [128, 128, 3, 3]
     dtype = "float32"
     min_val = float("-0.456589")
@@ -792,6 +864,7 @@ class Program_weight_tensor_parameter_71:
 
 class Program_weight_tensor_parameter_72:
     name = "parameter_72"
+    original_name = "batch_norm_6.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.329727")
@@ -803,6 +876,7 @@ class Program_weight_tensor_parameter_72:
 
 class Program_weight_tensor_parameter_73:
     name = "parameter_73"
+    original_name = "batch_norm_6.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.190817")
@@ -814,6 +888,7 @@ class Program_weight_tensor_parameter_73:
 
 class Program_weight_tensor_parameter_74:
     name = "parameter_74"
+    original_name = "batch_norm_6.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.172372")
@@ -825,6 +900,7 @@ class Program_weight_tensor_parameter_74:
 
 class Program_weight_tensor_parameter_75:
     name = "parameter_75"
+    original_name = "batch_norm_6.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.49122")
@@ -836,6 +912,7 @@ class Program_weight_tensor_parameter_75:
 
 class Program_weight_tensor_parameter_76:
     name = "parameter_76"
+    original_name = "conv2d_6.w_0"
     shape = [128, 64, 3, 3]
     dtype = "float32"
     min_val = float("-0.415849")
@@ -847,6 +924,7 @@ class Program_weight_tensor_parameter_76:
 
 class Program_weight_tensor_parameter_77:
     name = "parameter_77"
+    original_name = "batch_norm_5.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -856,6 +934,7 @@ class Program_weight_tensor_parameter_77:
 
 class Program_weight_tensor_parameter_78:
     name = "parameter_78"
+    original_name = "batch_norm_5.w_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -865,6 +944,7 @@ class Program_weight_tensor_parameter_78:
 
 class Program_weight_tensor_parameter_79:
     name = "parameter_79"
+    original_name = "batch_norm_5.w_2"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -874,6 +954,7 @@ class Program_weight_tensor_parameter_79:
 
 class Program_weight_tensor_parameter_80:
     name = "parameter_80"
+    original_name = "batch_norm_5.w_1"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -883,6 +964,7 @@ class Program_weight_tensor_parameter_80:
 
 class Program_weight_tensor_parameter_81:
     name = "parameter_81"
+    original_name = "conv2d_5.w_0"
     shape = [64, 64, 3, 3]
     dtype = "float32"
     min_val = float("-0.580664")
@@ -894,6 +976,7 @@ class Program_weight_tensor_parameter_81:
 
 class Program_weight_tensor_parameter_82:
     name = "parameter_82"
+    original_name = "batch_norm_4.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -903,6 +986,7 @@ class Program_weight_tensor_parameter_82:
 
 class Program_weight_tensor_parameter_83:
     name = "parameter_83"
+    original_name = "batch_norm_4.w_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -912,6 +996,7 @@ class Program_weight_tensor_parameter_83:
 
 class Program_weight_tensor_parameter_84:
     name = "parameter_84"
+    original_name = "batch_norm_4.w_2"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -921,6 +1006,7 @@ class Program_weight_tensor_parameter_84:
 
 class Program_weight_tensor_parameter_85:
     name = "parameter_85"
+    original_name = "batch_norm_4.w_1"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -930,6 +1016,7 @@ class Program_weight_tensor_parameter_85:
 
 class Program_weight_tensor_parameter_86:
     name = "parameter_86"
+    original_name = "conv2d_4.w_0"
     shape = [64, 64, 3, 3]
     dtype = "float32"
     min_val = float("-0.372411")
@@ -941,6 +1028,7 @@ class Program_weight_tensor_parameter_86:
 
 class Program_weight_tensor_parameter_87:
     name = "parameter_87"
+    original_name = "batch_norm_3.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -950,6 +1038,7 @@ class Program_weight_tensor_parameter_87:
 
 class Program_weight_tensor_parameter_88:
     name = "parameter_88"
+    original_name = "batch_norm_3.w_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -959,6 +1048,7 @@ class Program_weight_tensor_parameter_88:
 
 class Program_weight_tensor_parameter_89:
     name = "parameter_89"
+    original_name = "batch_norm_3.w_2"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -968,6 +1058,7 @@ class Program_weight_tensor_parameter_89:
 
 class Program_weight_tensor_parameter_90:
     name = "parameter_90"
+    original_name = "batch_norm_3.w_1"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -977,6 +1068,7 @@ class Program_weight_tensor_parameter_90:
 
 class Program_weight_tensor_parameter_91:
     name = "parameter_91"
+    original_name = "conv2d_3.w_0"
     shape = [64, 64, 1, 1]
     dtype = "float32"
     min_val = float("-0.645605")
@@ -988,6 +1080,7 @@ class Program_weight_tensor_parameter_91:
 
 class Program_weight_tensor_parameter_92:
     name = "parameter_92"
+    original_name = "batch_norm_2.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -997,6 +1090,7 @@ class Program_weight_tensor_parameter_92:
 
 class Program_weight_tensor_parameter_93:
     name = "parameter_93"
+    original_name = "batch_norm_2.w_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -1006,6 +1100,7 @@ class Program_weight_tensor_parameter_93:
 
 class Program_weight_tensor_parameter_94:
     name = "parameter_94"
+    original_name = "batch_norm_2.w_2"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -1015,6 +1110,7 @@ class Program_weight_tensor_parameter_94:
 
 class Program_weight_tensor_parameter_95:
     name = "parameter_95"
+    original_name = "batch_norm_2.w_1"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -1024,6 +1120,7 @@ class Program_weight_tensor_parameter_95:
 
 class Program_weight_tensor_parameter_96:
     name = "parameter_96"
+    original_name = "conv2d_2.w_0"
     shape = [64, 64, 3, 3]
     dtype = "float32"
     min_val = float("-0.428959")
@@ -1035,6 +1132,7 @@ class Program_weight_tensor_parameter_96:
 
 class Program_weight_tensor_parameter_97:
     name = "parameter_97"
+    original_name = "batch_norm_1.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -1044,6 +1142,7 @@ class Program_weight_tensor_parameter_97:
 
 class Program_weight_tensor_parameter_98:
     name = "parameter_98"
+    original_name = "batch_norm_1.w_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -1053,6 +1152,7 @@ class Program_weight_tensor_parameter_98:
 
 class Program_weight_tensor_parameter_99:
     name = "parameter_99"
+    original_name = "batch_norm_1.w_2"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -1062,6 +1162,7 @@ class Program_weight_tensor_parameter_99:
 
 class Program_weight_tensor_parameter_100:
     name = "parameter_100"
+    original_name = "batch_norm_1.w_1"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -1071,6 +1172,7 @@ class Program_weight_tensor_parameter_100:
 
 class Program_weight_tensor_parameter_101:
     name = "parameter_101"
+    original_name = "conv2d_1.w_0"
     shape = [64, 64, 3, 3]
     dtype = "float32"
     min_val = float("-0.636645")
@@ -1082,6 +1184,7 @@ class Program_weight_tensor_parameter_101:
 
 class Program_weight_tensor_parameter_102:
     name = "parameter_102"
+    original_name = "batch_norm_0.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -1091,6 +1194,7 @@ class Program_weight_tensor_parameter_102:
 
 class Program_weight_tensor_parameter_103:
     name = "parameter_103"
+    original_name = "batch_norm_0.w_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -1100,6 +1204,7 @@ class Program_weight_tensor_parameter_103:
 
 class Program_weight_tensor_parameter_104:
     name = "parameter_104"
+    original_name = "batch_norm_0.w_2"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -1109,6 +1214,7 @@ class Program_weight_tensor_parameter_104:
 
 class Program_weight_tensor_parameter_105:
     name = "parameter_105"
+    original_name = "batch_norm_0.w_1"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -1118,6 +1224,7 @@ class Program_weight_tensor_parameter_105:
 
 class Program_weight_tensor_parameter_106:
     name = "parameter_106"
+    original_name = "conv2d_0.w_0"
     shape = [64, 3, 7, 7]
     dtype = "float32"
     min_val = float("-0.687591")

--- a/paddle_samples/PaddleX/SLANet/subgraph_0/input_meta.py
+++ b/paddle_samples/PaddleX/SLANet/subgraph_0/input_meta.py
@@ -1,5 +1,6 @@
 class Program_weight_tensor_data_0:
     name = "data_0"
+    original_name = "var_361"
     shape = [24, 3, 488, 488]
     dtype = "float32"
     min_val = float("-2.1179")

--- a/paddle_samples/PaddleX/SLANet/subgraph_0/weight_meta.py
+++ b/paddle_samples/PaddleX/SLANet/subgraph_0/weight_meta.py
@@ -1,5 +1,6 @@
 class Program_weight_tensor_parameter_0:
     name = "parameter_0"
+    original_name = "batch_norm2d_42.b_0"
     shape = [96]
     dtype = "float32"
     min_val = float("-0.24959")
@@ -11,6 +12,7 @@ class Program_weight_tensor_parameter_0:
 
 class Program_weight_tensor_parameter_1:
     name = "parameter_1"
+    original_name = "batch_norm2d_42.w_0"
     shape = [96]
     dtype = "float32"
     min_val = float("0.449565")
@@ -22,6 +24,7 @@ class Program_weight_tensor_parameter_1:
 
 class Program_weight_tensor_parameter_2:
     name = "parameter_2"
+    original_name = "batch_norm2d_42.w_2"
     shape = [96]
     dtype = "float32"
     min_val = float("2.93068")
@@ -33,6 +36,7 @@ class Program_weight_tensor_parameter_2:
 
 class Program_weight_tensor_parameter_3:
     name = "parameter_3"
+    original_name = "batch_norm2d_42.w_1"
     shape = [96]
     dtype = "float32"
     min_val = float("-2.34994")
@@ -44,6 +48,7 @@ class Program_weight_tensor_parameter_3:
 
 class Program_weight_tensor_parameter_4:
     name = "parameter_4"
+    original_name = "conv2d_73.w_0"
     shape = [96, 96, 1, 1]
     dtype = "float32"
     min_val = float("-1.04498")
@@ -55,6 +60,7 @@ class Program_weight_tensor_parameter_4:
 
 class Program_weight_tensor_parameter_5:
     name = "parameter_5"
+    original_name = "batch_norm2d_45.b_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -64,6 +70,7 @@ class Program_weight_tensor_parameter_5:
 
 class Program_weight_tensor_parameter_6:
     name = "parameter_6"
+    original_name = "batch_norm2d_45.w_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -73,6 +80,7 @@ class Program_weight_tensor_parameter_6:
 
 class Program_weight_tensor_parameter_7:
     name = "parameter_7"
+    original_name = "batch_norm2d_45.w_2"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -82,6 +90,7 @@ class Program_weight_tensor_parameter_7:
 
 class Program_weight_tensor_parameter_8:
     name = "parameter_8"
+    original_name = "batch_norm2d_45.w_1"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -91,6 +100,7 @@ class Program_weight_tensor_parameter_8:
 
 class Program_weight_tensor_parameter_9:
     name = "parameter_9"
+    original_name = "conv2d_76.w_0"
     shape = [48, 48, 1, 1]
     dtype = "float32"
     min_val = float("-1.21852")
@@ -102,6 +112,7 @@ class Program_weight_tensor_parameter_9:
 
 class Program_weight_tensor_parameter_10:
     name = "parameter_10"
+    original_name = "batch_norm2d_44.b_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -111,6 +122,7 @@ class Program_weight_tensor_parameter_10:
 
 class Program_weight_tensor_parameter_11:
     name = "parameter_11"
+    original_name = "batch_norm2d_44.w_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -120,6 +132,7 @@ class Program_weight_tensor_parameter_11:
 
 class Program_weight_tensor_parameter_12:
     name = "parameter_12"
+    original_name = "batch_norm2d_44.w_2"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -129,6 +142,7 @@ class Program_weight_tensor_parameter_12:
 
 class Program_weight_tensor_parameter_13:
     name = "parameter_13"
+    original_name = "batch_norm2d_44.w_1"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -138,6 +152,7 @@ class Program_weight_tensor_parameter_13:
 
 class Program_weight_tensor_parameter_14:
     name = "parameter_14"
+    original_name = "conv2d_75.w_0"
     shape = [48, 1, 5, 5]
     dtype = "float32"
     min_val = float("-1.18004")
@@ -149,6 +164,7 @@ class Program_weight_tensor_parameter_14:
 
 class Program_weight_tensor_parameter_15:
     name = "parameter_15"
+    original_name = "batch_norm2d_43.b_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -158,6 +174,7 @@ class Program_weight_tensor_parameter_15:
 
 class Program_weight_tensor_parameter_16:
     name = "parameter_16"
+    original_name = "batch_norm2d_43.w_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -167,6 +184,7 @@ class Program_weight_tensor_parameter_16:
 
 class Program_weight_tensor_parameter_17:
     name = "parameter_17"
+    original_name = "batch_norm2d_43.w_2"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -176,6 +194,7 @@ class Program_weight_tensor_parameter_17:
 
 class Program_weight_tensor_parameter_18:
     name = "parameter_18"
+    original_name = "batch_norm2d_43.w_1"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -185,6 +204,7 @@ class Program_weight_tensor_parameter_18:
 
 class Program_weight_tensor_parameter_19:
     name = "parameter_19"
+    original_name = "conv2d_74.w_0"
     shape = [48, 48, 1, 1]
     dtype = "float32"
     min_val = float("-1.20729")
@@ -196,6 +216,7 @@ class Program_weight_tensor_parameter_19:
 
 class Program_weight_tensor_parameter_20:
     name = "parameter_20"
+    original_name = "batch_norm2d_40.b_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -205,6 +226,7 @@ class Program_weight_tensor_parameter_20:
 
 class Program_weight_tensor_parameter_21:
     name = "parameter_21"
+    original_name = "batch_norm2d_40.w_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -214,6 +236,7 @@ class Program_weight_tensor_parameter_21:
 
 class Program_weight_tensor_parameter_22:
     name = "parameter_22"
+    original_name = "batch_norm2d_40.w_2"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -223,6 +246,7 @@ class Program_weight_tensor_parameter_22:
 
 class Program_weight_tensor_parameter_23:
     name = "parameter_23"
+    original_name = "batch_norm2d_40.w_1"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -232,6 +256,7 @@ class Program_weight_tensor_parameter_23:
 
 class Program_weight_tensor_parameter_24:
     name = "parameter_24"
+    original_name = "conv2d_71.w_0"
     shape = [48, 192, 1, 1]
     dtype = "float32"
     min_val = float("-1.53561")
@@ -243,6 +268,7 @@ class Program_weight_tensor_parameter_24:
 
 class Program_weight_tensor_parameter_25:
     name = "parameter_25"
+    original_name = "batch_norm2d_41.b_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -252,6 +278,7 @@ class Program_weight_tensor_parameter_25:
 
 class Program_weight_tensor_parameter_26:
     name = "parameter_26"
+    original_name = "batch_norm2d_41.w_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -261,6 +288,7 @@ class Program_weight_tensor_parameter_26:
 
 class Program_weight_tensor_parameter_27:
     name = "parameter_27"
+    original_name = "batch_norm2d_41.w_2"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -270,6 +298,7 @@ class Program_weight_tensor_parameter_27:
 
 class Program_weight_tensor_parameter_28:
     name = "parameter_28"
+    original_name = "batch_norm2d_41.w_1"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -279,6 +308,7 @@ class Program_weight_tensor_parameter_28:
 
 class Program_weight_tensor_parameter_29:
     name = "parameter_29"
+    original_name = "conv2d_72.w_0"
     shape = [48, 192, 1, 1]
     dtype = "float32"
     min_val = float("-1.21655")
@@ -290,6 +320,7 @@ class Program_weight_tensor_parameter_29:
 
 class Program_weight_tensor_parameter_30:
     name = "parameter_30"
+    original_name = "batch_norm2d_39.b_0"
     shape = [96]
     dtype = "float32"
     min_val = float("-0.767027")
@@ -301,6 +332,7 @@ class Program_weight_tensor_parameter_30:
 
 class Program_weight_tensor_parameter_31:
     name = "parameter_31"
+    original_name = "batch_norm2d_39.w_0"
     shape = [96]
     dtype = "float32"
     min_val = float("0.446288")
@@ -312,6 +344,7 @@ class Program_weight_tensor_parameter_31:
 
 class Program_weight_tensor_parameter_32:
     name = "parameter_32"
+    original_name = "batch_norm2d_39.w_2"
     shape = [96]
     dtype = "float32"
     min_val = float("2.87005")
@@ -323,6 +356,7 @@ class Program_weight_tensor_parameter_32:
 
 class Program_weight_tensor_parameter_33:
     name = "parameter_33"
+    original_name = "batch_norm2d_39.w_1"
     shape = [96]
     dtype = "float32"
     min_val = float("-2.08306")
@@ -334,6 +368,7 @@ class Program_weight_tensor_parameter_33:
 
 class Program_weight_tensor_parameter_34:
     name = "parameter_34"
+    original_name = "conv2d_70.w_0"
     shape = [96, 96, 1, 1]
     dtype = "float32"
     min_val = float("-1.26513")
@@ -345,6 +380,7 @@ class Program_weight_tensor_parameter_34:
 
 class Program_weight_tensor_parameter_35:
     name = "parameter_35"
+    original_name = "batch_norm2d_38.b_0"
     shape = [96]
     dtype = "float32"
     min_val = float("-0.712146")
@@ -356,6 +392,7 @@ class Program_weight_tensor_parameter_35:
 
 class Program_weight_tensor_parameter_36:
     name = "parameter_36"
+    original_name = "batch_norm2d_38.w_0"
     shape = [96]
     dtype = "float32"
     min_val = float("0.61526")
@@ -367,6 +404,7 @@ class Program_weight_tensor_parameter_36:
 
 class Program_weight_tensor_parameter_37:
     name = "parameter_37"
+    original_name = "batch_norm2d_38.w_2"
     shape = [96]
     dtype = "float32"
     min_val = float("0.0580731")
@@ -378,6 +416,7 @@ class Program_weight_tensor_parameter_37:
 
 class Program_weight_tensor_parameter_38:
     name = "parameter_38"
+    original_name = "batch_norm2d_38.w_1"
     shape = [96]
     dtype = "float32"
     min_val = float("-2.55002")
@@ -389,6 +428,7 @@ class Program_weight_tensor_parameter_38:
 
 class Program_weight_tensor_parameter_39:
     name = "parameter_39"
+    original_name = "conv2d_69.w_0"
     shape = [96, 1, 5, 5]
     dtype = "float32"
     min_val = float("-1.47908")
@@ -400,6 +440,7 @@ class Program_weight_tensor_parameter_39:
 
 class Program_weight_tensor_parameter_40:
     name = "parameter_40"
+    original_name = "batch_norm2d_34.b_0"
     shape = [96]
     dtype = "float32"
     min_val = float("-0.734562")
@@ -411,6 +452,7 @@ class Program_weight_tensor_parameter_40:
 
 class Program_weight_tensor_parameter_41:
     name = "parameter_41"
+    original_name = "batch_norm2d_34.w_0"
     shape = [96]
     dtype = "float32"
     min_val = float("0.176593")
@@ -422,6 +464,7 @@ class Program_weight_tensor_parameter_41:
 
 class Program_weight_tensor_parameter_42:
     name = "parameter_42"
+    original_name = "batch_norm2d_34.w_2"
     shape = [96]
     dtype = "float32"
     min_val = float("2.69034")
@@ -433,6 +476,7 @@ class Program_weight_tensor_parameter_42:
 
 class Program_weight_tensor_parameter_43:
     name = "parameter_43"
+    original_name = "batch_norm2d_34.w_1"
     shape = [96]
     dtype = "float32"
     min_val = float("-2.03681")
@@ -444,6 +488,7 @@ class Program_weight_tensor_parameter_43:
 
 class Program_weight_tensor_parameter_44:
     name = "parameter_44"
+    original_name = "conv2d_65.w_0"
     shape = [96, 96, 1, 1]
     dtype = "float32"
     min_val = float("-1.34596")
@@ -455,6 +500,7 @@ class Program_weight_tensor_parameter_44:
 
 class Program_weight_tensor_parameter_45:
     name = "parameter_45"
+    original_name = "batch_norm2d_37.b_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -464,6 +510,7 @@ class Program_weight_tensor_parameter_45:
 
 class Program_weight_tensor_parameter_46:
     name = "parameter_46"
+    original_name = "batch_norm2d_37.w_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -473,6 +520,7 @@ class Program_weight_tensor_parameter_46:
 
 class Program_weight_tensor_parameter_47:
     name = "parameter_47"
+    original_name = "batch_norm2d_37.w_2"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -482,6 +530,7 @@ class Program_weight_tensor_parameter_47:
 
 class Program_weight_tensor_parameter_48:
     name = "parameter_48"
+    original_name = "batch_norm2d_37.w_1"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -491,6 +540,7 @@ class Program_weight_tensor_parameter_48:
 
 class Program_weight_tensor_parameter_49:
     name = "parameter_49"
+    original_name = "conv2d_68.w_0"
     shape = [48, 48, 1, 1]
     dtype = "float32"
     min_val = float("-1.32546")
@@ -502,6 +552,7 @@ class Program_weight_tensor_parameter_49:
 
 class Program_weight_tensor_parameter_50:
     name = "parameter_50"
+    original_name = "batch_norm2d_36.b_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -511,6 +562,7 @@ class Program_weight_tensor_parameter_50:
 
 class Program_weight_tensor_parameter_51:
     name = "parameter_51"
+    original_name = "batch_norm2d_36.w_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -520,6 +572,7 @@ class Program_weight_tensor_parameter_51:
 
 class Program_weight_tensor_parameter_52:
     name = "parameter_52"
+    original_name = "batch_norm2d_36.w_2"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -529,6 +582,7 @@ class Program_weight_tensor_parameter_52:
 
 class Program_weight_tensor_parameter_53:
     name = "parameter_53"
+    original_name = "batch_norm2d_36.w_1"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -538,6 +592,7 @@ class Program_weight_tensor_parameter_53:
 
 class Program_weight_tensor_parameter_54:
     name = "parameter_54"
+    original_name = "conv2d_67.w_0"
     shape = [48, 1, 5, 5]
     dtype = "float32"
     min_val = float("-1.1691")
@@ -549,6 +604,7 @@ class Program_weight_tensor_parameter_54:
 
 class Program_weight_tensor_parameter_55:
     name = "parameter_55"
+    original_name = "batch_norm2d_35.b_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -558,6 +614,7 @@ class Program_weight_tensor_parameter_55:
 
 class Program_weight_tensor_parameter_56:
     name = "parameter_56"
+    original_name = "batch_norm2d_35.w_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -567,6 +624,7 @@ class Program_weight_tensor_parameter_56:
 
 class Program_weight_tensor_parameter_57:
     name = "parameter_57"
+    original_name = "batch_norm2d_35.w_2"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -576,6 +634,7 @@ class Program_weight_tensor_parameter_57:
 
 class Program_weight_tensor_parameter_58:
     name = "parameter_58"
+    original_name = "batch_norm2d_35.w_1"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -585,6 +644,7 @@ class Program_weight_tensor_parameter_58:
 
 class Program_weight_tensor_parameter_59:
     name = "parameter_59"
+    original_name = "conv2d_66.w_0"
     shape = [48, 48, 1, 1]
     dtype = "float32"
     min_val = float("-1.0265")
@@ -596,6 +656,7 @@ class Program_weight_tensor_parameter_59:
 
 class Program_weight_tensor_parameter_60:
     name = "parameter_60"
+    original_name = "batch_norm2d_32.b_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -605,6 +666,7 @@ class Program_weight_tensor_parameter_60:
 
 class Program_weight_tensor_parameter_61:
     name = "parameter_61"
+    original_name = "batch_norm2d_32.w_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -614,6 +676,7 @@ class Program_weight_tensor_parameter_61:
 
 class Program_weight_tensor_parameter_62:
     name = "parameter_62"
+    original_name = "batch_norm2d_32.w_2"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -623,6 +686,7 @@ class Program_weight_tensor_parameter_62:
 
 class Program_weight_tensor_parameter_63:
     name = "parameter_63"
+    original_name = "batch_norm2d_32.w_1"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -632,6 +696,7 @@ class Program_weight_tensor_parameter_63:
 
 class Program_weight_tensor_parameter_64:
     name = "parameter_64"
+    original_name = "conv2d_63.w_0"
     shape = [48, 192, 1, 1]
     dtype = "float32"
     min_val = float("-0.960827")
@@ -643,6 +708,7 @@ class Program_weight_tensor_parameter_64:
 
 class Program_weight_tensor_parameter_65:
     name = "parameter_65"
+    original_name = "batch_norm2d_33.b_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -652,6 +718,7 @@ class Program_weight_tensor_parameter_65:
 
 class Program_weight_tensor_parameter_66:
     name = "parameter_66"
+    original_name = "batch_norm2d_33.w_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -661,6 +728,7 @@ class Program_weight_tensor_parameter_66:
 
 class Program_weight_tensor_parameter_67:
     name = "parameter_67"
+    original_name = "batch_norm2d_33.w_2"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -670,6 +738,7 @@ class Program_weight_tensor_parameter_67:
 
 class Program_weight_tensor_parameter_68:
     name = "parameter_68"
+    original_name = "batch_norm2d_33.w_1"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -679,6 +748,7 @@ class Program_weight_tensor_parameter_68:
 
 class Program_weight_tensor_parameter_69:
     name = "parameter_69"
+    original_name = "conv2d_64.w_0"
     shape = [48, 192, 1, 1]
     dtype = "float32"
     min_val = float("-1.08864")
@@ -690,6 +760,7 @@ class Program_weight_tensor_parameter_69:
 
 class Program_weight_tensor_parameter_70:
     name = "parameter_70"
+    original_name = "batch_norm2d_31.b_0"
     shape = [96]
     dtype = "float32"
     min_val = float("-0.558187")
@@ -701,6 +772,7 @@ class Program_weight_tensor_parameter_70:
 
 class Program_weight_tensor_parameter_71:
     name = "parameter_71"
+    original_name = "batch_norm2d_31.w_0"
     shape = [96]
     dtype = "float32"
     min_val = float("0.778347")
@@ -712,6 +784,7 @@ class Program_weight_tensor_parameter_71:
 
 class Program_weight_tensor_parameter_72:
     name = "parameter_72"
+    original_name = "batch_norm2d_31.w_2"
     shape = [96]
     dtype = "float32"
     min_val = float("2.30858")
@@ -723,6 +796,7 @@ class Program_weight_tensor_parameter_72:
 
 class Program_weight_tensor_parameter_73:
     name = "parameter_73"
+    original_name = "batch_norm2d_31.w_1"
     shape = [96]
     dtype = "float32"
     min_val = float("-1.75973")
@@ -734,6 +808,7 @@ class Program_weight_tensor_parameter_73:
 
 class Program_weight_tensor_parameter_74:
     name = "parameter_74"
+    original_name = "conv2d_62.w_0"
     shape = [96, 96, 1, 1]
     dtype = "float32"
     min_val = float("-1.03494")
@@ -745,6 +820,7 @@ class Program_weight_tensor_parameter_74:
 
 class Program_weight_tensor_parameter_75:
     name = "parameter_75"
+    original_name = "batch_norm2d_30.b_0"
     shape = [96]
     dtype = "float32"
     min_val = float("-0.519722")
@@ -756,6 +832,7 @@ class Program_weight_tensor_parameter_75:
 
 class Program_weight_tensor_parameter_76:
     name = "parameter_76"
+    original_name = "batch_norm2d_30.w_0"
     shape = [96]
     dtype = "float32"
     min_val = float("0.552081")
@@ -767,6 +844,7 @@ class Program_weight_tensor_parameter_76:
 
 class Program_weight_tensor_parameter_77:
     name = "parameter_77"
+    original_name = "batch_norm2d_30.w_2"
     shape = [96]
     dtype = "float32"
     min_val = float("0.187755")
@@ -778,6 +856,7 @@ class Program_weight_tensor_parameter_77:
 
 class Program_weight_tensor_parameter_78:
     name = "parameter_78"
+    original_name = "batch_norm2d_30.w_1"
     shape = [96]
     dtype = "float32"
     min_val = float("-2.48098")
@@ -789,6 +868,7 @@ class Program_weight_tensor_parameter_78:
 
 class Program_weight_tensor_parameter_79:
     name = "parameter_79"
+    original_name = "conv2d_61.w_0"
     shape = [96, 1, 5, 5]
     dtype = "float32"
     min_val = float("-1.07229")
@@ -800,6 +880,7 @@ class Program_weight_tensor_parameter_79:
 
 class Program_weight_tensor_parameter_80:
     name = "parameter_80"
+    original_name = "batch_norm2d_26.b_0"
     shape = [96]
     dtype = "float32"
     min_val = float("-0.567286")
@@ -811,6 +892,7 @@ class Program_weight_tensor_parameter_80:
 
 class Program_weight_tensor_parameter_81:
     name = "parameter_81"
+    original_name = "batch_norm2d_26.w_0"
     shape = [96]
     dtype = "float32"
     min_val = float("0.466077")
@@ -822,6 +904,7 @@ class Program_weight_tensor_parameter_81:
 
 class Program_weight_tensor_parameter_82:
     name = "parameter_82"
+    original_name = "batch_norm2d_26.w_2"
     shape = [96]
     dtype = "float32"
     min_val = float("2.01437")
@@ -833,6 +916,7 @@ class Program_weight_tensor_parameter_82:
 
 class Program_weight_tensor_parameter_83:
     name = "parameter_83"
+    original_name = "batch_norm2d_26.w_1"
     shape = [96]
     dtype = "float32"
     min_val = float("-1.63445")
@@ -844,6 +928,7 @@ class Program_weight_tensor_parameter_83:
 
 class Program_weight_tensor_parameter_84:
     name = "parameter_84"
+    original_name = "conv2d_57.w_0"
     shape = [96, 96, 1, 1]
     dtype = "float32"
     min_val = float("-1.16383")
@@ -855,6 +940,7 @@ class Program_weight_tensor_parameter_84:
 
 class Program_weight_tensor_parameter_85:
     name = "parameter_85"
+    original_name = "batch_norm2d_29.b_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -864,6 +950,7 @@ class Program_weight_tensor_parameter_85:
 
 class Program_weight_tensor_parameter_86:
     name = "parameter_86"
+    original_name = "batch_norm2d_29.w_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -873,6 +960,7 @@ class Program_weight_tensor_parameter_86:
 
 class Program_weight_tensor_parameter_87:
     name = "parameter_87"
+    original_name = "batch_norm2d_29.w_2"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -882,6 +970,7 @@ class Program_weight_tensor_parameter_87:
 
 class Program_weight_tensor_parameter_88:
     name = "parameter_88"
+    original_name = "batch_norm2d_29.w_1"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -891,6 +980,7 @@ class Program_weight_tensor_parameter_88:
 
 class Program_weight_tensor_parameter_89:
     name = "parameter_89"
+    original_name = "conv2d_60.w_0"
     shape = [48, 48, 1, 1]
     dtype = "float32"
     min_val = float("-1.05803")
@@ -902,6 +992,7 @@ class Program_weight_tensor_parameter_89:
 
 class Program_weight_tensor_parameter_90:
     name = "parameter_90"
+    original_name = "batch_norm2d_28.b_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -911,6 +1002,7 @@ class Program_weight_tensor_parameter_90:
 
 class Program_weight_tensor_parameter_91:
     name = "parameter_91"
+    original_name = "batch_norm2d_28.w_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -920,6 +1012,7 @@ class Program_weight_tensor_parameter_91:
 
 class Program_weight_tensor_parameter_92:
     name = "parameter_92"
+    original_name = "batch_norm2d_28.w_2"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -929,6 +1022,7 @@ class Program_weight_tensor_parameter_92:
 
 class Program_weight_tensor_parameter_93:
     name = "parameter_93"
+    original_name = "batch_norm2d_28.w_1"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -938,6 +1032,7 @@ class Program_weight_tensor_parameter_93:
 
 class Program_weight_tensor_parameter_94:
     name = "parameter_94"
+    original_name = "conv2d_59.w_0"
     shape = [48, 1, 5, 5]
     dtype = "float32"
     min_val = float("-1.24165")
@@ -949,6 +1044,7 @@ class Program_weight_tensor_parameter_94:
 
 class Program_weight_tensor_parameter_95:
     name = "parameter_95"
+    original_name = "batch_norm2d_27.b_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -958,6 +1054,7 @@ class Program_weight_tensor_parameter_95:
 
 class Program_weight_tensor_parameter_96:
     name = "parameter_96"
+    original_name = "batch_norm2d_27.w_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -967,6 +1064,7 @@ class Program_weight_tensor_parameter_96:
 
 class Program_weight_tensor_parameter_97:
     name = "parameter_97"
+    original_name = "batch_norm2d_27.w_2"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -976,6 +1074,7 @@ class Program_weight_tensor_parameter_97:
 
 class Program_weight_tensor_parameter_98:
     name = "parameter_98"
+    original_name = "batch_norm2d_27.w_1"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -985,6 +1084,7 @@ class Program_weight_tensor_parameter_98:
 
 class Program_weight_tensor_parameter_99:
     name = "parameter_99"
+    original_name = "conv2d_58.w_0"
     shape = [48, 48, 1, 1]
     dtype = "float32"
     min_val = float("-1.20297")
@@ -996,6 +1096,7 @@ class Program_weight_tensor_parameter_99:
 
 class Program_weight_tensor_parameter_100:
     name = "parameter_100"
+    original_name = "batch_norm2d_24.b_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1005,6 +1106,7 @@ class Program_weight_tensor_parameter_100:
 
 class Program_weight_tensor_parameter_101:
     name = "parameter_101"
+    original_name = "batch_norm2d_24.w_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1014,6 +1116,7 @@ class Program_weight_tensor_parameter_101:
 
 class Program_weight_tensor_parameter_102:
     name = "parameter_102"
+    original_name = "batch_norm2d_24.w_2"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1023,6 +1126,7 @@ class Program_weight_tensor_parameter_102:
 
 class Program_weight_tensor_parameter_103:
     name = "parameter_103"
+    original_name = "batch_norm2d_24.w_1"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1032,6 +1136,7 @@ class Program_weight_tensor_parameter_103:
 
 class Program_weight_tensor_parameter_104:
     name = "parameter_104"
+    original_name = "conv2d_55.w_0"
     shape = [48, 192, 1, 1]
     dtype = "float32"
     min_val = float("-1.04492")
@@ -1043,6 +1148,7 @@ class Program_weight_tensor_parameter_104:
 
 class Program_weight_tensor_parameter_105:
     name = "parameter_105"
+    original_name = "batch_norm2d_25.b_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1052,6 +1158,7 @@ class Program_weight_tensor_parameter_105:
 
 class Program_weight_tensor_parameter_106:
     name = "parameter_106"
+    original_name = "batch_norm2d_25.w_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1061,6 +1168,7 @@ class Program_weight_tensor_parameter_106:
 
 class Program_weight_tensor_parameter_107:
     name = "parameter_107"
+    original_name = "batch_norm2d_25.w_2"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1070,6 +1178,7 @@ class Program_weight_tensor_parameter_107:
 
 class Program_weight_tensor_parameter_108:
     name = "parameter_108"
+    original_name = "batch_norm2d_25.w_1"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1079,6 +1188,7 @@ class Program_weight_tensor_parameter_108:
 
 class Program_weight_tensor_parameter_109:
     name = "parameter_109"
+    original_name = "conv2d_56.w_0"
     shape = [48, 192, 1, 1]
     dtype = "float32"
     min_val = float("-0.959834")
@@ -1090,6 +1200,7 @@ class Program_weight_tensor_parameter_109:
 
 class Program_weight_tensor_parameter_110:
     name = "parameter_110"
+    original_name = "batch_norm2d_23.b_0"
     shape = [96]
     dtype = "float32"
     min_val = float("-0.471762")
@@ -1101,6 +1212,7 @@ class Program_weight_tensor_parameter_110:
 
 class Program_weight_tensor_parameter_111:
     name = "parameter_111"
+    original_name = "batch_norm2d_23.w_0"
     shape = [96]
     dtype = "float32"
     min_val = float("0.603814")
@@ -1112,6 +1224,7 @@ class Program_weight_tensor_parameter_111:
 
 class Program_weight_tensor_parameter_112:
     name = "parameter_112"
+    original_name = "batch_norm2d_23.w_2"
     shape = [96]
     dtype = "float32"
     min_val = float("2.80003")
@@ -1123,6 +1236,7 @@ class Program_weight_tensor_parameter_112:
 
 class Program_weight_tensor_parameter_113:
     name = "parameter_113"
+    original_name = "batch_norm2d_23.w_1"
     shape = [96]
     dtype = "float32"
     min_val = float("-2.68788")
@@ -1134,6 +1248,7 @@ class Program_weight_tensor_parameter_113:
 
 class Program_weight_tensor_parameter_114:
     name = "parameter_114"
+    original_name = "conv2d_54.w_0"
     shape = [96, 96, 1, 1]
     dtype = "float32"
     min_val = float("-1.119")
@@ -1145,6 +1260,7 @@ class Program_weight_tensor_parameter_114:
 
 class Program_weight_tensor_parameter_115:
     name = "parameter_115"
+    original_name = "batch_norm2d_22.b_0"
     shape = [96]
     dtype = "float32"
     min_val = float("-0.543295")
@@ -1156,6 +1272,7 @@ class Program_weight_tensor_parameter_115:
 
 class Program_weight_tensor_parameter_116:
     name = "parameter_116"
+    original_name = "batch_norm2d_22.w_0"
     shape = [96]
     dtype = "float32"
     min_val = float("0.618166")
@@ -1167,6 +1284,7 @@ class Program_weight_tensor_parameter_116:
 
 class Program_weight_tensor_parameter_117:
     name = "parameter_117"
+    original_name = "batch_norm2d_22.w_2"
     shape = [96]
     dtype = "float32"
     min_val = float("0.291178")
@@ -1178,6 +1296,7 @@ class Program_weight_tensor_parameter_117:
 
 class Program_weight_tensor_parameter_118:
     name = "parameter_118"
+    original_name = "batch_norm2d_22.w_1"
     shape = [96]
     dtype = "float32"
     min_val = float("-1.2388")
@@ -1189,6 +1308,7 @@ class Program_weight_tensor_parameter_118:
 
 class Program_weight_tensor_parameter_119:
     name = "parameter_119"
+    original_name = "conv2d_53.w_0"
     shape = [96, 1, 5, 5]
     dtype = "float32"
     min_val = float("-1.12981")
@@ -1200,6 +1320,7 @@ class Program_weight_tensor_parameter_119:
 
 class Program_weight_tensor_parameter_120:
     name = "parameter_120"
+    original_name = "batch_norm2d_18.b_0"
     shape = [96]
     dtype = "float32"
     min_val = float("-0.560678")
@@ -1211,6 +1332,7 @@ class Program_weight_tensor_parameter_120:
 
 class Program_weight_tensor_parameter_121:
     name = "parameter_121"
+    original_name = "batch_norm2d_18.w_0"
     shape = [96]
     dtype = "float32"
     min_val = float("0.661022")
@@ -1222,6 +1344,7 @@ class Program_weight_tensor_parameter_121:
 
 class Program_weight_tensor_parameter_122:
     name = "parameter_122"
+    original_name = "batch_norm2d_18.w_2"
     shape = [96]
     dtype = "float32"
     min_val = float("2.87781")
@@ -1233,6 +1356,7 @@ class Program_weight_tensor_parameter_122:
 
 class Program_weight_tensor_parameter_123:
     name = "parameter_123"
+    original_name = "batch_norm2d_18.w_1"
     shape = [96]
     dtype = "float32"
     min_val = float("-1.62306")
@@ -1244,6 +1368,7 @@ class Program_weight_tensor_parameter_123:
 
 class Program_weight_tensor_parameter_124:
     name = "parameter_124"
+    original_name = "conv2d_49.w_0"
     shape = [96, 96, 1, 1]
     dtype = "float32"
     min_val = float("-1.20651")
@@ -1255,6 +1380,7 @@ class Program_weight_tensor_parameter_124:
 
 class Program_weight_tensor_parameter_125:
     name = "parameter_125"
+    original_name = "batch_norm2d_21.b_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1264,6 +1390,7 @@ class Program_weight_tensor_parameter_125:
 
 class Program_weight_tensor_parameter_126:
     name = "parameter_126"
+    original_name = "batch_norm2d_21.w_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1273,6 +1400,7 @@ class Program_weight_tensor_parameter_126:
 
 class Program_weight_tensor_parameter_127:
     name = "parameter_127"
+    original_name = "batch_norm2d_21.w_2"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1282,6 +1410,7 @@ class Program_weight_tensor_parameter_127:
 
 class Program_weight_tensor_parameter_128:
     name = "parameter_128"
+    original_name = "batch_norm2d_21.w_1"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1291,6 +1420,7 @@ class Program_weight_tensor_parameter_128:
 
 class Program_weight_tensor_parameter_129:
     name = "parameter_129"
+    original_name = "conv2d_52.w_0"
     shape = [48, 48, 1, 1]
     dtype = "float32"
     min_val = float("-1.26117")
@@ -1302,6 +1432,7 @@ class Program_weight_tensor_parameter_129:
 
 class Program_weight_tensor_parameter_130:
     name = "parameter_130"
+    original_name = "batch_norm2d_20.b_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1311,6 +1442,7 @@ class Program_weight_tensor_parameter_130:
 
 class Program_weight_tensor_parameter_131:
     name = "parameter_131"
+    original_name = "batch_norm2d_20.w_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1320,6 +1452,7 @@ class Program_weight_tensor_parameter_131:
 
 class Program_weight_tensor_parameter_132:
     name = "parameter_132"
+    original_name = "batch_norm2d_20.w_2"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1329,6 +1462,7 @@ class Program_weight_tensor_parameter_132:
 
 class Program_weight_tensor_parameter_133:
     name = "parameter_133"
+    original_name = "batch_norm2d_20.w_1"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1338,6 +1472,7 @@ class Program_weight_tensor_parameter_133:
 
 class Program_weight_tensor_parameter_134:
     name = "parameter_134"
+    original_name = "conv2d_51.w_0"
     shape = [48, 1, 5, 5]
     dtype = "float32"
     min_val = float("-1.10175")
@@ -1349,6 +1484,7 @@ class Program_weight_tensor_parameter_134:
 
 class Program_weight_tensor_parameter_135:
     name = "parameter_135"
+    original_name = "batch_norm2d_19.b_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1358,6 +1494,7 @@ class Program_weight_tensor_parameter_135:
 
 class Program_weight_tensor_parameter_136:
     name = "parameter_136"
+    original_name = "batch_norm2d_19.w_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1367,6 +1504,7 @@ class Program_weight_tensor_parameter_136:
 
 class Program_weight_tensor_parameter_137:
     name = "parameter_137"
+    original_name = "batch_norm2d_19.w_2"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1376,6 +1514,7 @@ class Program_weight_tensor_parameter_137:
 
 class Program_weight_tensor_parameter_138:
     name = "parameter_138"
+    original_name = "batch_norm2d_19.w_1"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1385,6 +1524,7 @@ class Program_weight_tensor_parameter_138:
 
 class Program_weight_tensor_parameter_139:
     name = "parameter_139"
+    original_name = "conv2d_50.w_0"
     shape = [48, 48, 1, 1]
     dtype = "float32"
     min_val = float("-1.39181")
@@ -1396,6 +1536,7 @@ class Program_weight_tensor_parameter_139:
 
 class Program_weight_tensor_parameter_140:
     name = "parameter_140"
+    original_name = "batch_norm2d_16.b_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1405,6 +1546,7 @@ class Program_weight_tensor_parameter_140:
 
 class Program_weight_tensor_parameter_141:
     name = "parameter_141"
+    original_name = "batch_norm2d_16.w_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1414,6 +1556,7 @@ class Program_weight_tensor_parameter_141:
 
 class Program_weight_tensor_parameter_142:
     name = "parameter_142"
+    original_name = "batch_norm2d_16.w_2"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1423,6 +1566,7 @@ class Program_weight_tensor_parameter_142:
 
 class Program_weight_tensor_parameter_143:
     name = "parameter_143"
+    original_name = "batch_norm2d_16.w_1"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1432,6 +1576,7 @@ class Program_weight_tensor_parameter_143:
 
 class Program_weight_tensor_parameter_144:
     name = "parameter_144"
+    original_name = "conv2d_47.w_0"
     shape = [48, 192, 1, 1]
     dtype = "float32"
     min_val = float("-1.03054")
@@ -1443,6 +1588,7 @@ class Program_weight_tensor_parameter_144:
 
 class Program_weight_tensor_parameter_145:
     name = "parameter_145"
+    original_name = "batch_norm2d_17.b_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1452,6 +1598,7 @@ class Program_weight_tensor_parameter_145:
 
 class Program_weight_tensor_parameter_146:
     name = "parameter_146"
+    original_name = "batch_norm2d_17.w_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1461,6 +1608,7 @@ class Program_weight_tensor_parameter_146:
 
 class Program_weight_tensor_parameter_147:
     name = "parameter_147"
+    original_name = "batch_norm2d_17.w_2"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1470,6 +1618,7 @@ class Program_weight_tensor_parameter_147:
 
 class Program_weight_tensor_parameter_148:
     name = "parameter_148"
+    original_name = "batch_norm2d_17.w_1"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1479,6 +1628,7 @@ class Program_weight_tensor_parameter_148:
 
 class Program_weight_tensor_parameter_149:
     name = "parameter_149"
+    original_name = "conv2d_48.w_0"
     shape = [48, 192, 1, 1]
     dtype = "float32"
     min_val = float("-1.0192")
@@ -1490,6 +1640,7 @@ class Program_weight_tensor_parameter_149:
 
 class Program_weight_tensor_parameter_150:
     name = "parameter_150"
+    original_name = "batch_norm2d_12.b_0"
     shape = [96]
     dtype = "float32"
     min_val = float("-0.551726")
@@ -1501,6 +1652,7 @@ class Program_weight_tensor_parameter_150:
 
 class Program_weight_tensor_parameter_151:
     name = "parameter_151"
+    original_name = "batch_norm2d_12.w_0"
     shape = [96]
     dtype = "float32"
     min_val = float("0.664316")
@@ -1512,6 +1664,7 @@ class Program_weight_tensor_parameter_151:
 
 class Program_weight_tensor_parameter_152:
     name = "parameter_152"
+    original_name = "batch_norm2d_12.w_2"
     shape = [96]
     dtype = "float32"
     min_val = float("2.97301")
@@ -1523,6 +1676,7 @@ class Program_weight_tensor_parameter_152:
 
 class Program_weight_tensor_parameter_153:
     name = "parameter_153"
+    original_name = "batch_norm2d_12.w_1"
     shape = [96]
     dtype = "float32"
     min_val = float("-1.85289")
@@ -1534,6 +1688,7 @@ class Program_weight_tensor_parameter_153:
 
 class Program_weight_tensor_parameter_154:
     name = "parameter_154"
+    original_name = "conv2d_43.w_0"
     shape = [96, 96, 1, 1]
     dtype = "float32"
     min_val = float("-1.50373")
@@ -1545,6 +1700,7 @@ class Program_weight_tensor_parameter_154:
 
 class Program_weight_tensor_parameter_155:
     name = "parameter_155"
+    original_name = "batch_norm2d_15.b_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1554,6 +1710,7 @@ class Program_weight_tensor_parameter_155:
 
 class Program_weight_tensor_parameter_156:
     name = "parameter_156"
+    original_name = "batch_norm2d_15.w_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1563,6 +1720,7 @@ class Program_weight_tensor_parameter_156:
 
 class Program_weight_tensor_parameter_157:
     name = "parameter_157"
+    original_name = "batch_norm2d_15.w_2"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1572,6 +1730,7 @@ class Program_weight_tensor_parameter_157:
 
 class Program_weight_tensor_parameter_158:
     name = "parameter_158"
+    original_name = "batch_norm2d_15.w_1"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1581,6 +1740,7 @@ class Program_weight_tensor_parameter_158:
 
 class Program_weight_tensor_parameter_159:
     name = "parameter_159"
+    original_name = "conv2d_46.w_0"
     shape = [48, 48, 1, 1]
     dtype = "float32"
     min_val = float("-0.939612")
@@ -1592,6 +1752,7 @@ class Program_weight_tensor_parameter_159:
 
 class Program_weight_tensor_parameter_160:
     name = "parameter_160"
+    original_name = "batch_norm2d_14.b_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1601,6 +1762,7 @@ class Program_weight_tensor_parameter_160:
 
 class Program_weight_tensor_parameter_161:
     name = "parameter_161"
+    original_name = "batch_norm2d_14.w_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1610,6 +1772,7 @@ class Program_weight_tensor_parameter_161:
 
 class Program_weight_tensor_parameter_162:
     name = "parameter_162"
+    original_name = "batch_norm2d_14.w_2"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1619,6 +1782,7 @@ class Program_weight_tensor_parameter_162:
 
 class Program_weight_tensor_parameter_163:
     name = "parameter_163"
+    original_name = "batch_norm2d_14.w_1"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1628,6 +1792,7 @@ class Program_weight_tensor_parameter_163:
 
 class Program_weight_tensor_parameter_164:
     name = "parameter_164"
+    original_name = "conv2d_45.w_0"
     shape = [48, 1, 5, 5]
     dtype = "float32"
     min_val = float("-1.10802")
@@ -1639,6 +1804,7 @@ class Program_weight_tensor_parameter_164:
 
 class Program_weight_tensor_parameter_165:
     name = "parameter_165"
+    original_name = "batch_norm2d_13.b_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1648,6 +1814,7 @@ class Program_weight_tensor_parameter_165:
 
 class Program_weight_tensor_parameter_166:
     name = "parameter_166"
+    original_name = "batch_norm2d_13.w_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1657,6 +1824,7 @@ class Program_weight_tensor_parameter_166:
 
 class Program_weight_tensor_parameter_167:
     name = "parameter_167"
+    original_name = "batch_norm2d_13.w_2"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1666,6 +1834,7 @@ class Program_weight_tensor_parameter_167:
 
 class Program_weight_tensor_parameter_168:
     name = "parameter_168"
+    original_name = "batch_norm2d_13.w_1"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1675,6 +1844,7 @@ class Program_weight_tensor_parameter_168:
 
 class Program_weight_tensor_parameter_169:
     name = "parameter_169"
+    original_name = "conv2d_44.w_0"
     shape = [48, 48, 1, 1]
     dtype = "float32"
     min_val = float("-1.00147")
@@ -1686,6 +1856,7 @@ class Program_weight_tensor_parameter_169:
 
 class Program_weight_tensor_parameter_170:
     name = "parameter_170"
+    original_name = "batch_norm2d_10.b_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1695,6 +1866,7 @@ class Program_weight_tensor_parameter_170:
 
 class Program_weight_tensor_parameter_171:
     name = "parameter_171"
+    original_name = "batch_norm2d_10.w_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1704,6 +1876,7 @@ class Program_weight_tensor_parameter_171:
 
 class Program_weight_tensor_parameter_172:
     name = "parameter_172"
+    original_name = "batch_norm2d_10.w_2"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1713,6 +1886,7 @@ class Program_weight_tensor_parameter_172:
 
 class Program_weight_tensor_parameter_173:
     name = "parameter_173"
+    original_name = "batch_norm2d_10.w_1"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1722,6 +1896,7 @@ class Program_weight_tensor_parameter_173:
 
 class Program_weight_tensor_parameter_174:
     name = "parameter_174"
+    original_name = "conv2d_41.w_0"
     shape = [48, 192, 1, 1]
     dtype = "float32"
     min_val = float("-1.12391")
@@ -1733,6 +1908,7 @@ class Program_weight_tensor_parameter_174:
 
 class Program_weight_tensor_parameter_175:
     name = "parameter_175"
+    original_name = "batch_norm2d_11.b_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1742,6 +1918,7 @@ class Program_weight_tensor_parameter_175:
 
 class Program_weight_tensor_parameter_176:
     name = "parameter_176"
+    original_name = "batch_norm2d_11.w_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1751,6 +1928,7 @@ class Program_weight_tensor_parameter_176:
 
 class Program_weight_tensor_parameter_177:
     name = "parameter_177"
+    original_name = "batch_norm2d_11.w_2"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1760,6 +1938,7 @@ class Program_weight_tensor_parameter_177:
 
 class Program_weight_tensor_parameter_178:
     name = "parameter_178"
+    original_name = "batch_norm2d_11.w_1"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1769,6 +1948,7 @@ class Program_weight_tensor_parameter_178:
 
 class Program_weight_tensor_parameter_179:
     name = "parameter_179"
+    original_name = "conv2d_42.w_0"
     shape = [48, 192, 1, 1]
     dtype = "float32"
     min_val = float("-1.2298")
@@ -1780,6 +1960,7 @@ class Program_weight_tensor_parameter_179:
 
 class Program_weight_tensor_parameter_180:
     name = "parameter_180"
+    original_name = "batch_norm2d_6.b_0"
     shape = [96]
     dtype = "float32"
     min_val = float("-0.482343")
@@ -1791,6 +1972,7 @@ class Program_weight_tensor_parameter_180:
 
 class Program_weight_tensor_parameter_181:
     name = "parameter_181"
+    original_name = "batch_norm2d_6.w_0"
     shape = [96]
     dtype = "float32"
     min_val = float("0.670714")
@@ -1802,6 +1984,7 @@ class Program_weight_tensor_parameter_181:
 
 class Program_weight_tensor_parameter_182:
     name = "parameter_182"
+    original_name = "batch_norm2d_6.w_2"
     shape = [96]
     dtype = "float32"
     min_val = float("2.57973")
@@ -1813,6 +1996,7 @@ class Program_weight_tensor_parameter_182:
 
 class Program_weight_tensor_parameter_183:
     name = "parameter_183"
+    original_name = "batch_norm2d_6.w_1"
     shape = [96]
     dtype = "float32"
     min_val = float("-2.01387")
@@ -1824,6 +2008,7 @@ class Program_weight_tensor_parameter_183:
 
 class Program_weight_tensor_parameter_184:
     name = "parameter_184"
+    original_name = "conv2d_37.w_0"
     shape = [96, 96, 1, 1]
     dtype = "float32"
     min_val = float("-0.991255")
@@ -1835,6 +2020,7 @@ class Program_weight_tensor_parameter_184:
 
 class Program_weight_tensor_parameter_185:
     name = "parameter_185"
+    original_name = "batch_norm2d_9.b_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1844,6 +2030,7 @@ class Program_weight_tensor_parameter_185:
 
 class Program_weight_tensor_parameter_186:
     name = "parameter_186"
+    original_name = "batch_norm2d_9.w_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1853,6 +2040,7 @@ class Program_weight_tensor_parameter_186:
 
 class Program_weight_tensor_parameter_187:
     name = "parameter_187"
+    original_name = "batch_norm2d_9.w_2"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1862,6 +2050,7 @@ class Program_weight_tensor_parameter_187:
 
 class Program_weight_tensor_parameter_188:
     name = "parameter_188"
+    original_name = "batch_norm2d_9.w_1"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1871,6 +2060,7 @@ class Program_weight_tensor_parameter_188:
 
 class Program_weight_tensor_parameter_189:
     name = "parameter_189"
+    original_name = "conv2d_40.w_0"
     shape = [48, 48, 1, 1]
     dtype = "float32"
     min_val = float("-1.11426")
@@ -1882,6 +2072,7 @@ class Program_weight_tensor_parameter_189:
 
 class Program_weight_tensor_parameter_190:
     name = "parameter_190"
+    original_name = "batch_norm2d_8.b_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1891,6 +2082,7 @@ class Program_weight_tensor_parameter_190:
 
 class Program_weight_tensor_parameter_191:
     name = "parameter_191"
+    original_name = "batch_norm2d_8.w_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1900,6 +2092,7 @@ class Program_weight_tensor_parameter_191:
 
 class Program_weight_tensor_parameter_192:
     name = "parameter_192"
+    original_name = "batch_norm2d_8.w_2"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1909,6 +2102,7 @@ class Program_weight_tensor_parameter_192:
 
 class Program_weight_tensor_parameter_193:
     name = "parameter_193"
+    original_name = "batch_norm2d_8.w_1"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1918,6 +2112,7 @@ class Program_weight_tensor_parameter_193:
 
 class Program_weight_tensor_parameter_194:
     name = "parameter_194"
+    original_name = "conv2d_39.w_0"
     shape = [48, 1, 5, 5]
     dtype = "float32"
     min_val = float("-1.01961")
@@ -1929,6 +2124,7 @@ class Program_weight_tensor_parameter_194:
 
 class Program_weight_tensor_parameter_195:
     name = "parameter_195"
+    original_name = "batch_norm2d_7.b_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1938,6 +2134,7 @@ class Program_weight_tensor_parameter_195:
 
 class Program_weight_tensor_parameter_196:
     name = "parameter_196"
+    original_name = "batch_norm2d_7.w_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1947,6 +2144,7 @@ class Program_weight_tensor_parameter_196:
 
 class Program_weight_tensor_parameter_197:
     name = "parameter_197"
+    original_name = "batch_norm2d_7.w_2"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1956,6 +2154,7 @@ class Program_weight_tensor_parameter_197:
 
 class Program_weight_tensor_parameter_198:
     name = "parameter_198"
+    original_name = "batch_norm2d_7.w_1"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1965,6 +2164,7 @@ class Program_weight_tensor_parameter_198:
 
 class Program_weight_tensor_parameter_199:
     name = "parameter_199"
+    original_name = "conv2d_38.w_0"
     shape = [48, 48, 1, 1]
     dtype = "float32"
     min_val = float("-0.983634")
@@ -1976,6 +2176,7 @@ class Program_weight_tensor_parameter_199:
 
 class Program_weight_tensor_parameter_200:
     name = "parameter_200"
+    original_name = "batch_norm2d_4.b_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1985,6 +2186,7 @@ class Program_weight_tensor_parameter_200:
 
 class Program_weight_tensor_parameter_201:
     name = "parameter_201"
+    original_name = "batch_norm2d_4.w_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1994,6 +2196,7 @@ class Program_weight_tensor_parameter_201:
 
 class Program_weight_tensor_parameter_202:
     name = "parameter_202"
+    original_name = "batch_norm2d_4.w_2"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -2003,6 +2206,7 @@ class Program_weight_tensor_parameter_202:
 
 class Program_weight_tensor_parameter_203:
     name = "parameter_203"
+    original_name = "batch_norm2d_4.w_1"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -2012,6 +2216,7 @@ class Program_weight_tensor_parameter_203:
 
 class Program_weight_tensor_parameter_204:
     name = "parameter_204"
+    original_name = "conv2d_35.w_0"
     shape = [48, 192, 1, 1]
     dtype = "float32"
     min_val = float("-1.33669")
@@ -2023,6 +2228,7 @@ class Program_weight_tensor_parameter_204:
 
 class Program_weight_tensor_parameter_205:
     name = "parameter_205"
+    original_name = "batch_norm2d_5.b_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -2032,6 +2238,7 @@ class Program_weight_tensor_parameter_205:
 
 class Program_weight_tensor_parameter_206:
     name = "parameter_206"
+    original_name = "batch_norm2d_5.w_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -2041,6 +2248,7 @@ class Program_weight_tensor_parameter_206:
 
 class Program_weight_tensor_parameter_207:
     name = "parameter_207"
+    original_name = "batch_norm2d_5.w_2"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -2050,6 +2258,7 @@ class Program_weight_tensor_parameter_207:
 
 class Program_weight_tensor_parameter_208:
     name = "parameter_208"
+    original_name = "batch_norm2d_5.w_1"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -2059,6 +2268,7 @@ class Program_weight_tensor_parameter_208:
 
 class Program_weight_tensor_parameter_209:
     name = "parameter_209"
+    original_name = "conv2d_36.w_0"
     shape = [48, 192, 1, 1]
     dtype = "float32"
     min_val = float("-1.38097")
@@ -2070,6 +2280,7 @@ class Program_weight_tensor_parameter_209:
 
 class Program_weight_tensor_parameter_210:
     name = "parameter_210"
+    original_name = "batch_norm2d_3.b_0"
     shape = [96]
     dtype = "float32"
     min_val = float("-0.237802")
@@ -2081,6 +2292,7 @@ class Program_weight_tensor_parameter_210:
 
 class Program_weight_tensor_parameter_211:
     name = "parameter_211"
+    original_name = "batch_norm2d_3.w_0"
     shape = [96]
     dtype = "float32"
     min_val = float("0.882038")
@@ -2092,6 +2304,7 @@ class Program_weight_tensor_parameter_211:
 
 class Program_weight_tensor_parameter_212:
     name = "parameter_212"
+    original_name = "batch_norm2d_3.w_2"
     shape = [96]
     dtype = "float32"
     min_val = float("62.3976")
@@ -2103,6 +2316,7 @@ class Program_weight_tensor_parameter_212:
 
 class Program_weight_tensor_parameter_213:
     name = "parameter_213"
+    original_name = "batch_norm2d_3.w_1"
     shape = [96]
     dtype = "float32"
     min_val = float("-13.5523")
@@ -2114,6 +2328,7 @@ class Program_weight_tensor_parameter_213:
 
 class Program_weight_tensor_parameter_214:
     name = "parameter_214"
+    original_name = "conv2d_34.w_0"
     shape = [96, 512, 1, 1]
     dtype = "float32"
     min_val = float("-2.09646")
@@ -2125,6 +2340,7 @@ class Program_weight_tensor_parameter_214:
 
 class Program_weight_tensor_parameter_215:
     name = "parameter_215"
+    original_name = "batch_norm2d_2.b_0"
     shape = [96]
     dtype = "float32"
     min_val = float("-0.587668")
@@ -2136,6 +2352,7 @@ class Program_weight_tensor_parameter_215:
 
 class Program_weight_tensor_parameter_216:
     name = "parameter_216"
+    original_name = "batch_norm2d_2.w_0"
     shape = [96]
     dtype = "float32"
     min_val = float("0.518918")
@@ -2147,6 +2364,7 @@ class Program_weight_tensor_parameter_216:
 
 class Program_weight_tensor_parameter_217:
     name = "parameter_217"
+    original_name = "batch_norm2d_2.w_2"
     shape = [96]
     dtype = "float32"
     min_val = float("1.99622")
@@ -2158,6 +2376,7 @@ class Program_weight_tensor_parameter_217:
 
 class Program_weight_tensor_parameter_218:
     name = "parameter_218"
+    original_name = "batch_norm2d_2.w_1"
     shape = [96]
     dtype = "float32"
     min_val = float("-2.45523")
@@ -2169,6 +2388,7 @@ class Program_weight_tensor_parameter_218:
 
 class Program_weight_tensor_parameter_219:
     name = "parameter_219"
+    original_name = "conv2d_33.w_0"
     shape = [96, 256, 1, 1]
     dtype = "float32"
     min_val = float("-1.24805")
@@ -2180,6 +2400,7 @@ class Program_weight_tensor_parameter_219:
 
 class Program_weight_tensor_parameter_220:
     name = "parameter_220"
+    original_name = "batch_norm2d_1.b_0"
     shape = [96]
     dtype = "float32"
     min_val = float("-0.65098")
@@ -2191,6 +2412,7 @@ class Program_weight_tensor_parameter_220:
 
 class Program_weight_tensor_parameter_221:
     name = "parameter_221"
+    original_name = "batch_norm2d_1.w_0"
     shape = [96]
     dtype = "float32"
     min_val = float("0.668796")
@@ -2202,6 +2424,7 @@ class Program_weight_tensor_parameter_221:
 
 class Program_weight_tensor_parameter_222:
     name = "parameter_222"
+    original_name = "batch_norm2d_1.w_2"
     shape = [96]
     dtype = "float32"
     min_val = float("1.02184")
@@ -2213,6 +2436,7 @@ class Program_weight_tensor_parameter_222:
 
 class Program_weight_tensor_parameter_223:
     name = "parameter_223"
+    original_name = "batch_norm2d_1.w_1"
     shape = [96]
     dtype = "float32"
     min_val = float("-1.73317")
@@ -2224,6 +2448,7 @@ class Program_weight_tensor_parameter_223:
 
 class Program_weight_tensor_parameter_224:
     name = "parameter_224"
+    original_name = "conv2d_32.w_0"
     shape = [96, 128, 1, 1]
     dtype = "float32"
     min_val = float("-1.41707")
@@ -2235,6 +2460,7 @@ class Program_weight_tensor_parameter_224:
 
 class Program_weight_tensor_parameter_225:
     name = "parameter_225"
+    original_name = "batch_norm2d_0.b_0"
     shape = [96]
     dtype = "float32"
     min_val = float("-0.628921")
@@ -2246,6 +2472,7 @@ class Program_weight_tensor_parameter_225:
 
 class Program_weight_tensor_parameter_226:
     name = "parameter_226"
+    original_name = "batch_norm2d_0.w_0"
     shape = [96]
     dtype = "float32"
     min_val = float("0.430088")
@@ -2257,6 +2484,7 @@ class Program_weight_tensor_parameter_226:
 
 class Program_weight_tensor_parameter_227:
     name = "parameter_227"
+    original_name = "batch_norm2d_0.w_2"
     shape = [96]
     dtype = "float32"
     min_val = float("0.484083")
@@ -2268,6 +2496,7 @@ class Program_weight_tensor_parameter_227:
 
 class Program_weight_tensor_parameter_228:
     name = "parameter_228"
+    original_name = "batch_norm2d_0.w_1"
     shape = [96]
     dtype = "float32"
     min_val = float("-3.19169")
@@ -2279,6 +2508,7 @@ class Program_weight_tensor_parameter_228:
 
 class Program_weight_tensor_parameter_229:
     name = "parameter_229"
+    original_name = "conv2d_31.w_0"
     shape = [96, 64, 1, 1]
     dtype = "float32"
     min_val = float("-1.13987")
@@ -2290,6 +2520,7 @@ class Program_weight_tensor_parameter_229:
 
 class Program_weight_tensor_parameter_230:
     name = "parameter_230"
+    original_name = "batch_norm_26.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-1.71557")
@@ -2301,6 +2532,7 @@ class Program_weight_tensor_parameter_230:
 
 class Program_weight_tensor_parameter_231:
     name = "parameter_231"
+    original_name = "batch_norm_26.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("1.58651")
@@ -2312,6 +2544,7 @@ class Program_weight_tensor_parameter_231:
 
 class Program_weight_tensor_parameter_232:
     name = "parameter_232"
+    original_name = "batch_norm_26.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("1.19276")
@@ -2323,6 +2556,7 @@ class Program_weight_tensor_parameter_232:
 
 class Program_weight_tensor_parameter_233:
     name = "parameter_233"
+    original_name = "batch_norm_26.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-1.21129")
@@ -2334,6 +2568,7 @@ class Program_weight_tensor_parameter_233:
 
 class Program_weight_tensor_parameter_234:
     name = "parameter_234"
+    original_name = "conv2d_30.w_0"
     shape = [512, 512, 1, 1]
     dtype = "float32"
     min_val = float("-3.54385")
@@ -2345,6 +2580,7 @@ class Program_weight_tensor_parameter_234:
 
 class Program_weight_tensor_parameter_235:
     name = "parameter_235"
+    original_name = "conv2d_29.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.57823")
@@ -2356,6 +2592,7 @@ class Program_weight_tensor_parameter_235:
 
 class Program_weight_tensor_parameter_236:
     name = "parameter_236"
+    original_name = "conv2d_29.w_0"
     shape = [512, 128, 1, 1]
     dtype = "float32"
     min_val = float("-1.77783")
@@ -2367,6 +2604,7 @@ class Program_weight_tensor_parameter_236:
 
 class Program_weight_tensor_parameter_237:
     name = "parameter_237"
+    original_name = "conv2d_28.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.320701")
@@ -2378,6 +2616,7 @@ class Program_weight_tensor_parameter_237:
 
 class Program_weight_tensor_parameter_238:
     name = "parameter_238"
+    original_name = "conv2d_28.w_0"
     shape = [128, 512, 1, 1]
     dtype = "float32"
     min_val = float("-2.31025")
@@ -2389,6 +2628,7 @@ class Program_weight_tensor_parameter_238:
 
 class Program_weight_tensor_parameter_239:
     name = "parameter_239"
+    original_name = "batch_norm_25.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-1.17827")
@@ -2400,6 +2640,7 @@ class Program_weight_tensor_parameter_239:
 
 class Program_weight_tensor_parameter_240:
     name = "parameter_240"
+    original_name = "batch_norm_25.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("0.275889")
@@ -2411,6 +2652,7 @@ class Program_weight_tensor_parameter_240:
 
 class Program_weight_tensor_parameter_241:
     name = "parameter_241"
+    original_name = "batch_norm_25.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("0.00226333")
@@ -2422,6 +2664,7 @@ class Program_weight_tensor_parameter_241:
 
 class Program_weight_tensor_parameter_242:
     name = "parameter_242"
+    original_name = "batch_norm_25.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-2.23921")
@@ -2433,6 +2676,7 @@ class Program_weight_tensor_parameter_242:
 
 class Program_weight_tensor_parameter_243:
     name = "parameter_243"
+    original_name = "conv2d_27.w_0"
     shape = [512, 1, 5, 5]
     dtype = "float32"
     min_val = float("-2.88061")
@@ -2444,6 +2688,7 @@ class Program_weight_tensor_parameter_243:
 
 class Program_weight_tensor_parameter_244:
     name = "parameter_244"
+    original_name = "batch_norm_24.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-1.73834")
@@ -2455,6 +2700,7 @@ class Program_weight_tensor_parameter_244:
 
 class Program_weight_tensor_parameter_245:
     name = "parameter_245"
+    original_name = "batch_norm_24.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-1.10718")
@@ -2466,6 +2712,7 @@ class Program_weight_tensor_parameter_245:
 
 class Program_weight_tensor_parameter_246:
     name = "parameter_246"
+    original_name = "batch_norm_24.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("1.11557")
@@ -2477,6 +2724,7 @@ class Program_weight_tensor_parameter_246:
 
 class Program_weight_tensor_parameter_247:
     name = "parameter_247"
+    original_name = "batch_norm_24.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-2.90242")
@@ -2488,6 +2736,7 @@ class Program_weight_tensor_parameter_247:
 
 class Program_weight_tensor_parameter_248:
     name = "parameter_248"
+    original_name = "conv2d_26.w_0"
     shape = [512, 256, 1, 1]
     dtype = "float32"
     min_val = float("-3.45796")
@@ -2499,6 +2748,7 @@ class Program_weight_tensor_parameter_248:
 
 class Program_weight_tensor_parameter_249:
     name = "parameter_249"
+    original_name = "conv2d_25.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.80427")
@@ -2510,6 +2760,7 @@ class Program_weight_tensor_parameter_249:
 
 class Program_weight_tensor_parameter_250:
     name = "parameter_250"
+    original_name = "conv2d_25.w_0"
     shape = [256, 64, 1, 1]
     dtype = "float32"
     min_val = float("-1.24379")
@@ -2521,6 +2772,7 @@ class Program_weight_tensor_parameter_250:
 
 class Program_weight_tensor_parameter_251:
     name = "parameter_251"
+    original_name = "conv2d_24.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -2530,6 +2782,7 @@ class Program_weight_tensor_parameter_251:
 
 class Program_weight_tensor_parameter_252:
     name = "parameter_252"
+    original_name = "conv2d_24.w_0"
     shape = [64, 256, 1, 1]
     dtype = "float32"
     min_val = float("-2.02268")
@@ -2541,6 +2794,7 @@ class Program_weight_tensor_parameter_252:
 
 class Program_weight_tensor_parameter_253:
     name = "parameter_253"
+    original_name = "batch_norm_23.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.790023")
@@ -2552,6 +2806,7 @@ class Program_weight_tensor_parameter_253:
 
 class Program_weight_tensor_parameter_254:
     name = "parameter_254"
+    original_name = "batch_norm_23.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.316892")
@@ -2563,6 +2818,7 @@ class Program_weight_tensor_parameter_254:
 
 class Program_weight_tensor_parameter_255:
     name = "parameter_255"
+    original_name = "batch_norm_23.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.0101875")
@@ -2574,6 +2830,7 @@ class Program_weight_tensor_parameter_255:
 
 class Program_weight_tensor_parameter_256:
     name = "parameter_256"
+    original_name = "batch_norm_23.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-2.88328")
@@ -2585,6 +2842,7 @@ class Program_weight_tensor_parameter_256:
 
 class Program_weight_tensor_parameter_257:
     name = "parameter_257"
+    original_name = "conv2d_23.w_0"
     shape = [256, 1, 5, 5]
     dtype = "float32"
     min_val = float("-1.77129")
@@ -2596,6 +2854,7 @@ class Program_weight_tensor_parameter_257:
 
 class Program_weight_tensor_parameter_258:
     name = "parameter_258"
+    original_name = "batch_norm_22.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.60557")
@@ -2607,6 +2866,7 @@ class Program_weight_tensor_parameter_258:
 
 class Program_weight_tensor_parameter_259:
     name = "parameter_259"
+    original_name = "batch_norm_22.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.291733")
@@ -2618,6 +2878,7 @@ class Program_weight_tensor_parameter_259:
 
 class Program_weight_tensor_parameter_260:
     name = "parameter_260"
+    original_name = "batch_norm_22.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("1.77819")
@@ -2629,6 +2890,7 @@ class Program_weight_tensor_parameter_260:
 
 class Program_weight_tensor_parameter_261:
     name = "parameter_261"
+    original_name = "batch_norm_22.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-5.22167")
@@ -2640,6 +2902,7 @@ class Program_weight_tensor_parameter_261:
 
 class Program_weight_tensor_parameter_262:
     name = "parameter_262"
+    original_name = "conv2d_22.w_0"
     shape = [256, 256, 1, 1]
     dtype = "float32"
     min_val = float("-3.89883")
@@ -2651,6 +2914,7 @@ class Program_weight_tensor_parameter_262:
 
 class Program_weight_tensor_parameter_263:
     name = "parameter_263"
+    original_name = "batch_norm_21.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.86908")
@@ -2662,6 +2926,7 @@ class Program_weight_tensor_parameter_263:
 
 class Program_weight_tensor_parameter_264:
     name = "parameter_264"
+    original_name = "batch_norm_21.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.244702")
@@ -2673,6 +2938,7 @@ class Program_weight_tensor_parameter_264:
 
 class Program_weight_tensor_parameter_265:
     name = "parameter_265"
+    original_name = "batch_norm_21.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.0060596")
@@ -2684,6 +2950,7 @@ class Program_weight_tensor_parameter_265:
 
 class Program_weight_tensor_parameter_266:
     name = "parameter_266"
+    original_name = "batch_norm_21.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.89884")
@@ -2695,6 +2962,7 @@ class Program_weight_tensor_parameter_266:
 
 class Program_weight_tensor_parameter_267:
     name = "parameter_267"
+    original_name = "conv2d_21.w_0"
     shape = [256, 1, 5, 5]
     dtype = "float32"
     min_val = float("-2.88969")
@@ -2706,6 +2974,7 @@ class Program_weight_tensor_parameter_267:
 
 class Program_weight_tensor_parameter_268:
     name = "parameter_268"
+    original_name = "batch_norm_20.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.63077")
@@ -2717,6 +2986,7 @@ class Program_weight_tensor_parameter_268:
 
 class Program_weight_tensor_parameter_269:
     name = "parameter_269"
+    original_name = "batch_norm_20.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.855135")
@@ -2728,6 +2998,7 @@ class Program_weight_tensor_parameter_269:
 
 class Program_weight_tensor_parameter_270:
     name = "parameter_270"
+    original_name = "batch_norm_20.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("1.82152")
@@ -2739,6 +3010,7 @@ class Program_weight_tensor_parameter_270:
 
 class Program_weight_tensor_parameter_271:
     name = "parameter_271"
+    original_name = "batch_norm_20.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-5.81962")
@@ -2750,6 +3022,7 @@ class Program_weight_tensor_parameter_271:
 
 class Program_weight_tensor_parameter_272:
     name = "parameter_272"
+    original_name = "conv2d_20.w_0"
     shape = [256, 256, 1, 1]
     dtype = "float32"
     min_val = float("-2.04992")
@@ -2761,6 +3034,7 @@ class Program_weight_tensor_parameter_272:
 
 class Program_weight_tensor_parameter_273:
     name = "parameter_273"
+    original_name = "batch_norm_19.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.87227")
@@ -2772,6 +3046,7 @@ class Program_weight_tensor_parameter_273:
 
 class Program_weight_tensor_parameter_274:
     name = "parameter_274"
+    original_name = "batch_norm_19.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.172692")
@@ -2783,6 +3058,7 @@ class Program_weight_tensor_parameter_274:
 
 class Program_weight_tensor_parameter_275:
     name = "parameter_275"
+    original_name = "batch_norm_19.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.00188424")
@@ -2794,6 +3070,7 @@ class Program_weight_tensor_parameter_275:
 
 class Program_weight_tensor_parameter_276:
     name = "parameter_276"
+    original_name = "batch_norm_19.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-6.434")
@@ -2805,6 +3082,7 @@ class Program_weight_tensor_parameter_276:
 
 class Program_weight_tensor_parameter_277:
     name = "parameter_277"
+    original_name = "conv2d_19.w_0"
     shape = [256, 1, 5, 5]
     dtype = "float32"
     min_val = float("-2.38921")
@@ -2816,6 +3094,7 @@ class Program_weight_tensor_parameter_277:
 
 class Program_weight_tensor_parameter_278:
     name = "parameter_278"
+    original_name = "batch_norm_18.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.58909")
@@ -2827,6 +3106,7 @@ class Program_weight_tensor_parameter_278:
 
 class Program_weight_tensor_parameter_279:
     name = "parameter_279"
+    original_name = "batch_norm_18.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.556579")
@@ -2838,6 +3118,7 @@ class Program_weight_tensor_parameter_279:
 
 class Program_weight_tensor_parameter_280:
     name = "parameter_280"
+    original_name = "batch_norm_18.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("2.55615")
@@ -2849,6 +3130,7 @@ class Program_weight_tensor_parameter_280:
 
 class Program_weight_tensor_parameter_281:
     name = "parameter_281"
+    original_name = "batch_norm_18.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-4.30402")
@@ -2860,6 +3142,7 @@ class Program_weight_tensor_parameter_281:
 
 class Program_weight_tensor_parameter_282:
     name = "parameter_282"
+    original_name = "conv2d_18.w_0"
     shape = [256, 256, 1, 1]
     dtype = "float32"
     min_val = float("-2.02532")
@@ -2871,6 +3154,7 @@ class Program_weight_tensor_parameter_282:
 
 class Program_weight_tensor_parameter_283:
     name = "parameter_283"
+    original_name = "batch_norm_17.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.81883")
@@ -2882,6 +3166,7 @@ class Program_weight_tensor_parameter_283:
 
 class Program_weight_tensor_parameter_284:
     name = "parameter_284"
+    original_name = "batch_norm_17.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.217403")
@@ -2893,6 +3178,7 @@ class Program_weight_tensor_parameter_284:
 
 class Program_weight_tensor_parameter_285:
     name = "parameter_285"
+    original_name = "batch_norm_17.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.00311972")
@@ -2904,6 +3190,7 @@ class Program_weight_tensor_parameter_285:
 
 class Program_weight_tensor_parameter_286:
     name = "parameter_286"
+    original_name = "batch_norm_17.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.89883")
@@ -2915,6 +3202,7 @@ class Program_weight_tensor_parameter_286:
 
 class Program_weight_tensor_parameter_287:
     name = "parameter_287"
+    original_name = "conv2d_17.w_0"
     shape = [256, 1, 5, 5]
     dtype = "float32"
     min_val = float("-2.15778")
@@ -2926,6 +3214,7 @@ class Program_weight_tensor_parameter_287:
 
 class Program_weight_tensor_parameter_288:
     name = "parameter_288"
+    original_name = "batch_norm_16.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.60112")
@@ -2937,6 +3226,7 @@ class Program_weight_tensor_parameter_288:
 
 class Program_weight_tensor_parameter_289:
     name = "parameter_289"
+    original_name = "batch_norm_16.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.401886")
@@ -2948,6 +3238,7 @@ class Program_weight_tensor_parameter_289:
 
 class Program_weight_tensor_parameter_290:
     name = "parameter_290"
+    original_name = "batch_norm_16.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("1.74456")
@@ -2959,6 +3250,7 @@ class Program_weight_tensor_parameter_290:
 
 class Program_weight_tensor_parameter_291:
     name = "parameter_291"
+    original_name = "batch_norm_16.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-4.92284")
@@ -2970,6 +3262,7 @@ class Program_weight_tensor_parameter_291:
 
 class Program_weight_tensor_parameter_292:
     name = "parameter_292"
+    original_name = "conv2d_16.w_0"
     shape = [256, 256, 1, 1]
     dtype = "float32"
     min_val = float("-2.3778")
@@ -2981,6 +3274,7 @@ class Program_weight_tensor_parameter_292:
 
 class Program_weight_tensor_parameter_293:
     name = "parameter_293"
+    original_name = "batch_norm_15.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.78632")
@@ -2992,6 +3286,7 @@ class Program_weight_tensor_parameter_293:
 
 class Program_weight_tensor_parameter_294:
     name = "parameter_294"
+    original_name = "batch_norm_15.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.745224")
@@ -3003,6 +3298,7 @@ class Program_weight_tensor_parameter_294:
 
 class Program_weight_tensor_parameter_295:
     name = "parameter_295"
+    original_name = "batch_norm_15.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.0041583")
@@ -3014,6 +3310,7 @@ class Program_weight_tensor_parameter_295:
 
 class Program_weight_tensor_parameter_296:
     name = "parameter_296"
+    original_name = "batch_norm_15.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-2.81039")
@@ -3025,6 +3322,7 @@ class Program_weight_tensor_parameter_296:
 
 class Program_weight_tensor_parameter_297:
     name = "parameter_297"
+    original_name = "conv2d_15.w_0"
     shape = [256, 1, 5, 5]
     dtype = "float32"
     min_val = float("-2.44779")
@@ -3036,6 +3334,7 @@ class Program_weight_tensor_parameter_297:
 
 class Program_weight_tensor_parameter_298:
     name = "parameter_298"
+    original_name = "batch_norm_14.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.65779")
@@ -3047,6 +3346,7 @@ class Program_weight_tensor_parameter_298:
 
 class Program_weight_tensor_parameter_299:
     name = "parameter_299"
+    original_name = "batch_norm_14.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.342176")
@@ -3058,6 +3358,7 @@ class Program_weight_tensor_parameter_299:
 
 class Program_weight_tensor_parameter_300:
     name = "parameter_300"
+    original_name = "batch_norm_14.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.485063")
@@ -3069,6 +3370,7 @@ class Program_weight_tensor_parameter_300:
 
 class Program_weight_tensor_parameter_301:
     name = "parameter_301"
+    original_name = "batch_norm_14.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-3.58223")
@@ -3080,6 +3382,7 @@ class Program_weight_tensor_parameter_301:
 
 class Program_weight_tensor_parameter_302:
     name = "parameter_302"
+    original_name = "conv2d_14.w_0"
     shape = [256, 256, 1, 1]
     dtype = "float32"
     min_val = float("-3.08002")
@@ -3091,6 +3394,7 @@ class Program_weight_tensor_parameter_302:
 
 class Program_weight_tensor_parameter_303:
     name = "parameter_303"
+    original_name = "batch_norm_13.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.93348")
@@ -3102,6 +3406,7 @@ class Program_weight_tensor_parameter_303:
 
 class Program_weight_tensor_parameter_304:
     name = "parameter_304"
+    original_name = "batch_norm_13.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.324591")
@@ -3113,6 +3418,7 @@ class Program_weight_tensor_parameter_304:
 
 class Program_weight_tensor_parameter_305:
     name = "parameter_305"
+    original_name = "batch_norm_13.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.00156945")
@@ -3124,6 +3430,7 @@ class Program_weight_tensor_parameter_305:
 
 class Program_weight_tensor_parameter_306:
     name = "parameter_306"
+    original_name = "batch_norm_13.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-3.11251")
@@ -3135,6 +3442,7 @@ class Program_weight_tensor_parameter_306:
 
 class Program_weight_tensor_parameter_307:
     name = "parameter_307"
+    original_name = "conv2d_13.w_0"
     shape = [256, 1, 5, 5]
     dtype = "float32"
     min_val = float("-2.05819")
@@ -3146,6 +3454,7 @@ class Program_weight_tensor_parameter_307:
 
 class Program_weight_tensor_parameter_308:
     name = "parameter_308"
+    original_name = "batch_norm_12.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.77141")
@@ -3157,6 +3466,7 @@ class Program_weight_tensor_parameter_308:
 
 class Program_weight_tensor_parameter_309:
     name = "parameter_309"
+    original_name = "batch_norm_12.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.457618")
@@ -3168,6 +3478,7 @@ class Program_weight_tensor_parameter_309:
 
 class Program_weight_tensor_parameter_310:
     name = "parameter_310"
+    original_name = "batch_norm_12.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.80419")
@@ -3179,6 +3490,7 @@ class Program_weight_tensor_parameter_310:
 
 class Program_weight_tensor_parameter_311:
     name = "parameter_311"
+    original_name = "batch_norm_12.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-10.4407")
@@ -3190,6 +3502,7 @@ class Program_weight_tensor_parameter_311:
 
 class Program_weight_tensor_parameter_312:
     name = "parameter_312"
+    original_name = "conv2d_12.w_0"
     shape = [256, 128, 1, 1]
     dtype = "float32"
     min_val = float("-2.04216")
@@ -3201,6 +3514,7 @@ class Program_weight_tensor_parameter_312:
 
 class Program_weight_tensor_parameter_313:
     name = "parameter_313"
+    original_name = "batch_norm_11.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.43421")
@@ -3212,6 +3526,7 @@ class Program_weight_tensor_parameter_313:
 
 class Program_weight_tensor_parameter_314:
     name = "parameter_314"
+    original_name = "batch_norm_11.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.200504")
@@ -3223,6 +3538,7 @@ class Program_weight_tensor_parameter_314:
 
 class Program_weight_tensor_parameter_315:
     name = "parameter_315"
+    original_name = "batch_norm_11.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.00605463")
@@ -3234,6 +3550,7 @@ class Program_weight_tensor_parameter_315:
 
 class Program_weight_tensor_parameter_316:
     name = "parameter_316"
+    original_name = "batch_norm_11.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-3.71303")
@@ -3245,6 +3562,7 @@ class Program_weight_tensor_parameter_316:
 
 class Program_weight_tensor_parameter_317:
     name = "parameter_317"
+    original_name = "conv2d_11.w_0"
     shape = [128, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.881321")
@@ -3256,6 +3574,7 @@ class Program_weight_tensor_parameter_317:
 
 class Program_weight_tensor_parameter_318:
     name = "parameter_318"
+    original_name = "batch_norm_10.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.94309")
@@ -3267,6 +3586,7 @@ class Program_weight_tensor_parameter_318:
 
 class Program_weight_tensor_parameter_319:
     name = "parameter_319"
+    original_name = "batch_norm_10.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.13086")
@@ -3278,6 +3598,7 @@ class Program_weight_tensor_parameter_319:
 
 class Program_weight_tensor_parameter_320:
     name = "parameter_320"
+    original_name = "batch_norm_10.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.644214")
@@ -3289,6 +3610,7 @@ class Program_weight_tensor_parameter_320:
 
 class Program_weight_tensor_parameter_321:
     name = "parameter_321"
+    original_name = "batch_norm_10.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-6.86004")
@@ -3300,6 +3622,7 @@ class Program_weight_tensor_parameter_321:
 
 class Program_weight_tensor_parameter_322:
     name = "parameter_322"
+    original_name = "conv2d_10.w_0"
     shape = [128, 128, 1, 1]
     dtype = "float32"
     min_val = float("-2.5569")
@@ -3311,6 +3634,7 @@ class Program_weight_tensor_parameter_322:
 
 class Program_weight_tensor_parameter_323:
     name = "parameter_323"
+    original_name = "batch_norm_9.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.60027")
@@ -3322,6 +3646,7 @@ class Program_weight_tensor_parameter_323:
 
 class Program_weight_tensor_parameter_324:
     name = "parameter_324"
+    original_name = "batch_norm_9.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.405329")
@@ -3333,6 +3658,7 @@ class Program_weight_tensor_parameter_324:
 
 class Program_weight_tensor_parameter_325:
     name = "parameter_325"
+    original_name = "batch_norm_9.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("8.45411e-05")
@@ -3344,6 +3670,7 @@ class Program_weight_tensor_parameter_325:
 
 class Program_weight_tensor_parameter_326:
     name = "parameter_326"
+    original_name = "batch_norm_9.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-2.28361")
@@ -3355,6 +3682,7 @@ class Program_weight_tensor_parameter_326:
 
 class Program_weight_tensor_parameter_327:
     name = "parameter_327"
+    original_name = "conv2d_9.w_0"
     shape = [128, 1, 3, 3]
     dtype = "float32"
     min_val = float("-2.17113")
@@ -3366,6 +3694,7 @@ class Program_weight_tensor_parameter_327:
 
 class Program_weight_tensor_parameter_328:
     name = "parameter_328"
+    original_name = "batch_norm_8.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.26719")
@@ -3377,6 +3706,7 @@ class Program_weight_tensor_parameter_328:
 
 class Program_weight_tensor_parameter_329:
     name = "parameter_329"
+    original_name = "batch_norm_8.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.879856")
@@ -3388,6 +3718,7 @@ class Program_weight_tensor_parameter_329:
 
 class Program_weight_tensor_parameter_330:
     name = "parameter_330"
+    original_name = "batch_norm_8.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.323433")
@@ -3399,6 +3730,7 @@ class Program_weight_tensor_parameter_330:
 
 class Program_weight_tensor_parameter_331:
     name = "parameter_331"
+    original_name = "batch_norm_8.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-9.41271")
@@ -3410,6 +3742,7 @@ class Program_weight_tensor_parameter_331:
 
 class Program_weight_tensor_parameter_332:
     name = "parameter_332"
+    original_name = "conv2d_8.w_0"
     shape = [128, 64, 1, 1]
     dtype = "float32"
     min_val = float("-2.16179")
@@ -3421,6 +3754,7 @@ class Program_weight_tensor_parameter_332:
 
 class Program_weight_tensor_parameter_333:
     name = "parameter_333"
+    original_name = "batch_norm_7.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -3430,6 +3764,7 @@ class Program_weight_tensor_parameter_333:
 
 class Program_weight_tensor_parameter_334:
     name = "parameter_334"
+    original_name = "batch_norm_7.w_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -3439,6 +3774,7 @@ class Program_weight_tensor_parameter_334:
 
 class Program_weight_tensor_parameter_335:
     name = "parameter_335"
+    original_name = "batch_norm_7.w_2"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -3448,6 +3784,7 @@ class Program_weight_tensor_parameter_335:
 
 class Program_weight_tensor_parameter_336:
     name = "parameter_336"
+    original_name = "batch_norm_7.w_1"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -3457,6 +3794,7 @@ class Program_weight_tensor_parameter_336:
 
 class Program_weight_tensor_parameter_337:
     name = "parameter_337"
+    original_name = "conv2d_7.w_0"
     shape = [64, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.796547")
@@ -3468,6 +3806,7 @@ class Program_weight_tensor_parameter_337:
 
 class Program_weight_tensor_parameter_338:
     name = "parameter_338"
+    original_name = "batch_norm_6.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -3477,6 +3816,7 @@ class Program_weight_tensor_parameter_338:
 
 class Program_weight_tensor_parameter_339:
     name = "parameter_339"
+    original_name = "batch_norm_6.w_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -3486,6 +3826,7 @@ class Program_weight_tensor_parameter_339:
 
 class Program_weight_tensor_parameter_340:
     name = "parameter_340"
+    original_name = "batch_norm_6.w_2"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -3495,6 +3836,7 @@ class Program_weight_tensor_parameter_340:
 
 class Program_weight_tensor_parameter_341:
     name = "parameter_341"
+    original_name = "batch_norm_6.w_1"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -3504,6 +3846,7 @@ class Program_weight_tensor_parameter_341:
 
 class Program_weight_tensor_parameter_342:
     name = "parameter_342"
+    original_name = "conv2d_6.w_0"
     shape = [64, 64, 1, 1]
     dtype = "float32"
     min_val = float("-2.60463")
@@ -3515,6 +3858,7 @@ class Program_weight_tensor_parameter_342:
 
 class Program_weight_tensor_parameter_343:
     name = "parameter_343"
+    original_name = "batch_norm_5.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -3524,6 +3868,7 @@ class Program_weight_tensor_parameter_343:
 
 class Program_weight_tensor_parameter_344:
     name = "parameter_344"
+    original_name = "batch_norm_5.w_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -3533,6 +3878,7 @@ class Program_weight_tensor_parameter_344:
 
 class Program_weight_tensor_parameter_345:
     name = "parameter_345"
+    original_name = "batch_norm_5.w_2"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -3542,6 +3888,7 @@ class Program_weight_tensor_parameter_345:
 
 class Program_weight_tensor_parameter_346:
     name = "parameter_346"
+    original_name = "batch_norm_5.w_1"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -3551,6 +3898,7 @@ class Program_weight_tensor_parameter_346:
 
 class Program_weight_tensor_parameter_347:
     name = "parameter_347"
+    original_name = "conv2d_5.w_0"
     shape = [64, 1, 3, 3]
     dtype = "float32"
     min_val = float("-2.32673")
@@ -3562,6 +3910,7 @@ class Program_weight_tensor_parameter_347:
 
 class Program_weight_tensor_parameter_348:
     name = "parameter_348"
+    original_name = "batch_norm_4.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -3571,6 +3920,7 @@ class Program_weight_tensor_parameter_348:
 
 class Program_weight_tensor_parameter_349:
     name = "parameter_349"
+    original_name = "batch_norm_4.w_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -3580,6 +3930,7 @@ class Program_weight_tensor_parameter_349:
 
 class Program_weight_tensor_parameter_350:
     name = "parameter_350"
+    original_name = "batch_norm_4.w_2"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -3589,6 +3940,7 @@ class Program_weight_tensor_parameter_350:
 
 class Program_weight_tensor_parameter_351:
     name = "parameter_351"
+    original_name = "batch_norm_4.w_1"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -3598,6 +3950,7 @@ class Program_weight_tensor_parameter_351:
 
 class Program_weight_tensor_parameter_352:
     name = "parameter_352"
+    original_name = "conv2d_4.w_0"
     shape = [64, 32, 1, 1]
     dtype = "float32"
     min_val = float("-2.34407")
@@ -3609,6 +3962,7 @@ class Program_weight_tensor_parameter_352:
 
 class Program_weight_tensor_parameter_353:
     name = "parameter_353"
+    original_name = "batch_norm_3.b_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -3618,6 +3972,7 @@ class Program_weight_tensor_parameter_353:
 
 class Program_weight_tensor_parameter_354:
     name = "parameter_354"
+    original_name = "batch_norm_3.w_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -3627,6 +3982,7 @@ class Program_weight_tensor_parameter_354:
 
 class Program_weight_tensor_parameter_355:
     name = "parameter_355"
+    original_name = "batch_norm_3.w_2"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -3636,6 +3992,7 @@ class Program_weight_tensor_parameter_355:
 
 class Program_weight_tensor_parameter_356:
     name = "parameter_356"
+    original_name = "batch_norm_3.w_1"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -3645,6 +4002,7 @@ class Program_weight_tensor_parameter_356:
 
 class Program_weight_tensor_parameter_357:
     name = "parameter_357"
+    original_name = "conv2d_3.w_0"
     shape = [32, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.866371")
@@ -3656,6 +4014,7 @@ class Program_weight_tensor_parameter_357:
 
 class Program_weight_tensor_parameter_358:
     name = "parameter_358"
+    original_name = "batch_norm_2.b_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -3665,6 +4024,7 @@ class Program_weight_tensor_parameter_358:
 
 class Program_weight_tensor_parameter_359:
     name = "parameter_359"
+    original_name = "batch_norm_2.w_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -3674,6 +4034,7 @@ class Program_weight_tensor_parameter_359:
 
 class Program_weight_tensor_parameter_360:
     name = "parameter_360"
+    original_name = "batch_norm_2.w_2"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -3683,6 +4044,7 @@ class Program_weight_tensor_parameter_360:
 
 class Program_weight_tensor_parameter_361:
     name = "parameter_361"
+    original_name = "batch_norm_2.w_1"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -3692,6 +4054,7 @@ class Program_weight_tensor_parameter_361:
 
 class Program_weight_tensor_parameter_362:
     name = "parameter_362"
+    original_name = "conv2d_2.w_0"
     shape = [32, 16, 1, 1]
     dtype = "float32"
     min_val = float("-3.98461")
@@ -3703,6 +4066,7 @@ class Program_weight_tensor_parameter_362:
 
 class Program_weight_tensor_parameter_363:
     name = "parameter_363"
+    original_name = "batch_norm_1.b_0"
     shape = [16]
     dtype = "float32"
     min_val = float("0")
@@ -3712,6 +4076,7 @@ class Program_weight_tensor_parameter_363:
 
 class Program_weight_tensor_parameter_364:
     name = "parameter_364"
+    original_name = "batch_norm_1.w_0"
     shape = [16]
     dtype = "float32"
     min_val = float("0")
@@ -3721,6 +4086,7 @@ class Program_weight_tensor_parameter_364:
 
 class Program_weight_tensor_parameter_365:
     name = "parameter_365"
+    original_name = "batch_norm_1.w_2"
     shape = [16]
     dtype = "float32"
     min_val = float("0")
@@ -3730,6 +4096,7 @@ class Program_weight_tensor_parameter_365:
 
 class Program_weight_tensor_parameter_366:
     name = "parameter_366"
+    original_name = "batch_norm_1.w_1"
     shape = [16]
     dtype = "float32"
     min_val = float("0")
@@ -3739,6 +4106,7 @@ class Program_weight_tensor_parameter_366:
 
 class Program_weight_tensor_parameter_367:
     name = "parameter_367"
+    original_name = "conv2d_1.w_0"
     shape = [16, 1, 3, 3]
     dtype = "float32"
     min_val = float("-3.11002")
@@ -3750,6 +4118,7 @@ class Program_weight_tensor_parameter_367:
 
 class Program_weight_tensor_parameter_368:
     name = "parameter_368"
+    original_name = "batch_norm_0.b_0"
     shape = [16]
     dtype = "float32"
     min_val = float("0")
@@ -3759,6 +4128,7 @@ class Program_weight_tensor_parameter_368:
 
 class Program_weight_tensor_parameter_369:
     name = "parameter_369"
+    original_name = "batch_norm_0.w_0"
     shape = [16]
     dtype = "float32"
     min_val = float("0")
@@ -3768,6 +4138,7 @@ class Program_weight_tensor_parameter_369:
 
 class Program_weight_tensor_parameter_370:
     name = "parameter_370"
+    original_name = "batch_norm_0.w_2"
     shape = [16]
     dtype = "float32"
     min_val = float("0")
@@ -3777,6 +4148,7 @@ class Program_weight_tensor_parameter_370:
 
 class Program_weight_tensor_parameter_371:
     name = "parameter_371"
+    original_name = "batch_norm_0.w_1"
     shape = [16]
     dtype = "float32"
     min_val = float("0")
@@ -3786,6 +4158,7 @@ class Program_weight_tensor_parameter_371:
 
 class Program_weight_tensor_parameter_372:
     name = "parameter_372"
+    original_name = "conv2d_0.w_0"
     shape = [16, 3, 3, 3]
     dtype = "float32"
     min_val = float("-2.21975")

--- a/paddle_samples/PaddleX/SLANet/subgraph_2/input_meta.py
+++ b/paddle_samples/PaddleX/SLANet/subgraph_2/input_meta.py
@@ -1,5 +1,6 @@
 class Program_weight_tensor_data_0:
     name = "data_0"
+    original_name = "var_664"
     shape = [4, 3, 488, 488]
     dtype = "float32"
     min_val = float("-2.1179")

--- a/paddle_samples/PaddleX/SLANet/subgraph_2/weight_meta.py
+++ b/paddle_samples/PaddleX/SLANet/subgraph_2/weight_meta.py
@@ -1,5 +1,6 @@
 class Program_weight_tensor_parameter_0:
     name = "parameter_0"
+    original_name = "batch_norm2d_42.b_0"
     shape = [96]
     dtype = "float32"
     min_val = float("-0.24959")
@@ -11,6 +12,7 @@ class Program_weight_tensor_parameter_0:
 
 class Program_weight_tensor_parameter_1:
     name = "parameter_1"
+    original_name = "batch_norm2d_42.w_0"
     shape = [96]
     dtype = "float32"
     min_val = float("0.449565")
@@ -22,6 +24,7 @@ class Program_weight_tensor_parameter_1:
 
 class Program_weight_tensor_parameter_2:
     name = "parameter_2"
+    original_name = "batch_norm2d_42.w_2"
     shape = [96]
     dtype = "float32"
     min_val = float("2.93068")
@@ -33,6 +36,7 @@ class Program_weight_tensor_parameter_2:
 
 class Program_weight_tensor_parameter_3:
     name = "parameter_3"
+    original_name = "batch_norm2d_42.w_1"
     shape = [96]
     dtype = "float32"
     min_val = float("-2.34994")
@@ -44,6 +48,7 @@ class Program_weight_tensor_parameter_3:
 
 class Program_weight_tensor_parameter_4:
     name = "parameter_4"
+    original_name = "conv2d_73.w_0"
     shape = [96, 96, 1, 1]
     dtype = "float32"
     min_val = float("-1.04498")
@@ -55,6 +60,7 @@ class Program_weight_tensor_parameter_4:
 
 class Program_weight_tensor_parameter_5:
     name = "parameter_5"
+    original_name = "batch_norm2d_45.b_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -64,6 +70,7 @@ class Program_weight_tensor_parameter_5:
 
 class Program_weight_tensor_parameter_6:
     name = "parameter_6"
+    original_name = "batch_norm2d_45.w_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -73,6 +80,7 @@ class Program_weight_tensor_parameter_6:
 
 class Program_weight_tensor_parameter_7:
     name = "parameter_7"
+    original_name = "batch_norm2d_45.w_2"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -82,6 +90,7 @@ class Program_weight_tensor_parameter_7:
 
 class Program_weight_tensor_parameter_8:
     name = "parameter_8"
+    original_name = "batch_norm2d_45.w_1"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -91,6 +100,7 @@ class Program_weight_tensor_parameter_8:
 
 class Program_weight_tensor_parameter_9:
     name = "parameter_9"
+    original_name = "conv2d_76.w_0"
     shape = [48, 48, 1, 1]
     dtype = "float32"
     min_val = float("-1.21852")
@@ -102,6 +112,7 @@ class Program_weight_tensor_parameter_9:
 
 class Program_weight_tensor_parameter_10:
     name = "parameter_10"
+    original_name = "batch_norm2d_44.b_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -111,6 +122,7 @@ class Program_weight_tensor_parameter_10:
 
 class Program_weight_tensor_parameter_11:
     name = "parameter_11"
+    original_name = "batch_norm2d_44.w_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -120,6 +132,7 @@ class Program_weight_tensor_parameter_11:
 
 class Program_weight_tensor_parameter_12:
     name = "parameter_12"
+    original_name = "batch_norm2d_44.w_2"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -129,6 +142,7 @@ class Program_weight_tensor_parameter_12:
 
 class Program_weight_tensor_parameter_13:
     name = "parameter_13"
+    original_name = "batch_norm2d_44.w_1"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -138,6 +152,7 @@ class Program_weight_tensor_parameter_13:
 
 class Program_weight_tensor_parameter_14:
     name = "parameter_14"
+    original_name = "conv2d_75.w_0"
     shape = [48, 1, 5, 5]
     dtype = "float32"
     min_val = float("-1.18004")
@@ -149,6 +164,7 @@ class Program_weight_tensor_parameter_14:
 
 class Program_weight_tensor_parameter_15:
     name = "parameter_15"
+    original_name = "batch_norm2d_43.b_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -158,6 +174,7 @@ class Program_weight_tensor_parameter_15:
 
 class Program_weight_tensor_parameter_16:
     name = "parameter_16"
+    original_name = "batch_norm2d_43.w_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -167,6 +184,7 @@ class Program_weight_tensor_parameter_16:
 
 class Program_weight_tensor_parameter_17:
     name = "parameter_17"
+    original_name = "batch_norm2d_43.w_2"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -176,6 +194,7 @@ class Program_weight_tensor_parameter_17:
 
 class Program_weight_tensor_parameter_18:
     name = "parameter_18"
+    original_name = "batch_norm2d_43.w_1"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -185,6 +204,7 @@ class Program_weight_tensor_parameter_18:
 
 class Program_weight_tensor_parameter_19:
     name = "parameter_19"
+    original_name = "conv2d_74.w_0"
     shape = [48, 48, 1, 1]
     dtype = "float32"
     min_val = float("-1.20729")
@@ -196,6 +216,7 @@ class Program_weight_tensor_parameter_19:
 
 class Program_weight_tensor_parameter_20:
     name = "parameter_20"
+    original_name = "batch_norm2d_40.b_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -205,6 +226,7 @@ class Program_weight_tensor_parameter_20:
 
 class Program_weight_tensor_parameter_21:
     name = "parameter_21"
+    original_name = "batch_norm2d_40.w_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -214,6 +236,7 @@ class Program_weight_tensor_parameter_21:
 
 class Program_weight_tensor_parameter_22:
     name = "parameter_22"
+    original_name = "batch_norm2d_40.w_2"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -223,6 +246,7 @@ class Program_weight_tensor_parameter_22:
 
 class Program_weight_tensor_parameter_23:
     name = "parameter_23"
+    original_name = "batch_norm2d_40.w_1"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -232,6 +256,7 @@ class Program_weight_tensor_parameter_23:
 
 class Program_weight_tensor_parameter_24:
     name = "parameter_24"
+    original_name = "conv2d_71.w_0"
     shape = [48, 192, 1, 1]
     dtype = "float32"
     min_val = float("-1.53561")
@@ -243,6 +268,7 @@ class Program_weight_tensor_parameter_24:
 
 class Program_weight_tensor_parameter_25:
     name = "parameter_25"
+    original_name = "batch_norm2d_41.b_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -252,6 +278,7 @@ class Program_weight_tensor_parameter_25:
 
 class Program_weight_tensor_parameter_26:
     name = "parameter_26"
+    original_name = "batch_norm2d_41.w_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -261,6 +288,7 @@ class Program_weight_tensor_parameter_26:
 
 class Program_weight_tensor_parameter_27:
     name = "parameter_27"
+    original_name = "batch_norm2d_41.w_2"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -270,6 +298,7 @@ class Program_weight_tensor_parameter_27:
 
 class Program_weight_tensor_parameter_28:
     name = "parameter_28"
+    original_name = "batch_norm2d_41.w_1"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -279,6 +308,7 @@ class Program_weight_tensor_parameter_28:
 
 class Program_weight_tensor_parameter_29:
     name = "parameter_29"
+    original_name = "conv2d_72.w_0"
     shape = [48, 192, 1, 1]
     dtype = "float32"
     min_val = float("-1.21655")
@@ -290,6 +320,7 @@ class Program_weight_tensor_parameter_29:
 
 class Program_weight_tensor_parameter_30:
     name = "parameter_30"
+    original_name = "batch_norm2d_39.b_0"
     shape = [96]
     dtype = "float32"
     min_val = float("-0.767027")
@@ -301,6 +332,7 @@ class Program_weight_tensor_parameter_30:
 
 class Program_weight_tensor_parameter_31:
     name = "parameter_31"
+    original_name = "batch_norm2d_39.w_0"
     shape = [96]
     dtype = "float32"
     min_val = float("0.446288")
@@ -312,6 +344,7 @@ class Program_weight_tensor_parameter_31:
 
 class Program_weight_tensor_parameter_32:
     name = "parameter_32"
+    original_name = "batch_norm2d_39.w_2"
     shape = [96]
     dtype = "float32"
     min_val = float("2.87005")
@@ -323,6 +356,7 @@ class Program_weight_tensor_parameter_32:
 
 class Program_weight_tensor_parameter_33:
     name = "parameter_33"
+    original_name = "batch_norm2d_39.w_1"
     shape = [96]
     dtype = "float32"
     min_val = float("-2.08306")
@@ -334,6 +368,7 @@ class Program_weight_tensor_parameter_33:
 
 class Program_weight_tensor_parameter_34:
     name = "parameter_34"
+    original_name = "conv2d_70.w_0"
     shape = [96, 96, 1, 1]
     dtype = "float32"
     min_val = float("-1.26513")
@@ -345,6 +380,7 @@ class Program_weight_tensor_parameter_34:
 
 class Program_weight_tensor_parameter_35:
     name = "parameter_35"
+    original_name = "batch_norm2d_38.b_0"
     shape = [96]
     dtype = "float32"
     min_val = float("-0.712146")
@@ -356,6 +392,7 @@ class Program_weight_tensor_parameter_35:
 
 class Program_weight_tensor_parameter_36:
     name = "parameter_36"
+    original_name = "batch_norm2d_38.w_0"
     shape = [96]
     dtype = "float32"
     min_val = float("0.61526")
@@ -367,6 +404,7 @@ class Program_weight_tensor_parameter_36:
 
 class Program_weight_tensor_parameter_37:
     name = "parameter_37"
+    original_name = "batch_norm2d_38.w_2"
     shape = [96]
     dtype = "float32"
     min_val = float("0.0580731")
@@ -378,6 +416,7 @@ class Program_weight_tensor_parameter_37:
 
 class Program_weight_tensor_parameter_38:
     name = "parameter_38"
+    original_name = "batch_norm2d_38.w_1"
     shape = [96]
     dtype = "float32"
     min_val = float("-2.55002")
@@ -389,6 +428,7 @@ class Program_weight_tensor_parameter_38:
 
 class Program_weight_tensor_parameter_39:
     name = "parameter_39"
+    original_name = "conv2d_69.w_0"
     shape = [96, 1, 5, 5]
     dtype = "float32"
     min_val = float("-1.47908")
@@ -400,6 +440,7 @@ class Program_weight_tensor_parameter_39:
 
 class Program_weight_tensor_parameter_40:
     name = "parameter_40"
+    original_name = "batch_norm2d_34.b_0"
     shape = [96]
     dtype = "float32"
     min_val = float("-0.734562")
@@ -411,6 +452,7 @@ class Program_weight_tensor_parameter_40:
 
 class Program_weight_tensor_parameter_41:
     name = "parameter_41"
+    original_name = "batch_norm2d_34.w_0"
     shape = [96]
     dtype = "float32"
     min_val = float("0.176593")
@@ -422,6 +464,7 @@ class Program_weight_tensor_parameter_41:
 
 class Program_weight_tensor_parameter_42:
     name = "parameter_42"
+    original_name = "batch_norm2d_34.w_2"
     shape = [96]
     dtype = "float32"
     min_val = float("2.69034")
@@ -433,6 +476,7 @@ class Program_weight_tensor_parameter_42:
 
 class Program_weight_tensor_parameter_43:
     name = "parameter_43"
+    original_name = "batch_norm2d_34.w_1"
     shape = [96]
     dtype = "float32"
     min_val = float("-2.03681")
@@ -444,6 +488,7 @@ class Program_weight_tensor_parameter_43:
 
 class Program_weight_tensor_parameter_44:
     name = "parameter_44"
+    original_name = "conv2d_65.w_0"
     shape = [96, 96, 1, 1]
     dtype = "float32"
     min_val = float("-1.34596")
@@ -455,6 +500,7 @@ class Program_weight_tensor_parameter_44:
 
 class Program_weight_tensor_parameter_45:
     name = "parameter_45"
+    original_name = "batch_norm2d_37.b_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -464,6 +510,7 @@ class Program_weight_tensor_parameter_45:
 
 class Program_weight_tensor_parameter_46:
     name = "parameter_46"
+    original_name = "batch_norm2d_37.w_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -473,6 +520,7 @@ class Program_weight_tensor_parameter_46:
 
 class Program_weight_tensor_parameter_47:
     name = "parameter_47"
+    original_name = "batch_norm2d_37.w_2"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -482,6 +530,7 @@ class Program_weight_tensor_parameter_47:
 
 class Program_weight_tensor_parameter_48:
     name = "parameter_48"
+    original_name = "batch_norm2d_37.w_1"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -491,6 +540,7 @@ class Program_weight_tensor_parameter_48:
 
 class Program_weight_tensor_parameter_49:
     name = "parameter_49"
+    original_name = "conv2d_68.w_0"
     shape = [48, 48, 1, 1]
     dtype = "float32"
     min_val = float("-1.32546")
@@ -502,6 +552,7 @@ class Program_weight_tensor_parameter_49:
 
 class Program_weight_tensor_parameter_50:
     name = "parameter_50"
+    original_name = "batch_norm2d_36.b_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -511,6 +562,7 @@ class Program_weight_tensor_parameter_50:
 
 class Program_weight_tensor_parameter_51:
     name = "parameter_51"
+    original_name = "batch_norm2d_36.w_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -520,6 +572,7 @@ class Program_weight_tensor_parameter_51:
 
 class Program_weight_tensor_parameter_52:
     name = "parameter_52"
+    original_name = "batch_norm2d_36.w_2"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -529,6 +582,7 @@ class Program_weight_tensor_parameter_52:
 
 class Program_weight_tensor_parameter_53:
     name = "parameter_53"
+    original_name = "batch_norm2d_36.w_1"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -538,6 +592,7 @@ class Program_weight_tensor_parameter_53:
 
 class Program_weight_tensor_parameter_54:
     name = "parameter_54"
+    original_name = "conv2d_67.w_0"
     shape = [48, 1, 5, 5]
     dtype = "float32"
     min_val = float("-1.1691")
@@ -549,6 +604,7 @@ class Program_weight_tensor_parameter_54:
 
 class Program_weight_tensor_parameter_55:
     name = "parameter_55"
+    original_name = "batch_norm2d_35.b_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -558,6 +614,7 @@ class Program_weight_tensor_parameter_55:
 
 class Program_weight_tensor_parameter_56:
     name = "parameter_56"
+    original_name = "batch_norm2d_35.w_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -567,6 +624,7 @@ class Program_weight_tensor_parameter_56:
 
 class Program_weight_tensor_parameter_57:
     name = "parameter_57"
+    original_name = "batch_norm2d_35.w_2"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -576,6 +634,7 @@ class Program_weight_tensor_parameter_57:
 
 class Program_weight_tensor_parameter_58:
     name = "parameter_58"
+    original_name = "batch_norm2d_35.w_1"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -585,6 +644,7 @@ class Program_weight_tensor_parameter_58:
 
 class Program_weight_tensor_parameter_59:
     name = "parameter_59"
+    original_name = "conv2d_66.w_0"
     shape = [48, 48, 1, 1]
     dtype = "float32"
     min_val = float("-1.0265")
@@ -596,6 +656,7 @@ class Program_weight_tensor_parameter_59:
 
 class Program_weight_tensor_parameter_60:
     name = "parameter_60"
+    original_name = "batch_norm2d_32.b_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -605,6 +666,7 @@ class Program_weight_tensor_parameter_60:
 
 class Program_weight_tensor_parameter_61:
     name = "parameter_61"
+    original_name = "batch_norm2d_32.w_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -614,6 +676,7 @@ class Program_weight_tensor_parameter_61:
 
 class Program_weight_tensor_parameter_62:
     name = "parameter_62"
+    original_name = "batch_norm2d_32.w_2"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -623,6 +686,7 @@ class Program_weight_tensor_parameter_62:
 
 class Program_weight_tensor_parameter_63:
     name = "parameter_63"
+    original_name = "batch_norm2d_32.w_1"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -632,6 +696,7 @@ class Program_weight_tensor_parameter_63:
 
 class Program_weight_tensor_parameter_64:
     name = "parameter_64"
+    original_name = "conv2d_63.w_0"
     shape = [48, 192, 1, 1]
     dtype = "float32"
     min_val = float("-0.960827")
@@ -643,6 +708,7 @@ class Program_weight_tensor_parameter_64:
 
 class Program_weight_tensor_parameter_65:
     name = "parameter_65"
+    original_name = "batch_norm2d_33.b_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -652,6 +718,7 @@ class Program_weight_tensor_parameter_65:
 
 class Program_weight_tensor_parameter_66:
     name = "parameter_66"
+    original_name = "batch_norm2d_33.w_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -661,6 +728,7 @@ class Program_weight_tensor_parameter_66:
 
 class Program_weight_tensor_parameter_67:
     name = "parameter_67"
+    original_name = "batch_norm2d_33.w_2"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -670,6 +738,7 @@ class Program_weight_tensor_parameter_67:
 
 class Program_weight_tensor_parameter_68:
     name = "parameter_68"
+    original_name = "batch_norm2d_33.w_1"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -679,6 +748,7 @@ class Program_weight_tensor_parameter_68:
 
 class Program_weight_tensor_parameter_69:
     name = "parameter_69"
+    original_name = "conv2d_64.w_0"
     shape = [48, 192, 1, 1]
     dtype = "float32"
     min_val = float("-1.08864")
@@ -690,6 +760,7 @@ class Program_weight_tensor_parameter_69:
 
 class Program_weight_tensor_parameter_70:
     name = "parameter_70"
+    original_name = "batch_norm2d_31.b_0"
     shape = [96]
     dtype = "float32"
     min_val = float("-0.558187")
@@ -701,6 +772,7 @@ class Program_weight_tensor_parameter_70:
 
 class Program_weight_tensor_parameter_71:
     name = "parameter_71"
+    original_name = "batch_norm2d_31.w_0"
     shape = [96]
     dtype = "float32"
     min_val = float("0.778347")
@@ -712,6 +784,7 @@ class Program_weight_tensor_parameter_71:
 
 class Program_weight_tensor_parameter_72:
     name = "parameter_72"
+    original_name = "batch_norm2d_31.w_2"
     shape = [96]
     dtype = "float32"
     min_val = float("2.30858")
@@ -723,6 +796,7 @@ class Program_weight_tensor_parameter_72:
 
 class Program_weight_tensor_parameter_73:
     name = "parameter_73"
+    original_name = "batch_norm2d_31.w_1"
     shape = [96]
     dtype = "float32"
     min_val = float("-1.75973")
@@ -734,6 +808,7 @@ class Program_weight_tensor_parameter_73:
 
 class Program_weight_tensor_parameter_74:
     name = "parameter_74"
+    original_name = "conv2d_62.w_0"
     shape = [96, 96, 1, 1]
     dtype = "float32"
     min_val = float("-1.03494")
@@ -745,6 +820,7 @@ class Program_weight_tensor_parameter_74:
 
 class Program_weight_tensor_parameter_75:
     name = "parameter_75"
+    original_name = "batch_norm2d_30.b_0"
     shape = [96]
     dtype = "float32"
     min_val = float("-0.519722")
@@ -756,6 +832,7 @@ class Program_weight_tensor_parameter_75:
 
 class Program_weight_tensor_parameter_76:
     name = "parameter_76"
+    original_name = "batch_norm2d_30.w_0"
     shape = [96]
     dtype = "float32"
     min_val = float("0.552081")
@@ -767,6 +844,7 @@ class Program_weight_tensor_parameter_76:
 
 class Program_weight_tensor_parameter_77:
     name = "parameter_77"
+    original_name = "batch_norm2d_30.w_2"
     shape = [96]
     dtype = "float32"
     min_val = float("0.187755")
@@ -778,6 +856,7 @@ class Program_weight_tensor_parameter_77:
 
 class Program_weight_tensor_parameter_78:
     name = "parameter_78"
+    original_name = "batch_norm2d_30.w_1"
     shape = [96]
     dtype = "float32"
     min_val = float("-2.48098")
@@ -789,6 +868,7 @@ class Program_weight_tensor_parameter_78:
 
 class Program_weight_tensor_parameter_79:
     name = "parameter_79"
+    original_name = "conv2d_61.w_0"
     shape = [96, 1, 5, 5]
     dtype = "float32"
     min_val = float("-1.07229")
@@ -800,6 +880,7 @@ class Program_weight_tensor_parameter_79:
 
 class Program_weight_tensor_parameter_80:
     name = "parameter_80"
+    original_name = "batch_norm2d_26.b_0"
     shape = [96]
     dtype = "float32"
     min_val = float("-0.567286")
@@ -811,6 +892,7 @@ class Program_weight_tensor_parameter_80:
 
 class Program_weight_tensor_parameter_81:
     name = "parameter_81"
+    original_name = "batch_norm2d_26.w_0"
     shape = [96]
     dtype = "float32"
     min_val = float("0.466077")
@@ -822,6 +904,7 @@ class Program_weight_tensor_parameter_81:
 
 class Program_weight_tensor_parameter_82:
     name = "parameter_82"
+    original_name = "batch_norm2d_26.w_2"
     shape = [96]
     dtype = "float32"
     min_val = float("2.01437")
@@ -833,6 +916,7 @@ class Program_weight_tensor_parameter_82:
 
 class Program_weight_tensor_parameter_83:
     name = "parameter_83"
+    original_name = "batch_norm2d_26.w_1"
     shape = [96]
     dtype = "float32"
     min_val = float("-1.63445")
@@ -844,6 +928,7 @@ class Program_weight_tensor_parameter_83:
 
 class Program_weight_tensor_parameter_84:
     name = "parameter_84"
+    original_name = "conv2d_57.w_0"
     shape = [96, 96, 1, 1]
     dtype = "float32"
     min_val = float("-1.16383")
@@ -855,6 +940,7 @@ class Program_weight_tensor_parameter_84:
 
 class Program_weight_tensor_parameter_85:
     name = "parameter_85"
+    original_name = "batch_norm2d_29.b_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -864,6 +950,7 @@ class Program_weight_tensor_parameter_85:
 
 class Program_weight_tensor_parameter_86:
     name = "parameter_86"
+    original_name = "batch_norm2d_29.w_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -873,6 +960,7 @@ class Program_weight_tensor_parameter_86:
 
 class Program_weight_tensor_parameter_87:
     name = "parameter_87"
+    original_name = "batch_norm2d_29.w_2"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -882,6 +970,7 @@ class Program_weight_tensor_parameter_87:
 
 class Program_weight_tensor_parameter_88:
     name = "parameter_88"
+    original_name = "batch_norm2d_29.w_1"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -891,6 +980,7 @@ class Program_weight_tensor_parameter_88:
 
 class Program_weight_tensor_parameter_89:
     name = "parameter_89"
+    original_name = "conv2d_60.w_0"
     shape = [48, 48, 1, 1]
     dtype = "float32"
     min_val = float("-1.05803")
@@ -902,6 +992,7 @@ class Program_weight_tensor_parameter_89:
 
 class Program_weight_tensor_parameter_90:
     name = "parameter_90"
+    original_name = "batch_norm2d_28.b_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -911,6 +1002,7 @@ class Program_weight_tensor_parameter_90:
 
 class Program_weight_tensor_parameter_91:
     name = "parameter_91"
+    original_name = "batch_norm2d_28.w_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -920,6 +1012,7 @@ class Program_weight_tensor_parameter_91:
 
 class Program_weight_tensor_parameter_92:
     name = "parameter_92"
+    original_name = "batch_norm2d_28.w_2"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -929,6 +1022,7 @@ class Program_weight_tensor_parameter_92:
 
 class Program_weight_tensor_parameter_93:
     name = "parameter_93"
+    original_name = "batch_norm2d_28.w_1"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -938,6 +1032,7 @@ class Program_weight_tensor_parameter_93:
 
 class Program_weight_tensor_parameter_94:
     name = "parameter_94"
+    original_name = "conv2d_59.w_0"
     shape = [48, 1, 5, 5]
     dtype = "float32"
     min_val = float("-1.24165")
@@ -949,6 +1044,7 @@ class Program_weight_tensor_parameter_94:
 
 class Program_weight_tensor_parameter_95:
     name = "parameter_95"
+    original_name = "batch_norm2d_27.b_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -958,6 +1054,7 @@ class Program_weight_tensor_parameter_95:
 
 class Program_weight_tensor_parameter_96:
     name = "parameter_96"
+    original_name = "batch_norm2d_27.w_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -967,6 +1064,7 @@ class Program_weight_tensor_parameter_96:
 
 class Program_weight_tensor_parameter_97:
     name = "parameter_97"
+    original_name = "batch_norm2d_27.w_2"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -976,6 +1074,7 @@ class Program_weight_tensor_parameter_97:
 
 class Program_weight_tensor_parameter_98:
     name = "parameter_98"
+    original_name = "batch_norm2d_27.w_1"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -985,6 +1084,7 @@ class Program_weight_tensor_parameter_98:
 
 class Program_weight_tensor_parameter_99:
     name = "parameter_99"
+    original_name = "conv2d_58.w_0"
     shape = [48, 48, 1, 1]
     dtype = "float32"
     min_val = float("-1.20297")
@@ -996,6 +1096,7 @@ class Program_weight_tensor_parameter_99:
 
 class Program_weight_tensor_parameter_100:
     name = "parameter_100"
+    original_name = "batch_norm2d_24.b_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1005,6 +1106,7 @@ class Program_weight_tensor_parameter_100:
 
 class Program_weight_tensor_parameter_101:
     name = "parameter_101"
+    original_name = "batch_norm2d_24.w_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1014,6 +1116,7 @@ class Program_weight_tensor_parameter_101:
 
 class Program_weight_tensor_parameter_102:
     name = "parameter_102"
+    original_name = "batch_norm2d_24.w_2"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1023,6 +1126,7 @@ class Program_weight_tensor_parameter_102:
 
 class Program_weight_tensor_parameter_103:
     name = "parameter_103"
+    original_name = "batch_norm2d_24.w_1"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1032,6 +1136,7 @@ class Program_weight_tensor_parameter_103:
 
 class Program_weight_tensor_parameter_104:
     name = "parameter_104"
+    original_name = "conv2d_55.w_0"
     shape = [48, 192, 1, 1]
     dtype = "float32"
     min_val = float("-1.04492")
@@ -1043,6 +1148,7 @@ class Program_weight_tensor_parameter_104:
 
 class Program_weight_tensor_parameter_105:
     name = "parameter_105"
+    original_name = "batch_norm2d_25.b_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1052,6 +1158,7 @@ class Program_weight_tensor_parameter_105:
 
 class Program_weight_tensor_parameter_106:
     name = "parameter_106"
+    original_name = "batch_norm2d_25.w_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1061,6 +1168,7 @@ class Program_weight_tensor_parameter_106:
 
 class Program_weight_tensor_parameter_107:
     name = "parameter_107"
+    original_name = "batch_norm2d_25.w_2"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1070,6 +1178,7 @@ class Program_weight_tensor_parameter_107:
 
 class Program_weight_tensor_parameter_108:
     name = "parameter_108"
+    original_name = "batch_norm2d_25.w_1"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1079,6 +1188,7 @@ class Program_weight_tensor_parameter_108:
 
 class Program_weight_tensor_parameter_109:
     name = "parameter_109"
+    original_name = "conv2d_56.w_0"
     shape = [48, 192, 1, 1]
     dtype = "float32"
     min_val = float("-0.959834")
@@ -1090,6 +1200,7 @@ class Program_weight_tensor_parameter_109:
 
 class Program_weight_tensor_parameter_110:
     name = "parameter_110"
+    original_name = "batch_norm2d_23.b_0"
     shape = [96]
     dtype = "float32"
     min_val = float("-0.471762")
@@ -1101,6 +1212,7 @@ class Program_weight_tensor_parameter_110:
 
 class Program_weight_tensor_parameter_111:
     name = "parameter_111"
+    original_name = "batch_norm2d_23.w_0"
     shape = [96]
     dtype = "float32"
     min_val = float("0.603814")
@@ -1112,6 +1224,7 @@ class Program_weight_tensor_parameter_111:
 
 class Program_weight_tensor_parameter_112:
     name = "parameter_112"
+    original_name = "batch_norm2d_23.w_2"
     shape = [96]
     dtype = "float32"
     min_val = float("2.80003")
@@ -1123,6 +1236,7 @@ class Program_weight_tensor_parameter_112:
 
 class Program_weight_tensor_parameter_113:
     name = "parameter_113"
+    original_name = "batch_norm2d_23.w_1"
     shape = [96]
     dtype = "float32"
     min_val = float("-2.68788")
@@ -1134,6 +1248,7 @@ class Program_weight_tensor_parameter_113:
 
 class Program_weight_tensor_parameter_114:
     name = "parameter_114"
+    original_name = "conv2d_54.w_0"
     shape = [96, 96, 1, 1]
     dtype = "float32"
     min_val = float("-1.119")
@@ -1145,6 +1260,7 @@ class Program_weight_tensor_parameter_114:
 
 class Program_weight_tensor_parameter_115:
     name = "parameter_115"
+    original_name = "batch_norm2d_22.b_0"
     shape = [96]
     dtype = "float32"
     min_val = float("-0.543295")
@@ -1156,6 +1272,7 @@ class Program_weight_tensor_parameter_115:
 
 class Program_weight_tensor_parameter_116:
     name = "parameter_116"
+    original_name = "batch_norm2d_22.w_0"
     shape = [96]
     dtype = "float32"
     min_val = float("0.618166")
@@ -1167,6 +1284,7 @@ class Program_weight_tensor_parameter_116:
 
 class Program_weight_tensor_parameter_117:
     name = "parameter_117"
+    original_name = "batch_norm2d_22.w_2"
     shape = [96]
     dtype = "float32"
     min_val = float("0.291178")
@@ -1178,6 +1296,7 @@ class Program_weight_tensor_parameter_117:
 
 class Program_weight_tensor_parameter_118:
     name = "parameter_118"
+    original_name = "batch_norm2d_22.w_1"
     shape = [96]
     dtype = "float32"
     min_val = float("-1.2388")
@@ -1189,6 +1308,7 @@ class Program_weight_tensor_parameter_118:
 
 class Program_weight_tensor_parameter_119:
     name = "parameter_119"
+    original_name = "conv2d_53.w_0"
     shape = [96, 1, 5, 5]
     dtype = "float32"
     min_val = float("-1.12981")
@@ -1200,6 +1320,7 @@ class Program_weight_tensor_parameter_119:
 
 class Program_weight_tensor_parameter_120:
     name = "parameter_120"
+    original_name = "batch_norm2d_18.b_0"
     shape = [96]
     dtype = "float32"
     min_val = float("-0.560678")
@@ -1211,6 +1332,7 @@ class Program_weight_tensor_parameter_120:
 
 class Program_weight_tensor_parameter_121:
     name = "parameter_121"
+    original_name = "batch_norm2d_18.w_0"
     shape = [96]
     dtype = "float32"
     min_val = float("0.661022")
@@ -1222,6 +1344,7 @@ class Program_weight_tensor_parameter_121:
 
 class Program_weight_tensor_parameter_122:
     name = "parameter_122"
+    original_name = "batch_norm2d_18.w_2"
     shape = [96]
     dtype = "float32"
     min_val = float("2.87781")
@@ -1233,6 +1356,7 @@ class Program_weight_tensor_parameter_122:
 
 class Program_weight_tensor_parameter_123:
     name = "parameter_123"
+    original_name = "batch_norm2d_18.w_1"
     shape = [96]
     dtype = "float32"
     min_val = float("-1.62306")
@@ -1244,6 +1368,7 @@ class Program_weight_tensor_parameter_123:
 
 class Program_weight_tensor_parameter_124:
     name = "parameter_124"
+    original_name = "conv2d_49.w_0"
     shape = [96, 96, 1, 1]
     dtype = "float32"
     min_val = float("-1.20651")
@@ -1255,6 +1380,7 @@ class Program_weight_tensor_parameter_124:
 
 class Program_weight_tensor_parameter_125:
     name = "parameter_125"
+    original_name = "batch_norm2d_21.b_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1264,6 +1390,7 @@ class Program_weight_tensor_parameter_125:
 
 class Program_weight_tensor_parameter_126:
     name = "parameter_126"
+    original_name = "batch_norm2d_21.w_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1273,6 +1400,7 @@ class Program_weight_tensor_parameter_126:
 
 class Program_weight_tensor_parameter_127:
     name = "parameter_127"
+    original_name = "batch_norm2d_21.w_2"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1282,6 +1410,7 @@ class Program_weight_tensor_parameter_127:
 
 class Program_weight_tensor_parameter_128:
     name = "parameter_128"
+    original_name = "batch_norm2d_21.w_1"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1291,6 +1420,7 @@ class Program_weight_tensor_parameter_128:
 
 class Program_weight_tensor_parameter_129:
     name = "parameter_129"
+    original_name = "conv2d_52.w_0"
     shape = [48, 48, 1, 1]
     dtype = "float32"
     min_val = float("-1.26117")
@@ -1302,6 +1432,7 @@ class Program_weight_tensor_parameter_129:
 
 class Program_weight_tensor_parameter_130:
     name = "parameter_130"
+    original_name = "batch_norm2d_20.b_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1311,6 +1442,7 @@ class Program_weight_tensor_parameter_130:
 
 class Program_weight_tensor_parameter_131:
     name = "parameter_131"
+    original_name = "batch_norm2d_20.w_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1320,6 +1452,7 @@ class Program_weight_tensor_parameter_131:
 
 class Program_weight_tensor_parameter_132:
     name = "parameter_132"
+    original_name = "batch_norm2d_20.w_2"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1329,6 +1462,7 @@ class Program_weight_tensor_parameter_132:
 
 class Program_weight_tensor_parameter_133:
     name = "parameter_133"
+    original_name = "batch_norm2d_20.w_1"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1338,6 +1472,7 @@ class Program_weight_tensor_parameter_133:
 
 class Program_weight_tensor_parameter_134:
     name = "parameter_134"
+    original_name = "conv2d_51.w_0"
     shape = [48, 1, 5, 5]
     dtype = "float32"
     min_val = float("-1.10175")
@@ -1349,6 +1484,7 @@ class Program_weight_tensor_parameter_134:
 
 class Program_weight_tensor_parameter_135:
     name = "parameter_135"
+    original_name = "batch_norm2d_19.b_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1358,6 +1494,7 @@ class Program_weight_tensor_parameter_135:
 
 class Program_weight_tensor_parameter_136:
     name = "parameter_136"
+    original_name = "batch_norm2d_19.w_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1367,6 +1504,7 @@ class Program_weight_tensor_parameter_136:
 
 class Program_weight_tensor_parameter_137:
     name = "parameter_137"
+    original_name = "batch_norm2d_19.w_2"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1376,6 +1514,7 @@ class Program_weight_tensor_parameter_137:
 
 class Program_weight_tensor_parameter_138:
     name = "parameter_138"
+    original_name = "batch_norm2d_19.w_1"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1385,6 +1524,7 @@ class Program_weight_tensor_parameter_138:
 
 class Program_weight_tensor_parameter_139:
     name = "parameter_139"
+    original_name = "conv2d_50.w_0"
     shape = [48, 48, 1, 1]
     dtype = "float32"
     min_val = float("-1.39181")
@@ -1396,6 +1536,7 @@ class Program_weight_tensor_parameter_139:
 
 class Program_weight_tensor_parameter_140:
     name = "parameter_140"
+    original_name = "batch_norm2d_16.b_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1405,6 +1546,7 @@ class Program_weight_tensor_parameter_140:
 
 class Program_weight_tensor_parameter_141:
     name = "parameter_141"
+    original_name = "batch_norm2d_16.w_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1414,6 +1556,7 @@ class Program_weight_tensor_parameter_141:
 
 class Program_weight_tensor_parameter_142:
     name = "parameter_142"
+    original_name = "batch_norm2d_16.w_2"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1423,6 +1566,7 @@ class Program_weight_tensor_parameter_142:
 
 class Program_weight_tensor_parameter_143:
     name = "parameter_143"
+    original_name = "batch_norm2d_16.w_1"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1432,6 +1576,7 @@ class Program_weight_tensor_parameter_143:
 
 class Program_weight_tensor_parameter_144:
     name = "parameter_144"
+    original_name = "conv2d_47.w_0"
     shape = [48, 192, 1, 1]
     dtype = "float32"
     min_val = float("-1.03054")
@@ -1443,6 +1588,7 @@ class Program_weight_tensor_parameter_144:
 
 class Program_weight_tensor_parameter_145:
     name = "parameter_145"
+    original_name = "batch_norm2d_17.b_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1452,6 +1598,7 @@ class Program_weight_tensor_parameter_145:
 
 class Program_weight_tensor_parameter_146:
     name = "parameter_146"
+    original_name = "batch_norm2d_17.w_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1461,6 +1608,7 @@ class Program_weight_tensor_parameter_146:
 
 class Program_weight_tensor_parameter_147:
     name = "parameter_147"
+    original_name = "batch_norm2d_17.w_2"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1470,6 +1618,7 @@ class Program_weight_tensor_parameter_147:
 
 class Program_weight_tensor_parameter_148:
     name = "parameter_148"
+    original_name = "batch_norm2d_17.w_1"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1479,6 +1628,7 @@ class Program_weight_tensor_parameter_148:
 
 class Program_weight_tensor_parameter_149:
     name = "parameter_149"
+    original_name = "conv2d_48.w_0"
     shape = [48, 192, 1, 1]
     dtype = "float32"
     min_val = float("-1.0192")
@@ -1490,6 +1640,7 @@ class Program_weight_tensor_parameter_149:
 
 class Program_weight_tensor_parameter_150:
     name = "parameter_150"
+    original_name = "batch_norm2d_12.b_0"
     shape = [96]
     dtype = "float32"
     min_val = float("-0.551726")
@@ -1501,6 +1652,7 @@ class Program_weight_tensor_parameter_150:
 
 class Program_weight_tensor_parameter_151:
     name = "parameter_151"
+    original_name = "batch_norm2d_12.w_0"
     shape = [96]
     dtype = "float32"
     min_val = float("0.664316")
@@ -1512,6 +1664,7 @@ class Program_weight_tensor_parameter_151:
 
 class Program_weight_tensor_parameter_152:
     name = "parameter_152"
+    original_name = "batch_norm2d_12.w_2"
     shape = [96]
     dtype = "float32"
     min_val = float("2.97301")
@@ -1523,6 +1676,7 @@ class Program_weight_tensor_parameter_152:
 
 class Program_weight_tensor_parameter_153:
     name = "parameter_153"
+    original_name = "batch_norm2d_12.w_1"
     shape = [96]
     dtype = "float32"
     min_val = float("-1.85289")
@@ -1534,6 +1688,7 @@ class Program_weight_tensor_parameter_153:
 
 class Program_weight_tensor_parameter_154:
     name = "parameter_154"
+    original_name = "conv2d_43.w_0"
     shape = [96, 96, 1, 1]
     dtype = "float32"
     min_val = float("-1.50373")
@@ -1545,6 +1700,7 @@ class Program_weight_tensor_parameter_154:
 
 class Program_weight_tensor_parameter_155:
     name = "parameter_155"
+    original_name = "batch_norm2d_15.b_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1554,6 +1710,7 @@ class Program_weight_tensor_parameter_155:
 
 class Program_weight_tensor_parameter_156:
     name = "parameter_156"
+    original_name = "batch_norm2d_15.w_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1563,6 +1720,7 @@ class Program_weight_tensor_parameter_156:
 
 class Program_weight_tensor_parameter_157:
     name = "parameter_157"
+    original_name = "batch_norm2d_15.w_2"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1572,6 +1730,7 @@ class Program_weight_tensor_parameter_157:
 
 class Program_weight_tensor_parameter_158:
     name = "parameter_158"
+    original_name = "batch_norm2d_15.w_1"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1581,6 +1740,7 @@ class Program_weight_tensor_parameter_158:
 
 class Program_weight_tensor_parameter_159:
     name = "parameter_159"
+    original_name = "conv2d_46.w_0"
     shape = [48, 48, 1, 1]
     dtype = "float32"
     min_val = float("-0.939612")
@@ -1592,6 +1752,7 @@ class Program_weight_tensor_parameter_159:
 
 class Program_weight_tensor_parameter_160:
     name = "parameter_160"
+    original_name = "batch_norm2d_14.b_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1601,6 +1762,7 @@ class Program_weight_tensor_parameter_160:
 
 class Program_weight_tensor_parameter_161:
     name = "parameter_161"
+    original_name = "batch_norm2d_14.w_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1610,6 +1772,7 @@ class Program_weight_tensor_parameter_161:
 
 class Program_weight_tensor_parameter_162:
     name = "parameter_162"
+    original_name = "batch_norm2d_14.w_2"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1619,6 +1782,7 @@ class Program_weight_tensor_parameter_162:
 
 class Program_weight_tensor_parameter_163:
     name = "parameter_163"
+    original_name = "batch_norm2d_14.w_1"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1628,6 +1792,7 @@ class Program_weight_tensor_parameter_163:
 
 class Program_weight_tensor_parameter_164:
     name = "parameter_164"
+    original_name = "conv2d_45.w_0"
     shape = [48, 1, 5, 5]
     dtype = "float32"
     min_val = float("-1.10802")
@@ -1639,6 +1804,7 @@ class Program_weight_tensor_parameter_164:
 
 class Program_weight_tensor_parameter_165:
     name = "parameter_165"
+    original_name = "batch_norm2d_13.b_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1648,6 +1814,7 @@ class Program_weight_tensor_parameter_165:
 
 class Program_weight_tensor_parameter_166:
     name = "parameter_166"
+    original_name = "batch_norm2d_13.w_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1657,6 +1824,7 @@ class Program_weight_tensor_parameter_166:
 
 class Program_weight_tensor_parameter_167:
     name = "parameter_167"
+    original_name = "batch_norm2d_13.w_2"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1666,6 +1834,7 @@ class Program_weight_tensor_parameter_167:
 
 class Program_weight_tensor_parameter_168:
     name = "parameter_168"
+    original_name = "batch_norm2d_13.w_1"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1675,6 +1844,7 @@ class Program_weight_tensor_parameter_168:
 
 class Program_weight_tensor_parameter_169:
     name = "parameter_169"
+    original_name = "conv2d_44.w_0"
     shape = [48, 48, 1, 1]
     dtype = "float32"
     min_val = float("-1.00147")
@@ -1686,6 +1856,7 @@ class Program_weight_tensor_parameter_169:
 
 class Program_weight_tensor_parameter_170:
     name = "parameter_170"
+    original_name = "batch_norm2d_10.b_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1695,6 +1866,7 @@ class Program_weight_tensor_parameter_170:
 
 class Program_weight_tensor_parameter_171:
     name = "parameter_171"
+    original_name = "batch_norm2d_10.w_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1704,6 +1876,7 @@ class Program_weight_tensor_parameter_171:
 
 class Program_weight_tensor_parameter_172:
     name = "parameter_172"
+    original_name = "batch_norm2d_10.w_2"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1713,6 +1886,7 @@ class Program_weight_tensor_parameter_172:
 
 class Program_weight_tensor_parameter_173:
     name = "parameter_173"
+    original_name = "batch_norm2d_10.w_1"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1722,6 +1896,7 @@ class Program_weight_tensor_parameter_173:
 
 class Program_weight_tensor_parameter_174:
     name = "parameter_174"
+    original_name = "conv2d_41.w_0"
     shape = [48, 192, 1, 1]
     dtype = "float32"
     min_val = float("-1.12391")
@@ -1733,6 +1908,7 @@ class Program_weight_tensor_parameter_174:
 
 class Program_weight_tensor_parameter_175:
     name = "parameter_175"
+    original_name = "batch_norm2d_11.b_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1742,6 +1918,7 @@ class Program_weight_tensor_parameter_175:
 
 class Program_weight_tensor_parameter_176:
     name = "parameter_176"
+    original_name = "batch_norm2d_11.w_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1751,6 +1928,7 @@ class Program_weight_tensor_parameter_176:
 
 class Program_weight_tensor_parameter_177:
     name = "parameter_177"
+    original_name = "batch_norm2d_11.w_2"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1760,6 +1938,7 @@ class Program_weight_tensor_parameter_177:
 
 class Program_weight_tensor_parameter_178:
     name = "parameter_178"
+    original_name = "batch_norm2d_11.w_1"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1769,6 +1948,7 @@ class Program_weight_tensor_parameter_178:
 
 class Program_weight_tensor_parameter_179:
     name = "parameter_179"
+    original_name = "conv2d_42.w_0"
     shape = [48, 192, 1, 1]
     dtype = "float32"
     min_val = float("-1.2298")
@@ -1780,6 +1960,7 @@ class Program_weight_tensor_parameter_179:
 
 class Program_weight_tensor_parameter_180:
     name = "parameter_180"
+    original_name = "batch_norm2d_6.b_0"
     shape = [96]
     dtype = "float32"
     min_val = float("-0.482343")
@@ -1791,6 +1972,7 @@ class Program_weight_tensor_parameter_180:
 
 class Program_weight_tensor_parameter_181:
     name = "parameter_181"
+    original_name = "batch_norm2d_6.w_0"
     shape = [96]
     dtype = "float32"
     min_val = float("0.670714")
@@ -1802,6 +1984,7 @@ class Program_weight_tensor_parameter_181:
 
 class Program_weight_tensor_parameter_182:
     name = "parameter_182"
+    original_name = "batch_norm2d_6.w_2"
     shape = [96]
     dtype = "float32"
     min_val = float("2.57973")
@@ -1813,6 +1996,7 @@ class Program_weight_tensor_parameter_182:
 
 class Program_weight_tensor_parameter_183:
     name = "parameter_183"
+    original_name = "batch_norm2d_6.w_1"
     shape = [96]
     dtype = "float32"
     min_val = float("-2.01387")
@@ -1824,6 +2008,7 @@ class Program_weight_tensor_parameter_183:
 
 class Program_weight_tensor_parameter_184:
     name = "parameter_184"
+    original_name = "conv2d_37.w_0"
     shape = [96, 96, 1, 1]
     dtype = "float32"
     min_val = float("-0.991255")
@@ -1835,6 +2020,7 @@ class Program_weight_tensor_parameter_184:
 
 class Program_weight_tensor_parameter_185:
     name = "parameter_185"
+    original_name = "batch_norm2d_9.b_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1844,6 +2030,7 @@ class Program_weight_tensor_parameter_185:
 
 class Program_weight_tensor_parameter_186:
     name = "parameter_186"
+    original_name = "batch_norm2d_9.w_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1853,6 +2040,7 @@ class Program_weight_tensor_parameter_186:
 
 class Program_weight_tensor_parameter_187:
     name = "parameter_187"
+    original_name = "batch_norm2d_9.w_2"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1862,6 +2050,7 @@ class Program_weight_tensor_parameter_187:
 
 class Program_weight_tensor_parameter_188:
     name = "parameter_188"
+    original_name = "batch_norm2d_9.w_1"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1871,6 +2060,7 @@ class Program_weight_tensor_parameter_188:
 
 class Program_weight_tensor_parameter_189:
     name = "parameter_189"
+    original_name = "conv2d_40.w_0"
     shape = [48, 48, 1, 1]
     dtype = "float32"
     min_val = float("-1.11426")
@@ -1882,6 +2072,7 @@ class Program_weight_tensor_parameter_189:
 
 class Program_weight_tensor_parameter_190:
     name = "parameter_190"
+    original_name = "batch_norm2d_8.b_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1891,6 +2082,7 @@ class Program_weight_tensor_parameter_190:
 
 class Program_weight_tensor_parameter_191:
     name = "parameter_191"
+    original_name = "batch_norm2d_8.w_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1900,6 +2092,7 @@ class Program_weight_tensor_parameter_191:
 
 class Program_weight_tensor_parameter_192:
     name = "parameter_192"
+    original_name = "batch_norm2d_8.w_2"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1909,6 +2102,7 @@ class Program_weight_tensor_parameter_192:
 
 class Program_weight_tensor_parameter_193:
     name = "parameter_193"
+    original_name = "batch_norm2d_8.w_1"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1918,6 +2112,7 @@ class Program_weight_tensor_parameter_193:
 
 class Program_weight_tensor_parameter_194:
     name = "parameter_194"
+    original_name = "conv2d_39.w_0"
     shape = [48, 1, 5, 5]
     dtype = "float32"
     min_val = float("-1.01961")
@@ -1929,6 +2124,7 @@ class Program_weight_tensor_parameter_194:
 
 class Program_weight_tensor_parameter_195:
     name = "parameter_195"
+    original_name = "batch_norm2d_7.b_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1938,6 +2134,7 @@ class Program_weight_tensor_parameter_195:
 
 class Program_weight_tensor_parameter_196:
     name = "parameter_196"
+    original_name = "batch_norm2d_7.w_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1947,6 +2144,7 @@ class Program_weight_tensor_parameter_196:
 
 class Program_weight_tensor_parameter_197:
     name = "parameter_197"
+    original_name = "batch_norm2d_7.w_2"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1956,6 +2154,7 @@ class Program_weight_tensor_parameter_197:
 
 class Program_weight_tensor_parameter_198:
     name = "parameter_198"
+    original_name = "batch_norm2d_7.w_1"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1965,6 +2164,7 @@ class Program_weight_tensor_parameter_198:
 
 class Program_weight_tensor_parameter_199:
     name = "parameter_199"
+    original_name = "conv2d_38.w_0"
     shape = [48, 48, 1, 1]
     dtype = "float32"
     min_val = float("-0.983634")
@@ -1976,6 +2176,7 @@ class Program_weight_tensor_parameter_199:
 
 class Program_weight_tensor_parameter_200:
     name = "parameter_200"
+    original_name = "batch_norm2d_4.b_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1985,6 +2186,7 @@ class Program_weight_tensor_parameter_200:
 
 class Program_weight_tensor_parameter_201:
     name = "parameter_201"
+    original_name = "batch_norm2d_4.w_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -1994,6 +2196,7 @@ class Program_weight_tensor_parameter_201:
 
 class Program_weight_tensor_parameter_202:
     name = "parameter_202"
+    original_name = "batch_norm2d_4.w_2"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -2003,6 +2206,7 @@ class Program_weight_tensor_parameter_202:
 
 class Program_weight_tensor_parameter_203:
     name = "parameter_203"
+    original_name = "batch_norm2d_4.w_1"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -2012,6 +2216,7 @@ class Program_weight_tensor_parameter_203:
 
 class Program_weight_tensor_parameter_204:
     name = "parameter_204"
+    original_name = "conv2d_35.w_0"
     shape = [48, 192, 1, 1]
     dtype = "float32"
     min_val = float("-1.33669")
@@ -2023,6 +2228,7 @@ class Program_weight_tensor_parameter_204:
 
 class Program_weight_tensor_parameter_205:
     name = "parameter_205"
+    original_name = "batch_norm2d_5.b_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -2032,6 +2238,7 @@ class Program_weight_tensor_parameter_205:
 
 class Program_weight_tensor_parameter_206:
     name = "parameter_206"
+    original_name = "batch_norm2d_5.w_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -2041,6 +2248,7 @@ class Program_weight_tensor_parameter_206:
 
 class Program_weight_tensor_parameter_207:
     name = "parameter_207"
+    original_name = "batch_norm2d_5.w_2"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -2050,6 +2258,7 @@ class Program_weight_tensor_parameter_207:
 
 class Program_weight_tensor_parameter_208:
     name = "parameter_208"
+    original_name = "batch_norm2d_5.w_1"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -2059,6 +2268,7 @@ class Program_weight_tensor_parameter_208:
 
 class Program_weight_tensor_parameter_209:
     name = "parameter_209"
+    original_name = "conv2d_36.w_0"
     shape = [48, 192, 1, 1]
     dtype = "float32"
     min_val = float("-1.38097")
@@ -2070,6 +2280,7 @@ class Program_weight_tensor_parameter_209:
 
 class Program_weight_tensor_parameter_210:
     name = "parameter_210"
+    original_name = "batch_norm2d_3.b_0"
     shape = [96]
     dtype = "float32"
     min_val = float("-0.237802")
@@ -2081,6 +2292,7 @@ class Program_weight_tensor_parameter_210:
 
 class Program_weight_tensor_parameter_211:
     name = "parameter_211"
+    original_name = "batch_norm2d_3.w_0"
     shape = [96]
     dtype = "float32"
     min_val = float("0.882038")
@@ -2092,6 +2304,7 @@ class Program_weight_tensor_parameter_211:
 
 class Program_weight_tensor_parameter_212:
     name = "parameter_212"
+    original_name = "batch_norm2d_3.w_2"
     shape = [96]
     dtype = "float32"
     min_val = float("62.3976")
@@ -2103,6 +2316,7 @@ class Program_weight_tensor_parameter_212:
 
 class Program_weight_tensor_parameter_213:
     name = "parameter_213"
+    original_name = "batch_norm2d_3.w_1"
     shape = [96]
     dtype = "float32"
     min_val = float("-13.5523")
@@ -2114,6 +2328,7 @@ class Program_weight_tensor_parameter_213:
 
 class Program_weight_tensor_parameter_214:
     name = "parameter_214"
+    original_name = "conv2d_34.w_0"
     shape = [96, 512, 1, 1]
     dtype = "float32"
     min_val = float("-2.09646")
@@ -2125,6 +2340,7 @@ class Program_weight_tensor_parameter_214:
 
 class Program_weight_tensor_parameter_215:
     name = "parameter_215"
+    original_name = "batch_norm2d_2.b_0"
     shape = [96]
     dtype = "float32"
     min_val = float("-0.587668")
@@ -2136,6 +2352,7 @@ class Program_weight_tensor_parameter_215:
 
 class Program_weight_tensor_parameter_216:
     name = "parameter_216"
+    original_name = "batch_norm2d_2.w_0"
     shape = [96]
     dtype = "float32"
     min_val = float("0.518918")
@@ -2147,6 +2364,7 @@ class Program_weight_tensor_parameter_216:
 
 class Program_weight_tensor_parameter_217:
     name = "parameter_217"
+    original_name = "batch_norm2d_2.w_2"
     shape = [96]
     dtype = "float32"
     min_val = float("1.99622")
@@ -2158,6 +2376,7 @@ class Program_weight_tensor_parameter_217:
 
 class Program_weight_tensor_parameter_218:
     name = "parameter_218"
+    original_name = "batch_norm2d_2.w_1"
     shape = [96]
     dtype = "float32"
     min_val = float("-2.45523")
@@ -2169,6 +2388,7 @@ class Program_weight_tensor_parameter_218:
 
 class Program_weight_tensor_parameter_219:
     name = "parameter_219"
+    original_name = "conv2d_33.w_0"
     shape = [96, 256, 1, 1]
     dtype = "float32"
     min_val = float("-1.24805")
@@ -2180,6 +2400,7 @@ class Program_weight_tensor_parameter_219:
 
 class Program_weight_tensor_parameter_220:
     name = "parameter_220"
+    original_name = "batch_norm2d_1.b_0"
     shape = [96]
     dtype = "float32"
     min_val = float("-0.65098")
@@ -2191,6 +2412,7 @@ class Program_weight_tensor_parameter_220:
 
 class Program_weight_tensor_parameter_221:
     name = "parameter_221"
+    original_name = "batch_norm2d_1.w_0"
     shape = [96]
     dtype = "float32"
     min_val = float("0.668796")
@@ -2202,6 +2424,7 @@ class Program_weight_tensor_parameter_221:
 
 class Program_weight_tensor_parameter_222:
     name = "parameter_222"
+    original_name = "batch_norm2d_1.w_2"
     shape = [96]
     dtype = "float32"
     min_val = float("1.02184")
@@ -2213,6 +2436,7 @@ class Program_weight_tensor_parameter_222:
 
 class Program_weight_tensor_parameter_223:
     name = "parameter_223"
+    original_name = "batch_norm2d_1.w_1"
     shape = [96]
     dtype = "float32"
     min_val = float("-1.73317")
@@ -2224,6 +2448,7 @@ class Program_weight_tensor_parameter_223:
 
 class Program_weight_tensor_parameter_224:
     name = "parameter_224"
+    original_name = "conv2d_32.w_0"
     shape = [96, 128, 1, 1]
     dtype = "float32"
     min_val = float("-1.41707")
@@ -2235,6 +2460,7 @@ class Program_weight_tensor_parameter_224:
 
 class Program_weight_tensor_parameter_225:
     name = "parameter_225"
+    original_name = "batch_norm2d_0.b_0"
     shape = [96]
     dtype = "float32"
     min_val = float("-0.628921")
@@ -2246,6 +2472,7 @@ class Program_weight_tensor_parameter_225:
 
 class Program_weight_tensor_parameter_226:
     name = "parameter_226"
+    original_name = "batch_norm2d_0.w_0"
     shape = [96]
     dtype = "float32"
     min_val = float("0.430088")
@@ -2257,6 +2484,7 @@ class Program_weight_tensor_parameter_226:
 
 class Program_weight_tensor_parameter_227:
     name = "parameter_227"
+    original_name = "batch_norm2d_0.w_2"
     shape = [96]
     dtype = "float32"
     min_val = float("0.484083")
@@ -2268,6 +2496,7 @@ class Program_weight_tensor_parameter_227:
 
 class Program_weight_tensor_parameter_228:
     name = "parameter_228"
+    original_name = "batch_norm2d_0.w_1"
     shape = [96]
     dtype = "float32"
     min_val = float("-3.19169")
@@ -2279,6 +2508,7 @@ class Program_weight_tensor_parameter_228:
 
 class Program_weight_tensor_parameter_229:
     name = "parameter_229"
+    original_name = "conv2d_31.w_0"
     shape = [96, 64, 1, 1]
     dtype = "float32"
     min_val = float("-1.13987")
@@ -2290,6 +2520,7 @@ class Program_weight_tensor_parameter_229:
 
 class Program_weight_tensor_parameter_230:
     name = "parameter_230"
+    original_name = "batch_norm_26.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-1.71557")
@@ -2301,6 +2532,7 @@ class Program_weight_tensor_parameter_230:
 
 class Program_weight_tensor_parameter_231:
     name = "parameter_231"
+    original_name = "batch_norm_26.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("1.58651")
@@ -2312,6 +2544,7 @@ class Program_weight_tensor_parameter_231:
 
 class Program_weight_tensor_parameter_232:
     name = "parameter_232"
+    original_name = "batch_norm_26.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("1.19276")
@@ -2323,6 +2556,7 @@ class Program_weight_tensor_parameter_232:
 
 class Program_weight_tensor_parameter_233:
     name = "parameter_233"
+    original_name = "batch_norm_26.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-1.21129")
@@ -2334,6 +2568,7 @@ class Program_weight_tensor_parameter_233:
 
 class Program_weight_tensor_parameter_234:
     name = "parameter_234"
+    original_name = "conv2d_30.w_0"
     shape = [512, 512, 1, 1]
     dtype = "float32"
     min_val = float("-3.54385")
@@ -2345,6 +2580,7 @@ class Program_weight_tensor_parameter_234:
 
 class Program_weight_tensor_parameter_235:
     name = "parameter_235"
+    original_name = "conv2d_29.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.57823")
@@ -2356,6 +2592,7 @@ class Program_weight_tensor_parameter_235:
 
 class Program_weight_tensor_parameter_236:
     name = "parameter_236"
+    original_name = "conv2d_29.w_0"
     shape = [512, 128, 1, 1]
     dtype = "float32"
     min_val = float("-1.77783")
@@ -2367,6 +2604,7 @@ class Program_weight_tensor_parameter_236:
 
 class Program_weight_tensor_parameter_237:
     name = "parameter_237"
+    original_name = "conv2d_28.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.320701")
@@ -2378,6 +2616,7 @@ class Program_weight_tensor_parameter_237:
 
 class Program_weight_tensor_parameter_238:
     name = "parameter_238"
+    original_name = "conv2d_28.w_0"
     shape = [128, 512, 1, 1]
     dtype = "float32"
     min_val = float("-2.31025")
@@ -2389,6 +2628,7 @@ class Program_weight_tensor_parameter_238:
 
 class Program_weight_tensor_parameter_239:
     name = "parameter_239"
+    original_name = "batch_norm_25.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-1.17827")
@@ -2400,6 +2640,7 @@ class Program_weight_tensor_parameter_239:
 
 class Program_weight_tensor_parameter_240:
     name = "parameter_240"
+    original_name = "batch_norm_25.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("0.275889")
@@ -2411,6 +2652,7 @@ class Program_weight_tensor_parameter_240:
 
 class Program_weight_tensor_parameter_241:
     name = "parameter_241"
+    original_name = "batch_norm_25.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("0.00226333")
@@ -2422,6 +2664,7 @@ class Program_weight_tensor_parameter_241:
 
 class Program_weight_tensor_parameter_242:
     name = "parameter_242"
+    original_name = "batch_norm_25.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-2.23921")
@@ -2433,6 +2676,7 @@ class Program_weight_tensor_parameter_242:
 
 class Program_weight_tensor_parameter_243:
     name = "parameter_243"
+    original_name = "conv2d_27.w_0"
     shape = [512, 1, 5, 5]
     dtype = "float32"
     min_val = float("-2.88061")
@@ -2444,6 +2688,7 @@ class Program_weight_tensor_parameter_243:
 
 class Program_weight_tensor_parameter_244:
     name = "parameter_244"
+    original_name = "batch_norm_24.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-1.73834")
@@ -2455,6 +2700,7 @@ class Program_weight_tensor_parameter_244:
 
 class Program_weight_tensor_parameter_245:
     name = "parameter_245"
+    original_name = "batch_norm_24.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-1.10718")
@@ -2466,6 +2712,7 @@ class Program_weight_tensor_parameter_245:
 
 class Program_weight_tensor_parameter_246:
     name = "parameter_246"
+    original_name = "batch_norm_24.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("1.11557")
@@ -2477,6 +2724,7 @@ class Program_weight_tensor_parameter_246:
 
 class Program_weight_tensor_parameter_247:
     name = "parameter_247"
+    original_name = "batch_norm_24.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-2.90242")
@@ -2488,6 +2736,7 @@ class Program_weight_tensor_parameter_247:
 
 class Program_weight_tensor_parameter_248:
     name = "parameter_248"
+    original_name = "conv2d_26.w_0"
     shape = [512, 256, 1, 1]
     dtype = "float32"
     min_val = float("-3.45796")
@@ -2499,6 +2748,7 @@ class Program_weight_tensor_parameter_248:
 
 class Program_weight_tensor_parameter_249:
     name = "parameter_249"
+    original_name = "conv2d_25.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.80427")
@@ -2510,6 +2760,7 @@ class Program_weight_tensor_parameter_249:
 
 class Program_weight_tensor_parameter_250:
     name = "parameter_250"
+    original_name = "conv2d_25.w_0"
     shape = [256, 64, 1, 1]
     dtype = "float32"
     min_val = float("-1.24379")
@@ -2521,6 +2772,7 @@ class Program_weight_tensor_parameter_250:
 
 class Program_weight_tensor_parameter_251:
     name = "parameter_251"
+    original_name = "conv2d_24.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -2530,6 +2782,7 @@ class Program_weight_tensor_parameter_251:
 
 class Program_weight_tensor_parameter_252:
     name = "parameter_252"
+    original_name = "conv2d_24.w_0"
     shape = [64, 256, 1, 1]
     dtype = "float32"
     min_val = float("-2.02268")
@@ -2541,6 +2794,7 @@ class Program_weight_tensor_parameter_252:
 
 class Program_weight_tensor_parameter_253:
     name = "parameter_253"
+    original_name = "batch_norm_23.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.790023")
@@ -2552,6 +2806,7 @@ class Program_weight_tensor_parameter_253:
 
 class Program_weight_tensor_parameter_254:
     name = "parameter_254"
+    original_name = "batch_norm_23.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.316892")
@@ -2563,6 +2818,7 @@ class Program_weight_tensor_parameter_254:
 
 class Program_weight_tensor_parameter_255:
     name = "parameter_255"
+    original_name = "batch_norm_23.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.0101875")
@@ -2574,6 +2830,7 @@ class Program_weight_tensor_parameter_255:
 
 class Program_weight_tensor_parameter_256:
     name = "parameter_256"
+    original_name = "batch_norm_23.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-2.88328")
@@ -2585,6 +2842,7 @@ class Program_weight_tensor_parameter_256:
 
 class Program_weight_tensor_parameter_257:
     name = "parameter_257"
+    original_name = "conv2d_23.w_0"
     shape = [256, 1, 5, 5]
     dtype = "float32"
     min_val = float("-1.77129")
@@ -2596,6 +2854,7 @@ class Program_weight_tensor_parameter_257:
 
 class Program_weight_tensor_parameter_258:
     name = "parameter_258"
+    original_name = "batch_norm_22.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.60557")
@@ -2607,6 +2866,7 @@ class Program_weight_tensor_parameter_258:
 
 class Program_weight_tensor_parameter_259:
     name = "parameter_259"
+    original_name = "batch_norm_22.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.291733")
@@ -2618,6 +2878,7 @@ class Program_weight_tensor_parameter_259:
 
 class Program_weight_tensor_parameter_260:
     name = "parameter_260"
+    original_name = "batch_norm_22.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("1.77819")
@@ -2629,6 +2890,7 @@ class Program_weight_tensor_parameter_260:
 
 class Program_weight_tensor_parameter_261:
     name = "parameter_261"
+    original_name = "batch_norm_22.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-5.22167")
@@ -2640,6 +2902,7 @@ class Program_weight_tensor_parameter_261:
 
 class Program_weight_tensor_parameter_262:
     name = "parameter_262"
+    original_name = "conv2d_22.w_0"
     shape = [256, 256, 1, 1]
     dtype = "float32"
     min_val = float("-3.89883")
@@ -2651,6 +2914,7 @@ class Program_weight_tensor_parameter_262:
 
 class Program_weight_tensor_parameter_263:
     name = "parameter_263"
+    original_name = "batch_norm_21.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.86908")
@@ -2662,6 +2926,7 @@ class Program_weight_tensor_parameter_263:
 
 class Program_weight_tensor_parameter_264:
     name = "parameter_264"
+    original_name = "batch_norm_21.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.244702")
@@ -2673,6 +2938,7 @@ class Program_weight_tensor_parameter_264:
 
 class Program_weight_tensor_parameter_265:
     name = "parameter_265"
+    original_name = "batch_norm_21.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.0060596")
@@ -2684,6 +2950,7 @@ class Program_weight_tensor_parameter_265:
 
 class Program_weight_tensor_parameter_266:
     name = "parameter_266"
+    original_name = "batch_norm_21.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.89884")
@@ -2695,6 +2962,7 @@ class Program_weight_tensor_parameter_266:
 
 class Program_weight_tensor_parameter_267:
     name = "parameter_267"
+    original_name = "conv2d_21.w_0"
     shape = [256, 1, 5, 5]
     dtype = "float32"
     min_val = float("-2.88969")
@@ -2706,6 +2974,7 @@ class Program_weight_tensor_parameter_267:
 
 class Program_weight_tensor_parameter_268:
     name = "parameter_268"
+    original_name = "batch_norm_20.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.63077")
@@ -2717,6 +2986,7 @@ class Program_weight_tensor_parameter_268:
 
 class Program_weight_tensor_parameter_269:
     name = "parameter_269"
+    original_name = "batch_norm_20.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.855135")
@@ -2728,6 +2998,7 @@ class Program_weight_tensor_parameter_269:
 
 class Program_weight_tensor_parameter_270:
     name = "parameter_270"
+    original_name = "batch_norm_20.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("1.82152")
@@ -2739,6 +3010,7 @@ class Program_weight_tensor_parameter_270:
 
 class Program_weight_tensor_parameter_271:
     name = "parameter_271"
+    original_name = "batch_norm_20.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-5.81962")
@@ -2750,6 +3022,7 @@ class Program_weight_tensor_parameter_271:
 
 class Program_weight_tensor_parameter_272:
     name = "parameter_272"
+    original_name = "conv2d_20.w_0"
     shape = [256, 256, 1, 1]
     dtype = "float32"
     min_val = float("-2.04992")
@@ -2761,6 +3034,7 @@ class Program_weight_tensor_parameter_272:
 
 class Program_weight_tensor_parameter_273:
     name = "parameter_273"
+    original_name = "batch_norm_19.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.87227")
@@ -2772,6 +3046,7 @@ class Program_weight_tensor_parameter_273:
 
 class Program_weight_tensor_parameter_274:
     name = "parameter_274"
+    original_name = "batch_norm_19.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.172692")
@@ -2783,6 +3058,7 @@ class Program_weight_tensor_parameter_274:
 
 class Program_weight_tensor_parameter_275:
     name = "parameter_275"
+    original_name = "batch_norm_19.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.00188424")
@@ -2794,6 +3070,7 @@ class Program_weight_tensor_parameter_275:
 
 class Program_weight_tensor_parameter_276:
     name = "parameter_276"
+    original_name = "batch_norm_19.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-6.434")
@@ -2805,6 +3082,7 @@ class Program_weight_tensor_parameter_276:
 
 class Program_weight_tensor_parameter_277:
     name = "parameter_277"
+    original_name = "conv2d_19.w_0"
     shape = [256, 1, 5, 5]
     dtype = "float32"
     min_val = float("-2.38921")
@@ -2816,6 +3094,7 @@ class Program_weight_tensor_parameter_277:
 
 class Program_weight_tensor_parameter_278:
     name = "parameter_278"
+    original_name = "batch_norm_18.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.58909")
@@ -2827,6 +3106,7 @@ class Program_weight_tensor_parameter_278:
 
 class Program_weight_tensor_parameter_279:
     name = "parameter_279"
+    original_name = "batch_norm_18.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.556579")
@@ -2838,6 +3118,7 @@ class Program_weight_tensor_parameter_279:
 
 class Program_weight_tensor_parameter_280:
     name = "parameter_280"
+    original_name = "batch_norm_18.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("2.55615")
@@ -2849,6 +3130,7 @@ class Program_weight_tensor_parameter_280:
 
 class Program_weight_tensor_parameter_281:
     name = "parameter_281"
+    original_name = "batch_norm_18.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-4.30402")
@@ -2860,6 +3142,7 @@ class Program_weight_tensor_parameter_281:
 
 class Program_weight_tensor_parameter_282:
     name = "parameter_282"
+    original_name = "conv2d_18.w_0"
     shape = [256, 256, 1, 1]
     dtype = "float32"
     min_val = float("-2.02532")
@@ -2871,6 +3154,7 @@ class Program_weight_tensor_parameter_282:
 
 class Program_weight_tensor_parameter_283:
     name = "parameter_283"
+    original_name = "batch_norm_17.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.81883")
@@ -2882,6 +3166,7 @@ class Program_weight_tensor_parameter_283:
 
 class Program_weight_tensor_parameter_284:
     name = "parameter_284"
+    original_name = "batch_norm_17.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.217403")
@@ -2893,6 +3178,7 @@ class Program_weight_tensor_parameter_284:
 
 class Program_weight_tensor_parameter_285:
     name = "parameter_285"
+    original_name = "batch_norm_17.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.00311972")
@@ -2904,6 +3190,7 @@ class Program_weight_tensor_parameter_285:
 
 class Program_weight_tensor_parameter_286:
     name = "parameter_286"
+    original_name = "batch_norm_17.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.89883")
@@ -2915,6 +3202,7 @@ class Program_weight_tensor_parameter_286:
 
 class Program_weight_tensor_parameter_287:
     name = "parameter_287"
+    original_name = "conv2d_17.w_0"
     shape = [256, 1, 5, 5]
     dtype = "float32"
     min_val = float("-2.15778")
@@ -2926,6 +3214,7 @@ class Program_weight_tensor_parameter_287:
 
 class Program_weight_tensor_parameter_288:
     name = "parameter_288"
+    original_name = "batch_norm_16.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.60112")
@@ -2937,6 +3226,7 @@ class Program_weight_tensor_parameter_288:
 
 class Program_weight_tensor_parameter_289:
     name = "parameter_289"
+    original_name = "batch_norm_16.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.401886")
@@ -2948,6 +3238,7 @@ class Program_weight_tensor_parameter_289:
 
 class Program_weight_tensor_parameter_290:
     name = "parameter_290"
+    original_name = "batch_norm_16.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("1.74456")
@@ -2959,6 +3250,7 @@ class Program_weight_tensor_parameter_290:
 
 class Program_weight_tensor_parameter_291:
     name = "parameter_291"
+    original_name = "batch_norm_16.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-4.92284")
@@ -2970,6 +3262,7 @@ class Program_weight_tensor_parameter_291:
 
 class Program_weight_tensor_parameter_292:
     name = "parameter_292"
+    original_name = "conv2d_16.w_0"
     shape = [256, 256, 1, 1]
     dtype = "float32"
     min_val = float("-2.3778")
@@ -2981,6 +3274,7 @@ class Program_weight_tensor_parameter_292:
 
 class Program_weight_tensor_parameter_293:
     name = "parameter_293"
+    original_name = "batch_norm_15.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.78632")
@@ -2992,6 +3286,7 @@ class Program_weight_tensor_parameter_293:
 
 class Program_weight_tensor_parameter_294:
     name = "parameter_294"
+    original_name = "batch_norm_15.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.745224")
@@ -3003,6 +3298,7 @@ class Program_weight_tensor_parameter_294:
 
 class Program_weight_tensor_parameter_295:
     name = "parameter_295"
+    original_name = "batch_norm_15.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.0041583")
@@ -3014,6 +3310,7 @@ class Program_weight_tensor_parameter_295:
 
 class Program_weight_tensor_parameter_296:
     name = "parameter_296"
+    original_name = "batch_norm_15.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-2.81039")
@@ -3025,6 +3322,7 @@ class Program_weight_tensor_parameter_296:
 
 class Program_weight_tensor_parameter_297:
     name = "parameter_297"
+    original_name = "conv2d_15.w_0"
     shape = [256, 1, 5, 5]
     dtype = "float32"
     min_val = float("-2.44779")
@@ -3036,6 +3334,7 @@ class Program_weight_tensor_parameter_297:
 
 class Program_weight_tensor_parameter_298:
     name = "parameter_298"
+    original_name = "batch_norm_14.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.65779")
@@ -3047,6 +3346,7 @@ class Program_weight_tensor_parameter_298:
 
 class Program_weight_tensor_parameter_299:
     name = "parameter_299"
+    original_name = "batch_norm_14.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.342176")
@@ -3058,6 +3358,7 @@ class Program_weight_tensor_parameter_299:
 
 class Program_weight_tensor_parameter_300:
     name = "parameter_300"
+    original_name = "batch_norm_14.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.485063")
@@ -3069,6 +3370,7 @@ class Program_weight_tensor_parameter_300:
 
 class Program_weight_tensor_parameter_301:
     name = "parameter_301"
+    original_name = "batch_norm_14.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-3.58223")
@@ -3080,6 +3382,7 @@ class Program_weight_tensor_parameter_301:
 
 class Program_weight_tensor_parameter_302:
     name = "parameter_302"
+    original_name = "conv2d_14.w_0"
     shape = [256, 256, 1, 1]
     dtype = "float32"
     min_val = float("-3.08002")
@@ -3091,6 +3394,7 @@ class Program_weight_tensor_parameter_302:
 
 class Program_weight_tensor_parameter_303:
     name = "parameter_303"
+    original_name = "batch_norm_13.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.93348")
@@ -3102,6 +3406,7 @@ class Program_weight_tensor_parameter_303:
 
 class Program_weight_tensor_parameter_304:
     name = "parameter_304"
+    original_name = "batch_norm_13.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.324591")
@@ -3113,6 +3418,7 @@ class Program_weight_tensor_parameter_304:
 
 class Program_weight_tensor_parameter_305:
     name = "parameter_305"
+    original_name = "batch_norm_13.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.00156945")
@@ -3124,6 +3430,7 @@ class Program_weight_tensor_parameter_305:
 
 class Program_weight_tensor_parameter_306:
     name = "parameter_306"
+    original_name = "batch_norm_13.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-3.11251")
@@ -3135,6 +3442,7 @@ class Program_weight_tensor_parameter_306:
 
 class Program_weight_tensor_parameter_307:
     name = "parameter_307"
+    original_name = "conv2d_13.w_0"
     shape = [256, 1, 5, 5]
     dtype = "float32"
     min_val = float("-2.05819")
@@ -3146,6 +3454,7 @@ class Program_weight_tensor_parameter_307:
 
 class Program_weight_tensor_parameter_308:
     name = "parameter_308"
+    original_name = "batch_norm_12.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.77141")
@@ -3157,6 +3466,7 @@ class Program_weight_tensor_parameter_308:
 
 class Program_weight_tensor_parameter_309:
     name = "parameter_309"
+    original_name = "batch_norm_12.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.457618")
@@ -3168,6 +3478,7 @@ class Program_weight_tensor_parameter_309:
 
 class Program_weight_tensor_parameter_310:
     name = "parameter_310"
+    original_name = "batch_norm_12.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.80419")
@@ -3179,6 +3490,7 @@ class Program_weight_tensor_parameter_310:
 
 class Program_weight_tensor_parameter_311:
     name = "parameter_311"
+    original_name = "batch_norm_12.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-10.4407")
@@ -3190,6 +3502,7 @@ class Program_weight_tensor_parameter_311:
 
 class Program_weight_tensor_parameter_312:
     name = "parameter_312"
+    original_name = "conv2d_12.w_0"
     shape = [256, 128, 1, 1]
     dtype = "float32"
     min_val = float("-2.04216")
@@ -3201,6 +3514,7 @@ class Program_weight_tensor_parameter_312:
 
 class Program_weight_tensor_parameter_313:
     name = "parameter_313"
+    original_name = "batch_norm_11.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.43421")
@@ -3212,6 +3526,7 @@ class Program_weight_tensor_parameter_313:
 
 class Program_weight_tensor_parameter_314:
     name = "parameter_314"
+    original_name = "batch_norm_11.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.200504")
@@ -3223,6 +3538,7 @@ class Program_weight_tensor_parameter_314:
 
 class Program_weight_tensor_parameter_315:
     name = "parameter_315"
+    original_name = "batch_norm_11.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.00605463")
@@ -3234,6 +3550,7 @@ class Program_weight_tensor_parameter_315:
 
 class Program_weight_tensor_parameter_316:
     name = "parameter_316"
+    original_name = "batch_norm_11.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-3.71303")
@@ -3245,6 +3562,7 @@ class Program_weight_tensor_parameter_316:
 
 class Program_weight_tensor_parameter_317:
     name = "parameter_317"
+    original_name = "conv2d_11.w_0"
     shape = [128, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.881321")
@@ -3256,6 +3574,7 @@ class Program_weight_tensor_parameter_317:
 
 class Program_weight_tensor_parameter_318:
     name = "parameter_318"
+    original_name = "batch_norm_10.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.94309")
@@ -3267,6 +3586,7 @@ class Program_weight_tensor_parameter_318:
 
 class Program_weight_tensor_parameter_319:
     name = "parameter_319"
+    original_name = "batch_norm_10.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.13086")
@@ -3278,6 +3598,7 @@ class Program_weight_tensor_parameter_319:
 
 class Program_weight_tensor_parameter_320:
     name = "parameter_320"
+    original_name = "batch_norm_10.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.644214")
@@ -3289,6 +3610,7 @@ class Program_weight_tensor_parameter_320:
 
 class Program_weight_tensor_parameter_321:
     name = "parameter_321"
+    original_name = "batch_norm_10.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-6.86004")
@@ -3300,6 +3622,7 @@ class Program_weight_tensor_parameter_321:
 
 class Program_weight_tensor_parameter_322:
     name = "parameter_322"
+    original_name = "conv2d_10.w_0"
     shape = [128, 128, 1, 1]
     dtype = "float32"
     min_val = float("-2.5569")
@@ -3311,6 +3634,7 @@ class Program_weight_tensor_parameter_322:
 
 class Program_weight_tensor_parameter_323:
     name = "parameter_323"
+    original_name = "batch_norm_9.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.60027")
@@ -3322,6 +3646,7 @@ class Program_weight_tensor_parameter_323:
 
 class Program_weight_tensor_parameter_324:
     name = "parameter_324"
+    original_name = "batch_norm_9.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.405329")
@@ -3333,6 +3658,7 @@ class Program_weight_tensor_parameter_324:
 
 class Program_weight_tensor_parameter_325:
     name = "parameter_325"
+    original_name = "batch_norm_9.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("8.45411e-05")
@@ -3344,6 +3670,7 @@ class Program_weight_tensor_parameter_325:
 
 class Program_weight_tensor_parameter_326:
     name = "parameter_326"
+    original_name = "batch_norm_9.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-2.28361")
@@ -3355,6 +3682,7 @@ class Program_weight_tensor_parameter_326:
 
 class Program_weight_tensor_parameter_327:
     name = "parameter_327"
+    original_name = "conv2d_9.w_0"
     shape = [128, 1, 3, 3]
     dtype = "float32"
     min_val = float("-2.17113")
@@ -3366,6 +3694,7 @@ class Program_weight_tensor_parameter_327:
 
 class Program_weight_tensor_parameter_328:
     name = "parameter_328"
+    original_name = "batch_norm_8.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.26719")
@@ -3377,6 +3706,7 @@ class Program_weight_tensor_parameter_328:
 
 class Program_weight_tensor_parameter_329:
     name = "parameter_329"
+    original_name = "batch_norm_8.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.879856")
@@ -3388,6 +3718,7 @@ class Program_weight_tensor_parameter_329:
 
 class Program_weight_tensor_parameter_330:
     name = "parameter_330"
+    original_name = "batch_norm_8.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.323433")
@@ -3399,6 +3730,7 @@ class Program_weight_tensor_parameter_330:
 
 class Program_weight_tensor_parameter_331:
     name = "parameter_331"
+    original_name = "batch_norm_8.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-9.41271")
@@ -3410,6 +3742,7 @@ class Program_weight_tensor_parameter_331:
 
 class Program_weight_tensor_parameter_332:
     name = "parameter_332"
+    original_name = "conv2d_8.w_0"
     shape = [128, 64, 1, 1]
     dtype = "float32"
     min_val = float("-2.16179")
@@ -3421,6 +3754,7 @@ class Program_weight_tensor_parameter_332:
 
 class Program_weight_tensor_parameter_333:
     name = "parameter_333"
+    original_name = "batch_norm_7.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -3430,6 +3764,7 @@ class Program_weight_tensor_parameter_333:
 
 class Program_weight_tensor_parameter_334:
     name = "parameter_334"
+    original_name = "batch_norm_7.w_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -3439,6 +3774,7 @@ class Program_weight_tensor_parameter_334:
 
 class Program_weight_tensor_parameter_335:
     name = "parameter_335"
+    original_name = "batch_norm_7.w_2"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -3448,6 +3784,7 @@ class Program_weight_tensor_parameter_335:
 
 class Program_weight_tensor_parameter_336:
     name = "parameter_336"
+    original_name = "batch_norm_7.w_1"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -3457,6 +3794,7 @@ class Program_weight_tensor_parameter_336:
 
 class Program_weight_tensor_parameter_337:
     name = "parameter_337"
+    original_name = "conv2d_7.w_0"
     shape = [64, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.796547")
@@ -3468,6 +3806,7 @@ class Program_weight_tensor_parameter_337:
 
 class Program_weight_tensor_parameter_338:
     name = "parameter_338"
+    original_name = "batch_norm_6.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -3477,6 +3816,7 @@ class Program_weight_tensor_parameter_338:
 
 class Program_weight_tensor_parameter_339:
     name = "parameter_339"
+    original_name = "batch_norm_6.w_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -3486,6 +3826,7 @@ class Program_weight_tensor_parameter_339:
 
 class Program_weight_tensor_parameter_340:
     name = "parameter_340"
+    original_name = "batch_norm_6.w_2"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -3495,6 +3836,7 @@ class Program_weight_tensor_parameter_340:
 
 class Program_weight_tensor_parameter_341:
     name = "parameter_341"
+    original_name = "batch_norm_6.w_1"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -3504,6 +3846,7 @@ class Program_weight_tensor_parameter_341:
 
 class Program_weight_tensor_parameter_342:
     name = "parameter_342"
+    original_name = "conv2d_6.w_0"
     shape = [64, 64, 1, 1]
     dtype = "float32"
     min_val = float("-2.60463")
@@ -3515,6 +3858,7 @@ class Program_weight_tensor_parameter_342:
 
 class Program_weight_tensor_parameter_343:
     name = "parameter_343"
+    original_name = "batch_norm_5.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -3524,6 +3868,7 @@ class Program_weight_tensor_parameter_343:
 
 class Program_weight_tensor_parameter_344:
     name = "parameter_344"
+    original_name = "batch_norm_5.w_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -3533,6 +3878,7 @@ class Program_weight_tensor_parameter_344:
 
 class Program_weight_tensor_parameter_345:
     name = "parameter_345"
+    original_name = "batch_norm_5.w_2"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -3542,6 +3888,7 @@ class Program_weight_tensor_parameter_345:
 
 class Program_weight_tensor_parameter_346:
     name = "parameter_346"
+    original_name = "batch_norm_5.w_1"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -3551,6 +3898,7 @@ class Program_weight_tensor_parameter_346:
 
 class Program_weight_tensor_parameter_347:
     name = "parameter_347"
+    original_name = "conv2d_5.w_0"
     shape = [64, 1, 3, 3]
     dtype = "float32"
     min_val = float("-2.32673")
@@ -3562,6 +3910,7 @@ class Program_weight_tensor_parameter_347:
 
 class Program_weight_tensor_parameter_348:
     name = "parameter_348"
+    original_name = "batch_norm_4.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -3571,6 +3920,7 @@ class Program_weight_tensor_parameter_348:
 
 class Program_weight_tensor_parameter_349:
     name = "parameter_349"
+    original_name = "batch_norm_4.w_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -3580,6 +3930,7 @@ class Program_weight_tensor_parameter_349:
 
 class Program_weight_tensor_parameter_350:
     name = "parameter_350"
+    original_name = "batch_norm_4.w_2"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -3589,6 +3940,7 @@ class Program_weight_tensor_parameter_350:
 
 class Program_weight_tensor_parameter_351:
     name = "parameter_351"
+    original_name = "batch_norm_4.w_1"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -3598,6 +3950,7 @@ class Program_weight_tensor_parameter_351:
 
 class Program_weight_tensor_parameter_352:
     name = "parameter_352"
+    original_name = "conv2d_4.w_0"
     shape = [64, 32, 1, 1]
     dtype = "float32"
     min_val = float("-2.34407")
@@ -3609,6 +3962,7 @@ class Program_weight_tensor_parameter_352:
 
 class Program_weight_tensor_parameter_353:
     name = "parameter_353"
+    original_name = "batch_norm_3.b_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -3618,6 +3972,7 @@ class Program_weight_tensor_parameter_353:
 
 class Program_weight_tensor_parameter_354:
     name = "parameter_354"
+    original_name = "batch_norm_3.w_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -3627,6 +3982,7 @@ class Program_weight_tensor_parameter_354:
 
 class Program_weight_tensor_parameter_355:
     name = "parameter_355"
+    original_name = "batch_norm_3.w_2"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -3636,6 +3992,7 @@ class Program_weight_tensor_parameter_355:
 
 class Program_weight_tensor_parameter_356:
     name = "parameter_356"
+    original_name = "batch_norm_3.w_1"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -3645,6 +4002,7 @@ class Program_weight_tensor_parameter_356:
 
 class Program_weight_tensor_parameter_357:
     name = "parameter_357"
+    original_name = "conv2d_3.w_0"
     shape = [32, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.866371")
@@ -3656,6 +4014,7 @@ class Program_weight_tensor_parameter_357:
 
 class Program_weight_tensor_parameter_358:
     name = "parameter_358"
+    original_name = "batch_norm_2.b_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -3665,6 +4024,7 @@ class Program_weight_tensor_parameter_358:
 
 class Program_weight_tensor_parameter_359:
     name = "parameter_359"
+    original_name = "batch_norm_2.w_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -3674,6 +4034,7 @@ class Program_weight_tensor_parameter_359:
 
 class Program_weight_tensor_parameter_360:
     name = "parameter_360"
+    original_name = "batch_norm_2.w_2"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -3683,6 +4044,7 @@ class Program_weight_tensor_parameter_360:
 
 class Program_weight_tensor_parameter_361:
     name = "parameter_361"
+    original_name = "batch_norm_2.w_1"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -3692,6 +4054,7 @@ class Program_weight_tensor_parameter_361:
 
 class Program_weight_tensor_parameter_362:
     name = "parameter_362"
+    original_name = "conv2d_2.w_0"
     shape = [32, 16, 1, 1]
     dtype = "float32"
     min_val = float("-3.98461")
@@ -3703,6 +4066,7 @@ class Program_weight_tensor_parameter_362:
 
 class Program_weight_tensor_parameter_363:
     name = "parameter_363"
+    original_name = "batch_norm_1.b_0"
     shape = [16]
     dtype = "float32"
     min_val = float("0")
@@ -3712,6 +4076,7 @@ class Program_weight_tensor_parameter_363:
 
 class Program_weight_tensor_parameter_364:
     name = "parameter_364"
+    original_name = "batch_norm_1.w_0"
     shape = [16]
     dtype = "float32"
     min_val = float("0")
@@ -3721,6 +4086,7 @@ class Program_weight_tensor_parameter_364:
 
 class Program_weight_tensor_parameter_365:
     name = "parameter_365"
+    original_name = "batch_norm_1.w_2"
     shape = [16]
     dtype = "float32"
     min_val = float("0")
@@ -3730,6 +4096,7 @@ class Program_weight_tensor_parameter_365:
 
 class Program_weight_tensor_parameter_366:
     name = "parameter_366"
+    original_name = "batch_norm_1.w_1"
     shape = [16]
     dtype = "float32"
     min_val = float("0")
@@ -3739,6 +4106,7 @@ class Program_weight_tensor_parameter_366:
 
 class Program_weight_tensor_parameter_367:
     name = "parameter_367"
+    original_name = "conv2d_1.w_0"
     shape = [16, 1, 3, 3]
     dtype = "float32"
     min_val = float("-3.11002")
@@ -3750,6 +4118,7 @@ class Program_weight_tensor_parameter_367:
 
 class Program_weight_tensor_parameter_368:
     name = "parameter_368"
+    original_name = "batch_norm_0.b_0"
     shape = [16]
     dtype = "float32"
     min_val = float("0")
@@ -3759,6 +4128,7 @@ class Program_weight_tensor_parameter_368:
 
 class Program_weight_tensor_parameter_369:
     name = "parameter_369"
+    original_name = "batch_norm_0.w_0"
     shape = [16]
     dtype = "float32"
     min_val = float("0")
@@ -3768,6 +4138,7 @@ class Program_weight_tensor_parameter_369:
 
 class Program_weight_tensor_parameter_370:
     name = "parameter_370"
+    original_name = "batch_norm_0.w_2"
     shape = [16]
     dtype = "float32"
     min_val = float("0")
@@ -3777,6 +4148,7 @@ class Program_weight_tensor_parameter_370:
 
 class Program_weight_tensor_parameter_371:
     name = "parameter_371"
+    original_name = "batch_norm_0.w_1"
     shape = [16]
     dtype = "float32"
     min_val = float("0")
@@ -3786,6 +4158,7 @@ class Program_weight_tensor_parameter_371:
 
 class Program_weight_tensor_parameter_372:
     name = "parameter_372"
+    original_name = "conv2d_0.w_0"
     shape = [16, 3, 3, 3]
     dtype = "float32"
     min_val = float("-2.21975")

--- a/paddle_samples/PaddleX/SeaFormer_base/subgraph_1/input_meta.py
+++ b/paddle_samples/PaddleX/SeaFormer_base/subgraph_1/input_meta.py
@@ -1,5 +1,6 @@
 class Program_weight_tensor_data_0:
     name = "data_0"
+    original_name = "param_32"
     shape = [1, 128, 16]
     dtype = "float32"
     min_val = float("-0.0566335")
@@ -11,6 +12,7 @@ class Program_weight_tensor_data_0:
 
 class Program_weight_tensor_data_1:
     name = "data_1"
+    original_name = "param_33"
     shape = [1, 128, 16]
     dtype = "float32"
     min_val = float("-0.273705")
@@ -22,6 +24,7 @@ class Program_weight_tensor_data_1:
 
 class Program_weight_tensor_data_2:
     name = "data_2"
+    original_name = "param_34"
     shape = [1, 128, 16]
     dtype = "float32"
     min_val = float("-0.0565303")
@@ -33,6 +36,7 @@ class Program_weight_tensor_data_2:
 
 class Program_weight_tensor_data_3:
     name = "data_3"
+    original_name = "param_35"
     shape = [1, 128, 16]
     dtype = "float32"
     min_val = float("-0.147045")
@@ -44,6 +48,7 @@ class Program_weight_tensor_data_3:
 
 class Program_weight_tensor_data_4:
     name = "data_4"
+    original_name = "param_36"
     shape = [1, 128, 16]
     dtype = "float32"
     min_val = float("-0.326286")
@@ -55,6 +60,7 @@ class Program_weight_tensor_data_4:
 
 class Program_weight_tensor_data_5:
     name = "data_5"
+    original_name = "param_37"
     shape = [1, 128, 16]
     dtype = "float32"
     min_val = float("-0.0622126")
@@ -66,6 +72,7 @@ class Program_weight_tensor_data_5:
 
 class Program_weight_tensor_data_6:
     name = "data_6"
+    original_name = "param_38"
     shape = [1, 128, 16]
     dtype = "float32"
     min_val = float("-0.226519")
@@ -77,6 +84,7 @@ class Program_weight_tensor_data_6:
 
 class Program_weight_tensor_data_7:
     name = "data_7"
+    original_name = "param_39"
     shape = [1, 128, 16]
     dtype = "float32"
     min_val = float("-0.0420218")
@@ -88,6 +96,7 @@ class Program_weight_tensor_data_7:
 
 class Program_weight_tensor_data_8:
     name = "data_8"
+    original_name = "param_40"
     shape = [1, 128, 16]
     dtype = "float32"
     min_val = float("-0.0938621")
@@ -99,6 +108,7 @@ class Program_weight_tensor_data_8:
 
 class Program_weight_tensor_data_9:
     name = "data_9"
+    original_name = "param_41"
     shape = [1, 128, 16]
     dtype = "float32"
     min_val = float("-0.178287")
@@ -110,6 +120,7 @@ class Program_weight_tensor_data_9:
 
 class Program_weight_tensor_data_10:
     name = "data_10"
+    original_name = "param_42"
     shape = [1, 128, 16]
     dtype = "float32"
     min_val = float("-0.030272")
@@ -121,6 +132,7 @@ class Program_weight_tensor_data_10:
 
 class Program_weight_tensor_data_11:
     name = "data_11"
+    original_name = "param_43"
     shape = [1, 128, 16]
     dtype = "float32"
     min_val = float("-0.0619777")
@@ -132,6 +144,7 @@ class Program_weight_tensor_data_11:
 
 class Program_weight_tensor_data_12:
     name = "data_12"
+    original_name = "param_44"
     shape = [1, 128, 16]
     dtype = "float32"
     min_val = float("-0.0873398")
@@ -143,6 +156,7 @@ class Program_weight_tensor_data_12:
 
 class Program_weight_tensor_data_13:
     name = "data_13"
+    original_name = "param_45"
     shape = [1, 128, 16]
     dtype = "float32"
     min_val = float("-0.0652637")
@@ -154,6 +168,7 @@ class Program_weight_tensor_data_13:
 
 class Program_weight_tensor_data_14:
     name = "data_14"
+    original_name = "param_46"
     shape = [1, 128, 16]
     dtype = "float32"
     min_val = float("-0.209707")
@@ -165,6 +180,7 @@ class Program_weight_tensor_data_14:
 
 class Program_weight_tensor_data_15:
     name = "data_15"
+    original_name = "param_47"
     shape = [1, 128, 16]
     dtype = "float32"
     min_val = float("-0.0636572")
@@ -176,6 +192,7 @@ class Program_weight_tensor_data_15:
 
 class Program_weight_tensor_data_16:
     name = "data_16"
+    original_name = "param_48"
     shape = [1, 192, 16]
     dtype = "float32"
     min_val = float("-0.0611749")
@@ -187,6 +204,7 @@ class Program_weight_tensor_data_16:
 
 class Program_weight_tensor_data_17:
     name = "data_17"
+    original_name = "param_49"
     shape = [1, 192, 16]
     dtype = "float32"
     min_val = float("-0.133049")
@@ -198,6 +216,7 @@ class Program_weight_tensor_data_17:
 
 class Program_weight_tensor_data_18:
     name = "data_18"
+    original_name = "param_50"
     shape = [1, 192, 16]
     dtype = "float32"
     min_val = float("-0.0427048")
@@ -209,6 +228,7 @@ class Program_weight_tensor_data_18:
 
 class Program_weight_tensor_data_19:
     name = "data_19"
+    original_name = "param_51"
     shape = [1, 192, 16]
     dtype = "float32"
     min_val = float("-0.0401759")
@@ -220,6 +240,7 @@ class Program_weight_tensor_data_19:
 
 class Program_weight_tensor_data_20:
     name = "data_20"
+    original_name = "param_52"
     shape = [1, 192, 16]
     dtype = "float32"
     min_val = float("-0.0815997")
@@ -231,6 +252,7 @@ class Program_weight_tensor_data_20:
 
 class Program_weight_tensor_data_21:
     name = "data_21"
+    original_name = "param_53"
     shape = [1, 192, 16]
     dtype = "float32"
     min_val = float("-0.0394115")
@@ -242,6 +264,7 @@ class Program_weight_tensor_data_21:
 
 class Program_weight_tensor_data_22:
     name = "data_22"
+    original_name = "param_54"
     shape = [1, 192, 16]
     dtype = "float32"
     min_val = float("-0.0448185")
@@ -253,6 +276,7 @@ class Program_weight_tensor_data_22:
 
 class Program_weight_tensor_data_23:
     name = "data_23"
+    original_name = "param_55"
     shape = [1, 192, 16]
     dtype = "float32"
     min_val = float("-0.0233033")
@@ -264,6 +288,7 @@ class Program_weight_tensor_data_23:
 
 class Program_weight_tensor_data_24:
     name = "data_24"
+    original_name = "param_56"
     shape = [1, 192, 16]
     dtype = "float32"
     min_val = float("-0.137916")
@@ -275,6 +300,7 @@ class Program_weight_tensor_data_24:
 
 class Program_weight_tensor_data_25:
     name = "data_25"
+    original_name = "param_57"
     shape = [1, 192, 16]
     dtype = "float32"
     min_val = float("-0.0370194")
@@ -286,6 +312,7 @@ class Program_weight_tensor_data_25:
 
 class Program_weight_tensor_data_26:
     name = "data_26"
+    original_name = "param_58"
     shape = [1, 192, 16]
     dtype = "float32"
     min_val = float("-0.0724791")
@@ -297,6 +324,7 @@ class Program_weight_tensor_data_26:
 
 class Program_weight_tensor_data_27:
     name = "data_27"
+    original_name = "param_59"
     shape = [1, 192, 16]
     dtype = "float32"
     min_val = float("-0.0224005")
@@ -308,6 +336,7 @@ class Program_weight_tensor_data_27:
 
 class Program_weight_tensor_data_28:
     name = "data_28"
+    original_name = "param_60"
     shape = [1, 192, 16]
     dtype = "float32"
     min_val = float("-0.0450973")
@@ -319,6 +348,7 @@ class Program_weight_tensor_data_28:
 
 class Program_weight_tensor_data_29:
     name = "data_29"
+    original_name = "param_61"
     shape = [1, 192, 16]
     dtype = "float32"
     min_val = float("-0.037171")
@@ -330,6 +360,7 @@ class Program_weight_tensor_data_29:
 
 class Program_weight_tensor_data_30:
     name = "data_30"
+    original_name = "param_62"
     shape = [1, 192, 16]
     dtype = "float32"
     min_val = float("-0.0260485")
@@ -341,6 +372,7 @@ class Program_weight_tensor_data_30:
 
 class Program_weight_tensor_data_31:
     name = "data_31"
+    original_name = "param_63"
     shape = [1, 192, 16]
     dtype = "float32"
     min_val = float("-0.0275727")
@@ -352,6 +384,7 @@ class Program_weight_tensor_data_31:
 
 class Program_weight_tensor_data_32:
     name = "data_32"
+    original_name = "var_733"
     shape = [2, 3, 512, 512]
     dtype = "float32"
     min_val = float("-1.0")

--- a/paddle_samples/PaddleX/SeaFormer_base/subgraph_1/weight_meta.py
+++ b/paddle_samples/PaddleX/SeaFormer_base/subgraph_1/weight_meta.py
@@ -1,5 +1,6 @@
 class Program_weight_tensor_parameter_0:
     name = "parameter_0"
+    original_name = "batch_norm2d_106.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.444324")
@@ -11,6 +12,7 @@ class Program_weight_tensor_parameter_0:
 
 class Program_weight_tensor_parameter_1:
     name = "parameter_1"
+    original_name = "batch_norm2d_106.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.620753")
@@ -22,6 +24,7 @@ class Program_weight_tensor_parameter_1:
 
 class Program_weight_tensor_parameter_2:
     name = "parameter_2"
+    original_name = "batch_norm2d_106.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.00182379")
@@ -33,6 +36,7 @@ class Program_weight_tensor_parameter_2:
 
 class Program_weight_tensor_parameter_3:
     name = "parameter_3"
+    original_name = "batch_norm2d_106.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.276179")
@@ -44,6 +48,7 @@ class Program_weight_tensor_parameter_3:
 
 class Program_weight_tensor_parameter_4:
     name = "parameter_4"
+    original_name = "conv2d_114.w_0"
     shape = [256, 1024, 1, 1]
     dtype = "float32"
     min_val = float("-0.266127")
@@ -55,6 +60,7 @@ class Program_weight_tensor_parameter_4:
 
 class Program_weight_tensor_parameter_5:
     name = "parameter_5"
+    original_name = "conv2d_113.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-1.34023")
@@ -66,6 +72,7 @@ class Program_weight_tensor_parameter_5:
 
 class Program_weight_tensor_parameter_6:
     name = "parameter_6"
+    original_name = "conv2d_113.w_0"
     shape = [1024, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.35715")
@@ -77,6 +84,7 @@ class Program_weight_tensor_parameter_6:
 
 class Program_weight_tensor_parameter_7:
     name = "parameter_7"
+    original_name = "batch_norm2d_105.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-3.55411")
@@ -88,6 +96,7 @@ class Program_weight_tensor_parameter_7:
 
 class Program_weight_tensor_parameter_8:
     name = "parameter_8"
+    original_name = "batch_norm2d_105.w_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("0.292252")
@@ -99,6 +108,7 @@ class Program_weight_tensor_parameter_8:
 
 class Program_weight_tensor_parameter_9:
     name = "parameter_9"
+    original_name = "batch_norm2d_105.w_2"
     shape = [1024]
     dtype = "float32"
     min_val = float("5.60519e-45")
@@ -110,6 +120,7 @@ class Program_weight_tensor_parameter_9:
 
 class Program_weight_tensor_parameter_10:
     name = "parameter_10"
+    original_name = "batch_norm2d_105.w_1"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.281141")
@@ -121,6 +132,7 @@ class Program_weight_tensor_parameter_10:
 
 class Program_weight_tensor_parameter_11:
     name = "parameter_11"
+    original_name = "conv2d_112.w_0"
     shape = [1024, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.290805")
@@ -132,6 +144,7 @@ class Program_weight_tensor_parameter_11:
 
 class Program_weight_tensor_parameter_12:
     name = "parameter_12"
+    original_name = "batch_norm2d_100.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-3.04095")
@@ -143,6 +156,7 @@ class Program_weight_tensor_parameter_12:
 
 class Program_weight_tensor_parameter_13:
     name = "parameter_13"
+    original_name = "batch_norm2d_100.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.83421")
@@ -154,6 +168,7 @@ class Program_weight_tensor_parameter_13:
 
 class Program_weight_tensor_parameter_14:
     name = "parameter_14"
+    original_name = "batch_norm2d_100.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.0614481")
@@ -165,6 +180,7 @@ class Program_weight_tensor_parameter_14:
 
 class Program_weight_tensor_parameter_15:
     name = "parameter_15"
+    original_name = "batch_norm2d_100.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.733525")
@@ -176,6 +192,7 @@ class Program_weight_tensor_parameter_15:
 
 class Program_weight_tensor_parameter_16:
     name = "parameter_16"
+    original_name = "conv2d_107.w_0"
     shape = [256, 384, 1, 1]
     dtype = "float32"
     min_val = float("-0.416156")
@@ -187,6 +204,7 @@ class Program_weight_tensor_parameter_16:
 
 class Program_weight_tensor_parameter_17:
     name = "parameter_17"
+    original_name = "batch_norm2d_102.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-0.850026")
@@ -198,6 +216,7 @@ class Program_weight_tensor_parameter_17:
 
 class Program_weight_tensor_parameter_18:
     name = "parameter_18"
+    original_name = "batch_norm2d_102.w_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-1.32528")
@@ -209,6 +228,7 @@ class Program_weight_tensor_parameter_18:
 
 class Program_weight_tensor_parameter_19:
     name = "parameter_19"
+    original_name = "batch_norm2d_102.w_2"
     shape = [384]
     dtype = "float32"
     min_val = float("0.000328967")
@@ -220,6 +240,7 @@ class Program_weight_tensor_parameter_19:
 
 class Program_weight_tensor_parameter_20:
     name = "parameter_20"
+    original_name = "batch_norm2d_102.w_1"
     shape = [384]
     dtype = "float32"
     min_val = float("-0.182181")
@@ -231,6 +252,7 @@ class Program_weight_tensor_parameter_20:
 
 class Program_weight_tensor_parameter_21:
     name = "parameter_21"
+    original_name = "conv2d_109.w_0"
     shape = [384, 384, 1, 1]
     dtype = "float32"
     min_val = float("-0.283875")
@@ -242,6 +264,7 @@ class Program_weight_tensor_parameter_21:
 
 class Program_weight_tensor_parameter_22:
     name = "parameter_22"
+    original_name = "batch_norm2d_101.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-0.850053")
@@ -253,6 +276,7 @@ class Program_weight_tensor_parameter_22:
 
 class Program_weight_tensor_parameter_23:
     name = "parameter_23"
+    original_name = "batch_norm2d_101.w_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-1.30918")
@@ -264,6 +288,7 @@ class Program_weight_tensor_parameter_23:
 
 class Program_weight_tensor_parameter_24:
     name = "parameter_24"
+    original_name = "batch_norm2d_101.w_2"
     shape = [384]
     dtype = "float32"
     min_val = float("0.00035918")
@@ -275,6 +300,7 @@ class Program_weight_tensor_parameter_24:
 
 class Program_weight_tensor_parameter_25:
     name = "parameter_25"
+    original_name = "batch_norm2d_101.w_1"
     shape = [384]
     dtype = "float32"
     min_val = float("-0.309166")
@@ -286,6 +312,7 @@ class Program_weight_tensor_parameter_25:
 
 class Program_weight_tensor_parameter_26:
     name = "parameter_26"
+    original_name = "conv2d_108.w_0"
     shape = [384, 384, 1, 1]
     dtype = "float32"
     min_val = float("-0.299239")
@@ -297,6 +324,7 @@ class Program_weight_tensor_parameter_26:
 
 class Program_weight_tensor_parameter_27:
     name = "parameter_27"
+    original_name = "batch_norm2d_104.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-4.44376")
@@ -308,6 +336,7 @@ class Program_weight_tensor_parameter_27:
 
 class Program_weight_tensor_parameter_28:
     name = "parameter_28"
+    original_name = "batch_norm2d_104.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("1.50089")
@@ -319,6 +348,7 @@ class Program_weight_tensor_parameter_28:
 
 class Program_weight_tensor_parameter_29:
     name = "parameter_29"
+    original_name = "batch_norm2d_104.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.0292404")
@@ -330,6 +360,7 @@ class Program_weight_tensor_parameter_29:
 
 class Program_weight_tensor_parameter_30:
     name = "parameter_30"
+    original_name = "batch_norm2d_104.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.488884")
@@ -341,6 +372,7 @@ class Program_weight_tensor_parameter_30:
 
 class Program_weight_tensor_parameter_31:
     name = "parameter_31"
+    original_name = "conv2d_111.w_0"
     shape = [256, 768, 1, 1]
     dtype = "float32"
     min_val = float("-0.259371")
@@ -352,6 +384,7 @@ class Program_weight_tensor_parameter_31:
 
 class Program_weight_tensor_parameter_32:
     name = "parameter_32"
+    original_name = "batch_norm2d_103.b_0"
     shape = [768]
     dtype = "float32"
     min_val = float("-2.33753")
@@ -363,6 +396,7 @@ class Program_weight_tensor_parameter_32:
 
 class Program_weight_tensor_parameter_33:
     name = "parameter_33"
+    original_name = "batch_norm2d_103.w_0"
     shape = [768]
     dtype = "float32"
     min_val = float("0.366406")
@@ -374,6 +408,7 @@ class Program_weight_tensor_parameter_33:
 
 class Program_weight_tensor_parameter_34:
     name = "parameter_34"
+    original_name = "batch_norm2d_103.w_2"
     shape = [768]
     dtype = "float32"
     min_val = float("0.000197175")
@@ -385,6 +420,7 @@ class Program_weight_tensor_parameter_34:
 
 class Program_weight_tensor_parameter_35:
     name = "parameter_35"
+    original_name = "batch_norm2d_103.w_1"
     shape = [768]
     dtype = "float32"
     min_val = float("-0.437591")
@@ -396,6 +432,7 @@ class Program_weight_tensor_parameter_35:
 
 class Program_weight_tensor_parameter_36:
     name = "parameter_36"
+    original_name = "conv2d_110.w_0"
     shape = [768, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.286788")
@@ -407,6 +444,7 @@ class Program_weight_tensor_parameter_36:
 
 class Program_weight_tensor_parameter_37:
     name = "parameter_37"
+    original_name = "batch_norm2d_99.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-1.84706")
@@ -418,6 +456,7 @@ class Program_weight_tensor_parameter_37:
 
 class Program_weight_tensor_parameter_38:
     name = "parameter_38"
+    original_name = "batch_norm2d_99.w_0"
     shape = [384]
     dtype = "float32"
     min_val = float("0.169848")
@@ -429,6 +468,7 @@ class Program_weight_tensor_parameter_38:
 
 class Program_weight_tensor_parameter_39:
     name = "parameter_39"
+    original_name = "batch_norm2d_99.w_2"
     shape = [384]
     dtype = "float32"
     min_val = float("1.29156")
@@ -440,6 +480,7 @@ class Program_weight_tensor_parameter_39:
 
 class Program_weight_tensor_parameter_40:
     name = "parameter_40"
+    original_name = "batch_norm2d_99.w_1"
     shape = [384]
     dtype = "float32"
     min_val = float("-1.68954")
@@ -451,6 +492,7 @@ class Program_weight_tensor_parameter_40:
 
 class Program_weight_tensor_parameter_41:
     name = "parameter_41"
+    original_name = "conv2d_106.w_0"
     shape = [384, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.480865")
@@ -462,6 +504,7 @@ class Program_weight_tensor_parameter_41:
 
 class Program_weight_tensor_parameter_42:
     name = "parameter_42"
+    original_name = "batch_norm2d_98.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.522947")
@@ -473,6 +516,7 @@ class Program_weight_tensor_parameter_42:
 
 class Program_weight_tensor_parameter_43:
     name = "parameter_43"
+    original_name = "batch_norm2d_98.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("0.0974245")
@@ -484,6 +528,7 @@ class Program_weight_tensor_parameter_43:
 
 class Program_weight_tensor_parameter_44:
     name = "parameter_44"
+    original_name = "batch_norm2d_98.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("0.878147")
@@ -495,6 +540,7 @@ class Program_weight_tensor_parameter_44:
 
 class Program_weight_tensor_parameter_45:
     name = "parameter_45"
+    original_name = "batch_norm2d_98.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.700122")
@@ -506,6 +552,7 @@ class Program_weight_tensor_parameter_45:
 
 class Program_weight_tensor_parameter_46:
     name = "parameter_46"
+    original_name = "conv2d_105.w_0"
     shape = [192, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.240489")
@@ -517,6 +564,7 @@ class Program_weight_tensor_parameter_46:
 
 class Program_weight_tensor_parameter_47:
     name = "parameter_47"
+    original_name = "batch_norm2d_97.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.606751")
@@ -528,6 +576,7 @@ class Program_weight_tensor_parameter_47:
 
 class Program_weight_tensor_parameter_48:
     name = "parameter_48"
+    original_name = "batch_norm2d_97.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("0.151252")
@@ -539,6 +588,7 @@ class Program_weight_tensor_parameter_48:
 
 class Program_weight_tensor_parameter_49:
     name = "parameter_49"
+    original_name = "batch_norm2d_97.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("0.900985")
@@ -550,6 +600,7 @@ class Program_weight_tensor_parameter_49:
 
 class Program_weight_tensor_parameter_50:
     name = "parameter_50"
+    original_name = "batch_norm2d_97.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.419134")
@@ -561,6 +612,7 @@ class Program_weight_tensor_parameter_50:
 
 class Program_weight_tensor_parameter_51:
     name = "parameter_51"
+    original_name = "conv2d_104.w_0"
     shape = [192, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.263205")
@@ -572,6 +624,7 @@ class Program_weight_tensor_parameter_51:
 
 class Program_weight_tensor_parameter_52:
     name = "parameter_52"
+    original_name = "batch_norm2d_96.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.153423")
@@ -583,6 +636,7 @@ class Program_weight_tensor_parameter_52:
 
 class Program_weight_tensor_parameter_53:
     name = "parameter_53"
+    original_name = "batch_norm2d_96.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.671476")
@@ -594,6 +648,7 @@ class Program_weight_tensor_parameter_53:
 
 class Program_weight_tensor_parameter_54:
     name = "parameter_54"
+    original_name = "batch_norm2d_96.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.00202683")
@@ -605,6 +660,7 @@ class Program_weight_tensor_parameter_54:
 
 class Program_weight_tensor_parameter_55:
     name = "parameter_55"
+    original_name = "batch_norm2d_96.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.249653")
@@ -616,6 +672,7 @@ class Program_weight_tensor_parameter_55:
 
 class Program_weight_tensor_parameter_56:
     name = "parameter_56"
+    original_name = "conv2d_103.w_0"
     shape = [256, 1024, 1, 1]
     dtype = "float32"
     min_val = float("-0.491517")
@@ -627,6 +684,7 @@ class Program_weight_tensor_parameter_56:
 
 class Program_weight_tensor_parameter_57:
     name = "parameter_57"
+    original_name = "conv2d_102.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-1.60786")
@@ -638,6 +696,7 @@ class Program_weight_tensor_parameter_57:
 
 class Program_weight_tensor_parameter_58:
     name = "parameter_58"
+    original_name = "conv2d_102.w_0"
     shape = [1024, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.437132")
@@ -649,6 +708,7 @@ class Program_weight_tensor_parameter_58:
 
 class Program_weight_tensor_parameter_59:
     name = "parameter_59"
+    original_name = "batch_norm2d_95.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-4.07092")
@@ -660,6 +720,7 @@ class Program_weight_tensor_parameter_59:
 
 class Program_weight_tensor_parameter_60:
     name = "parameter_60"
+    original_name = "batch_norm2d_95.w_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("0.336777")
@@ -671,6 +732,7 @@ class Program_weight_tensor_parameter_60:
 
 class Program_weight_tensor_parameter_61:
     name = "parameter_61"
+    original_name = "batch_norm2d_95.w_2"
     shape = [1024]
     dtype = "float32"
     min_val = float("5.60519e-45")
@@ -682,6 +744,7 @@ class Program_weight_tensor_parameter_61:
 
 class Program_weight_tensor_parameter_62:
     name = "parameter_62"
+    original_name = "batch_norm2d_95.w_1"
     shape = [1024]
     dtype = "float32"
     min_val = float("-1.03216")
@@ -693,6 +756,7 @@ class Program_weight_tensor_parameter_62:
 
 class Program_weight_tensor_parameter_63:
     name = "parameter_63"
+    original_name = "conv2d_101.w_0"
     shape = [1024, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.380047")
@@ -704,6 +768,7 @@ class Program_weight_tensor_parameter_63:
 
 class Program_weight_tensor_parameter_64:
     name = "parameter_64"
+    original_name = "batch_norm2d_90.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-2.45081")
@@ -715,6 +780,7 @@ class Program_weight_tensor_parameter_64:
 
 class Program_weight_tensor_parameter_65:
     name = "parameter_65"
+    original_name = "batch_norm2d_90.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-2.54222")
@@ -726,6 +792,7 @@ class Program_weight_tensor_parameter_65:
 
 class Program_weight_tensor_parameter_66:
     name = "parameter_66"
+    original_name = "batch_norm2d_90.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.0449357")
@@ -737,6 +804,7 @@ class Program_weight_tensor_parameter_66:
 
 class Program_weight_tensor_parameter_67:
     name = "parameter_67"
+    original_name = "batch_norm2d_90.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.467567")
@@ -748,6 +816,7 @@ class Program_weight_tensor_parameter_67:
 
 class Program_weight_tensor_parameter_68:
     name = "parameter_68"
+    original_name = "conv2d_96.w_0"
     shape = [256, 384, 1, 1]
     dtype = "float32"
     min_val = float("-0.246068")
@@ -759,6 +828,7 @@ class Program_weight_tensor_parameter_68:
 
 class Program_weight_tensor_parameter_69:
     name = "parameter_69"
+    original_name = "batch_norm2d_92.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-0.961969")
@@ -770,6 +840,7 @@ class Program_weight_tensor_parameter_69:
 
 class Program_weight_tensor_parameter_70:
     name = "parameter_70"
+    original_name = "batch_norm2d_92.w_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-1.64044")
@@ -781,6 +852,7 @@ class Program_weight_tensor_parameter_70:
 
 class Program_weight_tensor_parameter_71:
     name = "parameter_71"
+    original_name = "batch_norm2d_92.w_2"
     shape = [384]
     dtype = "float32"
     min_val = float("0.000121344")
@@ -792,6 +864,7 @@ class Program_weight_tensor_parameter_71:
 
 class Program_weight_tensor_parameter_72:
     name = "parameter_72"
+    original_name = "batch_norm2d_92.w_1"
     shape = [384]
     dtype = "float32"
     min_val = float("-0.260095")
@@ -803,6 +876,7 @@ class Program_weight_tensor_parameter_72:
 
 class Program_weight_tensor_parameter_73:
     name = "parameter_73"
+    original_name = "conv2d_98.w_0"
     shape = [384, 384, 1, 1]
     dtype = "float32"
     min_val = float("-0.222563")
@@ -814,6 +888,7 @@ class Program_weight_tensor_parameter_73:
 
 class Program_weight_tensor_parameter_74:
     name = "parameter_74"
+    original_name = "batch_norm2d_91.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-0.961999")
@@ -825,6 +900,7 @@ class Program_weight_tensor_parameter_74:
 
 class Program_weight_tensor_parameter_75:
     name = "parameter_75"
+    original_name = "batch_norm2d_91.w_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-1.60289")
@@ -836,6 +912,7 @@ class Program_weight_tensor_parameter_75:
 
 class Program_weight_tensor_parameter_76:
     name = "parameter_76"
+    original_name = "batch_norm2d_91.w_2"
     shape = [384]
     dtype = "float32"
     min_val = float("0.000177405")
@@ -847,6 +924,7 @@ class Program_weight_tensor_parameter_76:
 
 class Program_weight_tensor_parameter_77:
     name = "parameter_77"
+    original_name = "batch_norm2d_91.w_1"
     shape = [384]
     dtype = "float32"
     min_val = float("-0.146489")
@@ -858,6 +936,7 @@ class Program_weight_tensor_parameter_77:
 
 class Program_weight_tensor_parameter_78:
     name = "parameter_78"
+    original_name = "conv2d_97.w_0"
     shape = [384, 384, 1, 1]
     dtype = "float32"
     min_val = float("-0.250236")
@@ -869,6 +948,7 @@ class Program_weight_tensor_parameter_78:
 
 class Program_weight_tensor_parameter_79:
     name = "parameter_79"
+    original_name = "batch_norm2d_94.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-2.51167")
@@ -880,6 +960,7 @@ class Program_weight_tensor_parameter_79:
 
 class Program_weight_tensor_parameter_80:
     name = "parameter_80"
+    original_name = "batch_norm2d_94.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("1.17717")
@@ -891,6 +972,7 @@ class Program_weight_tensor_parameter_80:
 
 class Program_weight_tensor_parameter_81:
     name = "parameter_81"
+    original_name = "batch_norm2d_94.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.0102202")
@@ -902,6 +984,7 @@ class Program_weight_tensor_parameter_81:
 
 class Program_weight_tensor_parameter_82:
     name = "parameter_82"
+    original_name = "batch_norm2d_94.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.471887")
@@ -913,6 +996,7 @@ class Program_weight_tensor_parameter_82:
 
 class Program_weight_tensor_parameter_83:
     name = "parameter_83"
+    original_name = "conv2d_100.w_0"
     shape = [256, 768, 1, 1]
     dtype = "float32"
     min_val = float("-0.534075")
@@ -924,6 +1008,7 @@ class Program_weight_tensor_parameter_83:
 
 class Program_weight_tensor_parameter_84:
     name = "parameter_84"
+    original_name = "batch_norm2d_93.b_0"
     shape = [768]
     dtype = "float32"
     min_val = float("-2.78729")
@@ -935,6 +1020,7 @@ class Program_weight_tensor_parameter_84:
 
 class Program_weight_tensor_parameter_85:
     name = "parameter_85"
+    original_name = "batch_norm2d_93.w_0"
     shape = [768]
     dtype = "float32"
     min_val = float("0.21226")
@@ -946,6 +1032,7 @@ class Program_weight_tensor_parameter_85:
 
 class Program_weight_tensor_parameter_86:
     name = "parameter_86"
+    original_name = "batch_norm2d_93.w_2"
     shape = [768]
     dtype = "float32"
     min_val = float("0.000170044")
@@ -957,6 +1044,7 @@ class Program_weight_tensor_parameter_86:
 
 class Program_weight_tensor_parameter_87:
     name = "parameter_87"
+    original_name = "batch_norm2d_93.w_1"
     shape = [768]
     dtype = "float32"
     min_val = float("-0.68698")
@@ -968,6 +1056,7 @@ class Program_weight_tensor_parameter_87:
 
 class Program_weight_tensor_parameter_88:
     name = "parameter_88"
+    original_name = "conv2d_99.w_0"
     shape = [768, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.210206")
@@ -979,6 +1068,7 @@ class Program_weight_tensor_parameter_88:
 
 class Program_weight_tensor_parameter_89:
     name = "parameter_89"
+    original_name = "batch_norm2d_89.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-2.09947")
@@ -990,6 +1080,7 @@ class Program_weight_tensor_parameter_89:
 
 class Program_weight_tensor_parameter_90:
     name = "parameter_90"
+    original_name = "batch_norm2d_89.w_0"
     shape = [384]
     dtype = "float32"
     min_val = float("0.144038")
@@ -1001,6 +1092,7 @@ class Program_weight_tensor_parameter_90:
 
 class Program_weight_tensor_parameter_91:
     name = "parameter_91"
+    original_name = "batch_norm2d_89.w_2"
     shape = [384]
     dtype = "float32"
     min_val = float("1.12788")
@@ -1012,6 +1104,7 @@ class Program_weight_tensor_parameter_91:
 
 class Program_weight_tensor_parameter_92:
     name = "parameter_92"
+    original_name = "batch_norm2d_89.w_1"
     shape = [384]
     dtype = "float32"
     min_val = float("-2.48818")
@@ -1023,6 +1116,7 @@ class Program_weight_tensor_parameter_92:
 
 class Program_weight_tensor_parameter_93:
     name = "parameter_93"
+    original_name = "conv2d_95.w_0"
     shape = [384, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.604431")
@@ -1034,6 +1128,7 @@ class Program_weight_tensor_parameter_93:
 
 class Program_weight_tensor_parameter_94:
     name = "parameter_94"
+    original_name = "batch_norm2d_88.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.804018")
@@ -1045,6 +1140,7 @@ class Program_weight_tensor_parameter_94:
 
 class Program_weight_tensor_parameter_95:
     name = "parameter_95"
+    original_name = "batch_norm2d_88.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("0.056415")
@@ -1056,6 +1152,7 @@ class Program_weight_tensor_parameter_95:
 
 class Program_weight_tensor_parameter_96:
     name = "parameter_96"
+    original_name = "batch_norm2d_88.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("0.692488")
@@ -1067,6 +1164,7 @@ class Program_weight_tensor_parameter_96:
 
 class Program_weight_tensor_parameter_97:
     name = "parameter_97"
+    original_name = "batch_norm2d_88.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-1.31931")
@@ -1078,6 +1176,7 @@ class Program_weight_tensor_parameter_97:
 
 class Program_weight_tensor_parameter_98:
     name = "parameter_98"
+    original_name = "conv2d_94.w_0"
     shape = [192, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.211676")
@@ -1089,6 +1188,7 @@ class Program_weight_tensor_parameter_98:
 
 class Program_weight_tensor_parameter_99:
     name = "parameter_99"
+    original_name = "batch_norm2d_87.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-1.24924")
@@ -1100,6 +1200,7 @@ class Program_weight_tensor_parameter_99:
 
 class Program_weight_tensor_parameter_100:
     name = "parameter_100"
+    original_name = "batch_norm2d_87.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("0.0925163")
@@ -1111,6 +1212,7 @@ class Program_weight_tensor_parameter_100:
 
 class Program_weight_tensor_parameter_101:
     name = "parameter_101"
+    original_name = "batch_norm2d_87.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("0.79422")
@@ -1122,6 +1224,7 @@ class Program_weight_tensor_parameter_101:
 
 class Program_weight_tensor_parameter_102:
     name = "parameter_102"
+    original_name = "batch_norm2d_87.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.758144")
@@ -1133,6 +1236,7 @@ class Program_weight_tensor_parameter_102:
 
 class Program_weight_tensor_parameter_103:
     name = "parameter_103"
+    original_name = "conv2d_93.w_0"
     shape = [192, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.285925")
@@ -1144,6 +1248,7 @@ class Program_weight_tensor_parameter_103:
 
 class Program_weight_tensor_parameter_104:
     name = "parameter_104"
+    original_name = "batch_norm2d_86.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.656979")
@@ -1155,6 +1260,7 @@ class Program_weight_tensor_parameter_104:
 
 class Program_weight_tensor_parameter_105:
     name = "parameter_105"
+    original_name = "batch_norm2d_86.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.509761")
@@ -1166,6 +1272,7 @@ class Program_weight_tensor_parameter_105:
 
 class Program_weight_tensor_parameter_106:
     name = "parameter_106"
+    original_name = "batch_norm2d_86.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.00152009")
@@ -1177,6 +1284,7 @@ class Program_weight_tensor_parameter_106:
 
 class Program_weight_tensor_parameter_107:
     name = "parameter_107"
+    original_name = "batch_norm2d_86.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.23656")
@@ -1188,6 +1296,7 @@ class Program_weight_tensor_parameter_107:
 
 class Program_weight_tensor_parameter_108:
     name = "parameter_108"
+    original_name = "conv2d_92.w_0"
     shape = [256, 1024, 1, 1]
     dtype = "float32"
     min_val = float("-0.462406")
@@ -1199,6 +1308,7 @@ class Program_weight_tensor_parameter_108:
 
 class Program_weight_tensor_parameter_109:
     name = "parameter_109"
+    original_name = "conv2d_91.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-1.7096")
@@ -1210,6 +1320,7 @@ class Program_weight_tensor_parameter_109:
 
 class Program_weight_tensor_parameter_110:
     name = "parameter_110"
+    original_name = "conv2d_91.w_0"
     shape = [1024, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.51296")
@@ -1221,6 +1332,7 @@ class Program_weight_tensor_parameter_110:
 
 class Program_weight_tensor_parameter_111:
     name = "parameter_111"
+    original_name = "batch_norm2d_85.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-4.37417")
@@ -1232,6 +1344,7 @@ class Program_weight_tensor_parameter_111:
 
 class Program_weight_tensor_parameter_112:
     name = "parameter_112"
+    original_name = "batch_norm2d_85.w_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("0.223791")
@@ -1243,6 +1356,7 @@ class Program_weight_tensor_parameter_112:
 
 class Program_weight_tensor_parameter_113:
     name = "parameter_113"
+    original_name = "batch_norm2d_85.w_2"
     shape = [1024]
     dtype = "float32"
     min_val = float("0.3011")
@@ -1254,6 +1368,7 @@ class Program_weight_tensor_parameter_113:
 
 class Program_weight_tensor_parameter_114:
     name = "parameter_114"
+    original_name = "batch_norm2d_85.w_1"
     shape = [1024]
     dtype = "float32"
     min_val = float("-0.873864")
@@ -1265,6 +1380,7 @@ class Program_weight_tensor_parameter_114:
 
 class Program_weight_tensor_parameter_115:
     name = "parameter_115"
+    original_name = "conv2d_90.w_0"
     shape = [1024, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.374988")
@@ -1276,6 +1392,7 @@ class Program_weight_tensor_parameter_115:
 
 class Program_weight_tensor_parameter_116:
     name = "parameter_116"
+    original_name = "batch_norm2d_80.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-2.41558")
@@ -1287,6 +1404,7 @@ class Program_weight_tensor_parameter_116:
 
 class Program_weight_tensor_parameter_117:
     name = "parameter_117"
+    original_name = "batch_norm2d_80.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-2.21238")
@@ -1298,6 +1416,7 @@ class Program_weight_tensor_parameter_117:
 
 class Program_weight_tensor_parameter_118:
     name = "parameter_118"
+    original_name = "batch_norm2d_80.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.12715")
@@ -1309,6 +1428,7 @@ class Program_weight_tensor_parameter_118:
 
 class Program_weight_tensor_parameter_119:
     name = "parameter_119"
+    original_name = "batch_norm2d_80.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.737314")
@@ -1320,6 +1440,7 @@ class Program_weight_tensor_parameter_119:
 
 class Program_weight_tensor_parameter_120:
     name = "parameter_120"
+    original_name = "conv2d_85.w_0"
     shape = [256, 384, 1, 1]
     dtype = "float32"
     min_val = float("-0.550376")
@@ -1331,6 +1452,7 @@ class Program_weight_tensor_parameter_120:
 
 class Program_weight_tensor_parameter_121:
     name = "parameter_121"
+    original_name = "batch_norm2d_82.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-1.37383")
@@ -1342,6 +1464,7 @@ class Program_weight_tensor_parameter_121:
 
 class Program_weight_tensor_parameter_122:
     name = "parameter_122"
+    original_name = "batch_norm2d_82.w_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-1.75081")
@@ -1353,6 +1476,7 @@ class Program_weight_tensor_parameter_122:
 
 class Program_weight_tensor_parameter_123:
     name = "parameter_123"
+    original_name = "batch_norm2d_82.w_2"
     shape = [384]
     dtype = "float32"
     min_val = float("0.000755778")
@@ -1364,6 +1488,7 @@ class Program_weight_tensor_parameter_123:
 
 class Program_weight_tensor_parameter_124:
     name = "parameter_124"
+    original_name = "batch_norm2d_82.w_1"
     shape = [384]
     dtype = "float32"
     min_val = float("-0.372716")
@@ -1375,6 +1500,7 @@ class Program_weight_tensor_parameter_124:
 
 class Program_weight_tensor_parameter_125:
     name = "parameter_125"
+    original_name = "conv2d_87.w_0"
     shape = [384, 384, 1, 1]
     dtype = "float32"
     min_val = float("-0.145661")
@@ -1386,6 +1512,7 @@ class Program_weight_tensor_parameter_125:
 
 class Program_weight_tensor_parameter_126:
     name = "parameter_126"
+    original_name = "batch_norm2d_81.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-1.37389")
@@ -1397,6 +1524,7 @@ class Program_weight_tensor_parameter_126:
 
 class Program_weight_tensor_parameter_127:
     name = "parameter_127"
+    original_name = "batch_norm2d_81.w_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-1.55823")
@@ -1408,6 +1536,7 @@ class Program_weight_tensor_parameter_127:
 
 class Program_weight_tensor_parameter_128:
     name = "parameter_128"
+    original_name = "batch_norm2d_81.w_2"
     shape = [384]
     dtype = "float32"
     min_val = float("0.000848167")
@@ -1419,6 +1548,7 @@ class Program_weight_tensor_parameter_128:
 
 class Program_weight_tensor_parameter_129:
     name = "parameter_129"
+    original_name = "batch_norm2d_81.w_1"
     shape = [384]
     dtype = "float32"
     min_val = float("-0.309302")
@@ -1430,6 +1560,7 @@ class Program_weight_tensor_parameter_129:
 
 class Program_weight_tensor_parameter_130:
     name = "parameter_130"
+    original_name = "conv2d_86.w_0"
     shape = [384, 384, 1, 1]
     dtype = "float32"
     min_val = float("-0.174078")
@@ -1441,6 +1572,7 @@ class Program_weight_tensor_parameter_130:
 
 class Program_weight_tensor_parameter_131:
     name = "parameter_131"
+    original_name = "batch_norm2d_84.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.76939")
@@ -1452,6 +1584,7 @@ class Program_weight_tensor_parameter_131:
 
 class Program_weight_tensor_parameter_132:
     name = "parameter_132"
+    original_name = "batch_norm2d_84.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.954846")
@@ -1463,6 +1596,7 @@ class Program_weight_tensor_parameter_132:
 
 class Program_weight_tensor_parameter_133:
     name = "parameter_133"
+    original_name = "batch_norm2d_84.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.00894244")
@@ -1474,6 +1608,7 @@ class Program_weight_tensor_parameter_133:
 
 class Program_weight_tensor_parameter_134:
     name = "parameter_134"
+    original_name = "batch_norm2d_84.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.346434")
@@ -1485,6 +1620,7 @@ class Program_weight_tensor_parameter_134:
 
 class Program_weight_tensor_parameter_135:
     name = "parameter_135"
+    original_name = "conv2d_89.w_0"
     shape = [256, 768, 1, 1]
     dtype = "float32"
     min_val = float("-0.387027")
@@ -1496,6 +1632,7 @@ class Program_weight_tensor_parameter_135:
 
 class Program_weight_tensor_parameter_136:
     name = "parameter_136"
+    original_name = "batch_norm2d_83.b_0"
     shape = [768]
     dtype = "float32"
     min_val = float("-5.31578")
@@ -1507,6 +1644,7 @@ class Program_weight_tensor_parameter_136:
 
 class Program_weight_tensor_parameter_137:
     name = "parameter_137"
+    original_name = "batch_norm2d_83.w_0"
     shape = [768]
     dtype = "float32"
     min_val = float("0.185496")
@@ -1518,6 +1656,7 @@ class Program_weight_tensor_parameter_137:
 
 class Program_weight_tensor_parameter_138:
     name = "parameter_138"
+    original_name = "batch_norm2d_83.w_2"
     shape = [768]
     dtype = "float32"
     min_val = float("0.000365502")
@@ -1529,6 +1668,7 @@ class Program_weight_tensor_parameter_138:
 
 class Program_weight_tensor_parameter_139:
     name = "parameter_139"
+    original_name = "batch_norm2d_83.w_1"
     shape = [768]
     dtype = "float32"
     min_val = float("-1.1485")
@@ -1540,6 +1680,7 @@ class Program_weight_tensor_parameter_139:
 
 class Program_weight_tensor_parameter_140:
     name = "parameter_140"
+    original_name = "conv2d_88.w_0"
     shape = [768, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.249049")
@@ -1551,6 +1692,7 @@ class Program_weight_tensor_parameter_140:
 
 class Program_weight_tensor_parameter_141:
     name = "parameter_141"
+    original_name = "batch_norm2d_79.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-3.28297")
@@ -1562,6 +1704,7 @@ class Program_weight_tensor_parameter_141:
 
 class Program_weight_tensor_parameter_142:
     name = "parameter_142"
+    original_name = "batch_norm2d_79.w_0"
     shape = [384]
     dtype = "float32"
     min_val = float("0.241517")
@@ -1573,6 +1716,7 @@ class Program_weight_tensor_parameter_142:
 
 class Program_weight_tensor_parameter_143:
     name = "parameter_143"
+    original_name = "batch_norm2d_79.w_2"
     shape = [384]
     dtype = "float32"
     min_val = float("1.13753")
@@ -1584,6 +1728,7 @@ class Program_weight_tensor_parameter_143:
 
 class Program_weight_tensor_parameter_144:
     name = "parameter_144"
+    original_name = "batch_norm2d_79.w_1"
     shape = [384]
     dtype = "float32"
     min_val = float("-2.78625")
@@ -1595,6 +1740,7 @@ class Program_weight_tensor_parameter_144:
 
 class Program_weight_tensor_parameter_145:
     name = "parameter_145"
+    original_name = "conv2d_84.w_0"
     shape = [384, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.46311")
@@ -1606,6 +1752,7 @@ class Program_weight_tensor_parameter_145:
 
 class Program_weight_tensor_parameter_146:
     name = "parameter_146"
+    original_name = "batch_norm2d_78.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.999212")
@@ -1617,6 +1764,7 @@ class Program_weight_tensor_parameter_146:
 
 class Program_weight_tensor_parameter_147:
     name = "parameter_147"
+    original_name = "batch_norm2d_78.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("0.0753603")
@@ -1628,6 +1776,7 @@ class Program_weight_tensor_parameter_147:
 
 class Program_weight_tensor_parameter_148:
     name = "parameter_148"
+    original_name = "batch_norm2d_78.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("0.754397")
@@ -1639,6 +1788,7 @@ class Program_weight_tensor_parameter_148:
 
 class Program_weight_tensor_parameter_149:
     name = "parameter_149"
+    original_name = "batch_norm2d_78.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-2.77602")
@@ -1650,6 +1800,7 @@ class Program_weight_tensor_parameter_149:
 
 class Program_weight_tensor_parameter_150:
     name = "parameter_150"
+    original_name = "conv2d_83.w_0"
     shape = [192, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.282251")
@@ -1661,6 +1812,7 @@ class Program_weight_tensor_parameter_150:
 
 class Program_weight_tensor_parameter_151:
     name = "parameter_151"
+    original_name = "batch_norm2d_77.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-1.47602")
@@ -1672,6 +1824,7 @@ class Program_weight_tensor_parameter_151:
 
 class Program_weight_tensor_parameter_152:
     name = "parameter_152"
+    original_name = "batch_norm2d_77.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("0.108658")
@@ -1683,6 +1836,7 @@ class Program_weight_tensor_parameter_152:
 
 class Program_weight_tensor_parameter_153:
     name = "parameter_153"
+    original_name = "batch_norm2d_77.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("0.703333")
@@ -1694,6 +1848,7 @@ class Program_weight_tensor_parameter_153:
 
 class Program_weight_tensor_parameter_154:
     name = "parameter_154"
+    original_name = "batch_norm2d_77.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-1.03925")
@@ -1705,6 +1860,7 @@ class Program_weight_tensor_parameter_154:
 
 class Program_weight_tensor_parameter_155:
     name = "parameter_155"
+    original_name = "conv2d_82.w_0"
     shape = [192, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.244025")
@@ -1716,6 +1872,7 @@ class Program_weight_tensor_parameter_155:
 
 class Program_weight_tensor_parameter_156:
     name = "parameter_156"
+    original_name = "batch_norm2d_76.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.63213")
@@ -1727,6 +1884,7 @@ class Program_weight_tensor_parameter_156:
 
 class Program_weight_tensor_parameter_157:
     name = "parameter_157"
+    original_name = "batch_norm2d_76.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.432403")
@@ -1738,6 +1896,7 @@ class Program_weight_tensor_parameter_157:
 
 class Program_weight_tensor_parameter_158:
     name = "parameter_158"
+    original_name = "batch_norm2d_76.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.0053514")
@@ -1749,6 +1908,7 @@ class Program_weight_tensor_parameter_158:
 
 class Program_weight_tensor_parameter_159:
     name = "parameter_159"
+    original_name = "batch_norm2d_76.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.451716")
@@ -1760,6 +1920,7 @@ class Program_weight_tensor_parameter_159:
 
 class Program_weight_tensor_parameter_160:
     name = "parameter_160"
+    original_name = "conv2d_81.w_0"
     shape = [256, 1024, 1, 1]
     dtype = "float32"
     min_val = float("-0.264072")
@@ -1771,6 +1932,7 @@ class Program_weight_tensor_parameter_160:
 
 class Program_weight_tensor_parameter_161:
     name = "parameter_161"
+    original_name = "conv2d_80.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-2.13262")
@@ -1782,6 +1944,7 @@ class Program_weight_tensor_parameter_161:
 
 class Program_weight_tensor_parameter_162:
     name = "parameter_162"
+    original_name = "conv2d_80.w_0"
     shape = [1024, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.485124")
@@ -1793,6 +1956,7 @@ class Program_weight_tensor_parameter_162:
 
 class Program_weight_tensor_parameter_163:
     name = "parameter_163"
+    original_name = "batch_norm2d_75.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-4.9109")
@@ -1804,6 +1968,7 @@ class Program_weight_tensor_parameter_163:
 
 class Program_weight_tensor_parameter_164:
     name = "parameter_164"
+    original_name = "batch_norm2d_75.w_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("0.348173")
@@ -1815,6 +1980,7 @@ class Program_weight_tensor_parameter_164:
 
 class Program_weight_tensor_parameter_165:
     name = "parameter_165"
+    original_name = "batch_norm2d_75.w_2"
     shape = [1024]
     dtype = "float32"
     min_val = float("0.483928")
@@ -1826,6 +1992,7 @@ class Program_weight_tensor_parameter_165:
 
 class Program_weight_tensor_parameter_166:
     name = "parameter_166"
+    original_name = "batch_norm2d_75.w_1"
     shape = [1024]
     dtype = "float32"
     min_val = float("-1.47585")
@@ -1837,6 +2004,7 @@ class Program_weight_tensor_parameter_166:
 
 class Program_weight_tensor_parameter_167:
     name = "parameter_167"
+    original_name = "conv2d_79.w_0"
     shape = [1024, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.255619")
@@ -1848,6 +2016,7 @@ class Program_weight_tensor_parameter_167:
 
 class Program_weight_tensor_parameter_168:
     name = "parameter_168"
+    original_name = "batch_norm2d_70.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-3.02624")
@@ -1859,6 +2028,7 @@ class Program_weight_tensor_parameter_168:
 
 class Program_weight_tensor_parameter_169:
     name = "parameter_169"
+    original_name = "batch_norm2d_70.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-2.2426")
@@ -1870,6 +2040,7 @@ class Program_weight_tensor_parameter_169:
 
 class Program_weight_tensor_parameter_170:
     name = "parameter_170"
+    original_name = "batch_norm2d_70.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.285191")
@@ -1881,6 +2052,7 @@ class Program_weight_tensor_parameter_170:
 
 class Program_weight_tensor_parameter_171:
     name = "parameter_171"
+    original_name = "batch_norm2d_70.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.51767")
@@ -1892,6 +2064,7 @@ class Program_weight_tensor_parameter_171:
 
 class Program_weight_tensor_parameter_172:
     name = "parameter_172"
+    original_name = "conv2d_74.w_0"
     shape = [256, 384, 1, 1]
     dtype = "float32"
     min_val = float("-0.371177")
@@ -1903,6 +2076,7 @@ class Program_weight_tensor_parameter_172:
 
 class Program_weight_tensor_parameter_173:
     name = "parameter_173"
+    original_name = "batch_norm2d_72.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-1.97915")
@@ -1914,6 +2088,7 @@ class Program_weight_tensor_parameter_173:
 
 class Program_weight_tensor_parameter_174:
     name = "parameter_174"
+    original_name = "batch_norm2d_72.w_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-1.82417")
@@ -1925,6 +2100,7 @@ class Program_weight_tensor_parameter_174:
 
 class Program_weight_tensor_parameter_175:
     name = "parameter_175"
+    original_name = "batch_norm2d_72.w_2"
     shape = [384]
     dtype = "float32"
     min_val = float("0.00602588")
@@ -1936,6 +2112,7 @@ class Program_weight_tensor_parameter_175:
 
 class Program_weight_tensor_parameter_176:
     name = "parameter_176"
+    original_name = "batch_norm2d_72.w_1"
     shape = [384]
     dtype = "float32"
     min_val = float("-0.760312")
@@ -1947,6 +2124,7 @@ class Program_weight_tensor_parameter_176:
 
 class Program_weight_tensor_parameter_177:
     name = "parameter_177"
+    original_name = "conv2d_76.w_0"
     shape = [384, 384, 1, 1]
     dtype = "float32"
     min_val = float("-0.289905")
@@ -1958,6 +2136,7 @@ class Program_weight_tensor_parameter_177:
 
 class Program_weight_tensor_parameter_178:
     name = "parameter_178"
+    original_name = "batch_norm2d_71.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-1.97923")
@@ -1969,6 +2148,7 @@ class Program_weight_tensor_parameter_178:
 
 class Program_weight_tensor_parameter_179:
     name = "parameter_179"
+    original_name = "batch_norm2d_71.w_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-1.75191")
@@ -1980,6 +2160,7 @@ class Program_weight_tensor_parameter_179:
 
 class Program_weight_tensor_parameter_180:
     name = "parameter_180"
+    original_name = "batch_norm2d_71.w_2"
     shape = [384]
     dtype = "float32"
     min_val = float("0.00838632")
@@ -1991,6 +2172,7 @@ class Program_weight_tensor_parameter_180:
 
 class Program_weight_tensor_parameter_181:
     name = "parameter_181"
+    original_name = "batch_norm2d_71.w_1"
     shape = [384]
     dtype = "float32"
     min_val = float("-0.439733")
@@ -2002,6 +2184,7 @@ class Program_weight_tensor_parameter_181:
 
 class Program_weight_tensor_parameter_182:
     name = "parameter_182"
+    original_name = "conv2d_75.w_0"
     shape = [384, 384, 1, 1]
     dtype = "float32"
     min_val = float("-0.186748")
@@ -2013,6 +2196,7 @@ class Program_weight_tensor_parameter_182:
 
 class Program_weight_tensor_parameter_183:
     name = "parameter_183"
+    original_name = "batch_norm2d_74.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-8.92138")
@@ -2024,6 +2208,7 @@ class Program_weight_tensor_parameter_183:
 
 class Program_weight_tensor_parameter_184:
     name = "parameter_184"
+    original_name = "batch_norm2d_74.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.807772")
@@ -2035,6 +2220,7 @@ class Program_weight_tensor_parameter_184:
 
 class Program_weight_tensor_parameter_185:
     name = "parameter_185"
+    original_name = "batch_norm2d_74.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.200753")
@@ -2046,6 +2232,7 @@ class Program_weight_tensor_parameter_185:
 
 class Program_weight_tensor_parameter_186:
     name = "parameter_186"
+    original_name = "batch_norm2d_74.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-2.83207")
@@ -2057,6 +2244,7 @@ class Program_weight_tensor_parameter_186:
 
 class Program_weight_tensor_parameter_187:
     name = "parameter_187"
+    original_name = "conv2d_78.w_0"
     shape = [256, 768, 1, 1]
     dtype = "float32"
     min_val = float("-0.473647")
@@ -2068,6 +2256,7 @@ class Program_weight_tensor_parameter_187:
 
 class Program_weight_tensor_parameter_188:
     name = "parameter_188"
+    original_name = "batch_norm2d_73.b_0"
     shape = [768]
     dtype = "float32"
     min_val = float("-3.88252")
@@ -2079,6 +2268,7 @@ class Program_weight_tensor_parameter_188:
 
 class Program_weight_tensor_parameter_189:
     name = "parameter_189"
+    original_name = "batch_norm2d_73.w_0"
     shape = [768]
     dtype = "float32"
     min_val = float("0.61965")
@@ -2090,6 +2280,7 @@ class Program_weight_tensor_parameter_189:
 
 class Program_weight_tensor_parameter_190:
     name = "parameter_190"
+    original_name = "batch_norm2d_73.w_2"
     shape = [768]
     dtype = "float32"
     min_val = float("0.000454662")
@@ -2101,6 +2292,7 @@ class Program_weight_tensor_parameter_190:
 
 class Program_weight_tensor_parameter_191:
     name = "parameter_191"
+    original_name = "batch_norm2d_73.w_1"
     shape = [768]
     dtype = "float32"
     min_val = float("-0.78607")
@@ -2112,6 +2304,7 @@ class Program_weight_tensor_parameter_191:
 
 class Program_weight_tensor_parameter_192:
     name = "parameter_192"
+    original_name = "conv2d_77.w_0"
     shape = [768, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.318483")
@@ -2123,6 +2316,7 @@ class Program_weight_tensor_parameter_192:
 
 class Program_weight_tensor_parameter_193:
     name = "parameter_193"
+    original_name = "batch_norm2d_69.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-2.81936")
@@ -2134,6 +2328,7 @@ class Program_weight_tensor_parameter_193:
 
 class Program_weight_tensor_parameter_194:
     name = "parameter_194"
+    original_name = "batch_norm2d_69.w_0"
     shape = [384]
     dtype = "float32"
     min_val = float("0.44987")
@@ -2145,6 +2340,7 @@ class Program_weight_tensor_parameter_194:
 
 class Program_weight_tensor_parameter_195:
     name = "parameter_195"
+    original_name = "batch_norm2d_69.w_2"
     shape = [384]
     dtype = "float32"
     min_val = float("0.775629")
@@ -2156,6 +2352,7 @@ class Program_weight_tensor_parameter_195:
 
 class Program_weight_tensor_parameter_196:
     name = "parameter_196"
+    original_name = "batch_norm2d_69.w_1"
     shape = [384]
     dtype = "float32"
     min_val = float("-0.827122")
@@ -2167,6 +2364,7 @@ class Program_weight_tensor_parameter_196:
 
 class Program_weight_tensor_parameter_197:
     name = "parameter_197"
+    original_name = "conv2d_73.w_0"
     shape = [384, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.415568")
@@ -2178,6 +2376,7 @@ class Program_weight_tensor_parameter_197:
 
 class Program_weight_tensor_parameter_198:
     name = "parameter_198"
+    original_name = "batch_norm2d_68.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-1.36632")
@@ -2189,6 +2388,7 @@ class Program_weight_tensor_parameter_198:
 
 class Program_weight_tensor_parameter_199:
     name = "parameter_199"
+    original_name = "batch_norm2d_68.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.146318")
@@ -2200,6 +2400,7 @@ class Program_weight_tensor_parameter_199:
 
 class Program_weight_tensor_parameter_200:
     name = "parameter_200"
+    original_name = "batch_norm2d_68.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("0.52274")
@@ -2211,6 +2412,7 @@ class Program_weight_tensor_parameter_200:
 
 class Program_weight_tensor_parameter_201:
     name = "parameter_201"
+    original_name = "batch_norm2d_68.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-1.032")
@@ -2222,6 +2424,7 @@ class Program_weight_tensor_parameter_201:
 
 class Program_weight_tensor_parameter_202:
     name = "parameter_202"
+    original_name = "conv2d_72.w_0"
     shape = [192, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.325781")
@@ -2233,6 +2436,7 @@ class Program_weight_tensor_parameter_202:
 
 class Program_weight_tensor_parameter_203:
     name = "parameter_203"
+    original_name = "batch_norm2d_67.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-3.71713")
@@ -2244,6 +2448,7 @@ class Program_weight_tensor_parameter_203:
 
 class Program_weight_tensor_parameter_204:
     name = "parameter_204"
+    original_name = "batch_norm2d_67.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("0.153002")
@@ -2255,6 +2460,7 @@ class Program_weight_tensor_parameter_204:
 
 class Program_weight_tensor_parameter_205:
     name = "parameter_205"
+    original_name = "batch_norm2d_67.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("0.524006")
@@ -2266,6 +2472,7 @@ class Program_weight_tensor_parameter_205:
 
 class Program_weight_tensor_parameter_206:
     name = "parameter_206"
+    original_name = "batch_norm2d_67.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.523299")
@@ -2277,6 +2484,7 @@ class Program_weight_tensor_parameter_206:
 
 class Program_weight_tensor_parameter_207:
     name = "parameter_207"
+    original_name = "conv2d_71.w_0"
     shape = [192, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.205408")
@@ -2288,6 +2496,7 @@ class Program_weight_tensor_parameter_207:
 
 class Program_weight_tensor_parameter_208:
     name = "parameter_208"
+    original_name = "batch_norm2d_26.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.63107")
@@ -2299,6 +2508,7 @@ class Program_weight_tensor_parameter_208:
 
 class Program_weight_tensor_parameter_209:
     name = "parameter_209"
+    original_name = "batch_norm2d_26.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.932252")
@@ -2310,6 +2520,7 @@ class Program_weight_tensor_parameter_209:
 
 class Program_weight_tensor_parameter_210:
     name = "parameter_210"
+    original_name = "batch_norm2d_26.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("3.02829")
@@ -2321,6 +2532,7 @@ class Program_weight_tensor_parameter_210:
 
 class Program_weight_tensor_parameter_211:
     name = "parameter_211"
+    original_name = "batch_norm2d_26.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-14.1805")
@@ -2332,6 +2544,7 @@ class Program_weight_tensor_parameter_211:
 
 class Program_weight_tensor_parameter_212:
     name = "parameter_212"
+    original_name = "conv2d_26.w_0"
     shape = [256, 1152, 1, 1]
     dtype = "float32"
     min_val = float("-0.755045")
@@ -2343,6 +2556,7 @@ class Program_weight_tensor_parameter_212:
 
 class Program_weight_tensor_parameter_213:
     name = "parameter_213"
+    original_name = "batch_norm2d_25.b_0"
     shape = [1152]
     dtype = "float32"
     min_val = float("-4.4475")
@@ -2354,6 +2568,7 @@ class Program_weight_tensor_parameter_213:
 
 class Program_weight_tensor_parameter_214:
     name = "parameter_214"
+    original_name = "batch_norm2d_25.w_0"
     shape = [1152]
     dtype = "float32"
     min_val = float("0.953929")
@@ -2365,6 +2580,7 @@ class Program_weight_tensor_parameter_214:
 
 class Program_weight_tensor_parameter_215:
     name = "parameter_215"
+    original_name = "batch_norm2d_25.w_2"
     shape = [1152]
     dtype = "float32"
     min_val = float("5.60519e-45")
@@ -2376,6 +2592,7 @@ class Program_weight_tensor_parameter_215:
 
 class Program_weight_tensor_parameter_216:
     name = "parameter_216"
+    original_name = "batch_norm2d_25.w_1"
     shape = [1152]
     dtype = "float32"
     min_val = float("-2.31309")
@@ -2387,6 +2604,7 @@ class Program_weight_tensor_parameter_216:
 
 class Program_weight_tensor_parameter_217:
     name = "parameter_217"
+    original_name = "conv2d_25.w_0"
     shape = [1152, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.405182")
@@ -2398,6 +2616,7 @@ class Program_weight_tensor_parameter_217:
 
 class Program_weight_tensor_parameter_218:
     name = "parameter_218"
+    original_name = "batch_norm2d_24.b_0"
     shape = [1152]
     dtype = "float32"
     min_val = float("-3.66278")
@@ -2409,6 +2628,7 @@ class Program_weight_tensor_parameter_218:
 
 class Program_weight_tensor_parameter_219:
     name = "parameter_219"
+    original_name = "batch_norm2d_24.w_0"
     shape = [1152]
     dtype = "float32"
     min_val = float("-1.46538")
@@ -2420,6 +2640,7 @@ class Program_weight_tensor_parameter_219:
 
 class Program_weight_tensor_parameter_220:
     name = "parameter_220"
+    original_name = "batch_norm2d_24.w_2"
     shape = [1152]
     dtype = "float32"
     min_val = float("5.60519e-45")
@@ -2431,6 +2652,7 @@ class Program_weight_tensor_parameter_220:
 
 class Program_weight_tensor_parameter_221:
     name = "parameter_221"
+    original_name = "batch_norm2d_24.w_1"
     shape = [1152]
     dtype = "float32"
     min_val = float("-6.28025")
@@ -2442,6 +2664,7 @@ class Program_weight_tensor_parameter_221:
 
 class Program_weight_tensor_parameter_222:
     name = "parameter_222"
+    original_name = "conv2d_24.w_0"
     shape = [1152, 192, 1, 1]
     dtype = "float32"
     min_val = float("-0.580588")
@@ -2453,6 +2676,7 @@ class Program_weight_tensor_parameter_222:
 
 class Program_weight_tensor_parameter_223:
     name = "parameter_223"
+    original_name = "batch_norm2d_66.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.689238")
@@ -2464,6 +2688,7 @@ class Program_weight_tensor_parameter_223:
 
 class Program_weight_tensor_parameter_224:
     name = "parameter_224"
+    original_name = "batch_norm2d_66.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.362266")
@@ -2475,6 +2700,7 @@ class Program_weight_tensor_parameter_224:
 
 class Program_weight_tensor_parameter_225:
     name = "parameter_225"
+    original_name = "batch_norm2d_66.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("0.00273522")
@@ -2486,6 +2712,7 @@ class Program_weight_tensor_parameter_225:
 
 class Program_weight_tensor_parameter_226:
     name = "parameter_226"
+    original_name = "batch_norm2d_66.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.262434")
@@ -2497,6 +2724,7 @@ class Program_weight_tensor_parameter_226:
 
 class Program_weight_tensor_parameter_227:
     name = "parameter_227"
+    original_name = "conv2d_70.w_0"
     shape = [192, 384, 1, 1]
     dtype = "float32"
     min_val = float("-1.11141")
@@ -2508,6 +2736,7 @@ class Program_weight_tensor_parameter_227:
 
 class Program_weight_tensor_parameter_228:
     name = "parameter_228"
+    original_name = "conv2d_69.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-1.7425")
@@ -2519,6 +2748,7 @@ class Program_weight_tensor_parameter_228:
 
 class Program_weight_tensor_parameter_229:
     name = "parameter_229"
+    original_name = "conv2d_69.w_0"
     shape = [384, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.451567")
@@ -2530,6 +2760,7 @@ class Program_weight_tensor_parameter_229:
 
 class Program_weight_tensor_parameter_230:
     name = "parameter_230"
+    original_name = "batch_norm2d_65.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-4.53214")
@@ -2541,6 +2772,7 @@ class Program_weight_tensor_parameter_230:
 
 class Program_weight_tensor_parameter_231:
     name = "parameter_231"
+    original_name = "batch_norm2d_65.w_0"
     shape = [384]
     dtype = "float32"
     min_val = float("0.465838")
@@ -2552,6 +2784,7 @@ class Program_weight_tensor_parameter_231:
 
 class Program_weight_tensor_parameter_232:
     name = "parameter_232"
+    original_name = "batch_norm2d_65.w_2"
     shape = [384]
     dtype = "float32"
     min_val = float("2.02185")
@@ -2563,6 +2796,7 @@ class Program_weight_tensor_parameter_232:
 
 class Program_weight_tensor_parameter_233:
     name = "parameter_233"
+    original_name = "batch_norm2d_65.w_1"
     shape = [384]
     dtype = "float32"
     min_val = float("-5.39453")
@@ -2574,6 +2808,7 @@ class Program_weight_tensor_parameter_233:
 
 class Program_weight_tensor_parameter_234:
     name = "parameter_234"
+    original_name = "conv2d_68.w_0"
     shape = [384, 192, 1, 1]
     dtype = "float32"
     min_val = float("-0.376148")
@@ -2585,6 +2820,7 @@ class Program_weight_tensor_parameter_234:
 
 class Program_weight_tensor_parameter_235:
     name = "parameter_235"
+    original_name = "batch_norm2d_60.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-3.55123")
@@ -2596,6 +2832,7 @@ class Program_weight_tensor_parameter_235:
 
 class Program_weight_tensor_parameter_236:
     name = "parameter_236"
+    original_name = "batch_norm2d_60.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-2.77147")
@@ -2607,6 +2844,7 @@ class Program_weight_tensor_parameter_236:
 
 class Program_weight_tensor_parameter_237:
     name = "parameter_237"
+    original_name = "batch_norm2d_60.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("0.0571532")
@@ -2618,6 +2856,7 @@ class Program_weight_tensor_parameter_237:
 
 class Program_weight_tensor_parameter_238:
     name = "parameter_238"
+    original_name = "batch_norm2d_60.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.493985")
@@ -2629,6 +2868,7 @@ class Program_weight_tensor_parameter_238:
 
 class Program_weight_tensor_parameter_239:
     name = "parameter_239"
+    original_name = "conv2d_63.w_0"
     shape = [192, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.355859")
@@ -2640,6 +2880,7 @@ class Program_weight_tensor_parameter_239:
 
 class Program_weight_tensor_parameter_240:
     name = "parameter_240"
+    original_name = "batch_norm2d_62.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-2.47692")
@@ -2651,6 +2892,7 @@ class Program_weight_tensor_parameter_240:
 
 class Program_weight_tensor_parameter_241:
     name = "parameter_241"
+    original_name = "batch_norm2d_62.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.28749")
@@ -2662,6 +2904,7 @@ class Program_weight_tensor_parameter_241:
 
 class Program_weight_tensor_parameter_242:
     name = "parameter_242"
+    original_name = "batch_norm2d_62.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.00351684")
@@ -2673,6 +2916,7 @@ class Program_weight_tensor_parameter_242:
 
 class Program_weight_tensor_parameter_243:
     name = "parameter_243"
+    original_name = "batch_norm2d_62.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.945651")
@@ -2684,6 +2928,7 @@ class Program_weight_tensor_parameter_243:
 
 class Program_weight_tensor_parameter_244:
     name = "parameter_244"
+    original_name = "conv2d_65.w_0"
     shape = [256, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.308585")
@@ -2695,6 +2940,7 @@ class Program_weight_tensor_parameter_244:
 
 class Program_weight_tensor_parameter_245:
     name = "parameter_245"
+    original_name = "batch_norm2d_61.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-2.47714")
@@ -2706,6 +2952,7 @@ class Program_weight_tensor_parameter_245:
 
 class Program_weight_tensor_parameter_246:
     name = "parameter_246"
+    original_name = "batch_norm2d_61.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.43903")
@@ -2717,6 +2964,7 @@ class Program_weight_tensor_parameter_246:
 
 class Program_weight_tensor_parameter_247:
     name = "parameter_247"
+    original_name = "batch_norm2d_61.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.0029389")
@@ -2728,6 +2976,7 @@ class Program_weight_tensor_parameter_247:
 
 class Program_weight_tensor_parameter_248:
     name = "parameter_248"
+    original_name = "batch_norm2d_61.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.689036")
@@ -2739,6 +2988,7 @@ class Program_weight_tensor_parameter_248:
 
 class Program_weight_tensor_parameter_249:
     name = "parameter_249"
+    original_name = "conv2d_64.w_0"
     shape = [256, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.292373")
@@ -2750,6 +3000,7 @@ class Program_weight_tensor_parameter_249:
 
 class Program_weight_tensor_parameter_250:
     name = "parameter_250"
+    original_name = "batch_norm2d_64.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-6.35526")
@@ -2761,6 +3012,7 @@ class Program_weight_tensor_parameter_250:
 
 class Program_weight_tensor_parameter_251:
     name = "parameter_251"
+    original_name = "batch_norm2d_64.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("0.880008")
@@ -2772,6 +3024,7 @@ class Program_weight_tensor_parameter_251:
 
 class Program_weight_tensor_parameter_252:
     name = "parameter_252"
+    original_name = "batch_norm2d_64.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("0.0623435")
@@ -2783,6 +3036,7 @@ class Program_weight_tensor_parameter_252:
 
 class Program_weight_tensor_parameter_253:
     name = "parameter_253"
+    original_name = "batch_norm2d_64.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.638282")
@@ -2794,6 +3048,7 @@ class Program_weight_tensor_parameter_253:
 
 class Program_weight_tensor_parameter_254:
     name = "parameter_254"
+    original_name = "conv2d_67.w_0"
     shape = [192, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.346639")
@@ -2805,6 +3060,7 @@ class Program_weight_tensor_parameter_254:
 
 class Program_weight_tensor_parameter_255:
     name = "parameter_255"
+    original_name = "batch_norm2d_63.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-3.50492")
@@ -2816,6 +3072,7 @@ class Program_weight_tensor_parameter_255:
 
 class Program_weight_tensor_parameter_256:
     name = "parameter_256"
+    original_name = "batch_norm2d_63.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("0.331937")
@@ -2827,6 +3084,7 @@ class Program_weight_tensor_parameter_256:
 
 class Program_weight_tensor_parameter_257:
     name = "parameter_257"
+    original_name = "batch_norm2d_63.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("0.0026259")
@@ -2838,6 +3096,7 @@ class Program_weight_tensor_parameter_257:
 
 class Program_weight_tensor_parameter_258:
     name = "parameter_258"
+    original_name = "batch_norm2d_63.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-1.3137")
@@ -2849,6 +3108,7 @@ class Program_weight_tensor_parameter_258:
 
 class Program_weight_tensor_parameter_259:
     name = "parameter_259"
+    original_name = "conv2d_66.w_0"
     shape = [512, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.343786")
@@ -2860,6 +3120,7 @@ class Program_weight_tensor_parameter_259:
 
 class Program_weight_tensor_parameter_260:
     name = "parameter_260"
+    original_name = "batch_norm2d_59.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-2.33199")
@@ -2871,6 +3132,7 @@ class Program_weight_tensor_parameter_260:
 
 class Program_weight_tensor_parameter_261:
     name = "parameter_261"
+    original_name = "batch_norm2d_59.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.347636")
@@ -2882,6 +3144,7 @@ class Program_weight_tensor_parameter_261:
 
 class Program_weight_tensor_parameter_262:
     name = "parameter_262"
+    original_name = "batch_norm2d_59.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("2.39514")
@@ -2893,6 +3156,7 @@ class Program_weight_tensor_parameter_262:
 
 class Program_weight_tensor_parameter_263:
     name = "parameter_263"
+    original_name = "batch_norm2d_59.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-7.71835")
@@ -2904,6 +3168,7 @@ class Program_weight_tensor_parameter_263:
 
 class Program_weight_tensor_parameter_264:
     name = "parameter_264"
+    original_name = "conv2d_62.w_0"
     shape = [256, 192, 1, 1]
     dtype = "float32"
     min_val = float("-0.471923")
@@ -2915,6 +3180,7 @@ class Program_weight_tensor_parameter_264:
 
 class Program_weight_tensor_parameter_265:
     name = "parameter_265"
+    original_name = "batch_norm2d_58.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.37125")
@@ -2926,6 +3192,7 @@ class Program_weight_tensor_parameter_265:
 
 class Program_weight_tensor_parameter_266:
     name = "parameter_266"
+    original_name = "batch_norm2d_58.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.209069")
@@ -2937,6 +3204,7 @@ class Program_weight_tensor_parameter_266:
 
 class Program_weight_tensor_parameter_267:
     name = "parameter_267"
+    original_name = "batch_norm2d_58.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("1.89321")
@@ -2948,6 +3216,7 @@ class Program_weight_tensor_parameter_267:
 
 class Program_weight_tensor_parameter_268:
     name = "parameter_268"
+    original_name = "batch_norm2d_58.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-5.97045")
@@ -2959,6 +3228,7 @@ class Program_weight_tensor_parameter_268:
 
 class Program_weight_tensor_parameter_269:
     name = "parameter_269"
+    original_name = "conv2d_61.w_0"
     shape = [128, 192, 1, 1]
     dtype = "float32"
     min_val = float("-0.265117")
@@ -2970,6 +3240,7 @@ class Program_weight_tensor_parameter_269:
 
 class Program_weight_tensor_parameter_270:
     name = "parameter_270"
+    original_name = "batch_norm2d_57.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-2.51829")
@@ -2981,6 +3252,7 @@ class Program_weight_tensor_parameter_270:
 
 class Program_weight_tensor_parameter_271:
     name = "parameter_271"
+    original_name = "batch_norm2d_57.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.199457")
@@ -2992,6 +3264,7 @@ class Program_weight_tensor_parameter_271:
 
 class Program_weight_tensor_parameter_272:
     name = "parameter_272"
+    original_name = "batch_norm2d_57.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("1.21972")
@@ -3003,6 +3276,7 @@ class Program_weight_tensor_parameter_272:
 
 class Program_weight_tensor_parameter_273:
     name = "parameter_273"
+    original_name = "batch_norm2d_57.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-2.60586")
@@ -3014,6 +3288,7 @@ class Program_weight_tensor_parameter_273:
 
 class Program_weight_tensor_parameter_274:
     name = "parameter_274"
+    original_name = "conv2d_60.w_0"
     shape = [128, 192, 1, 1]
     dtype = "float32"
     min_val = float("-0.280463")
@@ -3025,6 +3300,7 @@ class Program_weight_tensor_parameter_274:
 
 class Program_weight_tensor_parameter_275:
     name = "parameter_275"
+    original_name = "batch_norm2d_56.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.687833")
@@ -3036,6 +3312,7 @@ class Program_weight_tensor_parameter_275:
 
 class Program_weight_tensor_parameter_276:
     name = "parameter_276"
+    original_name = "batch_norm2d_56.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.302089")
@@ -3047,6 +3324,7 @@ class Program_weight_tensor_parameter_276:
 
 class Program_weight_tensor_parameter_277:
     name = "parameter_277"
+    original_name = "batch_norm2d_56.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("0.00299265")
@@ -3058,6 +3336,7 @@ class Program_weight_tensor_parameter_277:
 
 class Program_weight_tensor_parameter_278:
     name = "parameter_278"
+    original_name = "batch_norm2d_56.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.299724")
@@ -3069,6 +3348,7 @@ class Program_weight_tensor_parameter_278:
 
 class Program_weight_tensor_parameter_279:
     name = "parameter_279"
+    original_name = "conv2d_59.w_0"
     shape = [192, 384, 1, 1]
     dtype = "float32"
     min_val = float("-0.39026")
@@ -3080,6 +3360,7 @@ class Program_weight_tensor_parameter_279:
 
 class Program_weight_tensor_parameter_280:
     name = "parameter_280"
+    original_name = "conv2d_58.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-2.33871")
@@ -3091,6 +3372,7 @@ class Program_weight_tensor_parameter_280:
 
 class Program_weight_tensor_parameter_281:
     name = "parameter_281"
+    original_name = "conv2d_58.w_0"
     shape = [384, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.456093")
@@ -3102,6 +3384,7 @@ class Program_weight_tensor_parameter_281:
 
 class Program_weight_tensor_parameter_282:
     name = "parameter_282"
+    original_name = "batch_norm2d_55.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-4.02938")
@@ -3113,6 +3396,7 @@ class Program_weight_tensor_parameter_282:
 
 class Program_weight_tensor_parameter_283:
     name = "parameter_283"
+    original_name = "batch_norm2d_55.w_0"
     shape = [384]
     dtype = "float32"
     min_val = float("0.448078")
@@ -3124,6 +3408,7 @@ class Program_weight_tensor_parameter_283:
 
 class Program_weight_tensor_parameter_284:
     name = "parameter_284"
+    original_name = "batch_norm2d_55.w_2"
     shape = [384]
     dtype = "float32"
     min_val = float("1.83244")
@@ -3135,6 +3420,7 @@ class Program_weight_tensor_parameter_284:
 
 class Program_weight_tensor_parameter_285:
     name = "parameter_285"
+    original_name = "batch_norm2d_55.w_1"
     shape = [384]
     dtype = "float32"
     min_val = float("-5.38765")
@@ -3146,6 +3432,7 @@ class Program_weight_tensor_parameter_285:
 
 class Program_weight_tensor_parameter_286:
     name = "parameter_286"
+    original_name = "conv2d_57.w_0"
     shape = [384, 192, 1, 1]
     dtype = "float32"
     min_val = float("-0.477494")
@@ -3157,6 +3444,7 @@ class Program_weight_tensor_parameter_286:
 
 class Program_weight_tensor_parameter_287:
     name = "parameter_287"
+    original_name = "batch_norm2d_50.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-3.22916")
@@ -3168,6 +3456,7 @@ class Program_weight_tensor_parameter_287:
 
 class Program_weight_tensor_parameter_288:
     name = "parameter_288"
+    original_name = "batch_norm2d_50.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-2.96211")
@@ -3179,6 +3468,7 @@ class Program_weight_tensor_parameter_288:
 
 class Program_weight_tensor_parameter_289:
     name = "parameter_289"
+    original_name = "batch_norm2d_50.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("0.0871505")
@@ -3190,6 +3480,7 @@ class Program_weight_tensor_parameter_289:
 
 class Program_weight_tensor_parameter_290:
     name = "parameter_290"
+    original_name = "batch_norm2d_50.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.775717")
@@ -3201,6 +3492,7 @@ class Program_weight_tensor_parameter_290:
 
 class Program_weight_tensor_parameter_291:
     name = "parameter_291"
+    original_name = "conv2d_52.w_0"
     shape = [192, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.401393")
@@ -3212,6 +3504,7 @@ class Program_weight_tensor_parameter_291:
 
 class Program_weight_tensor_parameter_292:
     name = "parameter_292"
+    original_name = "batch_norm2d_52.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-2.08855")
@@ -3223,6 +3516,7 @@ class Program_weight_tensor_parameter_292:
 
 class Program_weight_tensor_parameter_293:
     name = "parameter_293"
+    original_name = "batch_norm2d_52.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.21394")
@@ -3234,6 +3528,7 @@ class Program_weight_tensor_parameter_293:
 
 class Program_weight_tensor_parameter_294:
     name = "parameter_294"
+    original_name = "batch_norm2d_52.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.00777059")
@@ -3245,6 +3540,7 @@ class Program_weight_tensor_parameter_294:
 
 class Program_weight_tensor_parameter_295:
     name = "parameter_295"
+    original_name = "batch_norm2d_52.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.627073")
@@ -3256,6 +3552,7 @@ class Program_weight_tensor_parameter_295:
 
 class Program_weight_tensor_parameter_296:
     name = "parameter_296"
+    original_name = "conv2d_54.w_0"
     shape = [256, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.359497")
@@ -3267,6 +3564,7 @@ class Program_weight_tensor_parameter_296:
 
 class Program_weight_tensor_parameter_297:
     name = "parameter_297"
+    original_name = "batch_norm2d_51.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-2.08853")
@@ -3278,6 +3576,7 @@ class Program_weight_tensor_parameter_297:
 
 class Program_weight_tensor_parameter_298:
     name = "parameter_298"
+    original_name = "batch_norm2d_51.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.18768")
@@ -3289,6 +3588,7 @@ class Program_weight_tensor_parameter_298:
 
 class Program_weight_tensor_parameter_299:
     name = "parameter_299"
+    original_name = "batch_norm2d_51.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.0043245")
@@ -3300,6 +3600,7 @@ class Program_weight_tensor_parameter_299:
 
 class Program_weight_tensor_parameter_300:
     name = "parameter_300"
+    original_name = "batch_norm2d_51.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.509205")
@@ -3311,6 +3612,7 @@ class Program_weight_tensor_parameter_300:
 
 class Program_weight_tensor_parameter_301:
     name = "parameter_301"
+    original_name = "conv2d_53.w_0"
     shape = [256, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.310715")
@@ -3322,6 +3624,7 @@ class Program_weight_tensor_parameter_301:
 
 class Program_weight_tensor_parameter_302:
     name = "parameter_302"
+    original_name = "batch_norm2d_54.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-9.5792")
@@ -3333,6 +3636,7 @@ class Program_weight_tensor_parameter_302:
 
 class Program_weight_tensor_parameter_303:
     name = "parameter_303"
+    original_name = "batch_norm2d_54.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("0.754398")
@@ -3344,6 +3648,7 @@ class Program_weight_tensor_parameter_303:
 
 class Program_weight_tensor_parameter_304:
     name = "parameter_304"
+    original_name = "batch_norm2d_54.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("0.0814359")
@@ -3355,6 +3660,7 @@ class Program_weight_tensor_parameter_304:
 
 class Program_weight_tensor_parameter_305:
     name = "parameter_305"
+    original_name = "batch_norm2d_54.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.685855")
@@ -3366,6 +3672,7 @@ class Program_weight_tensor_parameter_305:
 
 class Program_weight_tensor_parameter_306:
     name = "parameter_306"
+    original_name = "conv2d_56.w_0"
     shape = [192, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.375274")
@@ -3377,6 +3684,7 @@ class Program_weight_tensor_parameter_306:
 
 class Program_weight_tensor_parameter_307:
     name = "parameter_307"
+    original_name = "batch_norm2d_53.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-4.07368")
@@ -3388,6 +3696,7 @@ class Program_weight_tensor_parameter_307:
 
 class Program_weight_tensor_parameter_308:
     name = "parameter_308"
+    original_name = "batch_norm2d_53.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("0.509429")
@@ -3399,6 +3708,7 @@ class Program_weight_tensor_parameter_308:
 
 class Program_weight_tensor_parameter_309:
     name = "parameter_309"
+    original_name = "batch_norm2d_53.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("0.000132068")
@@ -3410,6 +3720,7 @@ class Program_weight_tensor_parameter_309:
 
 class Program_weight_tensor_parameter_310:
     name = "parameter_310"
+    original_name = "batch_norm2d_53.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-1.14546")
@@ -3421,6 +3732,7 @@ class Program_weight_tensor_parameter_310:
 
 class Program_weight_tensor_parameter_311:
     name = "parameter_311"
+    original_name = "conv2d_55.w_0"
     shape = [512, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.388427")
@@ -3432,6 +3744,7 @@ class Program_weight_tensor_parameter_311:
 
 class Program_weight_tensor_parameter_312:
     name = "parameter_312"
+    original_name = "batch_norm2d_49.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.73399")
@@ -3443,6 +3756,7 @@ class Program_weight_tensor_parameter_312:
 
 class Program_weight_tensor_parameter_313:
     name = "parameter_313"
+    original_name = "batch_norm2d_49.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.0454827")
@@ -3454,6 +3768,7 @@ class Program_weight_tensor_parameter_313:
 
 class Program_weight_tensor_parameter_314:
     name = "parameter_314"
+    original_name = "batch_norm2d_49.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("2.39051")
@@ -3465,6 +3780,7 @@ class Program_weight_tensor_parameter_314:
 
 class Program_weight_tensor_parameter_315:
     name = "parameter_315"
+    original_name = "batch_norm2d_49.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-5.7469")
@@ -3476,6 +3792,7 @@ class Program_weight_tensor_parameter_315:
 
 class Program_weight_tensor_parameter_316:
     name = "parameter_316"
+    original_name = "conv2d_51.w_0"
     shape = [256, 192, 1, 1]
     dtype = "float32"
     min_val = float("-0.503478")
@@ -3487,6 +3804,7 @@ class Program_weight_tensor_parameter_316:
 
 class Program_weight_tensor_parameter_317:
     name = "parameter_317"
+    original_name = "batch_norm2d_48.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.903812")
@@ -3498,6 +3816,7 @@ class Program_weight_tensor_parameter_317:
 
 class Program_weight_tensor_parameter_318:
     name = "parameter_318"
+    original_name = "batch_norm2d_48.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.177051")
@@ -3509,6 +3828,7 @@ class Program_weight_tensor_parameter_318:
 
 class Program_weight_tensor_parameter_319:
     name = "parameter_319"
+    original_name = "batch_norm2d_48.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("1.75765")
@@ -3520,6 +3840,7 @@ class Program_weight_tensor_parameter_319:
 
 class Program_weight_tensor_parameter_320:
     name = "parameter_320"
+    original_name = "batch_norm2d_48.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-4.07739")
@@ -3531,6 +3852,7 @@ class Program_weight_tensor_parameter_320:
 
 class Program_weight_tensor_parameter_321:
     name = "parameter_321"
+    original_name = "conv2d_50.w_0"
     shape = [128, 192, 1, 1]
     dtype = "float32"
     min_val = float("-0.366464")
@@ -3542,6 +3864,7 @@ class Program_weight_tensor_parameter_321:
 
 class Program_weight_tensor_parameter_322:
     name = "parameter_322"
+    original_name = "batch_norm2d_47.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.77522")
@@ -3553,6 +3876,7 @@ class Program_weight_tensor_parameter_322:
 
 class Program_weight_tensor_parameter_323:
     name = "parameter_323"
+    original_name = "batch_norm2d_47.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.364332")
@@ -3564,6 +3888,7 @@ class Program_weight_tensor_parameter_323:
 
 class Program_weight_tensor_parameter_324:
     name = "parameter_324"
+    original_name = "batch_norm2d_47.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("1.61177")
@@ -3575,6 +3900,7 @@ class Program_weight_tensor_parameter_324:
 
 class Program_weight_tensor_parameter_325:
     name = "parameter_325"
+    original_name = "batch_norm2d_47.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-4.11512")
@@ -3586,6 +3912,7 @@ class Program_weight_tensor_parameter_325:
 
 class Program_weight_tensor_parameter_326:
     name = "parameter_326"
+    original_name = "conv2d_49.w_0"
     shape = [128, 192, 1, 1]
     dtype = "float32"
     min_val = float("-0.333098")
@@ -3597,6 +3924,7 @@ class Program_weight_tensor_parameter_326:
 
 class Program_weight_tensor_parameter_327:
     name = "parameter_327"
+    original_name = "batch_norm2d_46.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-1.033")
@@ -3608,6 +3936,7 @@ class Program_weight_tensor_parameter_327:
 
 class Program_weight_tensor_parameter_328:
     name = "parameter_328"
+    original_name = "batch_norm2d_46.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("0.172")
@@ -3619,6 +3948,7 @@ class Program_weight_tensor_parameter_328:
 
 class Program_weight_tensor_parameter_329:
     name = "parameter_329"
+    original_name = "batch_norm2d_46.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("0.00499187")
@@ -3630,6 +3960,7 @@ class Program_weight_tensor_parameter_329:
 
 class Program_weight_tensor_parameter_330:
     name = "parameter_330"
+    original_name = "batch_norm2d_46.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.321193")
@@ -3641,6 +3972,7 @@ class Program_weight_tensor_parameter_330:
 
 class Program_weight_tensor_parameter_331:
     name = "parameter_331"
+    original_name = "conv2d_48.w_0"
     shape = [192, 384, 1, 1]
     dtype = "float32"
     min_val = float("-0.36836")
@@ -3652,6 +3984,7 @@ class Program_weight_tensor_parameter_331:
 
 class Program_weight_tensor_parameter_332:
     name = "parameter_332"
+    original_name = "conv2d_47.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-4.00805")
@@ -3663,6 +3996,7 @@ class Program_weight_tensor_parameter_332:
 
 class Program_weight_tensor_parameter_333:
     name = "parameter_333"
+    original_name = "conv2d_47.w_0"
     shape = [384, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.494967")
@@ -3674,6 +4008,7 @@ class Program_weight_tensor_parameter_333:
 
 class Program_weight_tensor_parameter_334:
     name = "parameter_334"
+    original_name = "batch_norm2d_45.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-4.86296")
@@ -3685,6 +4020,7 @@ class Program_weight_tensor_parameter_334:
 
 class Program_weight_tensor_parameter_335:
     name = "parameter_335"
+    original_name = "batch_norm2d_45.w_0"
     shape = [384]
     dtype = "float32"
     min_val = float("0.509197")
@@ -3696,6 +4032,7 @@ class Program_weight_tensor_parameter_335:
 
 class Program_weight_tensor_parameter_336:
     name = "parameter_336"
+    original_name = "batch_norm2d_45.w_2"
     shape = [384]
     dtype = "float32"
     min_val = float("1.95466")
@@ -3707,6 +4044,7 @@ class Program_weight_tensor_parameter_336:
 
 class Program_weight_tensor_parameter_337:
     name = "parameter_337"
+    original_name = "batch_norm2d_45.w_1"
     shape = [384]
     dtype = "float32"
     min_val = float("-3.8136")
@@ -3718,6 +4056,7 @@ class Program_weight_tensor_parameter_337:
 
 class Program_weight_tensor_parameter_338:
     name = "parameter_338"
+    original_name = "conv2d_46.w_0"
     shape = [384, 192, 1, 1]
     dtype = "float32"
     min_val = float("-0.574063")
@@ -3729,6 +4068,7 @@ class Program_weight_tensor_parameter_338:
 
 class Program_weight_tensor_parameter_339:
     name = "parameter_339"
+    original_name = "batch_norm2d_40.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-2.7387")
@@ -3740,6 +4080,7 @@ class Program_weight_tensor_parameter_339:
 
 class Program_weight_tensor_parameter_340:
     name = "parameter_340"
+    original_name = "batch_norm2d_40.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-2.48635")
@@ -3751,6 +4092,7 @@ class Program_weight_tensor_parameter_340:
 
 class Program_weight_tensor_parameter_341:
     name = "parameter_341"
+    original_name = "batch_norm2d_40.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("0.0988378")
@@ -3762,6 +4104,7 @@ class Program_weight_tensor_parameter_341:
 
 class Program_weight_tensor_parameter_342:
     name = "parameter_342"
+    original_name = "batch_norm2d_40.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-1.26303")
@@ -3773,6 +4116,7 @@ class Program_weight_tensor_parameter_342:
 
 class Program_weight_tensor_parameter_343:
     name = "parameter_343"
+    original_name = "conv2d_41.w_0"
     shape = [192, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.448255")
@@ -3784,6 +4128,7 @@ class Program_weight_tensor_parameter_343:
 
 class Program_weight_tensor_parameter_344:
     name = "parameter_344"
+    original_name = "batch_norm2d_42.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-2.29397")
@@ -3795,6 +4140,7 @@ class Program_weight_tensor_parameter_344:
 
 class Program_weight_tensor_parameter_345:
     name = "parameter_345"
+    original_name = "batch_norm2d_42.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.26713")
@@ -3806,6 +4152,7 @@ class Program_weight_tensor_parameter_345:
 
 class Program_weight_tensor_parameter_346:
     name = "parameter_346"
+    original_name = "batch_norm2d_42.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.00592565")
@@ -3817,6 +4164,7 @@ class Program_weight_tensor_parameter_346:
 
 class Program_weight_tensor_parameter_347:
     name = "parameter_347"
+    original_name = "batch_norm2d_42.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.879422")
@@ -3828,6 +4176,7 @@ class Program_weight_tensor_parameter_347:
 
 class Program_weight_tensor_parameter_348:
     name = "parameter_348"
+    original_name = "conv2d_43.w_0"
     shape = [256, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.375389")
@@ -3839,6 +4188,7 @@ class Program_weight_tensor_parameter_348:
 
 class Program_weight_tensor_parameter_349:
     name = "parameter_349"
+    original_name = "batch_norm2d_41.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-2.29392")
@@ -3850,6 +4200,7 @@ class Program_weight_tensor_parameter_349:
 
 class Program_weight_tensor_parameter_350:
     name = "parameter_350"
+    original_name = "batch_norm2d_41.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.68807")
@@ -3861,6 +4212,7 @@ class Program_weight_tensor_parameter_350:
 
 class Program_weight_tensor_parameter_351:
     name = "parameter_351"
+    original_name = "batch_norm2d_41.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.00596697")
@@ -3872,6 +4224,7 @@ class Program_weight_tensor_parameter_351:
 
 class Program_weight_tensor_parameter_352:
     name = "parameter_352"
+    original_name = "batch_norm2d_41.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.05752")
@@ -3883,6 +4236,7 @@ class Program_weight_tensor_parameter_352:
 
 class Program_weight_tensor_parameter_353:
     name = "parameter_353"
+    original_name = "conv2d_42.w_0"
     shape = [256, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.463738")
@@ -3894,6 +4248,7 @@ class Program_weight_tensor_parameter_353:
 
 class Program_weight_tensor_parameter_354:
     name = "parameter_354"
+    original_name = "batch_norm2d_44.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-7.62769")
@@ -3905,6 +4260,7 @@ class Program_weight_tensor_parameter_354:
 
 class Program_weight_tensor_parameter_355:
     name = "parameter_355"
+    original_name = "batch_norm2d_44.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("0.623422")
@@ -3916,6 +4272,7 @@ class Program_weight_tensor_parameter_355:
 
 class Program_weight_tensor_parameter_356:
     name = "parameter_356"
+    original_name = "batch_norm2d_44.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("0.102345")
@@ -3927,6 +4284,7 @@ class Program_weight_tensor_parameter_356:
 
 class Program_weight_tensor_parameter_357:
     name = "parameter_357"
+    original_name = "batch_norm2d_44.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-1.28738")
@@ -3938,6 +4296,7 @@ class Program_weight_tensor_parameter_357:
 
 class Program_weight_tensor_parameter_358:
     name = "parameter_358"
+    original_name = "conv2d_45.w_0"
     shape = [192, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.449978")
@@ -3949,6 +4308,7 @@ class Program_weight_tensor_parameter_358:
 
 class Program_weight_tensor_parameter_359:
     name = "parameter_359"
+    original_name = "batch_norm2d_43.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-4.60837")
@@ -3960,6 +4320,7 @@ class Program_weight_tensor_parameter_359:
 
 class Program_weight_tensor_parameter_360:
     name = "parameter_360"
+    original_name = "batch_norm2d_43.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("0.58129")
@@ -3971,6 +4332,7 @@ class Program_weight_tensor_parameter_360:
 
 class Program_weight_tensor_parameter_361:
     name = "parameter_361"
+    original_name = "batch_norm2d_43.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("0.000303453")
@@ -3982,6 +4344,7 @@ class Program_weight_tensor_parameter_361:
 
 class Program_weight_tensor_parameter_362:
     name = "parameter_362"
+    original_name = "batch_norm2d_43.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.914944")
@@ -3993,6 +4356,7 @@ class Program_weight_tensor_parameter_362:
 
 class Program_weight_tensor_parameter_363:
     name = "parameter_363"
+    original_name = "conv2d_44.w_0"
     shape = [512, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.418826")
@@ -4004,6 +4368,7 @@ class Program_weight_tensor_parameter_363:
 
 class Program_weight_tensor_parameter_364:
     name = "parameter_364"
+    original_name = "batch_norm2d_39.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.98846")
@@ -4015,6 +4380,7 @@ class Program_weight_tensor_parameter_364:
 
 class Program_weight_tensor_parameter_365:
     name = "parameter_365"
+    original_name = "batch_norm2d_39.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.0687501")
@@ -4026,6 +4392,7 @@ class Program_weight_tensor_parameter_365:
 
 class Program_weight_tensor_parameter_366:
     name = "parameter_366"
+    original_name = "batch_norm2d_39.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("2.2215")
@@ -4037,6 +4404,7 @@ class Program_weight_tensor_parameter_366:
 
 class Program_weight_tensor_parameter_367:
     name = "parameter_367"
+    original_name = "batch_norm2d_39.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-4.21177")
@@ -4048,6 +4416,7 @@ class Program_weight_tensor_parameter_367:
 
 class Program_weight_tensor_parameter_368:
     name = "parameter_368"
+    original_name = "conv2d_40.w_0"
     shape = [256, 192, 1, 1]
     dtype = "float32"
     min_val = float("-0.594718")
@@ -4059,6 +4428,7 @@ class Program_weight_tensor_parameter_368:
 
 class Program_weight_tensor_parameter_369:
     name = "parameter_369"
+    original_name = "batch_norm2d_38.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.07756")
@@ -4070,6 +4440,7 @@ class Program_weight_tensor_parameter_369:
 
 class Program_weight_tensor_parameter_370:
     name = "parameter_370"
+    original_name = "batch_norm2d_38.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.179252")
@@ -4081,6 +4452,7 @@ class Program_weight_tensor_parameter_370:
 
 class Program_weight_tensor_parameter_371:
     name = "parameter_371"
+    original_name = "batch_norm2d_38.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("1.77506")
@@ -4092,6 +4464,7 @@ class Program_weight_tensor_parameter_371:
 
 class Program_weight_tensor_parameter_372:
     name = "parameter_372"
+    original_name = "batch_norm2d_38.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-5.72948")
@@ -4103,6 +4476,7 @@ class Program_weight_tensor_parameter_372:
 
 class Program_weight_tensor_parameter_373:
     name = "parameter_373"
+    original_name = "conv2d_39.w_0"
     shape = [128, 192, 1, 1]
     dtype = "float32"
     min_val = float("-0.363712")
@@ -4114,6 +4488,7 @@ class Program_weight_tensor_parameter_373:
 
 class Program_weight_tensor_parameter_374:
     name = "parameter_374"
+    original_name = "batch_norm2d_37.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-2.59101")
@@ -4125,6 +4500,7 @@ class Program_weight_tensor_parameter_374:
 
 class Program_weight_tensor_parameter_375:
     name = "parameter_375"
+    original_name = "batch_norm2d_37.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.235688")
@@ -4136,6 +4512,7 @@ class Program_weight_tensor_parameter_375:
 
 class Program_weight_tensor_parameter_376:
     name = "parameter_376"
+    original_name = "batch_norm2d_37.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("1.54817")
@@ -4147,6 +4524,7 @@ class Program_weight_tensor_parameter_376:
 
 class Program_weight_tensor_parameter_377:
     name = "parameter_377"
+    original_name = "batch_norm2d_37.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-3.68781")
@@ -4158,6 +4536,7 @@ class Program_weight_tensor_parameter_377:
 
 class Program_weight_tensor_parameter_378:
     name = "parameter_378"
+    original_name = "conv2d_38.w_0"
     shape = [128, 192, 1, 1]
     dtype = "float32"
     min_val = float("-0.4665")
@@ -4169,6 +4548,7 @@ class Program_weight_tensor_parameter_378:
 
 class Program_weight_tensor_parameter_379:
     name = "parameter_379"
+    original_name = "batch_norm2d_36.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.0041992")
@@ -4180,6 +4560,7 @@ class Program_weight_tensor_parameter_379:
 
 class Program_weight_tensor_parameter_380:
     name = "parameter_380"
+    original_name = "batch_norm2d_36.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("0.455786")
@@ -4191,6 +4572,7 @@ class Program_weight_tensor_parameter_380:
 
 class Program_weight_tensor_parameter_381:
     name = "parameter_381"
+    original_name = "batch_norm2d_36.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("0.040161")
@@ -4202,6 +4584,7 @@ class Program_weight_tensor_parameter_381:
 
 class Program_weight_tensor_parameter_382:
     name = "parameter_382"
+    original_name = "batch_norm2d_36.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.98574")
@@ -4213,6 +4596,7 @@ class Program_weight_tensor_parameter_382:
 
 class Program_weight_tensor_parameter_383:
     name = "parameter_383"
+    original_name = "conv2d_37.w_0"
     shape = [192, 384, 1, 1]
     dtype = "float32"
     min_val = float("-0.462673")
@@ -4224,6 +4608,7 @@ class Program_weight_tensor_parameter_383:
 
 class Program_weight_tensor_parameter_384:
     name = "parameter_384"
+    original_name = "conv2d_36.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-3.28515")
@@ -4235,6 +4620,7 @@ class Program_weight_tensor_parameter_384:
 
 class Program_weight_tensor_parameter_385:
     name = "parameter_385"
+    original_name = "conv2d_36.w_0"
     shape = [384, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.626889")
@@ -4246,6 +4632,7 @@ class Program_weight_tensor_parameter_385:
 
 class Program_weight_tensor_parameter_386:
     name = "parameter_386"
+    original_name = "batch_norm2d_35.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-4.26322")
@@ -4257,6 +4644,7 @@ class Program_weight_tensor_parameter_386:
 
 class Program_weight_tensor_parameter_387:
     name = "parameter_387"
+    original_name = "batch_norm2d_35.w_0"
     shape = [384]
     dtype = "float32"
     min_val = float("0.761066")
@@ -4268,6 +4656,7 @@ class Program_weight_tensor_parameter_387:
 
 class Program_weight_tensor_parameter_388:
     name = "parameter_388"
+    original_name = "batch_norm2d_35.w_2"
     shape = [384]
     dtype = "float32"
     min_val = float("1.57152")
@@ -4279,6 +4668,7 @@ class Program_weight_tensor_parameter_388:
 
 class Program_weight_tensor_parameter_389:
     name = "parameter_389"
+    original_name = "batch_norm2d_35.w_1"
     shape = [384]
     dtype = "float32"
     min_val = float("-4.02355")
@@ -4290,6 +4680,7 @@ class Program_weight_tensor_parameter_389:
 
 class Program_weight_tensor_parameter_390:
     name = "parameter_390"
+    original_name = "conv2d_35.w_0"
     shape = [384, 192, 1, 1]
     dtype = "float32"
     min_val = float("-0.586609")
@@ -4301,6 +4692,7 @@ class Program_weight_tensor_parameter_390:
 
 class Program_weight_tensor_parameter_391:
     name = "parameter_391"
+    original_name = "batch_norm2d_30.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-3.30678")
@@ -4312,6 +4704,7 @@ class Program_weight_tensor_parameter_391:
 
 class Program_weight_tensor_parameter_392:
     name = "parameter_392"
+    original_name = "batch_norm2d_30.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-2.95465")
@@ -4323,6 +4716,7 @@ class Program_weight_tensor_parameter_392:
 
 class Program_weight_tensor_parameter_393:
     name = "parameter_393"
+    original_name = "batch_norm2d_30.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("0.132167")
@@ -4334,6 +4728,7 @@ class Program_weight_tensor_parameter_393:
 
 class Program_weight_tensor_parameter_394:
     name = "parameter_394"
+    original_name = "batch_norm2d_30.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-1.84728")
@@ -4345,6 +4740,7 @@ class Program_weight_tensor_parameter_394:
 
 class Program_weight_tensor_parameter_395:
     name = "parameter_395"
+    original_name = "conv2d_30.w_0"
     shape = [192, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.686685")
@@ -4356,6 +4752,7 @@ class Program_weight_tensor_parameter_395:
 
 class Program_weight_tensor_parameter_396:
     name = "parameter_396"
+    original_name = "batch_norm2d_32.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-5.18379")
@@ -4367,6 +4764,7 @@ class Program_weight_tensor_parameter_396:
 
 class Program_weight_tensor_parameter_397:
     name = "parameter_397"
+    original_name = "batch_norm2d_32.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-2.59159")
@@ -4378,6 +4776,7 @@ class Program_weight_tensor_parameter_397:
 
 class Program_weight_tensor_parameter_398:
     name = "parameter_398"
+    original_name = "batch_norm2d_32.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("5.60519e-45")
@@ -4389,6 +4788,7 @@ class Program_weight_tensor_parameter_398:
 
 class Program_weight_tensor_parameter_399:
     name = "parameter_399"
+    original_name = "batch_norm2d_32.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-2.17441")
@@ -4400,6 +4800,7 @@ class Program_weight_tensor_parameter_399:
 
 class Program_weight_tensor_parameter_400:
     name = "parameter_400"
+    original_name = "conv2d_32.w_0"
     shape = [256, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.716981")
@@ -4411,6 +4812,7 @@ class Program_weight_tensor_parameter_400:
 
 class Program_weight_tensor_parameter_401:
     name = "parameter_401"
+    original_name = "batch_norm2d_31.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-5.18379")
@@ -4422,6 +4824,7 @@ class Program_weight_tensor_parameter_401:
 
 class Program_weight_tensor_parameter_402:
     name = "parameter_402"
+    original_name = "batch_norm2d_31.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-3.87931")
@@ -4433,6 +4836,7 @@ class Program_weight_tensor_parameter_402:
 
 class Program_weight_tensor_parameter_403:
     name = "parameter_403"
+    original_name = "batch_norm2d_31.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("5.60519e-45")
@@ -4444,6 +4848,7 @@ class Program_weight_tensor_parameter_403:
 
 class Program_weight_tensor_parameter_404:
     name = "parameter_404"
+    original_name = "batch_norm2d_31.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.91858")
@@ -4455,6 +4860,7 @@ class Program_weight_tensor_parameter_404:
 
 class Program_weight_tensor_parameter_405:
     name = "parameter_405"
+    original_name = "conv2d_31.w_0"
     shape = [256, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.4015")
@@ -4466,6 +4872,7 @@ class Program_weight_tensor_parameter_405:
 
 class Program_weight_tensor_parameter_406:
     name = "parameter_406"
+    original_name = "batch_norm2d_34.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-13.8321")
@@ -4477,6 +4884,7 @@ class Program_weight_tensor_parameter_406:
 
 class Program_weight_tensor_parameter_407:
     name = "parameter_407"
+    original_name = "batch_norm2d_34.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("0.807039")
@@ -4488,6 +4896,7 @@ class Program_weight_tensor_parameter_407:
 
 class Program_weight_tensor_parameter_408:
     name = "parameter_408"
+    original_name = "batch_norm2d_34.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("0.236475")
@@ -4499,6 +4908,7 @@ class Program_weight_tensor_parameter_408:
 
 class Program_weight_tensor_parameter_409:
     name = "parameter_409"
+    original_name = "batch_norm2d_34.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-2.88675")
@@ -4510,6 +4920,7 @@ class Program_weight_tensor_parameter_409:
 
 class Program_weight_tensor_parameter_410:
     name = "parameter_410"
+    original_name = "conv2d_34.w_0"
     shape = [192, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.768846")
@@ -4521,6 +4932,7 @@ class Program_weight_tensor_parameter_410:
 
 class Program_weight_tensor_parameter_411:
     name = "parameter_411"
+    original_name = "batch_norm2d_33.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-4.28154")
@@ -4532,6 +4944,7 @@ class Program_weight_tensor_parameter_411:
 
 class Program_weight_tensor_parameter_412:
     name = "parameter_412"
+    original_name = "batch_norm2d_33.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("0.569248")
@@ -4543,6 +4956,7 @@ class Program_weight_tensor_parameter_412:
 
 class Program_weight_tensor_parameter_413:
     name = "parameter_413"
+    original_name = "batch_norm2d_33.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("0.000209552")
@@ -4554,6 +4968,7 @@ class Program_weight_tensor_parameter_413:
 
 class Program_weight_tensor_parameter_414:
     name = "parameter_414"
+    original_name = "batch_norm2d_33.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-5.5934")
@@ -4565,6 +4980,7 @@ class Program_weight_tensor_parameter_414:
 
 class Program_weight_tensor_parameter_415:
     name = "parameter_415"
+    original_name = "conv2d_33.w_0"
     shape = [512, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.66185")
@@ -4576,6 +4992,7 @@ class Program_weight_tensor_parameter_415:
 
 class Program_weight_tensor_parameter_416:
     name = "parameter_416"
+    original_name = "batch_norm2d_29.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-4.67162")
@@ -4587,6 +5004,7 @@ class Program_weight_tensor_parameter_416:
 
 class Program_weight_tensor_parameter_417:
     name = "parameter_417"
+    original_name = "batch_norm2d_29.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.0608727")
@@ -4598,6 +5016,7 @@ class Program_weight_tensor_parameter_417:
 
 class Program_weight_tensor_parameter_418:
     name = "parameter_418"
+    original_name = "batch_norm2d_29.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("1.64278")
@@ -4609,6 +5028,7 @@ class Program_weight_tensor_parameter_418:
 
 class Program_weight_tensor_parameter_419:
     name = "parameter_419"
+    original_name = "batch_norm2d_29.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.00383232")
@@ -4620,6 +5040,7 @@ class Program_weight_tensor_parameter_419:
 
 class Program_weight_tensor_parameter_420:
     name = "parameter_420"
+    original_name = "conv2d_29.w_0"
     shape = [256, 192, 1, 1]
     dtype = "float32"
     min_val = float("-0.790644")
@@ -4631,6 +5052,7 @@ class Program_weight_tensor_parameter_420:
 
 class Program_weight_tensor_parameter_421:
     name = "parameter_421"
+    original_name = "batch_norm2d_28.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.07544")
@@ -4642,6 +5064,7 @@ class Program_weight_tensor_parameter_421:
 
 class Program_weight_tensor_parameter_422:
     name = "parameter_422"
+    original_name = "batch_norm2d_28.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.050615")
@@ -4653,6 +5076,7 @@ class Program_weight_tensor_parameter_422:
 
 class Program_weight_tensor_parameter_423:
     name = "parameter_423"
+    original_name = "batch_norm2d_28.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("1.37511")
@@ -4664,6 +5088,7 @@ class Program_weight_tensor_parameter_423:
 
 class Program_weight_tensor_parameter_424:
     name = "parameter_424"
+    original_name = "batch_norm2d_28.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.00309017")
@@ -4675,6 +5100,7 @@ class Program_weight_tensor_parameter_424:
 
 class Program_weight_tensor_parameter_425:
     name = "parameter_425"
+    original_name = "conv2d_28.w_0"
     shape = [128, 192, 1, 1]
     dtype = "float32"
     min_val = float("-0.739743")
@@ -4686,6 +5112,7 @@ class Program_weight_tensor_parameter_425:
 
 class Program_weight_tensor_parameter_426:
     name = "parameter_426"
+    original_name = "batch_norm2d_27.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-5.38433")
@@ -4697,6 +5124,7 @@ class Program_weight_tensor_parameter_426:
 
 class Program_weight_tensor_parameter_427:
     name = "parameter_427"
+    original_name = "batch_norm2d_27.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.170599")
@@ -4708,6 +5136,7 @@ class Program_weight_tensor_parameter_427:
 
 class Program_weight_tensor_parameter_428:
     name = "parameter_428"
+    original_name = "batch_norm2d_27.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("1.11073")
@@ -4719,6 +5148,7 @@ class Program_weight_tensor_parameter_428:
 
 class Program_weight_tensor_parameter_429:
     name = "parameter_429"
+    original_name = "batch_norm2d_27.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.00158786")
@@ -4730,6 +5160,7 @@ class Program_weight_tensor_parameter_429:
 
 class Program_weight_tensor_parameter_430:
     name = "parameter_430"
+    original_name = "conv2d_27.w_0"
     shape = [128, 192, 1, 1]
     dtype = "float32"
     min_val = float("-0.610661")
@@ -4741,6 +5172,7 @@ class Program_weight_tensor_parameter_430:
 
 class Program_weight_tensor_parameter_431:
     name = "parameter_431"
+    original_name = "batch_norm2d_23.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.00445625")
@@ -4752,6 +5184,7 @@ class Program_weight_tensor_parameter_431:
 
 class Program_weight_tensor_parameter_432:
     name = "parameter_432"
+    original_name = "batch_norm2d_23.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("0.804435")
@@ -4763,6 +5196,7 @@ class Program_weight_tensor_parameter_432:
 
 class Program_weight_tensor_parameter_433:
     name = "parameter_433"
+    original_name = "batch_norm2d_23.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("2.19714")
@@ -4774,6 +5208,7 @@ class Program_weight_tensor_parameter_433:
 
 class Program_weight_tensor_parameter_434:
     name = "parameter_434"
+    original_name = "batch_norm2d_23.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-9.86938")
@@ -4785,6 +5220,7 @@ class Program_weight_tensor_parameter_434:
 
 class Program_weight_tensor_parameter_435:
     name = "parameter_435"
+    original_name = "conv2d_23.w_0"
     shape = [192, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.880126")
@@ -4796,6 +5232,7 @@ class Program_weight_tensor_parameter_435:
 
 class Program_weight_tensor_parameter_436:
     name = "parameter_436"
+    original_name = "batch_norm2d_22.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-14.0163")
@@ -4807,6 +5244,7 @@ class Program_weight_tensor_parameter_436:
 
 class Program_weight_tensor_parameter_437:
     name = "parameter_437"
+    original_name = "batch_norm2d_22.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("0.835915")
@@ -4818,6 +5256,7 @@ class Program_weight_tensor_parameter_437:
 
 class Program_weight_tensor_parameter_438:
     name = "parameter_438"
+    original_name = "batch_norm2d_22.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("5.60519e-45")
@@ -4829,6 +5268,7 @@ class Program_weight_tensor_parameter_438:
 
 class Program_weight_tensor_parameter_439:
     name = "parameter_439"
+    original_name = "batch_norm2d_22.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-3.9418")
@@ -4840,6 +5280,7 @@ class Program_weight_tensor_parameter_439:
 
 class Program_weight_tensor_parameter_440:
     name = "parameter_440"
+    original_name = "conv2d_22.w_0"
     shape = [512, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.362483")
@@ -4851,6 +5292,7 @@ class Program_weight_tensor_parameter_440:
 
 class Program_weight_tensor_parameter_441:
     name = "parameter_441"
+    original_name = "batch_norm2d_21.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-4.12017")
@@ -4862,6 +5304,7 @@ class Program_weight_tensor_parameter_441:
 
 class Program_weight_tensor_parameter_442:
     name = "parameter_442"
+    original_name = "batch_norm2d_21.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.0961572")
@@ -4873,6 +5316,7 @@ class Program_weight_tensor_parameter_442:
 
 class Program_weight_tensor_parameter_443:
     name = "parameter_443"
+    original_name = "batch_norm2d_21.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("5.60519e-45")
@@ -4884,6 +5328,7 @@ class Program_weight_tensor_parameter_443:
 
 class Program_weight_tensor_parameter_444:
     name = "parameter_444"
+    original_name = "batch_norm2d_21.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.00454968")
@@ -4895,6 +5340,7 @@ class Program_weight_tensor_parameter_444:
 
 class Program_weight_tensor_parameter_445:
     name = "parameter_445"
+    original_name = "conv2d_21.w_0"
     shape = [512, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.747659")
@@ -4906,6 +5352,7 @@ class Program_weight_tensor_parameter_445:
 
 class Program_weight_tensor_parameter_446:
     name = "parameter_446"
+    original_name = "batch_norm2d_20.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.00149904")
@@ -4917,6 +5364,7 @@ class Program_weight_tensor_parameter_446:
 
 class Program_weight_tensor_parameter_447:
     name = "parameter_447"
+    original_name = "batch_norm2d_20.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.915738")
@@ -4928,6 +5376,7 @@ class Program_weight_tensor_parameter_447:
 
 class Program_weight_tensor_parameter_448:
     name = "parameter_448"
+    original_name = "batch_norm2d_20.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.726651")
@@ -4939,6 +5388,7 @@ class Program_weight_tensor_parameter_448:
 
 class Program_weight_tensor_parameter_449:
     name = "parameter_449"
+    original_name = "batch_norm2d_20.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-6.00951")
@@ -4950,6 +5400,7 @@ class Program_weight_tensor_parameter_449:
 
 class Program_weight_tensor_parameter_450:
     name = "parameter_450"
+    original_name = "conv2d_20.w_0"
     shape = [128, 384, 1, 1]
     dtype = "float32"
     min_val = float("-0.718722")
@@ -4961,6 +5412,7 @@ class Program_weight_tensor_parameter_450:
 
 class Program_weight_tensor_parameter_451:
     name = "parameter_451"
+    original_name = "batch_norm2d_19.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-11.6774")
@@ -4972,6 +5424,7 @@ class Program_weight_tensor_parameter_451:
 
 class Program_weight_tensor_parameter_452:
     name = "parameter_452"
+    original_name = "batch_norm2d_19.w_0"
     shape = [384]
     dtype = "float32"
     min_val = float("0.647979")
@@ -4983,6 +5436,7 @@ class Program_weight_tensor_parameter_452:
 
 class Program_weight_tensor_parameter_453:
     name = "parameter_453"
+    original_name = "batch_norm2d_19.w_2"
     shape = [384]
     dtype = "float32"
     min_val = float("5.60519e-45")
@@ -4994,6 +5448,7 @@ class Program_weight_tensor_parameter_453:
 
 class Program_weight_tensor_parameter_454:
     name = "parameter_454"
+    original_name = "batch_norm2d_19.w_1"
     shape = [384]
     dtype = "float32"
     min_val = float("-2.42566")
@@ -5005,6 +5460,7 @@ class Program_weight_tensor_parameter_454:
 
 class Program_weight_tensor_parameter_455:
     name = "parameter_455"
+    original_name = "conv2d_19.w_0"
     shape = [384, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.659566")
@@ -5016,6 +5472,7 @@ class Program_weight_tensor_parameter_455:
 
 class Program_weight_tensor_parameter_456:
     name = "parameter_456"
+    original_name = "batch_norm2d_18.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-2.34286")
@@ -5027,6 +5484,7 @@ class Program_weight_tensor_parameter_456:
 
 class Program_weight_tensor_parameter_457:
     name = "parameter_457"
+    original_name = "batch_norm2d_18.w_0"
     shape = [384]
     dtype = "float32"
     min_val = float("0.189991")
@@ -5038,6 +5496,7 @@ class Program_weight_tensor_parameter_457:
 
 class Program_weight_tensor_parameter_458:
     name = "parameter_458"
+    original_name = "batch_norm2d_18.w_2"
     shape = [384]
     dtype = "float32"
     min_val = float("5.60519e-45")
@@ -5049,6 +5508,7 @@ class Program_weight_tensor_parameter_458:
 
 class Program_weight_tensor_parameter_459:
     name = "parameter_459"
+    original_name = "batch_norm2d_18.w_1"
     shape = [384]
     dtype = "float32"
     min_val = float("-0.00228189")
@@ -5060,6 +5520,7 @@ class Program_weight_tensor_parameter_459:
 
 class Program_weight_tensor_parameter_460:
     name = "parameter_460"
+    original_name = "conv2d_18.w_0"
     shape = [384, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.700424")
@@ -5071,6 +5532,7 @@ class Program_weight_tensor_parameter_460:
 
 class Program_weight_tensor_parameter_461:
     name = "parameter_461"
+    original_name = "batch_norm2d_17.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.00194708")
@@ -5082,6 +5544,7 @@ class Program_weight_tensor_parameter_461:
 
 class Program_weight_tensor_parameter_462:
     name = "parameter_462"
+    original_name = "batch_norm2d_17.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.863633")
@@ -5093,6 +5556,7 @@ class Program_weight_tensor_parameter_462:
 
 class Program_weight_tensor_parameter_463:
     name = "parameter_463"
+    original_name = "batch_norm2d_17.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("1.3603")
@@ -5104,6 +5568,7 @@ class Program_weight_tensor_parameter_463:
 
 class Program_weight_tensor_parameter_464:
     name = "parameter_464"
+    original_name = "batch_norm2d_17.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-18.7215")
@@ -5115,6 +5580,7 @@ class Program_weight_tensor_parameter_464:
 
 class Program_weight_tensor_parameter_465:
     name = "parameter_465"
+    original_name = "conv2d_17.w_0"
     shape = [128, 192, 1, 1]
     dtype = "float32"
     min_val = float("-0.712816")
@@ -5126,6 +5592,7 @@ class Program_weight_tensor_parameter_465:
 
 class Program_weight_tensor_parameter_466:
     name = "parameter_466"
+    original_name = "batch_norm2d_16.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-2.87042")
@@ -5137,6 +5604,7 @@ class Program_weight_tensor_parameter_466:
 
 class Program_weight_tensor_parameter_467:
     name = "parameter_467"
+    original_name = "batch_norm2d_16.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("1.591")
@@ -5148,6 +5616,7 @@ class Program_weight_tensor_parameter_467:
 
 class Program_weight_tensor_parameter_468:
     name = "parameter_468"
+    original_name = "batch_norm2d_16.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("0.122329")
@@ -5159,6 +5628,7 @@ class Program_weight_tensor_parameter_468:
 
 class Program_weight_tensor_parameter_469:
     name = "parameter_469"
+    original_name = "batch_norm2d_16.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-2.84039")
@@ -5170,6 +5640,7 @@ class Program_weight_tensor_parameter_469:
 
 class Program_weight_tensor_parameter_470:
     name = "parameter_470"
+    original_name = "conv2d_16.w_0"
     shape = [192, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.372667")
@@ -5181,6 +5652,7 @@ class Program_weight_tensor_parameter_470:
 
 class Program_weight_tensor_parameter_471:
     name = "parameter_471"
+    original_name = "batch_norm2d_15.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-3.90991")
@@ -5192,6 +5664,7 @@ class Program_weight_tensor_parameter_471:
 
 class Program_weight_tensor_parameter_472:
     name = "parameter_472"
+    original_name = "batch_norm2d_15.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("0.739289")
@@ -5203,6 +5676,7 @@ class Program_weight_tensor_parameter_472:
 
 class Program_weight_tensor_parameter_473:
     name = "parameter_473"
+    original_name = "batch_norm2d_15.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("14.6759")
@@ -5214,6 +5688,7 @@ class Program_weight_tensor_parameter_473:
 
 class Program_weight_tensor_parameter_474:
     name = "parameter_474"
+    original_name = "batch_norm2d_15.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.00645945")
@@ -5225,6 +5700,7 @@ class Program_weight_tensor_parameter_474:
 
 class Program_weight_tensor_parameter_475:
     name = "parameter_475"
+    original_name = "conv2d_15.w_0"
     shape = [192, 64, 1, 1]
     dtype = "float32"
     min_val = float("-1.29273")
@@ -5236,6 +5712,7 @@ class Program_weight_tensor_parameter_475:
 
 class Program_weight_tensor_parameter_476:
     name = "parameter_476"
+    original_name = "batch_norm2d_14.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -5245,6 +5722,7 @@ class Program_weight_tensor_parameter_476:
 
 class Program_weight_tensor_parameter_477:
     name = "parameter_477"
+    original_name = "batch_norm2d_14.w_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -5254,6 +5732,7 @@ class Program_weight_tensor_parameter_477:
 
 class Program_weight_tensor_parameter_478:
     name = "parameter_478"
+    original_name = "batch_norm2d_14.w_2"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -5263,6 +5742,7 @@ class Program_weight_tensor_parameter_478:
 
 class Program_weight_tensor_parameter_479:
     name = "parameter_479"
+    original_name = "batch_norm2d_14.w_1"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -5272,6 +5752,7 @@ class Program_weight_tensor_parameter_479:
 
 class Program_weight_tensor_parameter_480:
     name = "parameter_480"
+    original_name = "conv2d_14.w_0"
     shape = [64, 192, 1, 1]
     dtype = "float32"
     min_val = float("-0.668597")
@@ -5283,6 +5764,7 @@ class Program_weight_tensor_parameter_480:
 
 class Program_weight_tensor_parameter_481:
     name = "parameter_481"
+    original_name = "batch_norm2d_13.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-9.71686")
@@ -5294,6 +5776,7 @@ class Program_weight_tensor_parameter_481:
 
 class Program_weight_tensor_parameter_482:
     name = "parameter_482"
+    original_name = "batch_norm2d_13.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("0.648988")
@@ -5305,6 +5788,7 @@ class Program_weight_tensor_parameter_482:
 
 class Program_weight_tensor_parameter_483:
     name = "parameter_483"
+    original_name = "batch_norm2d_13.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("5.60519e-45")
@@ -5316,6 +5800,7 @@ class Program_weight_tensor_parameter_483:
 
 class Program_weight_tensor_parameter_484:
     name = "parameter_484"
+    original_name = "batch_norm2d_13.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-5.77433")
@@ -5327,6 +5812,7 @@ class Program_weight_tensor_parameter_484:
 
 class Program_weight_tensor_parameter_485:
     name = "parameter_485"
+    original_name = "conv2d_13.w_0"
     shape = [192, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.881269")
@@ -5338,6 +5824,7 @@ class Program_weight_tensor_parameter_485:
 
 class Program_weight_tensor_parameter_486:
     name = "parameter_486"
+    original_name = "batch_norm2d_12.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-6.04248")
@@ -5349,6 +5836,7 @@ class Program_weight_tensor_parameter_486:
 
 class Program_weight_tensor_parameter_487:
     name = "parameter_487"
+    original_name = "batch_norm2d_12.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.122395")
@@ -5360,6 +5848,7 @@ class Program_weight_tensor_parameter_487:
 
 class Program_weight_tensor_parameter_488:
     name = "parameter_488"
+    original_name = "batch_norm2d_12.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("5.60519e-45")
@@ -5371,6 +5860,7 @@ class Program_weight_tensor_parameter_488:
 
 class Program_weight_tensor_parameter_489:
     name = "parameter_489"
+    original_name = "batch_norm2d_12.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.00286923")
@@ -5382,6 +5872,7 @@ class Program_weight_tensor_parameter_489:
 
 class Program_weight_tensor_parameter_490:
     name = "parameter_490"
+    original_name = "conv2d_12.w_0"
     shape = [192, 64, 1, 1]
     dtype = "float32"
     min_val = float("-0.606748")
@@ -5393,6 +5884,7 @@ class Program_weight_tensor_parameter_490:
 
 class Program_weight_tensor_parameter_491:
     name = "parameter_491"
+    original_name = "batch_norm2d_11.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -5402,6 +5894,7 @@ class Program_weight_tensor_parameter_491:
 
 class Program_weight_tensor_parameter_492:
     name = "parameter_492"
+    original_name = "batch_norm2d_11.w_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -5411,6 +5904,7 @@ class Program_weight_tensor_parameter_492:
 
 class Program_weight_tensor_parameter_493:
     name = "parameter_493"
+    original_name = "batch_norm2d_11.w_2"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -5420,6 +5914,7 @@ class Program_weight_tensor_parameter_493:
 
 class Program_weight_tensor_parameter_494:
     name = "parameter_494"
+    original_name = "batch_norm2d_11.w_1"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -5429,6 +5924,7 @@ class Program_weight_tensor_parameter_494:
 
 class Program_weight_tensor_parameter_495:
     name = "parameter_495"
+    original_name = "conv2d_11.w_0"
     shape = [64, 96, 1, 1]
     dtype = "float32"
     min_val = float("-1.14419")
@@ -5440,6 +5936,7 @@ class Program_weight_tensor_parameter_495:
 
 class Program_weight_tensor_parameter_496:
     name = "parameter_496"
+    original_name = "batch_norm2d_10.b_0"
     shape = [96]
     dtype = "float32"
     min_val = float("-3.1359")
@@ -5451,6 +5948,7 @@ class Program_weight_tensor_parameter_496:
 
 class Program_weight_tensor_parameter_497:
     name = "parameter_497"
+    original_name = "batch_norm2d_10.w_0"
     shape = [96]
     dtype = "float32"
     min_val = float("1.45743")
@@ -5462,6 +5960,7 @@ class Program_weight_tensor_parameter_497:
 
 class Program_weight_tensor_parameter_498:
     name = "parameter_498"
+    original_name = "batch_norm2d_10.w_2"
     shape = [96]
     dtype = "float32"
     min_val = float("0.264823")
@@ -5473,6 +5972,7 @@ class Program_weight_tensor_parameter_498:
 
 class Program_weight_tensor_parameter_499:
     name = "parameter_499"
+    original_name = "batch_norm2d_10.w_1"
     shape = [96]
     dtype = "float32"
     min_val = float("-10.3712")
@@ -5484,6 +5984,7 @@ class Program_weight_tensor_parameter_499:
 
 class Program_weight_tensor_parameter_500:
     name = "parameter_500"
+    original_name = "conv2d_10.w_0"
     shape = [96, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.620461")
@@ -5495,6 +5996,7 @@ class Program_weight_tensor_parameter_500:
 
 class Program_weight_tensor_parameter_501:
     name = "parameter_501"
+    original_name = "batch_norm2d_9.b_0"
     shape = [96]
     dtype = "float32"
     min_val = float("-3.38958")
@@ -5506,6 +6008,7 @@ class Program_weight_tensor_parameter_501:
 
 class Program_weight_tensor_parameter_502:
     name = "parameter_502"
+    original_name = "batch_norm2d_9.w_0"
     shape = [96]
     dtype = "float32"
     min_val = float("1.33555")
@@ -5517,6 +6020,7 @@ class Program_weight_tensor_parameter_502:
 
 class Program_weight_tensor_parameter_503:
     name = "parameter_503"
+    original_name = "batch_norm2d_9.w_2"
     shape = [96]
     dtype = "float32"
     min_val = float("20.8827")
@@ -5528,6 +6032,7 @@ class Program_weight_tensor_parameter_503:
 
 class Program_weight_tensor_parameter_504:
     name = "parameter_504"
+    original_name = "batch_norm2d_9.w_1"
     shape = [96]
     dtype = "float32"
     min_val = float("-0.0116865")
@@ -5539,6 +6044,7 @@ class Program_weight_tensor_parameter_504:
 
 class Program_weight_tensor_parameter_505:
     name = "parameter_505"
+    original_name = "conv2d_9.w_0"
     shape = [96, 32, 1, 1]
     dtype = "float32"
     min_val = float("-1.76885")
@@ -5550,6 +6056,7 @@ class Program_weight_tensor_parameter_505:
 
 class Program_weight_tensor_parameter_506:
     name = "parameter_506"
+    original_name = "batch_norm2d_8.b_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -5559,6 +6066,7 @@ class Program_weight_tensor_parameter_506:
 
 class Program_weight_tensor_parameter_507:
     name = "parameter_507"
+    original_name = "batch_norm2d_8.w_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -5568,6 +6076,7 @@ class Program_weight_tensor_parameter_507:
 
 class Program_weight_tensor_parameter_508:
     name = "parameter_508"
+    original_name = "batch_norm2d_8.w_2"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -5577,6 +6086,7 @@ class Program_weight_tensor_parameter_508:
 
 class Program_weight_tensor_parameter_509:
     name = "parameter_509"
+    original_name = "batch_norm2d_8.w_1"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -5586,6 +6096,7 @@ class Program_weight_tensor_parameter_509:
 
 class Program_weight_tensor_parameter_510:
     name = "parameter_510"
+    original_name = "conv2d_8.w_0"
     shape = [32, 96, 1, 1]
     dtype = "float32"
     min_val = float("-1.18818")
@@ -5597,6 +6108,7 @@ class Program_weight_tensor_parameter_510:
 
 class Program_weight_tensor_parameter_511:
     name = "parameter_511"
+    original_name = "batch_norm2d_7.b_0"
     shape = [96]
     dtype = "float32"
     min_val = float("-6.3822")
@@ -5608,6 +6120,7 @@ class Program_weight_tensor_parameter_511:
 
 class Program_weight_tensor_parameter_512:
     name = "parameter_512"
+    original_name = "batch_norm2d_7.w_0"
     shape = [96]
     dtype = "float32"
     min_val = float("1.08328")
@@ -5619,6 +6132,7 @@ class Program_weight_tensor_parameter_512:
 
 class Program_weight_tensor_parameter_513:
     name = "parameter_513"
+    original_name = "batch_norm2d_7.w_2"
     shape = [96]
     dtype = "float32"
     min_val = float("0.0116719")
@@ -5630,6 +6144,7 @@ class Program_weight_tensor_parameter_513:
 
 class Program_weight_tensor_parameter_514:
     name = "parameter_514"
+    original_name = "batch_norm2d_7.w_1"
     shape = [96]
     dtype = "float32"
     min_val = float("-4.70344")
@@ -5641,6 +6156,7 @@ class Program_weight_tensor_parameter_514:
 
 class Program_weight_tensor_parameter_515:
     name = "parameter_515"
+    original_name = "conv2d_7.w_0"
     shape = [96, 1, 3, 3]
     dtype = "float32"
     min_val = float("-1.30675")
@@ -5652,6 +6168,7 @@ class Program_weight_tensor_parameter_515:
 
 class Program_weight_tensor_parameter_516:
     name = "parameter_516"
+    original_name = "batch_norm2d_6.b_0"
     shape = [96]
     dtype = "float32"
     min_val = float("-6.65618")
@@ -5663,6 +6180,7 @@ class Program_weight_tensor_parameter_516:
 
 class Program_weight_tensor_parameter_517:
     name = "parameter_517"
+    original_name = "batch_norm2d_6.w_0"
     shape = [96]
     dtype = "float32"
     min_val = float("0.388854")
@@ -5674,6 +6192,7 @@ class Program_weight_tensor_parameter_517:
 
 class Program_weight_tensor_parameter_518:
     name = "parameter_518"
+    original_name = "batch_norm2d_6.w_2"
     shape = [96]
     dtype = "float32"
     min_val = float("7.52144")
@@ -5685,6 +6204,7 @@ class Program_weight_tensor_parameter_518:
 
 class Program_weight_tensor_parameter_519:
     name = "parameter_519"
+    original_name = "batch_norm2d_6.w_1"
     shape = [96]
     dtype = "float32"
     min_val = float("-0.00558105")
@@ -5696,6 +6216,7 @@ class Program_weight_tensor_parameter_519:
 
 class Program_weight_tensor_parameter_520:
     name = "parameter_520"
+    original_name = "conv2d_6.w_0"
     shape = [96, 32, 1, 1]
     dtype = "float32"
     min_val = float("-1.06669")
@@ -5707,6 +6228,7 @@ class Program_weight_tensor_parameter_520:
 
 class Program_weight_tensor_parameter_521:
     name = "parameter_521"
+    original_name = "batch_norm2d_5.b_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -5716,6 +6238,7 @@ class Program_weight_tensor_parameter_521:
 
 class Program_weight_tensor_parameter_522:
     name = "parameter_522"
+    original_name = "batch_norm2d_5.w_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -5725,6 +6248,7 @@ class Program_weight_tensor_parameter_522:
 
 class Program_weight_tensor_parameter_523:
     name = "parameter_523"
+    original_name = "batch_norm2d_5.w_2"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -5734,6 +6258,7 @@ class Program_weight_tensor_parameter_523:
 
 class Program_weight_tensor_parameter_524:
     name = "parameter_524"
+    original_name = "batch_norm2d_5.w_1"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -5743,6 +6268,7 @@ class Program_weight_tensor_parameter_524:
 
 class Program_weight_tensor_parameter_525:
     name = "parameter_525"
+    original_name = "conv2d_5.w_0"
     shape = [32, 64, 1, 1]
     dtype = "float32"
     min_val = float("-1.2403")
@@ -5754,6 +6280,7 @@ class Program_weight_tensor_parameter_525:
 
 class Program_weight_tensor_parameter_526:
     name = "parameter_526"
+    original_name = "batch_norm2d_4.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -5763,6 +6290,7 @@ class Program_weight_tensor_parameter_526:
 
 class Program_weight_tensor_parameter_527:
     name = "parameter_527"
+    original_name = "batch_norm2d_4.w_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -5772,6 +6300,7 @@ class Program_weight_tensor_parameter_527:
 
 class Program_weight_tensor_parameter_528:
     name = "parameter_528"
+    original_name = "batch_norm2d_4.w_2"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -5781,6 +6310,7 @@ class Program_weight_tensor_parameter_528:
 
 class Program_weight_tensor_parameter_529:
     name = "parameter_529"
+    original_name = "batch_norm2d_4.w_1"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -5790,6 +6320,7 @@ class Program_weight_tensor_parameter_529:
 
 class Program_weight_tensor_parameter_530:
     name = "parameter_530"
+    original_name = "conv2d_4.w_0"
     shape = [64, 1, 3, 3]
     dtype = "float32"
     min_val = float("-1.29828")
@@ -5801,6 +6332,7 @@ class Program_weight_tensor_parameter_530:
 
 class Program_weight_tensor_parameter_531:
     name = "parameter_531"
+    original_name = "batch_norm2d_3.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -5810,6 +6342,7 @@ class Program_weight_tensor_parameter_531:
 
 class Program_weight_tensor_parameter_532:
     name = "parameter_532"
+    original_name = "batch_norm2d_3.w_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -5819,6 +6352,7 @@ class Program_weight_tensor_parameter_532:
 
 class Program_weight_tensor_parameter_533:
     name = "parameter_533"
+    original_name = "batch_norm2d_3.w_2"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -5828,6 +6362,7 @@ class Program_weight_tensor_parameter_533:
 
 class Program_weight_tensor_parameter_534:
     name = "parameter_534"
+    original_name = "batch_norm2d_3.w_1"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -5837,6 +6372,7 @@ class Program_weight_tensor_parameter_534:
 
 class Program_weight_tensor_parameter_535:
     name = "parameter_535"
+    original_name = "conv2d_3.w_0"
     shape = [64, 16, 1, 1]
     dtype = "float32"
     min_val = float("-1.78681")
@@ -5848,6 +6384,7 @@ class Program_weight_tensor_parameter_535:
 
 class Program_weight_tensor_parameter_536:
     name = "parameter_536"
+    original_name = "batch_norm2d_2.b_0"
     shape = [16]
     dtype = "float32"
     min_val = float("0")
@@ -5857,6 +6394,7 @@ class Program_weight_tensor_parameter_536:
 
 class Program_weight_tensor_parameter_537:
     name = "parameter_537"
+    original_name = "batch_norm2d_2.w_0"
     shape = [16]
     dtype = "float32"
     min_val = float("0")
@@ -5866,6 +6404,7 @@ class Program_weight_tensor_parameter_537:
 
 class Program_weight_tensor_parameter_538:
     name = "parameter_538"
+    original_name = "batch_norm2d_2.w_2"
     shape = [16]
     dtype = "float32"
     min_val = float("0")
@@ -5875,6 +6414,7 @@ class Program_weight_tensor_parameter_538:
 
 class Program_weight_tensor_parameter_539:
     name = "parameter_539"
+    original_name = "batch_norm2d_2.w_1"
     shape = [16]
     dtype = "float32"
     min_val = float("0")
@@ -5884,6 +6424,7 @@ class Program_weight_tensor_parameter_539:
 
 class Program_weight_tensor_parameter_540:
     name = "parameter_540"
+    original_name = "conv2d_2.w_0"
     shape = [16, 16, 1, 1]
     dtype = "float32"
     min_val = float("-1.60611")
@@ -5895,6 +6436,7 @@ class Program_weight_tensor_parameter_540:
 
 class Program_weight_tensor_parameter_541:
     name = "parameter_541"
+    original_name = "batch_norm2d_1.b_0"
     shape = [16]
     dtype = "float32"
     min_val = float("0")
@@ -5904,6 +6446,7 @@ class Program_weight_tensor_parameter_541:
 
 class Program_weight_tensor_parameter_542:
     name = "parameter_542"
+    original_name = "batch_norm2d_1.w_0"
     shape = [16]
     dtype = "float32"
     min_val = float("0")
@@ -5913,6 +6456,7 @@ class Program_weight_tensor_parameter_542:
 
 class Program_weight_tensor_parameter_543:
     name = "parameter_543"
+    original_name = "batch_norm2d_1.w_2"
     shape = [16]
     dtype = "float32"
     min_val = float("0")
@@ -5922,6 +6466,7 @@ class Program_weight_tensor_parameter_543:
 
 class Program_weight_tensor_parameter_544:
     name = "parameter_544"
+    original_name = "batch_norm2d_1.w_1"
     shape = [16]
     dtype = "float32"
     min_val = float("0")
@@ -5931,6 +6476,7 @@ class Program_weight_tensor_parameter_544:
 
 class Program_weight_tensor_parameter_545:
     name = "parameter_545"
+    original_name = "conv2d_1.w_0"
     shape = [16, 1, 3, 3]
     dtype = "float32"
     min_val = float("-1.85935")
@@ -5942,6 +6488,7 @@ class Program_weight_tensor_parameter_545:
 
 class Program_weight_tensor_parameter_546:
     name = "parameter_546"
+    original_name = "batch_norm2d_0.b_0"
     shape = [16]
     dtype = "float32"
     min_val = float("0")
@@ -5951,6 +6498,7 @@ class Program_weight_tensor_parameter_546:
 
 class Program_weight_tensor_parameter_547:
     name = "parameter_547"
+    original_name = "batch_norm2d_0.w_0"
     shape = [16]
     dtype = "float32"
     min_val = float("0")
@@ -5960,6 +6508,7 @@ class Program_weight_tensor_parameter_547:
 
 class Program_weight_tensor_parameter_548:
     name = "parameter_548"
+    original_name = "batch_norm2d_0.w_2"
     shape = [16]
     dtype = "float32"
     min_val = float("0")
@@ -5969,6 +6518,7 @@ class Program_weight_tensor_parameter_548:
 
 class Program_weight_tensor_parameter_549:
     name = "parameter_549"
+    original_name = "batch_norm2d_0.w_1"
     shape = [16]
     dtype = "float32"
     min_val = float("0")
@@ -5978,6 +6528,7 @@ class Program_weight_tensor_parameter_549:
 
 class Program_weight_tensor_parameter_550:
     name = "parameter_550"
+    original_name = "conv2d_0.w_0"
     shape = [16, 3, 3, 3]
     dtype = "float32"
     min_val = float("-1.96324")

--- a/paddle_samples/PaddleX/SeaFormer_large/subgraph_0/input_meta.py
+++ b/paddle_samples/PaddleX/SeaFormer_large/subgraph_0/input_meta.py
@@ -1,5 +1,6 @@
 class Program_weight_tensor_data_0:
     name = "data_0"
+    original_name = "param_36"
     shape = [1, 128, 16]
     dtype = "float32"
     min_val = float("-0.0616131")
@@ -11,6 +12,7 @@ class Program_weight_tensor_data_0:
 
 class Program_weight_tensor_data_1:
     name = "data_1"
+    original_name = "param_37"
     shape = [1, 128, 16]
     dtype = "float32"
     min_val = float("-0.094255")
@@ -22,6 +24,7 @@ class Program_weight_tensor_data_1:
 
 class Program_weight_tensor_data_2:
     name = "data_2"
+    original_name = "param_38"
     shape = [1, 128, 16]
     dtype = "float32"
     min_val = float("-0.0584204")
@@ -33,6 +36,7 @@ class Program_weight_tensor_data_2:
 
 class Program_weight_tensor_data_3:
     name = "data_3"
+    original_name = "param_39"
     shape = [1, 128, 16]
     dtype = "float32"
     min_val = float("-0.0902215")
@@ -44,6 +48,7 @@ class Program_weight_tensor_data_3:
 
 class Program_weight_tensor_data_4:
     name = "data_4"
+    original_name = "param_40"
     shape = [1, 128, 16]
     dtype = "float32"
     min_val = float("-0.0749156")
@@ -55,6 +60,7 @@ class Program_weight_tensor_data_4:
 
 class Program_weight_tensor_data_5:
     name = "data_5"
+    original_name = "param_41"
     shape = [1, 128, 16]
     dtype = "float32"
     min_val = float("-0.0505354")
@@ -66,6 +72,7 @@ class Program_weight_tensor_data_5:
 
 class Program_weight_tensor_data_6:
     name = "data_6"
+    original_name = "param_42"
     shape = [1, 128, 16]
     dtype = "float32"
     min_val = float("-0.0649039")
@@ -77,6 +84,7 @@ class Program_weight_tensor_data_6:
 
 class Program_weight_tensor_data_7:
     name = "data_7"
+    original_name = "param_43"
     shape = [1, 128, 16]
     dtype = "float32"
     min_val = float("-0.0240999")
@@ -88,6 +96,7 @@ class Program_weight_tensor_data_7:
 
 class Program_weight_tensor_data_8:
     name = "data_8"
+    original_name = "param_44"
     shape = [1, 128, 16]
     dtype = "float32"
     min_val = float("-0.0349523")
@@ -99,6 +108,7 @@ class Program_weight_tensor_data_8:
 
 class Program_weight_tensor_data_9:
     name = "data_9"
+    original_name = "param_45"
     shape = [1, 128, 16]
     dtype = "float32"
     min_val = float("-0.0358725")
@@ -110,6 +120,7 @@ class Program_weight_tensor_data_9:
 
 class Program_weight_tensor_data_10:
     name = "data_10"
+    original_name = "param_46"
     shape = [1, 128, 16]
     dtype = "float32"
     min_val = float("-0.0373391")
@@ -121,6 +132,7 @@ class Program_weight_tensor_data_10:
 
 class Program_weight_tensor_data_11:
     name = "data_11"
+    original_name = "param_47"
     shape = [1, 128, 16]
     dtype = "float32"
     min_val = float("-0.0348016")
@@ -132,6 +144,7 @@ class Program_weight_tensor_data_11:
 
 class Program_weight_tensor_data_12:
     name = "data_12"
+    original_name = "param_48"
     shape = [1, 160, 16]
     dtype = "float32"
     min_val = float("-0.221665")
@@ -143,6 +156,7 @@ class Program_weight_tensor_data_12:
 
 class Program_weight_tensor_data_13:
     name = "data_13"
+    original_name = "param_49"
     shape = [1, 160, 16]
     dtype = "float32"
     min_val = float("-0.337055")
@@ -154,6 +168,7 @@ class Program_weight_tensor_data_13:
 
 class Program_weight_tensor_data_14:
     name = "data_14"
+    original_name = "param_50"
     shape = [1, 160, 16]
     dtype = "float32"
     min_val = float("-0.1454")
@@ -165,6 +180,7 @@ class Program_weight_tensor_data_14:
 
 class Program_weight_tensor_data_15:
     name = "data_15"
+    original_name = "param_51"
     shape = [1, 160, 16]
     dtype = "float32"
     min_val = float("-0.0628425")
@@ -176,6 +192,7 @@ class Program_weight_tensor_data_15:
 
 class Program_weight_tensor_data_16:
     name = "data_16"
+    original_name = "param_52"
     shape = [1, 160, 16]
     dtype = "float32"
     min_val = float("-0.082528")
@@ -187,6 +204,7 @@ class Program_weight_tensor_data_16:
 
 class Program_weight_tensor_data_17:
     name = "data_17"
+    original_name = "param_53"
     shape = [1, 160, 16]
     dtype = "float32"
     min_val = float("-0.0549528")
@@ -198,6 +216,7 @@ class Program_weight_tensor_data_17:
 
 class Program_weight_tensor_data_18:
     name = "data_18"
+    original_name = "param_54"
     shape = [1, 160, 16]
     dtype = "float32"
     min_val = float("-0.164422")
@@ -209,6 +228,7 @@ class Program_weight_tensor_data_18:
 
 class Program_weight_tensor_data_19:
     name = "data_19"
+    original_name = "param_55"
     shape = [1, 160, 16]
     dtype = "float32"
     min_val = float("-0.127076")
@@ -220,6 +240,7 @@ class Program_weight_tensor_data_19:
 
 class Program_weight_tensor_data_20:
     name = "data_20"
+    original_name = "param_56"
     shape = [1, 160, 16]
     dtype = "float32"
     min_val = float("-0.0550395")
@@ -231,6 +252,7 @@ class Program_weight_tensor_data_20:
 
 class Program_weight_tensor_data_21:
     name = "data_21"
+    original_name = "param_57"
     shape = [1, 160, 16]
     dtype = "float32"
     min_val = float("-0.0465389")
@@ -242,6 +264,7 @@ class Program_weight_tensor_data_21:
 
 class Program_weight_tensor_data_22:
     name = "data_22"
+    original_name = "param_58"
     shape = [1, 160, 16]
     dtype = "float32"
     min_val = float("-0.0542174")
@@ -253,6 +276,7 @@ class Program_weight_tensor_data_22:
 
 class Program_weight_tensor_data_23:
     name = "data_23"
+    original_name = "param_59"
     shape = [1, 160, 16]
     dtype = "float32"
     min_val = float("-0.0371573")
@@ -264,6 +288,7 @@ class Program_weight_tensor_data_23:
 
 class Program_weight_tensor_data_24:
     name = "data_24"
+    original_name = "param_60"
     shape = [1, 192, 16]
     dtype = "float32"
     min_val = float("-0.16187")
@@ -275,6 +300,7 @@ class Program_weight_tensor_data_24:
 
 class Program_weight_tensor_data_25:
     name = "data_25"
+    original_name = "param_61"
     shape = [1, 192, 16]
     dtype = "float32"
     min_val = float("-0.0736103")
@@ -286,6 +312,7 @@ class Program_weight_tensor_data_25:
 
 class Program_weight_tensor_data_26:
     name = "data_26"
+    original_name = "param_62"
     shape = [1, 192, 16]
     dtype = "float32"
     min_val = float("-0.077627")
@@ -297,6 +324,7 @@ class Program_weight_tensor_data_26:
 
 class Program_weight_tensor_data_27:
     name = "data_27"
+    original_name = "param_63"
     shape = [1, 192, 16]
     dtype = "float32"
     min_val = float("-0.0292871")
@@ -308,6 +336,7 @@ class Program_weight_tensor_data_27:
 
 class Program_weight_tensor_data_28:
     name = "data_28"
+    original_name = "param_64"
     shape = [1, 192, 16]
     dtype = "float32"
     min_val = float("-0.0432462")
@@ -319,6 +348,7 @@ class Program_weight_tensor_data_28:
 
 class Program_weight_tensor_data_29:
     name = "data_29"
+    original_name = "param_65"
     shape = [1, 192, 16]
     dtype = "float32"
     min_val = float("-0.0653837")
@@ -330,6 +360,7 @@ class Program_weight_tensor_data_29:
 
 class Program_weight_tensor_data_30:
     name = "data_30"
+    original_name = "param_66"
     shape = [1, 192, 16]
     dtype = "float32"
     min_val = float("-0.0281936")
@@ -341,6 +372,7 @@ class Program_weight_tensor_data_30:
 
 class Program_weight_tensor_data_31:
     name = "data_31"
+    original_name = "param_67"
     shape = [1, 192, 16]
     dtype = "float32"
     min_val = float("-0.0237196")
@@ -352,6 +384,7 @@ class Program_weight_tensor_data_31:
 
 class Program_weight_tensor_data_32:
     name = "data_32"
+    original_name = "param_68"
     shape = [1, 192, 16]
     dtype = "float32"
     min_val = float("-0.0379655")
@@ -363,6 +396,7 @@ class Program_weight_tensor_data_32:
 
 class Program_weight_tensor_data_33:
     name = "data_33"
+    original_name = "param_69"
     shape = [1, 192, 16]
     dtype = "float32"
     min_val = float("-0.0266609")
@@ -374,6 +408,7 @@ class Program_weight_tensor_data_33:
 
 class Program_weight_tensor_data_34:
     name = "data_34"
+    original_name = "param_70"
     shape = [1, 192, 16]
     dtype = "float32"
     min_val = float("-0.0282759")
@@ -385,6 +420,7 @@ class Program_weight_tensor_data_34:
 
 class Program_weight_tensor_data_35:
     name = "data_35"
+    original_name = "param_71"
     shape = [1, 192, 16]
     dtype = "float32"
     min_val = float("-0.0335932")
@@ -396,6 +432,7 @@ class Program_weight_tensor_data_35:
 
 class Program_weight_tensor_data_36:
     name = "data_36"
+    original_name = "var_809"
     shape = [2, 3, 512, 512]
     dtype = "float32"
     min_val = float("-1.0")

--- a/paddle_samples/PaddleX/SeaFormer_large/subgraph_0/weight_meta.py
+++ b/paddle_samples/PaddleX/SeaFormer_large/subgraph_0/weight_meta.py
@@ -1,5 +1,6 @@
 class Program_weight_tensor_parameter_0:
     name = "parameter_0"
+    original_name = "batch_norm2d_117.b_0"
     shape = [320]
     dtype = "float32"
     min_val = float("-0.229649")
@@ -11,6 +12,7 @@ class Program_weight_tensor_parameter_0:
 
 class Program_weight_tensor_parameter_1:
     name = "parameter_1"
+    original_name = "batch_norm2d_117.w_0"
     shape = [320]
     dtype = "float32"
     min_val = float("0.480022")
@@ -22,6 +24,7 @@ class Program_weight_tensor_parameter_1:
 
 class Program_weight_tensor_parameter_2:
     name = "parameter_2"
+    original_name = "batch_norm2d_117.w_2"
     shape = [320]
     dtype = "float32"
     min_val = float("0.00150201")
@@ -33,6 +36,7 @@ class Program_weight_tensor_parameter_2:
 
 class Program_weight_tensor_parameter_3:
     name = "parameter_3"
+    original_name = "batch_norm2d_117.w_1"
     shape = [320]
     dtype = "float32"
     min_val = float("-0.436248")
@@ -44,6 +48,7 @@ class Program_weight_tensor_parameter_3:
 
 class Program_weight_tensor_parameter_4:
     name = "parameter_4"
+    original_name = "conv2d_126.w_0"
     shape = [320, 1920, 1, 1]
     dtype = "float32"
     min_val = float("-0.247903")
@@ -55,6 +60,7 @@ class Program_weight_tensor_parameter_4:
 
 class Program_weight_tensor_parameter_5:
     name = "parameter_5"
+    original_name = "conv2d_125.b_0"
     shape = [1920]
     dtype = "float32"
     min_val = float("-1.24306")
@@ -66,6 +72,7 @@ class Program_weight_tensor_parameter_5:
 
 class Program_weight_tensor_parameter_6:
     name = "parameter_6"
+    original_name = "conv2d_125.w_0"
     shape = [1920, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.286341")
@@ -77,6 +84,7 @@ class Program_weight_tensor_parameter_6:
 
 class Program_weight_tensor_parameter_7:
     name = "parameter_7"
+    original_name = "batch_norm2d_116.b_0"
     shape = [1920]
     dtype = "float32"
     min_val = float("-3.40089")
@@ -88,6 +96,7 @@ class Program_weight_tensor_parameter_7:
 
 class Program_weight_tensor_parameter_8:
     name = "parameter_8"
+    original_name = "batch_norm2d_116.w_0"
     shape = [1920]
     dtype = "float32"
     min_val = float("0.234928")
@@ -99,6 +108,7 @@ class Program_weight_tensor_parameter_8:
 
 class Program_weight_tensor_parameter_9:
     name = "parameter_9"
+    original_name = "batch_norm2d_116.w_2"
     shape = [1920]
     dtype = "float32"
     min_val = float("5.60519e-45")
@@ -110,6 +120,7 @@ class Program_weight_tensor_parameter_9:
 
 class Program_weight_tensor_parameter_10:
     name = "parameter_10"
+    original_name = "batch_norm2d_116.w_1"
     shape = [1920]
     dtype = "float32"
     min_val = float("-0.25946")
@@ -121,6 +132,7 @@ class Program_weight_tensor_parameter_10:
 
 class Program_weight_tensor_parameter_11:
     name = "parameter_11"
+    original_name = "conv2d_124.w_0"
     shape = [1920, 320, 1, 1]
     dtype = "float32"
     min_val = float("-0.300068")
@@ -132,6 +144,7 @@ class Program_weight_tensor_parameter_11:
 
 class Program_weight_tensor_parameter_12:
     name = "parameter_12"
+    original_name = "batch_norm2d_111.b_0"
     shape = [320]
     dtype = "float32"
     min_val = float("-3.08087")
@@ -143,6 +156,7 @@ class Program_weight_tensor_parameter_12:
 
 class Program_weight_tensor_parameter_13:
     name = "parameter_13"
+    original_name = "batch_norm2d_111.w_0"
     shape = [320]
     dtype = "float32"
     min_val = float("-2.07547")
@@ -154,6 +168,7 @@ class Program_weight_tensor_parameter_13:
 
 class Program_weight_tensor_parameter_14:
     name = "parameter_14"
+    original_name = "batch_norm2d_111.w_2"
     shape = [320]
     dtype = "float32"
     min_val = float("0.0716942")
@@ -165,6 +180,7 @@ class Program_weight_tensor_parameter_14:
 
 class Program_weight_tensor_parameter_15:
     name = "parameter_15"
+    original_name = "batch_norm2d_111.w_1"
     shape = [320]
     dtype = "float32"
     min_val = float("-2.40055")
@@ -176,6 +192,7 @@ class Program_weight_tensor_parameter_15:
 
 class Program_weight_tensor_parameter_16:
     name = "parameter_16"
+    original_name = "conv2d_119.w_0"
     shape = [320, 384, 1, 1]
     dtype = "float32"
     min_val = float("-0.449482")
@@ -187,6 +204,7 @@ class Program_weight_tensor_parameter_16:
 
 class Program_weight_tensor_parameter_17:
     name = "parameter_17"
+    original_name = "batch_norm2d_113.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-0.909614")
@@ -198,6 +216,7 @@ class Program_weight_tensor_parameter_17:
 
 class Program_weight_tensor_parameter_18:
     name = "parameter_18"
+    original_name = "batch_norm2d_113.w_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-1.27275")
@@ -209,6 +228,7 @@ class Program_weight_tensor_parameter_18:
 
 class Program_weight_tensor_parameter_19:
     name = "parameter_19"
+    original_name = "batch_norm2d_113.w_2"
     shape = [384]
     dtype = "float32"
     min_val = float("0.00040252")
@@ -220,6 +240,7 @@ class Program_weight_tensor_parameter_19:
 
 class Program_weight_tensor_parameter_20:
     name = "parameter_20"
+    original_name = "batch_norm2d_113.w_1"
     shape = [384]
     dtype = "float32"
     min_val = float("-0.299079")
@@ -231,6 +252,7 @@ class Program_weight_tensor_parameter_20:
 
 class Program_weight_tensor_parameter_21:
     name = "parameter_21"
+    original_name = "conv2d_121.w_0"
     shape = [384, 384, 1, 1]
     dtype = "float32"
     min_val = float("-0.332646")
@@ -242,6 +264,7 @@ class Program_weight_tensor_parameter_21:
 
 class Program_weight_tensor_parameter_22:
     name = "parameter_22"
+    original_name = "batch_norm2d_112.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-0.909631")
@@ -253,6 +276,7 @@ class Program_weight_tensor_parameter_22:
 
 class Program_weight_tensor_parameter_23:
     name = "parameter_23"
+    original_name = "batch_norm2d_112.w_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-1.56885")
@@ -264,6 +288,7 @@ class Program_weight_tensor_parameter_23:
 
 class Program_weight_tensor_parameter_24:
     name = "parameter_24"
+    original_name = "batch_norm2d_112.w_2"
     shape = [384]
     dtype = "float32"
     min_val = float("0.000362023")
@@ -275,6 +300,7 @@ class Program_weight_tensor_parameter_24:
 
 class Program_weight_tensor_parameter_25:
     name = "parameter_25"
+    original_name = "batch_norm2d_112.w_1"
     shape = [384]
     dtype = "float32"
     min_val = float("-0.59638")
@@ -286,6 +312,7 @@ class Program_weight_tensor_parameter_25:
 
 class Program_weight_tensor_parameter_26:
     name = "parameter_26"
+    original_name = "conv2d_120.w_0"
     shape = [384, 384, 1, 1]
     dtype = "float32"
     min_val = float("-0.372986")
@@ -297,6 +324,7 @@ class Program_weight_tensor_parameter_26:
 
 class Program_weight_tensor_parameter_27:
     name = "parameter_27"
+    original_name = "batch_norm2d_115.b_0"
     shape = [320]
     dtype = "float32"
     min_val = float("-5.95359")
@@ -308,6 +336,7 @@ class Program_weight_tensor_parameter_27:
 
 class Program_weight_tensor_parameter_28:
     name = "parameter_28"
+    original_name = "batch_norm2d_115.w_0"
     shape = [320]
     dtype = "float32"
     min_val = float("1.5324")
@@ -319,6 +348,7 @@ class Program_weight_tensor_parameter_28:
 
 class Program_weight_tensor_parameter_29:
     name = "parameter_29"
+    original_name = "batch_norm2d_115.w_2"
     shape = [320]
     dtype = "float32"
     min_val = float("0.0709667")
@@ -330,6 +360,7 @@ class Program_weight_tensor_parameter_29:
 
 class Program_weight_tensor_parameter_30:
     name = "parameter_30"
+    original_name = "batch_norm2d_115.w_1"
     shape = [320]
     dtype = "float32"
     min_val = float("-0.395777")
@@ -341,6 +372,7 @@ class Program_weight_tensor_parameter_30:
 
 class Program_weight_tensor_parameter_31:
     name = "parameter_31"
+    original_name = "conv2d_123.w_0"
     shape = [320, 768, 1, 1]
     dtype = "float32"
     min_val = float("-0.225338")
@@ -352,6 +384,7 @@ class Program_weight_tensor_parameter_31:
 
 class Program_weight_tensor_parameter_32:
     name = "parameter_32"
+    original_name = "batch_norm2d_114.b_0"
     shape = [768]
     dtype = "float32"
     min_val = float("-2.377")
@@ -363,6 +396,7 @@ class Program_weight_tensor_parameter_32:
 
 class Program_weight_tensor_parameter_33:
     name = "parameter_33"
+    original_name = "batch_norm2d_114.w_0"
     shape = [768]
     dtype = "float32"
     min_val = float("0.463022")
@@ -374,6 +408,7 @@ class Program_weight_tensor_parameter_33:
 
 class Program_weight_tensor_parameter_34:
     name = "parameter_34"
+    original_name = "batch_norm2d_114.w_2"
     shape = [768]
     dtype = "float32"
     min_val = float("0.000258268")
@@ -385,6 +420,7 @@ class Program_weight_tensor_parameter_34:
 
 class Program_weight_tensor_parameter_35:
     name = "parameter_35"
+    original_name = "batch_norm2d_114.w_1"
     shape = [768]
     dtype = "float32"
     min_val = float("-0.296376")
@@ -396,6 +432,7 @@ class Program_weight_tensor_parameter_35:
 
 class Program_weight_tensor_parameter_36:
     name = "parameter_36"
+    original_name = "conv2d_122.w_0"
     shape = [768, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.20319")
@@ -407,6 +444,7 @@ class Program_weight_tensor_parameter_36:
 
 class Program_weight_tensor_parameter_37:
     name = "parameter_37"
+    original_name = "batch_norm2d_110.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-1.93787")
@@ -418,6 +456,7 @@ class Program_weight_tensor_parameter_37:
 
 class Program_weight_tensor_parameter_38:
     name = "parameter_38"
+    original_name = "batch_norm2d_110.w_0"
     shape = [384]
     dtype = "float32"
     min_val = float("0.104152")
@@ -429,6 +468,7 @@ class Program_weight_tensor_parameter_38:
 
 class Program_weight_tensor_parameter_39:
     name = "parameter_39"
+    original_name = "batch_norm2d_110.w_2"
     shape = [384]
     dtype = "float32"
     min_val = float("1.12705")
@@ -440,6 +480,7 @@ class Program_weight_tensor_parameter_39:
 
 class Program_weight_tensor_parameter_40:
     name = "parameter_40"
+    original_name = "batch_norm2d_110.w_1"
     shape = [384]
     dtype = "float32"
     min_val = float("-1.89744")
@@ -451,6 +492,7 @@ class Program_weight_tensor_parameter_40:
 
 class Program_weight_tensor_parameter_41:
     name = "parameter_41"
+    original_name = "conv2d_118.w_0"
     shape = [384, 320, 1, 1]
     dtype = "float32"
     min_val = float("-0.370272")
@@ -462,6 +504,7 @@ class Program_weight_tensor_parameter_41:
 
 class Program_weight_tensor_parameter_42:
     name = "parameter_42"
+    original_name = "batch_norm2d_109.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.400303")
@@ -473,6 +516,7 @@ class Program_weight_tensor_parameter_42:
 
 class Program_weight_tensor_parameter_43:
     name = "parameter_43"
+    original_name = "batch_norm2d_109.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("0.102098")
@@ -484,6 +528,7 @@ class Program_weight_tensor_parameter_43:
 
 class Program_weight_tensor_parameter_44:
     name = "parameter_44"
+    original_name = "batch_norm2d_109.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("0.591051")
@@ -495,6 +540,7 @@ class Program_weight_tensor_parameter_44:
 
 class Program_weight_tensor_parameter_45:
     name = "parameter_45"
+    original_name = "batch_norm2d_109.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.625438")
@@ -506,6 +552,7 @@ class Program_weight_tensor_parameter_45:
 
 class Program_weight_tensor_parameter_46:
     name = "parameter_46"
+    original_name = "conv2d_117.w_0"
     shape = [192, 320, 1, 1]
     dtype = "float32"
     min_val = float("-0.269761")
@@ -517,6 +564,7 @@ class Program_weight_tensor_parameter_46:
 
 class Program_weight_tensor_parameter_47:
     name = "parameter_47"
+    original_name = "batch_norm2d_108.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.973273")
@@ -528,6 +576,7 @@ class Program_weight_tensor_parameter_47:
 
 class Program_weight_tensor_parameter_48:
     name = "parameter_48"
+    original_name = "batch_norm2d_108.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("0.125323")
@@ -539,6 +588,7 @@ class Program_weight_tensor_parameter_48:
 
 class Program_weight_tensor_parameter_49:
     name = "parameter_49"
+    original_name = "batch_norm2d_108.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("0.714769")
@@ -550,6 +600,7 @@ class Program_weight_tensor_parameter_49:
 
 class Program_weight_tensor_parameter_50:
     name = "parameter_50"
+    original_name = "batch_norm2d_108.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-1.19737")
@@ -561,6 +612,7 @@ class Program_weight_tensor_parameter_50:
 
 class Program_weight_tensor_parameter_51:
     name = "parameter_51"
+    original_name = "conv2d_116.w_0"
     shape = [192, 320, 1, 1]
     dtype = "float32"
     min_val = float("-0.340901")
@@ -572,6 +624,7 @@ class Program_weight_tensor_parameter_51:
 
 class Program_weight_tensor_parameter_52:
     name = "parameter_52"
+    original_name = "batch_norm2d_107.b_0"
     shape = [320]
     dtype = "float32"
     min_val = float("-0.442295")
@@ -583,6 +636,7 @@ class Program_weight_tensor_parameter_52:
 
 class Program_weight_tensor_parameter_53:
     name = "parameter_53"
+    original_name = "batch_norm2d_107.w_0"
     shape = [320]
     dtype = "float32"
     min_val = float("0.731801")
@@ -594,6 +648,7 @@ class Program_weight_tensor_parameter_53:
 
 class Program_weight_tensor_parameter_54:
     name = "parameter_54"
+    original_name = "batch_norm2d_107.w_2"
     shape = [320]
     dtype = "float32"
     min_val = float("0.00420873")
@@ -605,6 +660,7 @@ class Program_weight_tensor_parameter_54:
 
 class Program_weight_tensor_parameter_55:
     name = "parameter_55"
+    original_name = "batch_norm2d_107.w_1"
     shape = [320]
     dtype = "float32"
     min_val = float("-0.278969")
@@ -616,6 +672,7 @@ class Program_weight_tensor_parameter_55:
 
 class Program_weight_tensor_parameter_56:
     name = "parameter_56"
+    original_name = "conv2d_115.w_0"
     shape = [320, 1920, 1, 1]
     dtype = "float32"
     min_val = float("-0.40677")
@@ -627,6 +684,7 @@ class Program_weight_tensor_parameter_56:
 
 class Program_weight_tensor_parameter_57:
     name = "parameter_57"
+    original_name = "conv2d_114.b_0"
     shape = [1920]
     dtype = "float32"
     min_val = float("-1.66024")
@@ -638,6 +696,7 @@ class Program_weight_tensor_parameter_57:
 
 class Program_weight_tensor_parameter_58:
     name = "parameter_58"
+    original_name = "conv2d_114.w_0"
     shape = [1920, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.425072")
@@ -649,6 +708,7 @@ class Program_weight_tensor_parameter_58:
 
 class Program_weight_tensor_parameter_59:
     name = "parameter_59"
+    original_name = "batch_norm2d_106.b_0"
     shape = [1920]
     dtype = "float32"
     min_val = float("-4.09065")
@@ -660,6 +720,7 @@ class Program_weight_tensor_parameter_59:
 
 class Program_weight_tensor_parameter_60:
     name = "parameter_60"
+    original_name = "batch_norm2d_106.w_0"
     shape = [1920]
     dtype = "float32"
     min_val = float("0.406244")
@@ -671,6 +732,7 @@ class Program_weight_tensor_parameter_60:
 
 class Program_weight_tensor_parameter_61:
     name = "parameter_61"
+    original_name = "batch_norm2d_106.w_2"
     shape = [1920]
     dtype = "float32"
     min_val = float("5.60519e-45")
@@ -682,6 +744,7 @@ class Program_weight_tensor_parameter_61:
 
 class Program_weight_tensor_parameter_62:
     name = "parameter_62"
+    original_name = "batch_norm2d_106.w_1"
     shape = [1920]
     dtype = "float32"
     min_val = float("-1.30383")
@@ -693,6 +756,7 @@ class Program_weight_tensor_parameter_62:
 
 class Program_weight_tensor_parameter_63:
     name = "parameter_63"
+    original_name = "conv2d_113.w_0"
     shape = [1920, 320, 1, 1]
     dtype = "float32"
     min_val = float("-0.444507")
@@ -704,6 +768,7 @@ class Program_weight_tensor_parameter_63:
 
 class Program_weight_tensor_parameter_64:
     name = "parameter_64"
+    original_name = "batch_norm2d_101.b_0"
     shape = [320]
     dtype = "float32"
     min_val = float("-2.72908")
@@ -715,6 +780,7 @@ class Program_weight_tensor_parameter_64:
 
 class Program_weight_tensor_parameter_65:
     name = "parameter_65"
+    original_name = "batch_norm2d_101.w_0"
     shape = [320]
     dtype = "float32"
     min_val = float("-2.90576")
@@ -726,6 +792,7 @@ class Program_weight_tensor_parameter_65:
 
 class Program_weight_tensor_parameter_66:
     name = "parameter_66"
+    original_name = "batch_norm2d_101.w_2"
     shape = [320]
     dtype = "float32"
     min_val = float("0.0572597")
@@ -737,6 +804,7 @@ class Program_weight_tensor_parameter_66:
 
 class Program_weight_tensor_parameter_67:
     name = "parameter_67"
+    original_name = "batch_norm2d_101.w_1"
     shape = [320]
     dtype = "float32"
     min_val = float("-0.705983")
@@ -748,6 +816,7 @@ class Program_weight_tensor_parameter_67:
 
 class Program_weight_tensor_parameter_68:
     name = "parameter_68"
+    original_name = "conv2d_108.w_0"
     shape = [320, 384, 1, 1]
     dtype = "float32"
     min_val = float("-0.292427")
@@ -759,6 +828,7 @@ class Program_weight_tensor_parameter_68:
 
 class Program_weight_tensor_parameter_69:
     name = "parameter_69"
+    original_name = "batch_norm2d_103.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-1.15052")
@@ -770,6 +840,7 @@ class Program_weight_tensor_parameter_69:
 
 class Program_weight_tensor_parameter_70:
     name = "parameter_70"
+    original_name = "batch_norm2d_103.w_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-1.65349")
@@ -781,6 +852,7 @@ class Program_weight_tensor_parameter_70:
 
 class Program_weight_tensor_parameter_71:
     name = "parameter_71"
+    original_name = "batch_norm2d_103.w_2"
     shape = [384]
     dtype = "float32"
     min_val = float("0.000156281")
@@ -792,6 +864,7 @@ class Program_weight_tensor_parameter_71:
 
 class Program_weight_tensor_parameter_72:
     name = "parameter_72"
+    original_name = "batch_norm2d_103.w_1"
     shape = [384]
     dtype = "float32"
     min_val = float("-0.29911")
@@ -803,6 +876,7 @@ class Program_weight_tensor_parameter_72:
 
 class Program_weight_tensor_parameter_73:
     name = "parameter_73"
+    original_name = "conv2d_110.w_0"
     shape = [384, 384, 1, 1]
     dtype = "float32"
     min_val = float("-0.30009")
@@ -814,6 +888,7 @@ class Program_weight_tensor_parameter_73:
 
 class Program_weight_tensor_parameter_74:
     name = "parameter_74"
+    original_name = "batch_norm2d_102.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-1.15049")
@@ -825,6 +900,7 @@ class Program_weight_tensor_parameter_74:
 
 class Program_weight_tensor_parameter_75:
     name = "parameter_75"
+    original_name = "batch_norm2d_102.w_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-1.80157")
@@ -836,6 +912,7 @@ class Program_weight_tensor_parameter_75:
 
 class Program_weight_tensor_parameter_76:
     name = "parameter_76"
+    original_name = "batch_norm2d_102.w_2"
     shape = [384]
     dtype = "float32"
     min_val = float("9.5226e-05")
@@ -847,6 +924,7 @@ class Program_weight_tensor_parameter_76:
 
 class Program_weight_tensor_parameter_77:
     name = "parameter_77"
+    original_name = "batch_norm2d_102.w_1"
     shape = [384]
     dtype = "float32"
     min_val = float("-0.262222")
@@ -858,6 +936,7 @@ class Program_weight_tensor_parameter_77:
 
 class Program_weight_tensor_parameter_78:
     name = "parameter_78"
+    original_name = "conv2d_109.w_0"
     shape = [384, 384, 1, 1]
     dtype = "float32"
     min_val = float("-0.24735")
@@ -869,6 +948,7 @@ class Program_weight_tensor_parameter_78:
 
 class Program_weight_tensor_parameter_79:
     name = "parameter_79"
+    original_name = "batch_norm2d_105.b_0"
     shape = [320]
     dtype = "float32"
     min_val = float("-4.54835")
@@ -880,6 +960,7 @@ class Program_weight_tensor_parameter_79:
 
 class Program_weight_tensor_parameter_80:
     name = "parameter_80"
+    original_name = "batch_norm2d_105.w_0"
     shape = [320]
     dtype = "float32"
     min_val = float("1.27612")
@@ -891,6 +972,7 @@ class Program_weight_tensor_parameter_80:
 
 class Program_weight_tensor_parameter_81:
     name = "parameter_81"
+    original_name = "batch_norm2d_105.w_2"
     shape = [320]
     dtype = "float32"
     min_val = float("0.0125614")
@@ -902,6 +984,7 @@ class Program_weight_tensor_parameter_81:
 
 class Program_weight_tensor_parameter_82:
     name = "parameter_82"
+    original_name = "batch_norm2d_105.w_1"
     shape = [320]
     dtype = "float32"
     min_val = float("-0.43795")
@@ -913,6 +996,7 @@ class Program_weight_tensor_parameter_82:
 
 class Program_weight_tensor_parameter_83:
     name = "parameter_83"
+    original_name = "conv2d_112.w_0"
     shape = [320, 768, 1, 1]
     dtype = "float32"
     min_val = float("-0.364806")
@@ -924,6 +1008,7 @@ class Program_weight_tensor_parameter_83:
 
 class Program_weight_tensor_parameter_84:
     name = "parameter_84"
+    original_name = "batch_norm2d_104.b_0"
     shape = [768]
     dtype = "float32"
     min_val = float("-3.65284")
@@ -935,6 +1020,7 @@ class Program_weight_tensor_parameter_84:
 
 class Program_weight_tensor_parameter_85:
     name = "parameter_85"
+    original_name = "batch_norm2d_104.w_0"
     shape = [768]
     dtype = "float32"
     min_val = float("0.274258")
@@ -946,6 +1032,7 @@ class Program_weight_tensor_parameter_85:
 
 class Program_weight_tensor_parameter_86:
     name = "parameter_86"
+    original_name = "batch_norm2d_104.w_2"
     shape = [768]
     dtype = "float32"
     min_val = float("0.000411848")
@@ -957,6 +1044,7 @@ class Program_weight_tensor_parameter_86:
 
 class Program_weight_tensor_parameter_87:
     name = "parameter_87"
+    original_name = "batch_norm2d_104.w_1"
     shape = [768]
     dtype = "float32"
     min_val = float("-1.20943")
@@ -968,6 +1056,7 @@ class Program_weight_tensor_parameter_87:
 
 class Program_weight_tensor_parameter_88:
     name = "parameter_88"
+    original_name = "conv2d_111.w_0"
     shape = [768, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.370888")
@@ -979,6 +1068,7 @@ class Program_weight_tensor_parameter_88:
 
 class Program_weight_tensor_parameter_89:
     name = "parameter_89"
+    original_name = "batch_norm2d_100.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-2.50715")
@@ -990,6 +1080,7 @@ class Program_weight_tensor_parameter_89:
 
 class Program_weight_tensor_parameter_90:
     name = "parameter_90"
+    original_name = "batch_norm2d_100.w_0"
     shape = [384]
     dtype = "float32"
     min_val = float("0.185602")
@@ -1001,6 +1092,7 @@ class Program_weight_tensor_parameter_90:
 
 class Program_weight_tensor_parameter_91:
     name = "parameter_91"
+    original_name = "batch_norm2d_100.w_2"
     shape = [384]
     dtype = "float32"
     min_val = float("1.37728")
@@ -1012,6 +1104,7 @@ class Program_weight_tensor_parameter_91:
 
 class Program_weight_tensor_parameter_92:
     name = "parameter_92"
+    original_name = "batch_norm2d_100.w_1"
     shape = [384]
     dtype = "float32"
     min_val = float("-3.2603")
@@ -1023,6 +1116,7 @@ class Program_weight_tensor_parameter_92:
 
 class Program_weight_tensor_parameter_93:
     name = "parameter_93"
+    original_name = "conv2d_107.w_0"
     shape = [384, 320, 1, 1]
     dtype = "float32"
     min_val = float("-0.606176")
@@ -1034,6 +1128,7 @@ class Program_weight_tensor_parameter_93:
 
 class Program_weight_tensor_parameter_94:
     name = "parameter_94"
+    original_name = "batch_norm2d_99.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.563183")
@@ -1045,6 +1140,7 @@ class Program_weight_tensor_parameter_94:
 
 class Program_weight_tensor_parameter_95:
     name = "parameter_95"
+    original_name = "batch_norm2d_99.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.155222")
@@ -1056,6 +1152,7 @@ class Program_weight_tensor_parameter_95:
 
 class Program_weight_tensor_parameter_96:
     name = "parameter_96"
+    original_name = "batch_norm2d_99.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("0.899757")
@@ -1067,6 +1164,7 @@ class Program_weight_tensor_parameter_96:
 
 class Program_weight_tensor_parameter_97:
     name = "parameter_97"
+    original_name = "batch_norm2d_99.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-1.46227")
@@ -1078,6 +1176,7 @@ class Program_weight_tensor_parameter_97:
 
 class Program_weight_tensor_parameter_98:
     name = "parameter_98"
+    original_name = "conv2d_106.w_0"
     shape = [192, 320, 1, 1]
     dtype = "float32"
     min_val = float("-0.2472")
@@ -1089,6 +1188,7 @@ class Program_weight_tensor_parameter_98:
 
 class Program_weight_tensor_parameter_99:
     name = "parameter_99"
+    original_name = "batch_norm2d_98.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-2.34953")
@@ -1100,6 +1200,7 @@ class Program_weight_tensor_parameter_99:
 
 class Program_weight_tensor_parameter_100:
     name = "parameter_100"
+    original_name = "batch_norm2d_98.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("0.0985761")
@@ -1111,6 +1212,7 @@ class Program_weight_tensor_parameter_100:
 
 class Program_weight_tensor_parameter_101:
     name = "parameter_101"
+    original_name = "batch_norm2d_98.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("0.965359")
@@ -1122,6 +1224,7 @@ class Program_weight_tensor_parameter_101:
 
 class Program_weight_tensor_parameter_102:
     name = "parameter_102"
+    original_name = "batch_norm2d_98.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-1.04182")
@@ -1133,6 +1236,7 @@ class Program_weight_tensor_parameter_102:
 
 class Program_weight_tensor_parameter_103:
     name = "parameter_103"
+    original_name = "conv2d_105.w_0"
     shape = [192, 320, 1, 1]
     dtype = "float32"
     min_val = float("-0.324764")
@@ -1144,6 +1248,7 @@ class Program_weight_tensor_parameter_103:
 
 class Program_weight_tensor_parameter_104:
     name = "parameter_104"
+    original_name = "batch_norm2d_97.b_0"
     shape = [320]
     dtype = "float32"
     min_val = float("-0.576683")
@@ -1155,6 +1260,7 @@ class Program_weight_tensor_parameter_104:
 
 class Program_weight_tensor_parameter_105:
     name = "parameter_105"
+    original_name = "batch_norm2d_97.w_0"
     shape = [320]
     dtype = "float32"
     min_val = float("0.514513")
@@ -1166,6 +1272,7 @@ class Program_weight_tensor_parameter_105:
 
 class Program_weight_tensor_parameter_106:
     name = "parameter_106"
+    original_name = "batch_norm2d_97.w_2"
     shape = [320]
     dtype = "float32"
     min_val = float("0.00502788")
@@ -1177,6 +1284,7 @@ class Program_weight_tensor_parameter_106:
 
 class Program_weight_tensor_parameter_107:
     name = "parameter_107"
+    original_name = "batch_norm2d_97.w_1"
     shape = [320]
     dtype = "float32"
     min_val = float("-0.755885")
@@ -1188,6 +1296,7 @@ class Program_weight_tensor_parameter_107:
 
 class Program_weight_tensor_parameter_108:
     name = "parameter_108"
+    original_name = "conv2d_104.w_0"
     shape = [320, 1920, 1, 1]
     dtype = "float32"
     min_val = float("-0.523934")
@@ -1199,6 +1308,7 @@ class Program_weight_tensor_parameter_108:
 
 class Program_weight_tensor_parameter_109:
     name = "parameter_109"
+    original_name = "conv2d_103.b_0"
     shape = [1920]
     dtype = "float32"
     min_val = float("-2.1248")
@@ -1210,6 +1320,7 @@ class Program_weight_tensor_parameter_109:
 
 class Program_weight_tensor_parameter_110:
     name = "parameter_110"
+    original_name = "conv2d_103.w_0"
     shape = [1920, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.476586")
@@ -1221,6 +1332,7 @@ class Program_weight_tensor_parameter_110:
 
 class Program_weight_tensor_parameter_111:
     name = "parameter_111"
+    original_name = "batch_norm2d_96.b_0"
     shape = [1920]
     dtype = "float32"
     min_val = float("-4.42827")
@@ -1232,6 +1344,7 @@ class Program_weight_tensor_parameter_111:
 
 class Program_weight_tensor_parameter_112:
     name = "parameter_112"
+    original_name = "batch_norm2d_96.w_0"
     shape = [1920]
     dtype = "float32"
     min_val = float("0.240294")
@@ -1243,6 +1356,7 @@ class Program_weight_tensor_parameter_112:
 
 class Program_weight_tensor_parameter_113:
     name = "parameter_113"
+    original_name = "batch_norm2d_96.w_2"
     shape = [1920]
     dtype = "float32"
     min_val = float("0.454435")
@@ -1254,6 +1368,7 @@ class Program_weight_tensor_parameter_113:
 
 class Program_weight_tensor_parameter_114:
     name = "parameter_114"
+    original_name = "batch_norm2d_96.w_1"
     shape = [1920]
     dtype = "float32"
     min_val = float("-2.16696")
@@ -1265,6 +1380,7 @@ class Program_weight_tensor_parameter_114:
 
 class Program_weight_tensor_parameter_115:
     name = "parameter_115"
+    original_name = "conv2d_102.w_0"
     shape = [1920, 320, 1, 1]
     dtype = "float32"
     min_val = float("-0.355105")
@@ -1276,6 +1392,7 @@ class Program_weight_tensor_parameter_115:
 
 class Program_weight_tensor_parameter_116:
     name = "parameter_116"
+    original_name = "batch_norm2d_91.b_0"
     shape = [320]
     dtype = "float32"
     min_val = float("-3.50114")
@@ -1287,6 +1404,7 @@ class Program_weight_tensor_parameter_116:
 
 class Program_weight_tensor_parameter_117:
     name = "parameter_117"
+    original_name = "batch_norm2d_91.w_0"
     shape = [320]
     dtype = "float32"
     min_val = float("-2.59606")
@@ -1298,6 +1416,7 @@ class Program_weight_tensor_parameter_117:
 
 class Program_weight_tensor_parameter_118:
     name = "parameter_118"
+    original_name = "batch_norm2d_91.w_2"
     shape = [320]
     dtype = "float32"
     min_val = float("0.296766")
@@ -1309,6 +1428,7 @@ class Program_weight_tensor_parameter_118:
 
 class Program_weight_tensor_parameter_119:
     name = "parameter_119"
+    original_name = "batch_norm2d_91.w_1"
     shape = [320]
     dtype = "float32"
     min_val = float("-2.33442")
@@ -1320,6 +1440,7 @@ class Program_weight_tensor_parameter_119:
 
 class Program_weight_tensor_parameter_120:
     name = "parameter_120"
+    original_name = "conv2d_97.w_0"
     shape = [320, 384, 1, 1]
     dtype = "float32"
     min_val = float("-0.46812")
@@ -1331,6 +1452,7 @@ class Program_weight_tensor_parameter_120:
 
 class Program_weight_tensor_parameter_121:
     name = "parameter_121"
+    original_name = "batch_norm2d_93.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-1.45417")
@@ -1342,6 +1464,7 @@ class Program_weight_tensor_parameter_121:
 
 class Program_weight_tensor_parameter_122:
     name = "parameter_122"
+    original_name = "batch_norm2d_93.w_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-1.38557")
@@ -1353,6 +1476,7 @@ class Program_weight_tensor_parameter_122:
 
 class Program_weight_tensor_parameter_123:
     name = "parameter_123"
+    original_name = "batch_norm2d_93.w_2"
     shape = [384]
     dtype = "float32"
     min_val = float("0.00376301")
@@ -1364,6 +1488,7 @@ class Program_weight_tensor_parameter_123:
 
 class Program_weight_tensor_parameter_124:
     name = "parameter_124"
+    original_name = "batch_norm2d_93.w_1"
     shape = [384]
     dtype = "float32"
     min_val = float("-0.425901")
@@ -1375,6 +1500,7 @@ class Program_weight_tensor_parameter_124:
 
 class Program_weight_tensor_parameter_125:
     name = "parameter_125"
+    original_name = "conv2d_99.w_0"
     shape = [384, 384, 1, 1]
     dtype = "float32"
     min_val = float("-0.243521")
@@ -1386,6 +1512,7 @@ class Program_weight_tensor_parameter_125:
 
 class Program_weight_tensor_parameter_126:
     name = "parameter_126"
+    original_name = "batch_norm2d_92.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-1.45419")
@@ -1397,6 +1524,7 @@ class Program_weight_tensor_parameter_126:
 
 class Program_weight_tensor_parameter_127:
     name = "parameter_127"
+    original_name = "batch_norm2d_92.w_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-1.66169")
@@ -1408,6 +1536,7 @@ class Program_weight_tensor_parameter_127:
 
 class Program_weight_tensor_parameter_128:
     name = "parameter_128"
+    original_name = "batch_norm2d_92.w_2"
     shape = [384]
     dtype = "float32"
     min_val = float("0.00453924")
@@ -1419,6 +1548,7 @@ class Program_weight_tensor_parameter_128:
 
 class Program_weight_tensor_parameter_129:
     name = "parameter_129"
+    original_name = "batch_norm2d_92.w_1"
     shape = [384]
     dtype = "float32"
     min_val = float("-0.676337")
@@ -1430,6 +1560,7 @@ class Program_weight_tensor_parameter_129:
 
 class Program_weight_tensor_parameter_130:
     name = "parameter_130"
+    original_name = "conv2d_98.w_0"
     shape = [384, 384, 1, 1]
     dtype = "float32"
     min_val = float("-0.481495")
@@ -1441,6 +1572,7 @@ class Program_weight_tensor_parameter_130:
 
 class Program_weight_tensor_parameter_131:
     name = "parameter_131"
+    original_name = "batch_norm2d_95.b_0"
     shape = [320]
     dtype = "float32"
     min_val = float("-7.55241")
@@ -1452,6 +1584,7 @@ class Program_weight_tensor_parameter_131:
 
 class Program_weight_tensor_parameter_132:
     name = "parameter_132"
+    original_name = "batch_norm2d_95.w_0"
     shape = [320]
     dtype = "float32"
     min_val = float("0.645185")
@@ -1463,6 +1596,7 @@ class Program_weight_tensor_parameter_132:
 
 class Program_weight_tensor_parameter_133:
     name = "parameter_133"
+    original_name = "batch_norm2d_95.w_2"
     shape = [320]
     dtype = "float32"
     min_val = float("0.174985")
@@ -1474,6 +1608,7 @@ class Program_weight_tensor_parameter_133:
 
 class Program_weight_tensor_parameter_134:
     name = "parameter_134"
+    original_name = "batch_norm2d_95.w_1"
     shape = [320]
     dtype = "float32"
     min_val = float("-3.09145")
@@ -1485,6 +1620,7 @@ class Program_weight_tensor_parameter_134:
 
 class Program_weight_tensor_parameter_135:
     name = "parameter_135"
+    original_name = "conv2d_101.w_0"
     shape = [320, 768, 1, 1]
     dtype = "float32"
     min_val = float("-0.569815")
@@ -1496,6 +1632,7 @@ class Program_weight_tensor_parameter_135:
 
 class Program_weight_tensor_parameter_136:
     name = "parameter_136"
+    original_name = "batch_norm2d_94.b_0"
     shape = [768]
     dtype = "float32"
     min_val = float("-3.78401")
@@ -1507,6 +1644,7 @@ class Program_weight_tensor_parameter_136:
 
 class Program_weight_tensor_parameter_137:
     name = "parameter_137"
+    original_name = "batch_norm2d_94.w_0"
     shape = [768]
     dtype = "float32"
     min_val = float("0.472788")
@@ -1518,6 +1656,7 @@ class Program_weight_tensor_parameter_137:
 
 class Program_weight_tensor_parameter_138:
     name = "parameter_138"
+    original_name = "batch_norm2d_94.w_2"
     shape = [768]
     dtype = "float32"
     min_val = float("0.000426996")
@@ -1529,6 +1668,7 @@ class Program_weight_tensor_parameter_138:
 
 class Program_weight_tensor_parameter_139:
     name = "parameter_139"
+    original_name = "batch_norm2d_94.w_1"
     shape = [768]
     dtype = "float32"
     min_val = float("-0.953625")
@@ -1540,6 +1680,7 @@ class Program_weight_tensor_parameter_139:
 
 class Program_weight_tensor_parameter_140:
     name = "parameter_140"
+    original_name = "conv2d_100.w_0"
     shape = [768, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.348618")
@@ -1551,6 +1692,7 @@ class Program_weight_tensor_parameter_140:
 
 class Program_weight_tensor_parameter_141:
     name = "parameter_141"
+    original_name = "batch_norm2d_90.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-3.14659")
@@ -1562,6 +1704,7 @@ class Program_weight_tensor_parameter_141:
 
 class Program_weight_tensor_parameter_142:
     name = "parameter_142"
+    original_name = "batch_norm2d_90.w_0"
     shape = [384]
     dtype = "float32"
     min_val = float("0.364746")
@@ -1573,6 +1716,7 @@ class Program_weight_tensor_parameter_142:
 
 class Program_weight_tensor_parameter_143:
     name = "parameter_143"
+    original_name = "batch_norm2d_90.w_2"
     shape = [384]
     dtype = "float32"
     min_val = float("0.814647")
@@ -1584,6 +1728,7 @@ class Program_weight_tensor_parameter_143:
 
 class Program_weight_tensor_parameter_144:
     name = "parameter_144"
+    original_name = "batch_norm2d_90.w_1"
     shape = [384]
     dtype = "float32"
     min_val = float("-1.3355")
@@ -1595,6 +1740,7 @@ class Program_weight_tensor_parameter_144:
 
 class Program_weight_tensor_parameter_145:
     name = "parameter_145"
+    original_name = "conv2d_96.w_0"
     shape = [384, 320, 1, 1]
     dtype = "float32"
     min_val = float("-0.566185")
@@ -1606,6 +1752,7 @@ class Program_weight_tensor_parameter_145:
 
 class Program_weight_tensor_parameter_146:
     name = "parameter_146"
+    original_name = "batch_norm2d_89.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-1.23507")
@@ -1617,6 +1764,7 @@ class Program_weight_tensor_parameter_146:
 
 class Program_weight_tensor_parameter_147:
     name = "parameter_147"
+    original_name = "batch_norm2d_89.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("0.0745926")
@@ -1628,6 +1776,7 @@ class Program_weight_tensor_parameter_147:
 
 class Program_weight_tensor_parameter_148:
     name = "parameter_148"
+    original_name = "batch_norm2d_89.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("0.59513")
@@ -1639,6 +1788,7 @@ class Program_weight_tensor_parameter_148:
 
 class Program_weight_tensor_parameter_149:
     name = "parameter_149"
+    original_name = "batch_norm2d_89.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.553634")
@@ -1650,6 +1800,7 @@ class Program_weight_tensor_parameter_149:
 
 class Program_weight_tensor_parameter_150:
     name = "parameter_150"
+    original_name = "conv2d_95.w_0"
     shape = [192, 320, 1, 1]
     dtype = "float32"
     min_val = float("-0.228877")
@@ -1661,6 +1812,7 @@ class Program_weight_tensor_parameter_150:
 
 class Program_weight_tensor_parameter_151:
     name = "parameter_151"
+    original_name = "batch_norm2d_88.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-3.18293")
@@ -1672,6 +1824,7 @@ class Program_weight_tensor_parameter_151:
 
 class Program_weight_tensor_parameter_152:
     name = "parameter_152"
+    original_name = "batch_norm2d_88.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("0.116674")
@@ -1683,6 +1836,7 @@ class Program_weight_tensor_parameter_152:
 
 class Program_weight_tensor_parameter_153:
     name = "parameter_153"
+    original_name = "batch_norm2d_88.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("0.642785")
@@ -1694,6 +1848,7 @@ class Program_weight_tensor_parameter_153:
 
 class Program_weight_tensor_parameter_154:
     name = "parameter_154"
+    original_name = "batch_norm2d_88.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.526082")
@@ -1705,6 +1860,7 @@ class Program_weight_tensor_parameter_154:
 
 class Program_weight_tensor_parameter_155:
     name = "parameter_155"
+    original_name = "conv2d_94.w_0"
     shape = [192, 320, 1, 1]
     dtype = "float32"
     min_val = float("-0.375326")
@@ -1716,6 +1872,7 @@ class Program_weight_tensor_parameter_155:
 
 class Program_weight_tensor_parameter_156:
     name = "parameter_156"
+    original_name = "batch_norm2d_27.b_0"
     shape = [320]
     dtype = "float32"
     min_val = float("-0.587434")
@@ -1727,6 +1884,7 @@ class Program_weight_tensor_parameter_156:
 
 class Program_weight_tensor_parameter_157:
     name = "parameter_157"
+    original_name = "batch_norm2d_27.w_0"
     shape = [320]
     dtype = "float32"
     min_val = float("1.01605")
@@ -1738,6 +1896,7 @@ class Program_weight_tensor_parameter_157:
 
 class Program_weight_tensor_parameter_158:
     name = "parameter_158"
+    original_name = "batch_norm2d_27.w_2"
     shape = [320]
     dtype = "float32"
     min_val = float("6.03046")
@@ -1749,6 +1908,7 @@ class Program_weight_tensor_parameter_158:
 
 class Program_weight_tensor_parameter_159:
     name = "parameter_159"
+    original_name = "batch_norm2d_27.w_1"
     shape = [320]
     dtype = "float32"
     min_val = float("-7.76247")
@@ -1760,6 +1920,7 @@ class Program_weight_tensor_parameter_159:
 
 class Program_weight_tensor_parameter_160:
     name = "parameter_160"
+    original_name = "conv2d_27.w_0"
     shape = [320, 1536, 1, 1]
     dtype = "float32"
     min_val = float("-0.622795")
@@ -1771,6 +1932,7 @@ class Program_weight_tensor_parameter_160:
 
 class Program_weight_tensor_parameter_161:
     name = "parameter_161"
+    original_name = "batch_norm2d_26.b_0"
     shape = [1536]
     dtype = "float32"
     min_val = float("-4.14977")
@@ -1782,6 +1944,7 @@ class Program_weight_tensor_parameter_161:
 
 class Program_weight_tensor_parameter_162:
     name = "parameter_162"
+    original_name = "batch_norm2d_26.w_0"
     shape = [1536]
     dtype = "float32"
     min_val = float("0.940642")
@@ -1793,6 +1956,7 @@ class Program_weight_tensor_parameter_162:
 
 class Program_weight_tensor_parameter_163:
     name = "parameter_163"
+    original_name = "batch_norm2d_26.w_2"
     shape = [1536]
     dtype = "float32"
     min_val = float("5.60519e-45")
@@ -1804,6 +1968,7 @@ class Program_weight_tensor_parameter_163:
 
 class Program_weight_tensor_parameter_164:
     name = "parameter_164"
+    original_name = "batch_norm2d_26.w_1"
     shape = [1536]
     dtype = "float32"
     min_val = float("-2.76753")
@@ -1815,6 +1980,7 @@ class Program_weight_tensor_parameter_164:
 
 class Program_weight_tensor_parameter_165:
     name = "parameter_165"
+    original_name = "conv2d_26.w_0"
     shape = [1536, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.595182")
@@ -1826,6 +1992,7 @@ class Program_weight_tensor_parameter_165:
 
 class Program_weight_tensor_parameter_166:
     name = "parameter_166"
+    original_name = "batch_norm2d_25.b_0"
     shape = [1536]
     dtype = "float32"
     min_val = float("-3.05364")
@@ -1837,6 +2004,7 @@ class Program_weight_tensor_parameter_166:
 
 class Program_weight_tensor_parameter_167:
     name = "parameter_167"
+    original_name = "batch_norm2d_25.w_0"
     shape = [1536]
     dtype = "float32"
     min_val = float("-1.53986")
@@ -1848,6 +2016,7 @@ class Program_weight_tensor_parameter_167:
 
 class Program_weight_tensor_parameter_168:
     name = "parameter_168"
+    original_name = "batch_norm2d_25.w_2"
     shape = [1536]
     dtype = "float32"
     min_val = float("5.60519e-45")
@@ -1859,6 +2028,7 @@ class Program_weight_tensor_parameter_168:
 
 class Program_weight_tensor_parameter_169:
     name = "parameter_169"
+    original_name = "batch_norm2d_25.w_1"
     shape = [1536]
     dtype = "float32"
     min_val = float("-5.79975")
@@ -1870,6 +2040,7 @@ class Program_weight_tensor_parameter_169:
 
 class Program_weight_tensor_parameter_170:
     name = "parameter_170"
+    original_name = "conv2d_25.w_0"
     shape = [1536, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.766066")
@@ -1881,6 +2052,7 @@ class Program_weight_tensor_parameter_170:
 
 class Program_weight_tensor_parameter_171:
     name = "parameter_171"
+    original_name = "batch_norm2d_87.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.610275")
@@ -1892,6 +2064,7 @@ class Program_weight_tensor_parameter_171:
 
 class Program_weight_tensor_parameter_172:
     name = "parameter_172"
+    original_name = "batch_norm2d_87.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.181896")
@@ -1903,6 +2076,7 @@ class Program_weight_tensor_parameter_172:
 
 class Program_weight_tensor_parameter_173:
     name = "parameter_173"
+    original_name = "batch_norm2d_87.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.000653106")
@@ -1914,6 +2088,7 @@ class Program_weight_tensor_parameter_173:
 
 class Program_weight_tensor_parameter_174:
     name = "parameter_174"
+    original_name = "batch_norm2d_87.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.260646")
@@ -1925,6 +2100,7 @@ class Program_weight_tensor_parameter_174:
 
 class Program_weight_tensor_parameter_175:
     name = "parameter_175"
+    original_name = "conv2d_93.w_0"
     shape = [256, 1024, 1, 1]
     dtype = "float32"
     min_val = float("-0.375999")
@@ -1936,6 +2112,7 @@ class Program_weight_tensor_parameter_175:
 
 class Program_weight_tensor_parameter_176:
     name = "parameter_176"
+    original_name = "conv2d_92.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-1.72098")
@@ -1947,6 +2124,7 @@ class Program_weight_tensor_parameter_176:
 
 class Program_weight_tensor_parameter_177:
     name = "parameter_177"
+    original_name = "conv2d_92.w_0"
     shape = [1024, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.492833")
@@ -1958,6 +2136,7 @@ class Program_weight_tensor_parameter_177:
 
 class Program_weight_tensor_parameter_178:
     name = "parameter_178"
+    original_name = "batch_norm2d_86.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-3.02658")
@@ -1969,6 +2148,7 @@ class Program_weight_tensor_parameter_178:
 
 class Program_weight_tensor_parameter_179:
     name = "parameter_179"
+    original_name = "batch_norm2d_86.w_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("0.238288")
@@ -1980,6 +2160,7 @@ class Program_weight_tensor_parameter_179:
 
 class Program_weight_tensor_parameter_180:
     name = "parameter_180"
+    original_name = "batch_norm2d_86.w_2"
     shape = [1024]
     dtype = "float32"
     min_val = float("5.60519e-45")
@@ -1991,6 +2172,7 @@ class Program_weight_tensor_parameter_180:
 
 class Program_weight_tensor_parameter_181:
     name = "parameter_181"
+    original_name = "batch_norm2d_86.w_1"
     shape = [1024]
     dtype = "float32"
     min_val = float("-7.15995")
@@ -2002,6 +2184,7 @@ class Program_weight_tensor_parameter_181:
 
 class Program_weight_tensor_parameter_182:
     name = "parameter_182"
+    original_name = "conv2d_91.w_0"
     shape = [1024, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.31778")
@@ -2013,6 +2196,7 @@ class Program_weight_tensor_parameter_182:
 
 class Program_weight_tensor_parameter_183:
     name = "parameter_183"
+    original_name = "batch_norm2d_81.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-3.14208")
@@ -2024,6 +2208,7 @@ class Program_weight_tensor_parameter_183:
 
 class Program_weight_tensor_parameter_184:
     name = "parameter_184"
+    original_name = "batch_norm2d_81.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-2.9409")
@@ -2035,6 +2220,7 @@ class Program_weight_tensor_parameter_184:
 
 class Program_weight_tensor_parameter_185:
     name = "parameter_185"
+    original_name = "batch_norm2d_81.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.0100301")
@@ -2046,6 +2232,7 @@ class Program_weight_tensor_parameter_185:
 
 class Program_weight_tensor_parameter_186:
     name = "parameter_186"
+    original_name = "batch_norm2d_81.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.641803")
@@ -2057,6 +2244,7 @@ class Program_weight_tensor_parameter_186:
 
 class Program_weight_tensor_parameter_187:
     name = "parameter_187"
+    original_name = "conv2d_86.w_0"
     shape = [256, 320, 1, 1]
     dtype = "float32"
     min_val = float("-0.346897")
@@ -2068,6 +2256,7 @@ class Program_weight_tensor_parameter_187:
 
 class Program_weight_tensor_parameter_188:
     name = "parameter_188"
+    original_name = "batch_norm2d_83.b_0"
     shape = [320]
     dtype = "float32"
     min_val = float("-2.02549")
@@ -2079,6 +2268,7 @@ class Program_weight_tensor_parameter_188:
 
 class Program_weight_tensor_parameter_189:
     name = "parameter_189"
+    original_name = "batch_norm2d_83.w_0"
     shape = [320]
     dtype = "float32"
     min_val = float("-1.11158")
@@ -2090,6 +2280,7 @@ class Program_weight_tensor_parameter_189:
 
 class Program_weight_tensor_parameter_190:
     name = "parameter_190"
+    original_name = "batch_norm2d_83.w_2"
     shape = [320]
     dtype = "float32"
     min_val = float("0.000138835")
@@ -2101,6 +2292,7 @@ class Program_weight_tensor_parameter_190:
 
 class Program_weight_tensor_parameter_191:
     name = "parameter_191"
+    original_name = "batch_norm2d_83.w_1"
     shape = [320]
     dtype = "float32"
     min_val = float("-0.425027")
@@ -2112,6 +2304,7 @@ class Program_weight_tensor_parameter_191:
 
 class Program_weight_tensor_parameter_192:
     name = "parameter_192"
+    original_name = "conv2d_88.w_0"
     shape = [320, 320, 1, 1]
     dtype = "float32"
     min_val = float("-0.271036")
@@ -2123,6 +2316,7 @@ class Program_weight_tensor_parameter_192:
 
 class Program_weight_tensor_parameter_193:
     name = "parameter_193"
+    original_name = "batch_norm2d_82.b_0"
     shape = [320]
     dtype = "float32"
     min_val = float("-2.02549")
@@ -2134,6 +2328,7 @@ class Program_weight_tensor_parameter_193:
 
 class Program_weight_tensor_parameter_194:
     name = "parameter_194"
+    original_name = "batch_norm2d_82.w_0"
     shape = [320]
     dtype = "float32"
     min_val = float("-1.19818")
@@ -2145,6 +2340,7 @@ class Program_weight_tensor_parameter_194:
 
 class Program_weight_tensor_parameter_195:
     name = "parameter_195"
+    original_name = "batch_norm2d_82.w_2"
     shape = [320]
     dtype = "float32"
     min_val = float("0.000121332")
@@ -2156,6 +2352,7 @@ class Program_weight_tensor_parameter_195:
 
 class Program_weight_tensor_parameter_196:
     name = "parameter_196"
+    original_name = "batch_norm2d_82.w_1"
     shape = [320]
     dtype = "float32"
     min_val = float("-0.637261")
@@ -2167,6 +2364,7 @@ class Program_weight_tensor_parameter_196:
 
 class Program_weight_tensor_parameter_197:
     name = "parameter_197"
+    original_name = "conv2d_87.w_0"
     shape = [320, 320, 1, 1]
     dtype = "float32"
     min_val = float("-0.246832")
@@ -2178,6 +2376,7 @@ class Program_weight_tensor_parameter_197:
 
 class Program_weight_tensor_parameter_198:
     name = "parameter_198"
+    original_name = "batch_norm2d_85.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-8.66008")
@@ -2189,6 +2388,7 @@ class Program_weight_tensor_parameter_198:
 
 class Program_weight_tensor_parameter_199:
     name = "parameter_199"
+    original_name = "batch_norm2d_85.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.637349")
@@ -2200,6 +2400,7 @@ class Program_weight_tensor_parameter_199:
 
 class Program_weight_tensor_parameter_200:
     name = "parameter_200"
+    original_name = "batch_norm2d_85.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.00688179")
@@ -2211,6 +2412,7 @@ class Program_weight_tensor_parameter_200:
 
 class Program_weight_tensor_parameter_201:
     name = "parameter_201"
+    original_name = "batch_norm2d_85.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.660975")
@@ -2222,6 +2424,7 @@ class Program_weight_tensor_parameter_201:
 
 class Program_weight_tensor_parameter_202:
     name = "parameter_202"
+    original_name = "conv2d_90.w_0"
     shape = [256, 640, 1, 1]
     dtype = "float32"
     min_val = float("-0.35865")
@@ -2233,6 +2436,7 @@ class Program_weight_tensor_parameter_202:
 
 class Program_weight_tensor_parameter_203:
     name = "parameter_203"
+    original_name = "batch_norm2d_84.b_0"
     shape = [640]
     dtype = "float32"
     min_val = float("-3.12801")
@@ -2244,6 +2448,7 @@ class Program_weight_tensor_parameter_203:
 
 class Program_weight_tensor_parameter_204:
     name = "parameter_204"
+    original_name = "batch_norm2d_84.w_0"
     shape = [640]
     dtype = "float32"
     min_val = float("0.233174")
@@ -2255,6 +2460,7 @@ class Program_weight_tensor_parameter_204:
 
 class Program_weight_tensor_parameter_205:
     name = "parameter_205"
+    original_name = "batch_norm2d_84.w_2"
     shape = [640]
     dtype = "float32"
     min_val = float("5.60519e-45")
@@ -2266,6 +2472,7 @@ class Program_weight_tensor_parameter_205:
 
 class Program_weight_tensor_parameter_206:
     name = "parameter_206"
+    original_name = "batch_norm2d_84.w_1"
     shape = [640]
     dtype = "float32"
     min_val = float("-1.71422")
@@ -2277,6 +2484,7 @@ class Program_weight_tensor_parameter_206:
 
 class Program_weight_tensor_parameter_207:
     name = "parameter_207"
+    original_name = "conv2d_89.w_0"
     shape = [640, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.350734")
@@ -2288,6 +2496,7 @@ class Program_weight_tensor_parameter_207:
 
 class Program_weight_tensor_parameter_208:
     name = "parameter_208"
+    original_name = "batch_norm2d_80.b_0"
     shape = [320]
     dtype = "float32"
     min_val = float("-3.26354")
@@ -2299,6 +2508,7 @@ class Program_weight_tensor_parameter_208:
 
 class Program_weight_tensor_parameter_209:
     name = "parameter_209"
+    original_name = "batch_norm2d_80.w_0"
     shape = [320]
     dtype = "float32"
     min_val = float("0.243765")
@@ -2310,6 +2520,7 @@ class Program_weight_tensor_parameter_209:
 
 class Program_weight_tensor_parameter_210:
     name = "parameter_210"
+    original_name = "batch_norm2d_80.w_2"
     shape = [320]
     dtype = "float32"
     min_val = float("2.94396")
@@ -2321,6 +2532,7 @@ class Program_weight_tensor_parameter_210:
 
 class Program_weight_tensor_parameter_211:
     name = "parameter_211"
+    original_name = "batch_norm2d_80.w_1"
     shape = [320]
     dtype = "float32"
     min_val = float("-4.75039")
@@ -2332,6 +2544,7 @@ class Program_weight_tensor_parameter_211:
 
 class Program_weight_tensor_parameter_212:
     name = "parameter_212"
+    original_name = "conv2d_85.w_0"
     shape = [320, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.459157")
@@ -2343,6 +2556,7 @@ class Program_weight_tensor_parameter_212:
 
 class Program_weight_tensor_parameter_213:
     name = "parameter_213"
+    original_name = "batch_norm2d_79.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.966717")
@@ -2354,6 +2568,7 @@ class Program_weight_tensor_parameter_213:
 
 class Program_weight_tensor_parameter_214:
     name = "parameter_214"
+    original_name = "batch_norm2d_79.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.218642")
@@ -2365,6 +2580,7 @@ class Program_weight_tensor_parameter_214:
 
 class Program_weight_tensor_parameter_215:
     name = "parameter_215"
+    original_name = "batch_norm2d_79.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("1.89677")
@@ -2376,6 +2592,7 @@ class Program_weight_tensor_parameter_215:
 
 class Program_weight_tensor_parameter_216:
     name = "parameter_216"
+    original_name = "batch_norm2d_79.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-2.32028")
@@ -2387,6 +2604,7 @@ class Program_weight_tensor_parameter_216:
 
 class Program_weight_tensor_parameter_217:
     name = "parameter_217"
+    original_name = "conv2d_84.w_0"
     shape = [160, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.356426")
@@ -2398,6 +2616,7 @@ class Program_weight_tensor_parameter_217:
 
 class Program_weight_tensor_parameter_218:
     name = "parameter_218"
+    original_name = "batch_norm2d_78.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-2.38113")
@@ -2409,6 +2628,7 @@ class Program_weight_tensor_parameter_218:
 
 class Program_weight_tensor_parameter_219:
     name = "parameter_219"
+    original_name = "batch_norm2d_78.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.261781")
@@ -2420,6 +2640,7 @@ class Program_weight_tensor_parameter_219:
 
 class Program_weight_tensor_parameter_220:
     name = "parameter_220"
+    original_name = "batch_norm2d_78.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("1.39898")
@@ -2431,6 +2652,7 @@ class Program_weight_tensor_parameter_220:
 
 class Program_weight_tensor_parameter_221:
     name = "parameter_221"
+    original_name = "batch_norm2d_78.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-2.59864")
@@ -2442,6 +2664,7 @@ class Program_weight_tensor_parameter_221:
 
 class Program_weight_tensor_parameter_222:
     name = "parameter_222"
+    original_name = "conv2d_83.w_0"
     shape = [160, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.246446")
@@ -2453,6 +2676,7 @@ class Program_weight_tensor_parameter_222:
 
 class Program_weight_tensor_parameter_223:
     name = "parameter_223"
+    original_name = "batch_norm2d_77.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.02665")
@@ -2464,6 +2688,7 @@ class Program_weight_tensor_parameter_223:
 
 class Program_weight_tensor_parameter_224:
     name = "parameter_224"
+    original_name = "batch_norm2d_77.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.243859")
@@ -2475,6 +2700,7 @@ class Program_weight_tensor_parameter_224:
 
 class Program_weight_tensor_parameter_225:
     name = "parameter_225"
+    original_name = "batch_norm2d_77.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.00137178")
@@ -2486,6 +2712,7 @@ class Program_weight_tensor_parameter_225:
 
 class Program_weight_tensor_parameter_226:
     name = "parameter_226"
+    original_name = "batch_norm2d_77.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.126576")
@@ -2497,6 +2724,7 @@ class Program_weight_tensor_parameter_226:
 
 class Program_weight_tensor_parameter_227:
     name = "parameter_227"
+    original_name = "conv2d_82.w_0"
     shape = [256, 1024, 1, 1]
     dtype = "float32"
     min_val = float("-0.359988")
@@ -2508,6 +2736,7 @@ class Program_weight_tensor_parameter_227:
 
 class Program_weight_tensor_parameter_228:
     name = "parameter_228"
+    original_name = "conv2d_81.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-1.93214")
@@ -2519,6 +2748,7 @@ class Program_weight_tensor_parameter_228:
 
 class Program_weight_tensor_parameter_229:
     name = "parameter_229"
+    original_name = "conv2d_81.w_0"
     shape = [1024, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.401863")
@@ -2530,6 +2760,7 @@ class Program_weight_tensor_parameter_229:
 
 class Program_weight_tensor_parameter_230:
     name = "parameter_230"
+    original_name = "batch_norm2d_76.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-3.9215")
@@ -2541,6 +2772,7 @@ class Program_weight_tensor_parameter_230:
 
 class Program_weight_tensor_parameter_231:
     name = "parameter_231"
+    original_name = "batch_norm2d_76.w_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("0.243417")
@@ -2552,6 +2784,7 @@ class Program_weight_tensor_parameter_231:
 
 class Program_weight_tensor_parameter_232:
     name = "parameter_232"
+    original_name = "batch_norm2d_76.w_2"
     shape = [1024]
     dtype = "float32"
     min_val = float("5.60519e-45")
@@ -2563,6 +2796,7 @@ class Program_weight_tensor_parameter_232:
 
 class Program_weight_tensor_parameter_233:
     name = "parameter_233"
+    original_name = "batch_norm2d_76.w_1"
     shape = [1024]
     dtype = "float32"
     min_val = float("-4.33365")
@@ -2574,6 +2808,7 @@ class Program_weight_tensor_parameter_233:
 
 class Program_weight_tensor_parameter_234:
     name = "parameter_234"
+    original_name = "conv2d_80.w_0"
     shape = [1024, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.466906")
@@ -2585,6 +2820,7 @@ class Program_weight_tensor_parameter_234:
 
 class Program_weight_tensor_parameter_235:
     name = "parameter_235"
+    original_name = "batch_norm2d_71.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-3.25669")
@@ -2596,6 +2832,7 @@ class Program_weight_tensor_parameter_235:
 
 class Program_weight_tensor_parameter_236:
     name = "parameter_236"
+    original_name = "batch_norm2d_71.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-2.53526")
@@ -2607,6 +2844,7 @@ class Program_weight_tensor_parameter_236:
 
 class Program_weight_tensor_parameter_237:
     name = "parameter_237"
+    original_name = "batch_norm2d_71.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.0090161")
@@ -2618,6 +2856,7 @@ class Program_weight_tensor_parameter_237:
 
 class Program_weight_tensor_parameter_238:
     name = "parameter_238"
+    original_name = "batch_norm2d_71.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.77483")
@@ -2629,6 +2868,7 @@ class Program_weight_tensor_parameter_238:
 
 class Program_weight_tensor_parameter_239:
     name = "parameter_239"
+    original_name = "conv2d_75.w_0"
     shape = [256, 320, 1, 1]
     dtype = "float32"
     min_val = float("-0.306525")
@@ -2640,6 +2880,7 @@ class Program_weight_tensor_parameter_239:
 
 class Program_weight_tensor_parameter_240:
     name = "parameter_240"
+    original_name = "batch_norm2d_73.b_0"
     shape = [320]
     dtype = "float32"
     min_val = float("-1.80096")
@@ -2651,6 +2892,7 @@ class Program_weight_tensor_parameter_240:
 
 class Program_weight_tensor_parameter_241:
     name = "parameter_241"
+    original_name = "batch_norm2d_73.w_0"
     shape = [320]
     dtype = "float32"
     min_val = float("-1.06421")
@@ -2662,6 +2904,7 @@ class Program_weight_tensor_parameter_241:
 
 class Program_weight_tensor_parameter_242:
     name = "parameter_242"
+    original_name = "batch_norm2d_73.w_2"
     shape = [320]
     dtype = "float32"
     min_val = float("0.00364238")
@@ -2673,6 +2916,7 @@ class Program_weight_tensor_parameter_242:
 
 class Program_weight_tensor_parameter_243:
     name = "parameter_243"
+    original_name = "batch_norm2d_73.w_1"
     shape = [320]
     dtype = "float32"
     min_val = float("-0.57026")
@@ -2684,6 +2928,7 @@ class Program_weight_tensor_parameter_243:
 
 class Program_weight_tensor_parameter_244:
     name = "parameter_244"
+    original_name = "conv2d_77.w_0"
     shape = [320, 320, 1, 1]
     dtype = "float32"
     min_val = float("-0.325213")
@@ -2695,6 +2940,7 @@ class Program_weight_tensor_parameter_244:
 
 class Program_weight_tensor_parameter_245:
     name = "parameter_245"
+    original_name = "batch_norm2d_72.b_0"
     shape = [320]
     dtype = "float32"
     min_val = float("-1.80096")
@@ -2706,6 +2952,7 @@ class Program_weight_tensor_parameter_245:
 
 class Program_weight_tensor_parameter_246:
     name = "parameter_246"
+    original_name = "batch_norm2d_72.w_0"
     shape = [320]
     dtype = "float32"
     min_val = float("-1.0989")
@@ -2717,6 +2964,7 @@ class Program_weight_tensor_parameter_246:
 
 class Program_weight_tensor_parameter_247:
     name = "parameter_247"
+    original_name = "batch_norm2d_72.w_2"
     shape = [320]
     dtype = "float32"
     min_val = float("0.00502014")
@@ -2728,6 +2976,7 @@ class Program_weight_tensor_parameter_247:
 
 class Program_weight_tensor_parameter_248:
     name = "parameter_248"
+    original_name = "batch_norm2d_72.w_1"
     shape = [320]
     dtype = "float32"
     min_val = float("-0.506325")
@@ -2739,6 +2988,7 @@ class Program_weight_tensor_parameter_248:
 
 class Program_weight_tensor_parameter_249:
     name = "parameter_249"
+    original_name = "conv2d_76.w_0"
     shape = [320, 320, 1, 1]
     dtype = "float32"
     min_val = float("-0.267369")
@@ -2750,6 +3000,7 @@ class Program_weight_tensor_parameter_249:
 
 class Program_weight_tensor_parameter_250:
     name = "parameter_250"
+    original_name = "batch_norm2d_75.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-9.85902")
@@ -2761,6 +3012,7 @@ class Program_weight_tensor_parameter_250:
 
 class Program_weight_tensor_parameter_251:
     name = "parameter_251"
+    original_name = "batch_norm2d_75.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.459638")
@@ -2772,6 +3024,7 @@ class Program_weight_tensor_parameter_251:
 
 class Program_weight_tensor_parameter_252:
     name = "parameter_252"
+    original_name = "batch_norm2d_75.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.0101948")
@@ -2783,6 +3036,7 @@ class Program_weight_tensor_parameter_252:
 
 class Program_weight_tensor_parameter_253:
     name = "parameter_253"
+    original_name = "batch_norm2d_75.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.882369")
@@ -2794,6 +3048,7 @@ class Program_weight_tensor_parameter_253:
 
 class Program_weight_tensor_parameter_254:
     name = "parameter_254"
+    original_name = "conv2d_79.w_0"
     shape = [256, 640, 1, 1]
     dtype = "float32"
     min_val = float("-0.41151")
@@ -2805,6 +3060,7 @@ class Program_weight_tensor_parameter_254:
 
 class Program_weight_tensor_parameter_255:
     name = "parameter_255"
+    original_name = "batch_norm2d_74.b_0"
     shape = [640]
     dtype = "float32"
     min_val = float("-3.9183")
@@ -2816,6 +3072,7 @@ class Program_weight_tensor_parameter_255:
 
 class Program_weight_tensor_parameter_256:
     name = "parameter_256"
+    original_name = "batch_norm2d_74.w_0"
     shape = [640]
     dtype = "float32"
     min_val = float("0.397555")
@@ -2827,6 +3084,7 @@ class Program_weight_tensor_parameter_256:
 
 class Program_weight_tensor_parameter_257:
     name = "parameter_257"
+    original_name = "batch_norm2d_74.w_2"
     shape = [640]
     dtype = "float32"
     min_val = float("0.00120728")
@@ -2838,6 +3096,7 @@ class Program_weight_tensor_parameter_257:
 
 class Program_weight_tensor_parameter_258:
     name = "parameter_258"
+    original_name = "batch_norm2d_74.w_1"
     shape = [640]
     dtype = "float32"
     min_val = float("-0.870696")
@@ -2849,6 +3108,7 @@ class Program_weight_tensor_parameter_258:
 
 class Program_weight_tensor_parameter_259:
     name = "parameter_259"
+    original_name = "conv2d_78.w_0"
     shape = [640, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.339582")
@@ -2860,6 +3120,7 @@ class Program_weight_tensor_parameter_259:
 
 class Program_weight_tensor_parameter_260:
     name = "parameter_260"
+    original_name = "batch_norm2d_70.b_0"
     shape = [320]
     dtype = "float32"
     min_val = float("-1.61671")
@@ -2871,6 +3132,7 @@ class Program_weight_tensor_parameter_260:
 
 class Program_weight_tensor_parameter_261:
     name = "parameter_261"
+    original_name = "batch_norm2d_70.w_0"
     shape = [320]
     dtype = "float32"
     min_val = float("0.231808")
@@ -2882,6 +3144,7 @@ class Program_weight_tensor_parameter_261:
 
 class Program_weight_tensor_parameter_262:
     name = "parameter_262"
+    original_name = "batch_norm2d_70.w_2"
     shape = [320]
     dtype = "float32"
     min_val = float("3.64229")
@@ -2893,6 +3156,7 @@ class Program_weight_tensor_parameter_262:
 
 class Program_weight_tensor_parameter_263:
     name = "parameter_263"
+    original_name = "batch_norm2d_70.w_1"
     shape = [320]
     dtype = "float32"
     min_val = float("-3.58432")
@@ -2904,6 +3168,7 @@ class Program_weight_tensor_parameter_263:
 
 class Program_weight_tensor_parameter_264:
     name = "parameter_264"
+    original_name = "conv2d_74.w_0"
     shape = [320, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.788954")
@@ -2915,6 +3180,7 @@ class Program_weight_tensor_parameter_264:
 
 class Program_weight_tensor_parameter_265:
     name = "parameter_265"
+    original_name = "batch_norm2d_69.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-1.2597")
@@ -2926,6 +3192,7 @@ class Program_weight_tensor_parameter_265:
 
 class Program_weight_tensor_parameter_266:
     name = "parameter_266"
+    original_name = "batch_norm2d_69.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.151767")
@@ -2937,6 +3204,7 @@ class Program_weight_tensor_parameter_266:
 
 class Program_weight_tensor_parameter_267:
     name = "parameter_267"
+    original_name = "batch_norm2d_69.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("2.44454")
@@ -2948,6 +3216,7 @@ class Program_weight_tensor_parameter_267:
 
 class Program_weight_tensor_parameter_268:
     name = "parameter_268"
+    original_name = "batch_norm2d_69.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-4.3492")
@@ -2959,6 +3228,7 @@ class Program_weight_tensor_parameter_268:
 
 class Program_weight_tensor_parameter_269:
     name = "parameter_269"
+    original_name = "conv2d_73.w_0"
     shape = [160, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.314309")
@@ -2970,6 +3240,7 @@ class Program_weight_tensor_parameter_269:
 
 class Program_weight_tensor_parameter_270:
     name = "parameter_270"
+    original_name = "batch_norm2d_68.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-1.68006")
@@ -2981,6 +3252,7 @@ class Program_weight_tensor_parameter_270:
 
 class Program_weight_tensor_parameter_271:
     name = "parameter_271"
+    original_name = "batch_norm2d_68.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.263002")
@@ -2992,6 +3264,7 @@ class Program_weight_tensor_parameter_271:
 
 class Program_weight_tensor_parameter_272:
     name = "parameter_272"
+    original_name = "batch_norm2d_68.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("2.61291")
@@ -3003,6 +3276,7 @@ class Program_weight_tensor_parameter_272:
 
 class Program_weight_tensor_parameter_273:
     name = "parameter_273"
+    original_name = "batch_norm2d_68.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-2.01129")
@@ -3014,6 +3288,7 @@ class Program_weight_tensor_parameter_273:
 
 class Program_weight_tensor_parameter_274:
     name = "parameter_274"
+    original_name = "conv2d_72.w_0"
     shape = [160, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.666677")
@@ -3025,6 +3300,7 @@ class Program_weight_tensor_parameter_274:
 
 class Program_weight_tensor_parameter_275:
     name = "parameter_275"
+    original_name = "batch_norm2d_67.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.00223573")
@@ -3036,6 +3312,7 @@ class Program_weight_tensor_parameter_275:
 
 class Program_weight_tensor_parameter_276:
     name = "parameter_276"
+    original_name = "batch_norm2d_67.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.446807")
@@ -3047,6 +3324,7 @@ class Program_weight_tensor_parameter_276:
 
 class Program_weight_tensor_parameter_277:
     name = "parameter_277"
+    original_name = "batch_norm2d_67.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.0116926")
@@ -3058,6 +3336,7 @@ class Program_weight_tensor_parameter_277:
 
 class Program_weight_tensor_parameter_278:
     name = "parameter_278"
+    original_name = "batch_norm2d_67.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.245849")
@@ -3069,6 +3348,7 @@ class Program_weight_tensor_parameter_278:
 
 class Program_weight_tensor_parameter_279:
     name = "parameter_279"
+    original_name = "conv2d_71.w_0"
     shape = [256, 1024, 1, 1]
     dtype = "float32"
     min_val = float("-0.425934")
@@ -3080,6 +3360,7 @@ class Program_weight_tensor_parameter_279:
 
 class Program_weight_tensor_parameter_280:
     name = "parameter_280"
+    original_name = "conv2d_70.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-2.75719")
@@ -3091,6 +3372,7 @@ class Program_weight_tensor_parameter_280:
 
 class Program_weight_tensor_parameter_281:
     name = "parameter_281"
+    original_name = "conv2d_70.w_0"
     shape = [1024, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.484039")
@@ -3102,6 +3384,7 @@ class Program_weight_tensor_parameter_281:
 
 class Program_weight_tensor_parameter_282:
     name = "parameter_282"
+    original_name = "batch_norm2d_66.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-4.37077")
@@ -3113,6 +3396,7 @@ class Program_weight_tensor_parameter_282:
 
 class Program_weight_tensor_parameter_283:
     name = "parameter_283"
+    original_name = "batch_norm2d_66.w_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("0.445267")
@@ -3124,6 +3408,7 @@ class Program_weight_tensor_parameter_283:
 
 class Program_weight_tensor_parameter_284:
     name = "parameter_284"
+    original_name = "batch_norm2d_66.w_2"
     shape = [1024]
     dtype = "float32"
     min_val = float("1.88585")
@@ -3135,6 +3420,7 @@ class Program_weight_tensor_parameter_284:
 
 class Program_weight_tensor_parameter_285:
     name = "parameter_285"
+    original_name = "batch_norm2d_66.w_1"
     shape = [1024]
     dtype = "float32"
     min_val = float("-3.58519")
@@ -3146,6 +3432,7 @@ class Program_weight_tensor_parameter_285:
 
 class Program_weight_tensor_parameter_286:
     name = "parameter_286"
+    original_name = "conv2d_69.w_0"
     shape = [1024, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.422065")
@@ -3157,6 +3444,7 @@ class Program_weight_tensor_parameter_286:
 
 class Program_weight_tensor_parameter_287:
     name = "parameter_287"
+    original_name = "batch_norm2d_61.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-3.83309")
@@ -3168,6 +3456,7 @@ class Program_weight_tensor_parameter_287:
 
 class Program_weight_tensor_parameter_288:
     name = "parameter_288"
+    original_name = "batch_norm2d_61.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-3.78631")
@@ -3179,6 +3468,7 @@ class Program_weight_tensor_parameter_288:
 
 class Program_weight_tensor_parameter_289:
     name = "parameter_289"
+    original_name = "batch_norm2d_61.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.213413")
@@ -3190,6 +3480,7 @@ class Program_weight_tensor_parameter_289:
 
 class Program_weight_tensor_parameter_290:
     name = "parameter_290"
+    original_name = "batch_norm2d_61.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.60719")
@@ -3201,6 +3492,7 @@ class Program_weight_tensor_parameter_290:
 
 class Program_weight_tensor_parameter_291:
     name = "parameter_291"
+    original_name = "conv2d_64.w_0"
     shape = [256, 320, 1, 1]
     dtype = "float32"
     min_val = float("-0.535922")
@@ -3212,6 +3504,7 @@ class Program_weight_tensor_parameter_291:
 
 class Program_weight_tensor_parameter_292:
     name = "parameter_292"
+    original_name = "batch_norm2d_63.b_0"
     shape = [320]
     dtype = "float32"
     min_val = float("-2.46309")
@@ -3223,6 +3516,7 @@ class Program_weight_tensor_parameter_292:
 
 class Program_weight_tensor_parameter_293:
     name = "parameter_293"
+    original_name = "batch_norm2d_63.w_0"
     shape = [320]
     dtype = "float32"
     min_val = float("-2.33083")
@@ -3234,6 +3528,7 @@ class Program_weight_tensor_parameter_293:
 
 class Program_weight_tensor_parameter_294:
     name = "parameter_294"
+    original_name = "batch_norm2d_63.w_2"
     shape = [320]
     dtype = "float32"
     min_val = float("0.016103")
@@ -3245,6 +3540,7 @@ class Program_weight_tensor_parameter_294:
 
 class Program_weight_tensor_parameter_295:
     name = "parameter_295"
+    original_name = "batch_norm2d_63.w_1"
     shape = [320]
     dtype = "float32"
     min_val = float("-0.711876")
@@ -3256,6 +3552,7 @@ class Program_weight_tensor_parameter_295:
 
 class Program_weight_tensor_parameter_296:
     name = "parameter_296"
+    original_name = "conv2d_66.w_0"
     shape = [320, 320, 1, 1]
     dtype = "float32"
     min_val = float("-0.44291")
@@ -3267,6 +3564,7 @@ class Program_weight_tensor_parameter_296:
 
 class Program_weight_tensor_parameter_297:
     name = "parameter_297"
+    original_name = "batch_norm2d_62.b_0"
     shape = [320]
     dtype = "float32"
     min_val = float("-2.46302")
@@ -3278,6 +3576,7 @@ class Program_weight_tensor_parameter_297:
 
 class Program_weight_tensor_parameter_298:
     name = "parameter_298"
+    original_name = "batch_norm2d_62.w_0"
     shape = [320]
     dtype = "float32"
     min_val = float("-2.34327")
@@ -3289,6 +3588,7 @@ class Program_weight_tensor_parameter_298:
 
 class Program_weight_tensor_parameter_299:
     name = "parameter_299"
+    original_name = "batch_norm2d_62.w_2"
     shape = [320]
     dtype = "float32"
     min_val = float("0.0158695")
@@ -3300,6 +3600,7 @@ class Program_weight_tensor_parameter_299:
 
 class Program_weight_tensor_parameter_300:
     name = "parameter_300"
+    original_name = "batch_norm2d_62.w_1"
     shape = [320]
     dtype = "float32"
     min_val = float("-0.827037")
@@ -3311,6 +3612,7 @@ class Program_weight_tensor_parameter_300:
 
 class Program_weight_tensor_parameter_301:
     name = "parameter_301"
+    original_name = "conv2d_65.w_0"
     shape = [320, 320, 1, 1]
     dtype = "float32"
     min_val = float("-0.477861")
@@ -3322,6 +3624,7 @@ class Program_weight_tensor_parameter_301:
 
 class Program_weight_tensor_parameter_302:
     name = "parameter_302"
+    original_name = "batch_norm2d_65.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-14.7584")
@@ -3333,6 +3636,7 @@ class Program_weight_tensor_parameter_302:
 
 class Program_weight_tensor_parameter_303:
     name = "parameter_303"
+    original_name = "batch_norm2d_65.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.90638")
@@ -3344,6 +3648,7 @@ class Program_weight_tensor_parameter_303:
 
 class Program_weight_tensor_parameter_304:
     name = "parameter_304"
+    original_name = "batch_norm2d_65.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.265969")
@@ -3355,6 +3660,7 @@ class Program_weight_tensor_parameter_304:
 
 class Program_weight_tensor_parameter_305:
     name = "parameter_305"
+    original_name = "batch_norm2d_65.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-3.16623")
@@ -3366,6 +3672,7 @@ class Program_weight_tensor_parameter_305:
 
 class Program_weight_tensor_parameter_306:
     name = "parameter_306"
+    original_name = "conv2d_68.w_0"
     shape = [256, 640, 1, 1]
     dtype = "float32"
     min_val = float("-0.568453")
@@ -3377,6 +3684,7 @@ class Program_weight_tensor_parameter_306:
 
 class Program_weight_tensor_parameter_307:
     name = "parameter_307"
+    original_name = "batch_norm2d_64.b_0"
     shape = [640]
     dtype = "float32"
     min_val = float("-2.92899")
@@ -3388,6 +3696,7 @@ class Program_weight_tensor_parameter_307:
 
 class Program_weight_tensor_parameter_308:
     name = "parameter_308"
+    original_name = "batch_norm2d_64.w_0"
     shape = [640]
     dtype = "float32"
     min_val = float("0.732179")
@@ -3399,6 +3708,7 @@ class Program_weight_tensor_parameter_308:
 
 class Program_weight_tensor_parameter_309:
     name = "parameter_309"
+    original_name = "batch_norm2d_64.w_2"
     shape = [640]
     dtype = "float32"
     min_val = float("0.00206971")
@@ -3410,6 +3720,7 @@ class Program_weight_tensor_parameter_309:
 
 class Program_weight_tensor_parameter_310:
     name = "parameter_310"
+    original_name = "batch_norm2d_64.w_1"
     shape = [640]
     dtype = "float32"
     min_val = float("-2.12673")
@@ -3421,6 +3732,7 @@ class Program_weight_tensor_parameter_310:
 
 class Program_weight_tensor_parameter_311:
     name = "parameter_311"
+    original_name = "conv2d_67.w_0"
     shape = [640, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.504799")
@@ -3432,6 +3744,7 @@ class Program_weight_tensor_parameter_311:
 
 class Program_weight_tensor_parameter_312:
     name = "parameter_312"
+    original_name = "batch_norm2d_60.b_0"
     shape = [320]
     dtype = "float32"
     min_val = float("-2.42393")
@@ -3443,6 +3756,7 @@ class Program_weight_tensor_parameter_312:
 
 class Program_weight_tensor_parameter_313:
     name = "parameter_313"
+    original_name = "batch_norm2d_60.w_0"
     shape = [320]
     dtype = "float32"
     min_val = float("0.202478")
@@ -3454,6 +3768,7 @@ class Program_weight_tensor_parameter_313:
 
 class Program_weight_tensor_parameter_314:
     name = "parameter_314"
+    original_name = "batch_norm2d_60.w_2"
     shape = [320]
     dtype = "float32"
     min_val = float("3.35801")
@@ -3465,6 +3780,7 @@ class Program_weight_tensor_parameter_314:
 
 class Program_weight_tensor_parameter_315:
     name = "parameter_315"
+    original_name = "batch_norm2d_60.w_1"
     shape = [320]
     dtype = "float32"
     min_val = float("-0.00188769")
@@ -3476,6 +3792,7 @@ class Program_weight_tensor_parameter_315:
 
 class Program_weight_tensor_parameter_316:
     name = "parameter_316"
+    original_name = "conv2d_63.w_0"
     shape = [320, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.806728")
@@ -3487,6 +3804,7 @@ class Program_weight_tensor_parameter_316:
 
 class Program_weight_tensor_parameter_317:
     name = "parameter_317"
+    original_name = "batch_norm2d_59.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-1.06472")
@@ -3498,6 +3816,7 @@ class Program_weight_tensor_parameter_317:
 
 class Program_weight_tensor_parameter_318:
     name = "parameter_318"
+    original_name = "batch_norm2d_59.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.152409")
@@ -3509,6 +3828,7 @@ class Program_weight_tensor_parameter_318:
 
 class Program_weight_tensor_parameter_319:
     name = "parameter_319"
+    original_name = "batch_norm2d_59.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("2.4042")
@@ -3520,6 +3840,7 @@ class Program_weight_tensor_parameter_319:
 
 class Program_weight_tensor_parameter_320:
     name = "parameter_320"
+    original_name = "batch_norm2d_59.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.00138089")
@@ -3531,6 +3852,7 @@ class Program_weight_tensor_parameter_320:
 
 class Program_weight_tensor_parameter_321:
     name = "parameter_321"
+    original_name = "conv2d_62.w_0"
     shape = [160, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.330006")
@@ -3542,6 +3864,7 @@ class Program_weight_tensor_parameter_321:
 
 class Program_weight_tensor_parameter_322:
     name = "parameter_322"
+    original_name = "batch_norm2d_58.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-5.08651")
@@ -3553,6 +3876,7 @@ class Program_weight_tensor_parameter_322:
 
 class Program_weight_tensor_parameter_323:
     name = "parameter_323"
+    original_name = "batch_norm2d_58.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.234721")
@@ -3564,6 +3888,7 @@ class Program_weight_tensor_parameter_323:
 
 class Program_weight_tensor_parameter_324:
     name = "parameter_324"
+    original_name = "batch_norm2d_58.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("2.42007")
@@ -3575,6 +3900,7 @@ class Program_weight_tensor_parameter_324:
 
 class Program_weight_tensor_parameter_325:
     name = "parameter_325"
+    original_name = "batch_norm2d_58.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.00208176")
@@ -3586,6 +3912,7 @@ class Program_weight_tensor_parameter_325:
 
 class Program_weight_tensor_parameter_326:
     name = "parameter_326"
+    original_name = "conv2d_61.w_0"
     shape = [160, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.446906")
@@ -3597,6 +3924,7 @@ class Program_weight_tensor_parameter_326:
 
 class Program_weight_tensor_parameter_327:
     name = "parameter_327"
+    original_name = "batch_norm2d_24.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.00291752")
@@ -3608,6 +3936,7 @@ class Program_weight_tensor_parameter_327:
 
 class Program_weight_tensor_parameter_328:
     name = "parameter_328"
+    original_name = "batch_norm2d_24.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.446423")
@@ -3619,6 +3948,7 @@ class Program_weight_tensor_parameter_328:
 
 class Program_weight_tensor_parameter_329:
     name = "parameter_329"
+    original_name = "batch_norm2d_24.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("1.16611")
@@ -3630,6 +3960,7 @@ class Program_weight_tensor_parameter_329:
 
 class Program_weight_tensor_parameter_330:
     name = "parameter_330"
+    original_name = "batch_norm2d_24.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-12.5734")
@@ -3641,6 +3972,7 @@ class Program_weight_tensor_parameter_330:
 
 class Program_weight_tensor_parameter_331:
     name = "parameter_331"
+    original_name = "conv2d_24.w_0"
     shape = [256, 768, 1, 1]
     dtype = "float32"
     min_val = float("-0.903303")
@@ -3652,6 +3984,7 @@ class Program_weight_tensor_parameter_331:
 
 class Program_weight_tensor_parameter_332:
     name = "parameter_332"
+    original_name = "batch_norm2d_23.b_0"
     shape = [768]
     dtype = "float32"
     min_val = float("-3.95084")
@@ -3663,6 +3996,7 @@ class Program_weight_tensor_parameter_332:
 
 class Program_weight_tensor_parameter_333:
     name = "parameter_333"
+    original_name = "batch_norm2d_23.w_0"
     shape = [768]
     dtype = "float32"
     min_val = float("0.779437")
@@ -3674,6 +4008,7 @@ class Program_weight_tensor_parameter_333:
 
 class Program_weight_tensor_parameter_334:
     name = "parameter_334"
+    original_name = "batch_norm2d_23.w_2"
     shape = [768]
     dtype = "float32"
     min_val = float("5.60519e-45")
@@ -3685,6 +4020,7 @@ class Program_weight_tensor_parameter_334:
 
 class Program_weight_tensor_parameter_335:
     name = "parameter_335"
+    original_name = "batch_norm2d_23.w_1"
     shape = [768]
     dtype = "float32"
     min_val = float("-2.71514")
@@ -3696,6 +4032,7 @@ class Program_weight_tensor_parameter_335:
 
 class Program_weight_tensor_parameter_336:
     name = "parameter_336"
+    original_name = "conv2d_23.w_0"
     shape = [768, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.275831")
@@ -3707,6 +4044,7 @@ class Program_weight_tensor_parameter_336:
 
 class Program_weight_tensor_parameter_337:
     name = "parameter_337"
+    original_name = "batch_norm2d_22.b_0"
     shape = [768]
     dtype = "float32"
     min_val = float("-3.72653")
@@ -3718,6 +4056,7 @@ class Program_weight_tensor_parameter_337:
 
 class Program_weight_tensor_parameter_338:
     name = "parameter_338"
+    original_name = "batch_norm2d_22.w_0"
     shape = [768]
     dtype = "float32"
     min_val = float("-0.175196")
@@ -3729,6 +4068,7 @@ class Program_weight_tensor_parameter_338:
 
 class Program_weight_tensor_parameter_339:
     name = "parameter_339"
+    original_name = "batch_norm2d_22.w_2"
     shape = [768]
     dtype = "float32"
     min_val = float("5.60519e-45")
@@ -3740,6 +4080,7 @@ class Program_weight_tensor_parameter_339:
 
 class Program_weight_tensor_parameter_340:
     name = "parameter_340"
+    original_name = "batch_norm2d_22.w_1"
     shape = [768]
     dtype = "float32"
     min_val = float("-5.32831")
@@ -3751,6 +4092,7 @@ class Program_weight_tensor_parameter_340:
 
 class Program_weight_tensor_parameter_341:
     name = "parameter_341"
+    original_name = "conv2d_22.w_0"
     shape = [768, 192, 1, 1]
     dtype = "float32"
     min_val = float("-0.869617")
@@ -3762,6 +4104,7 @@ class Program_weight_tensor_parameter_341:
 
 class Program_weight_tensor_parameter_342:
     name = "parameter_342"
+    original_name = "batch_norm2d_57.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.38331")
@@ -3773,6 +4116,7 @@ class Program_weight_tensor_parameter_342:
 
 class Program_weight_tensor_parameter_343:
     name = "parameter_343"
+    original_name = "batch_norm2d_57.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.252442")
@@ -3784,6 +4128,7 @@ class Program_weight_tensor_parameter_343:
 
 class Program_weight_tensor_parameter_344:
     name = "parameter_344"
+    original_name = "batch_norm2d_57.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("0.000608938")
@@ -3795,6 +4140,7 @@ class Program_weight_tensor_parameter_344:
 
 class Program_weight_tensor_parameter_345:
     name = "parameter_345"
+    original_name = "batch_norm2d_57.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.20734")
@@ -3806,6 +4152,7 @@ class Program_weight_tensor_parameter_345:
 
 class Program_weight_tensor_parameter_346:
     name = "parameter_346"
+    original_name = "conv2d_60.w_0"
     shape = [192, 384, 1, 1]
     dtype = "float32"
     min_val = float("-0.431992")
@@ -3817,6 +4164,7 @@ class Program_weight_tensor_parameter_346:
 
 class Program_weight_tensor_parameter_347:
     name = "parameter_347"
+    original_name = "conv2d_59.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-1.80338")
@@ -3828,6 +4176,7 @@ class Program_weight_tensor_parameter_347:
 
 class Program_weight_tensor_parameter_348:
     name = "parameter_348"
+    original_name = "conv2d_59.w_0"
     shape = [384, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.404303")
@@ -3839,6 +4188,7 @@ class Program_weight_tensor_parameter_348:
 
 class Program_weight_tensor_parameter_349:
     name = "parameter_349"
+    original_name = "batch_norm2d_56.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-3.5668")
@@ -3850,6 +4200,7 @@ class Program_weight_tensor_parameter_349:
 
 class Program_weight_tensor_parameter_350:
     name = "parameter_350"
+    original_name = "batch_norm2d_56.w_0"
     shape = [384]
     dtype = "float32"
     min_val = float("0.461395")
@@ -3861,6 +4212,7 @@ class Program_weight_tensor_parameter_350:
 
 class Program_weight_tensor_parameter_351:
     name = "parameter_351"
+    original_name = "batch_norm2d_56.w_2"
     shape = [384]
     dtype = "float32"
     min_val = float("5.60519e-45")
@@ -3872,6 +4224,7 @@ class Program_weight_tensor_parameter_351:
 
 class Program_weight_tensor_parameter_352:
     name = "parameter_352"
+    original_name = "batch_norm2d_56.w_1"
     shape = [384]
     dtype = "float32"
     min_val = float("-4.15325")
@@ -3883,6 +4236,7 @@ class Program_weight_tensor_parameter_352:
 
 class Program_weight_tensor_parameter_353:
     name = "parameter_353"
+    original_name = "conv2d_58.w_0"
     shape = [384, 192, 1, 1]
     dtype = "float32"
     min_val = float("-0.501738")
@@ -3894,6 +4248,7 @@ class Program_weight_tensor_parameter_353:
 
 class Program_weight_tensor_parameter_354:
     name = "parameter_354"
+    original_name = "batch_norm2d_51.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-2.86809")
@@ -3905,6 +4260,7 @@ class Program_weight_tensor_parameter_354:
 
 class Program_weight_tensor_parameter_355:
     name = "parameter_355"
+    original_name = "batch_norm2d_51.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-2.48854")
@@ -3916,6 +4272,7 @@ class Program_weight_tensor_parameter_355:
 
 class Program_weight_tensor_parameter_356:
     name = "parameter_356"
+    original_name = "batch_norm2d_51.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("0.0490956")
@@ -3927,6 +4284,7 @@ class Program_weight_tensor_parameter_356:
 
 class Program_weight_tensor_parameter_357:
     name = "parameter_357"
+    original_name = "batch_norm2d_51.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.780348")
@@ -3938,6 +4296,7 @@ class Program_weight_tensor_parameter_357:
 
 class Program_weight_tensor_parameter_358:
     name = "parameter_358"
+    original_name = "conv2d_53.w_0"
     shape = [192, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.335722")
@@ -3949,6 +4308,7 @@ class Program_weight_tensor_parameter_358:
 
 class Program_weight_tensor_parameter_359:
     name = "parameter_359"
+    original_name = "batch_norm2d_53.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-2.27334")
@@ -3960,6 +4320,7 @@ class Program_weight_tensor_parameter_359:
 
 class Program_weight_tensor_parameter_360:
     name = "parameter_360"
+    original_name = "batch_norm2d_53.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.89172")
@@ -3971,6 +4332,7 @@ class Program_weight_tensor_parameter_360:
 
 class Program_weight_tensor_parameter_361:
     name = "parameter_361"
+    original_name = "batch_norm2d_53.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.000847218")
@@ -3982,6 +4344,7 @@ class Program_weight_tensor_parameter_361:
 
 class Program_weight_tensor_parameter_362:
     name = "parameter_362"
+    original_name = "batch_norm2d_53.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.49463")
@@ -3993,6 +4356,7 @@ class Program_weight_tensor_parameter_362:
 
 class Program_weight_tensor_parameter_363:
     name = "parameter_363"
+    original_name = "conv2d_55.w_0"
     shape = [256, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.31081")
@@ -4004,6 +4368,7 @@ class Program_weight_tensor_parameter_363:
 
 class Program_weight_tensor_parameter_364:
     name = "parameter_364"
+    original_name = "batch_norm2d_52.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-2.27341")
@@ -4015,6 +4380,7 @@ class Program_weight_tensor_parameter_364:
 
 class Program_weight_tensor_parameter_365:
     name = "parameter_365"
+    original_name = "batch_norm2d_52.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.998056")
@@ -4026,6 +4392,7 @@ class Program_weight_tensor_parameter_365:
 
 class Program_weight_tensor_parameter_366:
     name = "parameter_366"
+    original_name = "batch_norm2d_52.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.0023366")
@@ -4037,6 +4404,7 @@ class Program_weight_tensor_parameter_366:
 
 class Program_weight_tensor_parameter_367:
     name = "parameter_367"
+    original_name = "batch_norm2d_52.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.389931")
@@ -4048,6 +4416,7 @@ class Program_weight_tensor_parameter_367:
 
 class Program_weight_tensor_parameter_368:
     name = "parameter_368"
+    original_name = "conv2d_54.w_0"
     shape = [256, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.297192")
@@ -4059,6 +4428,7 @@ class Program_weight_tensor_parameter_368:
 
 class Program_weight_tensor_parameter_369:
     name = "parameter_369"
+    original_name = "batch_norm2d_55.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-4.41109")
@@ -4070,6 +4440,7 @@ class Program_weight_tensor_parameter_369:
 
 class Program_weight_tensor_parameter_370:
     name = "parameter_370"
+    original_name = "batch_norm2d_55.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.842436")
@@ -4081,6 +4452,7 @@ class Program_weight_tensor_parameter_370:
 
 class Program_weight_tensor_parameter_371:
     name = "parameter_371"
+    original_name = "batch_norm2d_55.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("0.0351716")
@@ -4092,6 +4464,7 @@ class Program_weight_tensor_parameter_371:
 
 class Program_weight_tensor_parameter_372:
     name = "parameter_372"
+    original_name = "batch_norm2d_55.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.520333")
@@ -4103,6 +4476,7 @@ class Program_weight_tensor_parameter_372:
 
 class Program_weight_tensor_parameter_373:
     name = "parameter_373"
+    original_name = "conv2d_57.w_0"
     shape = [192, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.549264")
@@ -4114,6 +4488,7 @@ class Program_weight_tensor_parameter_373:
 
 class Program_weight_tensor_parameter_374:
     name = "parameter_374"
+    original_name = "batch_norm2d_54.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-3.84019")
@@ -4125,6 +4500,7 @@ class Program_weight_tensor_parameter_374:
 
 class Program_weight_tensor_parameter_375:
     name = "parameter_375"
+    original_name = "batch_norm2d_54.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("0.434791")
@@ -4136,6 +4512,7 @@ class Program_weight_tensor_parameter_375:
 
 class Program_weight_tensor_parameter_376:
     name = "parameter_376"
+    original_name = "batch_norm2d_54.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("0.000348584")
@@ -4147,6 +4524,7 @@ class Program_weight_tensor_parameter_376:
 
 class Program_weight_tensor_parameter_377:
     name = "parameter_377"
+    original_name = "batch_norm2d_54.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-2.65241")
@@ -4158,6 +4536,7 @@ class Program_weight_tensor_parameter_377:
 
 class Program_weight_tensor_parameter_378:
     name = "parameter_378"
+    original_name = "conv2d_56.w_0"
     shape = [512, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.372721")
@@ -4169,6 +4548,7 @@ class Program_weight_tensor_parameter_378:
 
 class Program_weight_tensor_parameter_379:
     name = "parameter_379"
+    original_name = "batch_norm2d_50.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.83082")
@@ -4180,6 +4560,7 @@ class Program_weight_tensor_parameter_379:
 
 class Program_weight_tensor_parameter_380:
     name = "parameter_380"
+    original_name = "batch_norm2d_50.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.0674937")
@@ -4191,6 +4572,7 @@ class Program_weight_tensor_parameter_380:
 
 class Program_weight_tensor_parameter_381:
     name = "parameter_381"
+    original_name = "batch_norm2d_50.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("2.94702")
@@ -4202,6 +4584,7 @@ class Program_weight_tensor_parameter_381:
 
 class Program_weight_tensor_parameter_382:
     name = "parameter_382"
+    original_name = "batch_norm2d_50.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-4.35227")
@@ -4213,6 +4596,7 @@ class Program_weight_tensor_parameter_382:
 
 class Program_weight_tensor_parameter_383:
     name = "parameter_383"
+    original_name = "conv2d_52.w_0"
     shape = [256, 192, 1, 1]
     dtype = "float32"
     min_val = float("-0.616354")
@@ -4224,6 +4608,7 @@ class Program_weight_tensor_parameter_383:
 
 class Program_weight_tensor_parameter_384:
     name = "parameter_384"
+    original_name = "batch_norm2d_49.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.47184")
@@ -4235,6 +4620,7 @@ class Program_weight_tensor_parameter_384:
 
 class Program_weight_tensor_parameter_385:
     name = "parameter_385"
+    original_name = "batch_norm2d_49.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.0695279")
@@ -4246,6 +4632,7 @@ class Program_weight_tensor_parameter_385:
 
 class Program_weight_tensor_parameter_386:
     name = "parameter_386"
+    original_name = "batch_norm2d_49.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("2.19882")
@@ -4257,6 +4644,7 @@ class Program_weight_tensor_parameter_386:
 
 class Program_weight_tensor_parameter_387:
     name = "parameter_387"
+    original_name = "batch_norm2d_49.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-4.14942")
@@ -4268,6 +4656,7 @@ class Program_weight_tensor_parameter_387:
 
 class Program_weight_tensor_parameter_388:
     name = "parameter_388"
+    original_name = "conv2d_51.w_0"
     shape = [128, 192, 1, 1]
     dtype = "float32"
     min_val = float("-0.318064")
@@ -4279,6 +4668,7 @@ class Program_weight_tensor_parameter_388:
 
 class Program_weight_tensor_parameter_389:
     name = "parameter_389"
+    original_name = "batch_norm2d_48.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-2.17276")
@@ -4290,6 +4680,7 @@ class Program_weight_tensor_parameter_389:
 
 class Program_weight_tensor_parameter_390:
     name = "parameter_390"
+    original_name = "batch_norm2d_48.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.438293")
@@ -4301,6 +4692,7 @@ class Program_weight_tensor_parameter_390:
 
 class Program_weight_tensor_parameter_391:
     name = "parameter_391"
+    original_name = "batch_norm2d_48.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("2.16826")
@@ -4312,6 +4704,7 @@ class Program_weight_tensor_parameter_391:
 
 class Program_weight_tensor_parameter_392:
     name = "parameter_392"
+    original_name = "batch_norm2d_48.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-3.44073")
@@ -4323,6 +4716,7 @@ class Program_weight_tensor_parameter_392:
 
 class Program_weight_tensor_parameter_393:
     name = "parameter_393"
+    original_name = "conv2d_50.w_0"
     shape = [128, 192, 1, 1]
     dtype = "float32"
     min_val = float("-0.364896")
@@ -4334,6 +4728,7 @@ class Program_weight_tensor_parameter_393:
 
 class Program_weight_tensor_parameter_394:
     name = "parameter_394"
+    original_name = "batch_norm2d_47.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.663117")
@@ -4345,6 +4740,7 @@ class Program_weight_tensor_parameter_394:
 
 class Program_weight_tensor_parameter_395:
     name = "parameter_395"
+    original_name = "batch_norm2d_47.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.487621")
@@ -4356,6 +4752,7 @@ class Program_weight_tensor_parameter_395:
 
 class Program_weight_tensor_parameter_396:
     name = "parameter_396"
+    original_name = "batch_norm2d_47.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("0.00829716")
@@ -4367,6 +4764,7 @@ class Program_weight_tensor_parameter_396:
 
 class Program_weight_tensor_parameter_397:
     name = "parameter_397"
+    original_name = "batch_norm2d_47.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.310079")
@@ -4378,6 +4776,7 @@ class Program_weight_tensor_parameter_397:
 
 class Program_weight_tensor_parameter_398:
     name = "parameter_398"
+    original_name = "conv2d_49.w_0"
     shape = [192, 384, 1, 1]
     dtype = "float32"
     min_val = float("-0.436763")
@@ -4389,6 +4788,7 @@ class Program_weight_tensor_parameter_398:
 
 class Program_weight_tensor_parameter_399:
     name = "parameter_399"
+    original_name = "conv2d_48.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-2.09795")
@@ -4400,6 +4800,7 @@ class Program_weight_tensor_parameter_399:
 
 class Program_weight_tensor_parameter_400:
     name = "parameter_400"
+    original_name = "conv2d_48.w_0"
     shape = [384, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.504067")
@@ -4411,6 +4812,7 @@ class Program_weight_tensor_parameter_400:
 
 class Program_weight_tensor_parameter_401:
     name = "parameter_401"
+    original_name = "batch_norm2d_46.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-3.71581")
@@ -4422,6 +4824,7 @@ class Program_weight_tensor_parameter_401:
 
 class Program_weight_tensor_parameter_402:
     name = "parameter_402"
+    original_name = "batch_norm2d_46.w_0"
     shape = [384]
     dtype = "float32"
     min_val = float("0.459213")
@@ -4433,6 +4836,7 @@ class Program_weight_tensor_parameter_402:
 
 class Program_weight_tensor_parameter_403:
     name = "parameter_403"
+    original_name = "batch_norm2d_46.w_2"
     shape = [384]
     dtype = "float32"
     min_val = float("2.24748")
@@ -4444,6 +4848,7 @@ class Program_weight_tensor_parameter_403:
 
 class Program_weight_tensor_parameter_404:
     name = "parameter_404"
+    original_name = "batch_norm2d_46.w_1"
     shape = [384]
     dtype = "float32"
     min_val = float("-2.73513")
@@ -4455,6 +4860,7 @@ class Program_weight_tensor_parameter_404:
 
 class Program_weight_tensor_parameter_405:
     name = "parameter_405"
+    original_name = "conv2d_47.w_0"
     shape = [384, 192, 1, 1]
     dtype = "float32"
     min_val = float("-0.576944")
@@ -4466,6 +4872,7 @@ class Program_weight_tensor_parameter_405:
 
 class Program_weight_tensor_parameter_406:
     name = "parameter_406"
+    original_name = "batch_norm2d_41.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-3.43905")
@@ -4477,6 +4884,7 @@ class Program_weight_tensor_parameter_406:
 
 class Program_weight_tensor_parameter_407:
     name = "parameter_407"
+    original_name = "batch_norm2d_41.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-2.64728")
@@ -4488,6 +4896,7 @@ class Program_weight_tensor_parameter_407:
 
 class Program_weight_tensor_parameter_408:
     name = "parameter_408"
+    original_name = "batch_norm2d_41.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("0.0869177")
@@ -4499,6 +4908,7 @@ class Program_weight_tensor_parameter_408:
 
 class Program_weight_tensor_parameter_409:
     name = "parameter_409"
+    original_name = "batch_norm2d_41.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.972837")
@@ -4510,6 +4920,7 @@ class Program_weight_tensor_parameter_409:
 
 class Program_weight_tensor_parameter_410:
     name = "parameter_410"
+    original_name = "conv2d_42.w_0"
     shape = [192, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.382585")
@@ -4521,6 +4932,7 @@ class Program_weight_tensor_parameter_410:
 
 class Program_weight_tensor_parameter_411:
     name = "parameter_411"
+    original_name = "batch_norm2d_43.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-2.26468")
@@ -4532,6 +4944,7 @@ class Program_weight_tensor_parameter_411:
 
 class Program_weight_tensor_parameter_412:
     name = "parameter_412"
+    original_name = "batch_norm2d_43.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.25312")
@@ -4543,6 +4956,7 @@ class Program_weight_tensor_parameter_412:
 
 class Program_weight_tensor_parameter_413:
     name = "parameter_413"
+    original_name = "batch_norm2d_43.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.00333989")
@@ -4554,6 +4968,7 @@ class Program_weight_tensor_parameter_413:
 
 class Program_weight_tensor_parameter_414:
     name = "parameter_414"
+    original_name = "batch_norm2d_43.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.697609")
@@ -4565,6 +4980,7 @@ class Program_weight_tensor_parameter_414:
 
 class Program_weight_tensor_parameter_415:
     name = "parameter_415"
+    original_name = "conv2d_44.w_0"
     shape = [256, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.404951")
@@ -4576,6 +4992,7 @@ class Program_weight_tensor_parameter_415:
 
 class Program_weight_tensor_parameter_416:
     name = "parameter_416"
+    original_name = "batch_norm2d_42.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-2.26463")
@@ -4587,6 +5004,7 @@ class Program_weight_tensor_parameter_416:
 
 class Program_weight_tensor_parameter_417:
     name = "parameter_417"
+    original_name = "batch_norm2d_42.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.11569")
@@ -4598,6 +5016,7 @@ class Program_weight_tensor_parameter_417:
 
 class Program_weight_tensor_parameter_418:
     name = "parameter_418"
+    original_name = "batch_norm2d_42.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.00330448")
@@ -4609,6 +5028,7 @@ class Program_weight_tensor_parameter_418:
 
 class Program_weight_tensor_parameter_419:
     name = "parameter_419"
+    original_name = "batch_norm2d_42.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.905779")
@@ -4620,6 +5040,7 @@ class Program_weight_tensor_parameter_419:
 
 class Program_weight_tensor_parameter_420:
     name = "parameter_420"
+    original_name = "conv2d_43.w_0"
     shape = [256, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.442807")
@@ -4631,6 +5052,7 @@ class Program_weight_tensor_parameter_420:
 
 class Program_weight_tensor_parameter_421:
     name = "parameter_421"
+    original_name = "batch_norm2d_45.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-8.52949")
@@ -4642,6 +5064,7 @@ class Program_weight_tensor_parameter_421:
 
 class Program_weight_tensor_parameter_422:
     name = "parameter_422"
+    original_name = "batch_norm2d_45.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("0.377577")
@@ -4653,6 +5076,7 @@ class Program_weight_tensor_parameter_422:
 
 class Program_weight_tensor_parameter_423:
     name = "parameter_423"
+    original_name = "batch_norm2d_45.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("0.0562495")
@@ -4664,6 +5088,7 @@ class Program_weight_tensor_parameter_423:
 
 class Program_weight_tensor_parameter_424:
     name = "parameter_424"
+    original_name = "batch_norm2d_45.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.656445")
@@ -4675,6 +5100,7 @@ class Program_weight_tensor_parameter_424:
 
 class Program_weight_tensor_parameter_425:
     name = "parameter_425"
+    original_name = "conv2d_46.w_0"
     shape = [192, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.499566")
@@ -4686,6 +5112,7 @@ class Program_weight_tensor_parameter_425:
 
 class Program_weight_tensor_parameter_426:
     name = "parameter_426"
+    original_name = "batch_norm2d_44.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-3.47595")
@@ -4697,6 +5124,7 @@ class Program_weight_tensor_parameter_426:
 
 class Program_weight_tensor_parameter_427:
     name = "parameter_427"
+    original_name = "batch_norm2d_44.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("0.460851")
@@ -4708,6 +5136,7 @@ class Program_weight_tensor_parameter_427:
 
 class Program_weight_tensor_parameter_428:
     name = "parameter_428"
+    original_name = "batch_norm2d_44.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("0.000402557")
@@ -4719,6 +5148,7 @@ class Program_weight_tensor_parameter_428:
 
 class Program_weight_tensor_parameter_429:
     name = "parameter_429"
+    original_name = "batch_norm2d_44.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-2.19771")
@@ -4730,6 +5160,7 @@ class Program_weight_tensor_parameter_429:
 
 class Program_weight_tensor_parameter_430:
     name = "parameter_430"
+    original_name = "conv2d_45.w_0"
     shape = [512, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.449932")
@@ -4741,6 +5172,7 @@ class Program_weight_tensor_parameter_430:
 
 class Program_weight_tensor_parameter_431:
     name = "parameter_431"
+    original_name = "batch_norm2d_40.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-2.51423")
@@ -4752,6 +5184,7 @@ class Program_weight_tensor_parameter_431:
 
 class Program_weight_tensor_parameter_432:
     name = "parameter_432"
+    original_name = "batch_norm2d_40.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.0990217")
@@ -4763,6 +5196,7 @@ class Program_weight_tensor_parameter_432:
 
 class Program_weight_tensor_parameter_433:
     name = "parameter_433"
+    original_name = "batch_norm2d_40.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("1.7827")
@@ -4774,6 +5208,7 @@ class Program_weight_tensor_parameter_433:
 
 class Program_weight_tensor_parameter_434:
     name = "parameter_434"
+    original_name = "batch_norm2d_40.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-4.48331")
@@ -4785,6 +5220,7 @@ class Program_weight_tensor_parameter_434:
 
 class Program_weight_tensor_parameter_435:
     name = "parameter_435"
+    original_name = "conv2d_41.w_0"
     shape = [256, 192, 1, 1]
     dtype = "float32"
     min_val = float("-0.564274")
@@ -4796,6 +5232,7 @@ class Program_weight_tensor_parameter_435:
 
 class Program_weight_tensor_parameter_436:
     name = "parameter_436"
+    original_name = "batch_norm2d_39.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.24236")
@@ -4807,6 +5244,7 @@ class Program_weight_tensor_parameter_436:
 
 class Program_weight_tensor_parameter_437:
     name = "parameter_437"
+    original_name = "batch_norm2d_39.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.398663")
@@ -4818,6 +5256,7 @@ class Program_weight_tensor_parameter_437:
 
 class Program_weight_tensor_parameter_438:
     name = "parameter_438"
+    original_name = "batch_norm2d_39.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("1.99626")
@@ -4829,6 +5268,7 @@ class Program_weight_tensor_parameter_438:
 
 class Program_weight_tensor_parameter_439:
     name = "parameter_439"
+    original_name = "batch_norm2d_39.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-5.12003")
@@ -4840,6 +5280,7 @@ class Program_weight_tensor_parameter_439:
 
 class Program_weight_tensor_parameter_440:
     name = "parameter_440"
+    original_name = "conv2d_40.w_0"
     shape = [128, 192, 1, 1]
     dtype = "float32"
     min_val = float("-0.426841")
@@ -4851,6 +5292,7 @@ class Program_weight_tensor_parameter_440:
 
 class Program_weight_tensor_parameter_441:
     name = "parameter_441"
+    original_name = "batch_norm2d_38.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-2.43076")
@@ -4862,6 +5304,7 @@ class Program_weight_tensor_parameter_441:
 
 class Program_weight_tensor_parameter_442:
     name = "parameter_442"
+    original_name = "batch_norm2d_38.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.420167")
@@ -4873,6 +5316,7 @@ class Program_weight_tensor_parameter_442:
 
 class Program_weight_tensor_parameter_443:
     name = "parameter_443"
+    original_name = "batch_norm2d_38.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("2.09208")
@@ -4884,6 +5328,7 @@ class Program_weight_tensor_parameter_443:
 
 class Program_weight_tensor_parameter_444:
     name = "parameter_444"
+    original_name = "batch_norm2d_38.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-3.48908")
@@ -4895,6 +5340,7 @@ class Program_weight_tensor_parameter_444:
 
 class Program_weight_tensor_parameter_445:
     name = "parameter_445"
+    original_name = "conv2d_39.w_0"
     shape = [128, 192, 1, 1]
     dtype = "float32"
     min_val = float("-0.447854")
@@ -4906,6 +5352,7 @@ class Program_weight_tensor_parameter_445:
 
 class Program_weight_tensor_parameter_446:
     name = "parameter_446"
+    original_name = "batch_norm2d_37.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.00253299")
@@ -4917,6 +5364,7 @@ class Program_weight_tensor_parameter_446:
 
 class Program_weight_tensor_parameter_447:
     name = "parameter_447"
+    original_name = "batch_norm2d_37.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.404273")
@@ -4928,6 +5376,7 @@ class Program_weight_tensor_parameter_447:
 
 class Program_weight_tensor_parameter_448:
     name = "parameter_448"
+    original_name = "batch_norm2d_37.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("0.0184272")
@@ -4939,6 +5388,7 @@ class Program_weight_tensor_parameter_448:
 
 class Program_weight_tensor_parameter_449:
     name = "parameter_449"
+    original_name = "batch_norm2d_37.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.539406")
@@ -4950,6 +5400,7 @@ class Program_weight_tensor_parameter_449:
 
 class Program_weight_tensor_parameter_450:
     name = "parameter_450"
+    original_name = "conv2d_38.w_0"
     shape = [192, 384, 1, 1]
     dtype = "float32"
     min_val = float("-0.508454")
@@ -4961,6 +5412,7 @@ class Program_weight_tensor_parameter_450:
 
 class Program_weight_tensor_parameter_451:
     name = "parameter_451"
+    original_name = "conv2d_37.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-2.01899")
@@ -4972,6 +5424,7 @@ class Program_weight_tensor_parameter_451:
 
 class Program_weight_tensor_parameter_452:
     name = "parameter_452"
+    original_name = "conv2d_37.w_0"
     shape = [384, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.54935")
@@ -4983,6 +5436,7 @@ class Program_weight_tensor_parameter_452:
 
 class Program_weight_tensor_parameter_453:
     name = "parameter_453"
+    original_name = "batch_norm2d_36.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-4.60106")
@@ -4994,6 +5448,7 @@ class Program_weight_tensor_parameter_453:
 
 class Program_weight_tensor_parameter_454:
     name = "parameter_454"
+    original_name = "batch_norm2d_36.w_0"
     shape = [384]
     dtype = "float32"
     min_val = float("0.748219")
@@ -5005,6 +5460,7 @@ class Program_weight_tensor_parameter_454:
 
 class Program_weight_tensor_parameter_455:
     name = "parameter_455"
+    original_name = "batch_norm2d_36.w_2"
     shape = [384]
     dtype = "float32"
     min_val = float("2.08044")
@@ -5016,6 +5472,7 @@ class Program_weight_tensor_parameter_455:
 
 class Program_weight_tensor_parameter_456:
     name = "parameter_456"
+    original_name = "batch_norm2d_36.w_1"
     shape = [384]
     dtype = "float32"
     min_val = float("-4.26485")
@@ -5027,6 +5484,7 @@ class Program_weight_tensor_parameter_456:
 
 class Program_weight_tensor_parameter_457:
     name = "parameter_457"
+    original_name = "conv2d_36.w_0"
     shape = [384, 192, 1, 1]
     dtype = "float32"
     min_val = float("-0.921806")
@@ -5038,6 +5496,7 @@ class Program_weight_tensor_parameter_457:
 
 class Program_weight_tensor_parameter_458:
     name = "parameter_458"
+    original_name = "batch_norm2d_31.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-5.39403")
@@ -5049,6 +5508,7 @@ class Program_weight_tensor_parameter_458:
 
 class Program_weight_tensor_parameter_459:
     name = "parameter_459"
+    original_name = "batch_norm2d_31.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-3.7886")
@@ -5060,6 +5520,7 @@ class Program_weight_tensor_parameter_459:
 
 class Program_weight_tensor_parameter_460:
     name = "parameter_460"
+    original_name = "batch_norm2d_31.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("0.131239")
@@ -5071,6 +5532,7 @@ class Program_weight_tensor_parameter_460:
 
 class Program_weight_tensor_parameter_461:
     name = "parameter_461"
+    original_name = "batch_norm2d_31.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-2.44442")
@@ -5082,6 +5544,7 @@ class Program_weight_tensor_parameter_461:
 
 class Program_weight_tensor_parameter_462:
     name = "parameter_462"
+    original_name = "conv2d_31.w_0"
     shape = [192, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.715353")
@@ -5093,6 +5556,7 @@ class Program_weight_tensor_parameter_462:
 
 class Program_weight_tensor_parameter_463:
     name = "parameter_463"
+    original_name = "batch_norm2d_33.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-6.577")
@@ -5104,6 +5568,7 @@ class Program_weight_tensor_parameter_463:
 
 class Program_weight_tensor_parameter_464:
     name = "parameter_464"
+    original_name = "batch_norm2d_33.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.86917")
@@ -5115,6 +5580,7 @@ class Program_weight_tensor_parameter_464:
 
 class Program_weight_tensor_parameter_465:
     name = "parameter_465"
+    original_name = "batch_norm2d_33.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.0341843")
@@ -5126,6 +5592,7 @@ class Program_weight_tensor_parameter_465:
 
 class Program_weight_tensor_parameter_466:
     name = "parameter_466"
+    original_name = "batch_norm2d_33.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-2.18445")
@@ -5137,6 +5604,7 @@ class Program_weight_tensor_parameter_466:
 
 class Program_weight_tensor_parameter_467:
     name = "parameter_467"
+    original_name = "conv2d_33.w_0"
     shape = [256, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.465419")
@@ -5148,6 +5616,7 @@ class Program_weight_tensor_parameter_467:
 
 class Program_weight_tensor_parameter_468:
     name = "parameter_468"
+    original_name = "batch_norm2d_32.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-6.57694")
@@ -5159,6 +5628,7 @@ class Program_weight_tensor_parameter_468:
 
 class Program_weight_tensor_parameter_469:
     name = "parameter_469"
+    original_name = "batch_norm2d_32.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-2.63397")
@@ -5170,6 +5640,7 @@ class Program_weight_tensor_parameter_469:
 
 class Program_weight_tensor_parameter_470:
     name = "parameter_470"
+    original_name = "batch_norm2d_32.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.0341275")
@@ -5181,6 +5652,7 @@ class Program_weight_tensor_parameter_470:
 
 class Program_weight_tensor_parameter_471:
     name = "parameter_471"
+    original_name = "batch_norm2d_32.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.76635")
@@ -5192,6 +5664,7 @@ class Program_weight_tensor_parameter_471:
 
 class Program_weight_tensor_parameter_472:
     name = "parameter_472"
+    original_name = "conv2d_32.w_0"
     shape = [256, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.563237")
@@ -5203,6 +5676,7 @@ class Program_weight_tensor_parameter_472:
 
 class Program_weight_tensor_parameter_473:
     name = "parameter_473"
+    original_name = "batch_norm2d_35.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-11.7521")
@@ -5214,6 +5688,7 @@ class Program_weight_tensor_parameter_473:
 
 class Program_weight_tensor_parameter_474:
     name = "parameter_474"
+    original_name = "batch_norm2d_35.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("0.754008")
@@ -5225,6 +5700,7 @@ class Program_weight_tensor_parameter_474:
 
 class Program_weight_tensor_parameter_475:
     name = "parameter_475"
+    original_name = "batch_norm2d_35.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("0.194266")
@@ -5236,6 +5712,7 @@ class Program_weight_tensor_parameter_475:
 
 class Program_weight_tensor_parameter_476:
     name = "parameter_476"
+    original_name = "batch_norm2d_35.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-1.74006")
@@ -5247,6 +5724,7 @@ class Program_weight_tensor_parameter_476:
 
 class Program_weight_tensor_parameter_477:
     name = "parameter_477"
+    original_name = "conv2d_35.w_0"
     shape = [192, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.985883")
@@ -5258,6 +5736,7 @@ class Program_weight_tensor_parameter_477:
 
 class Program_weight_tensor_parameter_478:
     name = "parameter_478"
+    original_name = "batch_norm2d_34.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-6.28297")
@@ -5269,6 +5748,7 @@ class Program_weight_tensor_parameter_478:
 
 class Program_weight_tensor_parameter_479:
     name = "parameter_479"
+    original_name = "batch_norm2d_34.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("0.541938")
@@ -5280,6 +5760,7 @@ class Program_weight_tensor_parameter_479:
 
 class Program_weight_tensor_parameter_480:
     name = "parameter_480"
+    original_name = "batch_norm2d_34.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("0.00936178")
@@ -5291,6 +5772,7 @@ class Program_weight_tensor_parameter_480:
 
 class Program_weight_tensor_parameter_481:
     name = "parameter_481"
+    original_name = "batch_norm2d_34.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-5.47904")
@@ -5302,6 +5784,7 @@ class Program_weight_tensor_parameter_481:
 
 class Program_weight_tensor_parameter_482:
     name = "parameter_482"
+    original_name = "conv2d_34.w_0"
     shape = [512, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.487843")
@@ -5313,6 +5796,7 @@ class Program_weight_tensor_parameter_482:
 
 class Program_weight_tensor_parameter_483:
     name = "parameter_483"
+    original_name = "batch_norm2d_30.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-3.54703")
@@ -5324,6 +5808,7 @@ class Program_weight_tensor_parameter_483:
 
 class Program_weight_tensor_parameter_484:
     name = "parameter_484"
+    original_name = "batch_norm2d_30.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.34017")
@@ -5335,6 +5820,7 @@ class Program_weight_tensor_parameter_484:
 
 class Program_weight_tensor_parameter_485:
     name = "parameter_485"
+    original_name = "batch_norm2d_30.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("2.00998")
@@ -5346,6 +5832,7 @@ class Program_weight_tensor_parameter_485:
 
 class Program_weight_tensor_parameter_486:
     name = "parameter_486"
+    original_name = "batch_norm2d_30.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.00825529")
@@ -5357,6 +5844,7 @@ class Program_weight_tensor_parameter_486:
 
 class Program_weight_tensor_parameter_487:
     name = "parameter_487"
+    original_name = "conv2d_30.w_0"
     shape = [256, 192, 1, 1]
     dtype = "float32"
     min_val = float("-1.98372")
@@ -5368,6 +5856,7 @@ class Program_weight_tensor_parameter_487:
 
 class Program_weight_tensor_parameter_488:
     name = "parameter_488"
+    original_name = "batch_norm2d_29.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.935519")
@@ -5379,6 +5868,7 @@ class Program_weight_tensor_parameter_488:
 
 class Program_weight_tensor_parameter_489:
     name = "parameter_489"
+    original_name = "batch_norm2d_29.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.253949")
@@ -5390,6 +5880,7 @@ class Program_weight_tensor_parameter_489:
 
 class Program_weight_tensor_parameter_490:
     name = "parameter_490"
+    original_name = "batch_norm2d_29.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("1.60619")
@@ -5401,6 +5892,7 @@ class Program_weight_tensor_parameter_490:
 
 class Program_weight_tensor_parameter_491:
     name = "parameter_491"
+    original_name = "batch_norm2d_29.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.00525885")
@@ -5412,6 +5904,7 @@ class Program_weight_tensor_parameter_491:
 
 class Program_weight_tensor_parameter_492:
     name = "parameter_492"
+    original_name = "conv2d_29.w_0"
     shape = [128, 192, 1, 1]
     dtype = "float32"
     min_val = float("-0.564718")
@@ -5423,6 +5916,7 @@ class Program_weight_tensor_parameter_492:
 
 class Program_weight_tensor_parameter_493:
     name = "parameter_493"
+    original_name = "batch_norm2d_28.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-2.22974")
@@ -5434,6 +5928,7 @@ class Program_weight_tensor_parameter_493:
 
 class Program_weight_tensor_parameter_494:
     name = "parameter_494"
+    original_name = "batch_norm2d_28.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.256914")
@@ -5445,6 +5940,7 @@ class Program_weight_tensor_parameter_494:
 
 class Program_weight_tensor_parameter_495:
     name = "parameter_495"
+    original_name = "batch_norm2d_28.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.772038")
@@ -5456,6 +5952,7 @@ class Program_weight_tensor_parameter_495:
 
 class Program_weight_tensor_parameter_496:
     name = "parameter_496"
+    original_name = "batch_norm2d_28.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.00444755")
@@ -5467,6 +5964,7 @@ class Program_weight_tensor_parameter_496:
 
 class Program_weight_tensor_parameter_497:
     name = "parameter_497"
+    original_name = "conv2d_28.w_0"
     shape = [128, 192, 1, 1]
     dtype = "float32"
     min_val = float("-0.662259")
@@ -5478,6 +5976,7 @@ class Program_weight_tensor_parameter_497:
 
 class Program_weight_tensor_parameter_498:
     name = "parameter_498"
+    original_name = "batch_norm2d_21.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.0043859")
@@ -5489,6 +5988,7 @@ class Program_weight_tensor_parameter_498:
 
 class Program_weight_tensor_parameter_499:
     name = "parameter_499"
+    original_name = "batch_norm2d_21.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.37116")
@@ -5500,6 +6000,7 @@ class Program_weight_tensor_parameter_499:
 
 class Program_weight_tensor_parameter_500:
     name = "parameter_500"
+    original_name = "batch_norm2d_21.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("0.086575")
@@ -5511,6 +6012,7 @@ class Program_weight_tensor_parameter_500:
 
 class Program_weight_tensor_parameter_501:
     name = "parameter_501"
+    original_name = "batch_norm2d_21.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-2.18895")
@@ -5522,6 +6024,7 @@ class Program_weight_tensor_parameter_501:
 
 class Program_weight_tensor_parameter_502:
     name = "parameter_502"
+    original_name = "conv2d_21.w_0"
     shape = [192, 768, 1, 1]
     dtype = "float32"
     min_val = float("-0.493762")
@@ -5533,6 +6036,7 @@ class Program_weight_tensor_parameter_502:
 
 class Program_weight_tensor_parameter_503:
     name = "parameter_503"
+    original_name = "batch_norm2d_20.b_0"
     shape = [768]
     dtype = "float32"
     min_val = float("-4.70052")
@@ -5544,6 +6048,7 @@ class Program_weight_tensor_parameter_503:
 
 class Program_weight_tensor_parameter_504:
     name = "parameter_504"
+    original_name = "batch_norm2d_20.w_0"
     shape = [768]
     dtype = "float32"
     min_val = float("0.27206")
@@ -5555,6 +6060,7 @@ class Program_weight_tensor_parameter_504:
 
 class Program_weight_tensor_parameter_505:
     name = "parameter_505"
+    original_name = "batch_norm2d_20.w_2"
     shape = [768]
     dtype = "float32"
     min_val = float("5.60519e-45")
@@ -5566,6 +6072,7 @@ class Program_weight_tensor_parameter_505:
 
 class Program_weight_tensor_parameter_506:
     name = "parameter_506"
+    original_name = "batch_norm2d_20.w_1"
     shape = [768]
     dtype = "float32"
     min_val = float("-4.70767")
@@ -5577,6 +6084,7 @@ class Program_weight_tensor_parameter_506:
 
 class Program_weight_tensor_parameter_507:
     name = "parameter_507"
+    original_name = "conv2d_20.w_0"
     shape = [768, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.525494")
@@ -5588,6 +6096,7 @@ class Program_weight_tensor_parameter_507:
 
 class Program_weight_tensor_parameter_508:
     name = "parameter_508"
+    original_name = "batch_norm2d_19.b_0"
     shape = [768]
     dtype = "float32"
     min_val = float("-3.39529")
@@ -5599,6 +6108,7 @@ class Program_weight_tensor_parameter_508:
 
 class Program_weight_tensor_parameter_509:
     name = "parameter_509"
+    original_name = "batch_norm2d_19.w_0"
     shape = [768]
     dtype = "float32"
     min_val = float("0.0436978")
@@ -5610,6 +6120,7 @@ class Program_weight_tensor_parameter_509:
 
 class Program_weight_tensor_parameter_510:
     name = "parameter_510"
+    original_name = "batch_norm2d_19.w_2"
     shape = [768]
     dtype = "float32"
     min_val = float("5.60519e-45")
@@ -5621,6 +6132,7 @@ class Program_weight_tensor_parameter_510:
 
 class Program_weight_tensor_parameter_511:
     name = "parameter_511"
+    original_name = "batch_norm2d_19.w_1"
     shape = [768]
     dtype = "float32"
     min_val = float("-0.00264695")
@@ -5632,6 +6144,7 @@ class Program_weight_tensor_parameter_511:
 
 class Program_weight_tensor_parameter_512:
     name = "parameter_512"
+    original_name = "conv2d_19.w_0"
     shape = [768, 192, 1, 1]
     dtype = "float32"
     min_val = float("-0.593507")
@@ -5643,6 +6156,7 @@ class Program_weight_tensor_parameter_512:
 
 class Program_weight_tensor_parameter_513:
     name = "parameter_513"
+    original_name = "batch_norm2d_18.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.00353233")
@@ -5654,6 +6168,7 @@ class Program_weight_tensor_parameter_513:
 
 class Program_weight_tensor_parameter_514:
     name = "parameter_514"
+    original_name = "batch_norm2d_18.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("0.555361")
@@ -5665,6 +6180,7 @@ class Program_weight_tensor_parameter_514:
 
 class Program_weight_tensor_parameter_515:
     name = "parameter_515"
+    original_name = "batch_norm2d_18.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("2.08919")
@@ -5676,6 +6192,7 @@ class Program_weight_tensor_parameter_515:
 
 class Program_weight_tensor_parameter_516:
     name = "parameter_516"
+    original_name = "batch_norm2d_18.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-13.4359")
@@ -5687,6 +6204,7 @@ class Program_weight_tensor_parameter_516:
 
 class Program_weight_tensor_parameter_517:
     name = "parameter_517"
+    original_name = "conv2d_18.w_0"
     shape = [192, 512, 1, 1]
     dtype = "float32"
     min_val = float("-1.01869")
@@ -5698,6 +6216,7 @@ class Program_weight_tensor_parameter_517:
 
 class Program_weight_tensor_parameter_518:
     name = "parameter_518"
+    original_name = "batch_norm2d_17.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-4.36406")
@@ -5709,6 +6228,7 @@ class Program_weight_tensor_parameter_518:
 
 class Program_weight_tensor_parameter_519:
     name = "parameter_519"
+    original_name = "batch_norm2d_17.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("0.805398")
@@ -5720,6 +6240,7 @@ class Program_weight_tensor_parameter_519:
 
 class Program_weight_tensor_parameter_520:
     name = "parameter_520"
+    original_name = "batch_norm2d_17.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("5.60519e-45")
@@ -5731,6 +6252,7 @@ class Program_weight_tensor_parameter_520:
 
 class Program_weight_tensor_parameter_521:
     name = "parameter_521"
+    original_name = "batch_norm2d_17.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-2.13296")
@@ -5742,6 +6264,7 @@ class Program_weight_tensor_parameter_521:
 
 class Program_weight_tensor_parameter_522:
     name = "parameter_522"
+    original_name = "conv2d_17.w_0"
     shape = [512, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.32893")
@@ -5753,6 +6276,7 @@ class Program_weight_tensor_parameter_522:
 
 class Program_weight_tensor_parameter_523:
     name = "parameter_523"
+    original_name = "batch_norm2d_16.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-3.9817")
@@ -5764,6 +6288,7 @@ class Program_weight_tensor_parameter_523:
 
 class Program_weight_tensor_parameter_524:
     name = "parameter_524"
+    original_name = "batch_norm2d_16.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.155299")
@@ -5775,6 +6300,7 @@ class Program_weight_tensor_parameter_524:
 
 class Program_weight_tensor_parameter_525:
     name = "parameter_525"
+    original_name = "batch_norm2d_16.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("5.60519e-45")
@@ -5786,6 +6312,7 @@ class Program_weight_tensor_parameter_525:
 
 class Program_weight_tensor_parameter_526:
     name = "parameter_526"
+    original_name = "batch_norm2d_16.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.00635743")
@@ -5797,6 +6324,7 @@ class Program_weight_tensor_parameter_526:
 
 class Program_weight_tensor_parameter_527:
     name = "parameter_527"
+    original_name = "conv2d_16.w_0"
     shape = [512, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.894996")
@@ -5808,6 +6336,7 @@ class Program_weight_tensor_parameter_527:
 
 class Program_weight_tensor_parameter_528:
     name = "parameter_528"
+    original_name = "batch_norm2d_15.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.00174703")
@@ -5819,6 +6348,7 @@ class Program_weight_tensor_parameter_528:
 
 class Program_weight_tensor_parameter_529:
     name = "parameter_529"
+    original_name = "batch_norm2d_15.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.397975")
@@ -5830,6 +6360,7 @@ class Program_weight_tensor_parameter_529:
 
 class Program_weight_tensor_parameter_530:
     name = "parameter_530"
+    original_name = "batch_norm2d_15.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.462301")
@@ -5841,6 +6372,7 @@ class Program_weight_tensor_parameter_530:
 
 class Program_weight_tensor_parameter_531:
     name = "parameter_531"
+    original_name = "batch_norm2d_15.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-3.2773")
@@ -5852,6 +6384,7 @@ class Program_weight_tensor_parameter_531:
 
 class Program_weight_tensor_parameter_532:
     name = "parameter_532"
+    original_name = "conv2d_15.w_0"
     shape = [128, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.538039")
@@ -5863,6 +6396,7 @@ class Program_weight_tensor_parameter_532:
 
 class Program_weight_tensor_parameter_533:
     name = "parameter_533"
+    original_name = "batch_norm2d_14.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-8.95949")
@@ -5874,6 +6408,7 @@ class Program_weight_tensor_parameter_533:
 
 class Program_weight_tensor_parameter_534:
     name = "parameter_534"
+    original_name = "batch_norm2d_14.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("0.450742")
@@ -5885,6 +6420,7 @@ class Program_weight_tensor_parameter_534:
 
 class Program_weight_tensor_parameter_535:
     name = "parameter_535"
+    original_name = "batch_norm2d_14.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("5.60519e-45")
@@ -5896,6 +6432,7 @@ class Program_weight_tensor_parameter_535:
 
 class Program_weight_tensor_parameter_536:
     name = "parameter_536"
+    original_name = "batch_norm2d_14.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-8.27243")
@@ -5907,6 +6444,7 @@ class Program_weight_tensor_parameter_536:
 
 class Program_weight_tensor_parameter_537:
     name = "parameter_537"
+    original_name = "conv2d_14.w_0"
     shape = [512, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.860364")
@@ -5918,6 +6456,7 @@ class Program_weight_tensor_parameter_537:
 
 class Program_weight_tensor_parameter_538:
     name = "parameter_538"
+    original_name = "batch_norm2d_13.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-2.98845")
@@ -5929,6 +6468,7 @@ class Program_weight_tensor_parameter_538:
 
 class Program_weight_tensor_parameter_539:
     name = "parameter_539"
+    original_name = "batch_norm2d_13.w_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.0989321")
@@ -5940,6 +6480,7 @@ class Program_weight_tensor_parameter_539:
 
 class Program_weight_tensor_parameter_540:
     name = "parameter_540"
+    original_name = "batch_norm2d_13.w_2"
     shape = [512]
     dtype = "float32"
     min_val = float("5.60519e-45")
@@ -5951,6 +6492,7 @@ class Program_weight_tensor_parameter_540:
 
 class Program_weight_tensor_parameter_541:
     name = "parameter_541"
+    original_name = "batch_norm2d_13.w_1"
     shape = [512]
     dtype = "float32"
     min_val = float("-0.00247494")
@@ -5962,6 +6504,7 @@ class Program_weight_tensor_parameter_541:
 
 class Program_weight_tensor_parameter_542:
     name = "parameter_542"
+    original_name = "conv2d_13.w_0"
     shape = [512, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.472944")
@@ -5973,6 +6516,7 @@ class Program_weight_tensor_parameter_542:
 
 class Program_weight_tensor_parameter_543:
     name = "parameter_543"
+    original_name = "batch_norm2d_12.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.00239798")
@@ -5984,6 +6528,7 @@ class Program_weight_tensor_parameter_543:
 
 class Program_weight_tensor_parameter_544:
     name = "parameter_544"
+    original_name = "batch_norm2d_12.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.324123")
@@ -5995,6 +6540,7 @@ class Program_weight_tensor_parameter_544:
 
 class Program_weight_tensor_parameter_545:
     name = "parameter_545"
+    original_name = "batch_norm2d_12.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.900389")
@@ -6006,6 +6552,7 @@ class Program_weight_tensor_parameter_545:
 
 class Program_weight_tensor_parameter_546:
     name = "parameter_546"
+    original_name = "batch_norm2d_12.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-15.6566")
@@ -6017,6 +6564,7 @@ class Program_weight_tensor_parameter_546:
 
 class Program_weight_tensor_parameter_547:
     name = "parameter_547"
+    original_name = "conv2d_12.w_0"
     shape = [128, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.730066")
@@ -6028,6 +6576,7 @@ class Program_weight_tensor_parameter_547:
 
 class Program_weight_tensor_parameter_548:
     name = "parameter_548"
+    original_name = "batch_norm2d_11.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-4.09682")
@@ -6039,6 +6588,7 @@ class Program_weight_tensor_parameter_548:
 
 class Program_weight_tensor_parameter_549:
     name = "parameter_549"
+    original_name = "batch_norm2d_11.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("1.13877")
@@ -6050,6 +6600,7 @@ class Program_weight_tensor_parameter_549:
 
 class Program_weight_tensor_parameter_550:
     name = "parameter_550"
+    original_name = "batch_norm2d_11.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.0239029")
@@ -6061,6 +6612,7 @@ class Program_weight_tensor_parameter_550:
 
 class Program_weight_tensor_parameter_551:
     name = "parameter_551"
+    original_name = "batch_norm2d_11.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-6.0703")
@@ -6072,6 +6624,7 @@ class Program_weight_tensor_parameter_551:
 
 class Program_weight_tensor_parameter_552:
     name = "parameter_552"
+    original_name = "conv2d_11.w_0"
     shape = [256, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.482608")
@@ -6083,6 +6636,7 @@ class Program_weight_tensor_parameter_552:
 
 class Program_weight_tensor_parameter_553:
     name = "parameter_553"
+    original_name = "batch_norm2d_10.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-4.24843")
@@ -6094,6 +6648,7 @@ class Program_weight_tensor_parameter_553:
 
 class Program_weight_tensor_parameter_554:
     name = "parameter_554"
+    original_name = "batch_norm2d_10.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.681352")
@@ -6105,6 +6660,7 @@ class Program_weight_tensor_parameter_554:
 
 class Program_weight_tensor_parameter_555:
     name = "parameter_555"
+    original_name = "batch_norm2d_10.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("11.664")
@@ -6116,6 +6672,7 @@ class Program_weight_tensor_parameter_555:
 
 class Program_weight_tensor_parameter_556:
     name = "parameter_556"
+    original_name = "batch_norm2d_10.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.0100612")
@@ -6127,6 +6684,7 @@ class Program_weight_tensor_parameter_556:
 
 class Program_weight_tensor_parameter_557:
     name = "parameter_557"
+    original_name = "conv2d_10.w_0"
     shape = [256, 64, 1, 1]
     dtype = "float32"
     min_val = float("-1.34637")
@@ -6138,6 +6696,7 @@ class Program_weight_tensor_parameter_557:
 
 class Program_weight_tensor_parameter_558:
     name = "parameter_558"
+    original_name = "batch_norm2d_9.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -6147,6 +6706,7 @@ class Program_weight_tensor_parameter_558:
 
 class Program_weight_tensor_parameter_559:
     name = "parameter_559"
+    original_name = "batch_norm2d_9.w_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -6156,6 +6716,7 @@ class Program_weight_tensor_parameter_559:
 
 class Program_weight_tensor_parameter_560:
     name = "parameter_560"
+    original_name = "batch_norm2d_9.w_2"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -6165,6 +6726,7 @@ class Program_weight_tensor_parameter_560:
 
 class Program_weight_tensor_parameter_561:
     name = "parameter_561"
+    original_name = "batch_norm2d_9.w_1"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -6174,6 +6736,7 @@ class Program_weight_tensor_parameter_561:
 
 class Program_weight_tensor_parameter_562:
     name = "parameter_562"
+    original_name = "conv2d_9.w_0"
     shape = [64, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.589267")
@@ -6185,6 +6748,7 @@ class Program_weight_tensor_parameter_562:
 
 class Program_weight_tensor_parameter_563:
     name = "parameter_563"
+    original_name = "batch_norm2d_8.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-7.12632")
@@ -6196,6 +6760,7 @@ class Program_weight_tensor_parameter_563:
 
 class Program_weight_tensor_parameter_564:
     name = "parameter_564"
+    original_name = "batch_norm2d_8.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.808318")
@@ -6207,6 +6772,7 @@ class Program_weight_tensor_parameter_564:
 
 class Program_weight_tensor_parameter_565:
     name = "parameter_565"
+    original_name = "batch_norm2d_8.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("5.60519e-45")
@@ -6218,6 +6784,7 @@ class Program_weight_tensor_parameter_565:
 
 class Program_weight_tensor_parameter_566:
     name = "parameter_566"
+    original_name = "batch_norm2d_8.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-13.165")
@@ -6229,6 +6796,7 @@ class Program_weight_tensor_parameter_566:
 
 class Program_weight_tensor_parameter_567:
     name = "parameter_567"
+    original_name = "conv2d_8.w_0"
     shape = [256, 1, 3, 3]
     dtype = "float32"
     min_val = float("-1.05711")
@@ -6240,6 +6808,7 @@ class Program_weight_tensor_parameter_567:
 
 class Program_weight_tensor_parameter_568:
     name = "parameter_568"
+    original_name = "batch_norm2d_7.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-3.59158")
@@ -6251,6 +6820,7 @@ class Program_weight_tensor_parameter_568:
 
 class Program_weight_tensor_parameter_569:
     name = "parameter_569"
+    original_name = "batch_norm2d_7.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.022562")
@@ -6262,6 +6832,7 @@ class Program_weight_tensor_parameter_569:
 
 class Program_weight_tensor_parameter_570:
     name = "parameter_570"
+    original_name = "batch_norm2d_7.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("5.60519e-45")
@@ -6273,6 +6844,7 @@ class Program_weight_tensor_parameter_570:
 
 class Program_weight_tensor_parameter_571:
     name = "parameter_571"
+    original_name = "batch_norm2d_7.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.00675931")
@@ -6284,6 +6856,7 @@ class Program_weight_tensor_parameter_571:
 
 class Program_weight_tensor_parameter_572:
     name = "parameter_572"
+    original_name = "conv2d_7.w_0"
     shape = [256, 64, 1, 1]
     dtype = "float32"
     min_val = float("-0.826805")
@@ -6295,6 +6868,7 @@ class Program_weight_tensor_parameter_572:
 
 class Program_weight_tensor_parameter_573:
     name = "parameter_573"
+    original_name = "batch_norm2d_6.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -6304,6 +6878,7 @@ class Program_weight_tensor_parameter_573:
 
 class Program_weight_tensor_parameter_574:
     name = "parameter_574"
+    original_name = "batch_norm2d_6.w_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -6313,6 +6888,7 @@ class Program_weight_tensor_parameter_574:
 
 class Program_weight_tensor_parameter_575:
     name = "parameter_575"
+    original_name = "batch_norm2d_6.w_2"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -6322,6 +6898,7 @@ class Program_weight_tensor_parameter_575:
 
 class Program_weight_tensor_parameter_576:
     name = "parameter_576"
+    original_name = "batch_norm2d_6.w_1"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -6331,6 +6908,7 @@ class Program_weight_tensor_parameter_576:
 
 class Program_weight_tensor_parameter_577:
     name = "parameter_577"
+    original_name = "conv2d_6.w_0"
     shape = [64, 128, 1, 1]
     dtype = "float32"
     min_val = float("-1.14281")
@@ -6342,6 +6920,7 @@ class Program_weight_tensor_parameter_577:
 
 class Program_weight_tensor_parameter_578:
     name = "parameter_578"
+    original_name = "batch_norm2d_5.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.90779")
@@ -6353,6 +6932,7 @@ class Program_weight_tensor_parameter_578:
 
 class Program_weight_tensor_parameter_579:
     name = "parameter_579"
+    original_name = "batch_norm2d_5.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("1.29441")
@@ -6364,6 +6944,7 @@ class Program_weight_tensor_parameter_579:
 
 class Program_weight_tensor_parameter_580:
     name = "parameter_580"
+    original_name = "batch_norm2d_5.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.141417")
@@ -6375,6 +6956,7 @@ class Program_weight_tensor_parameter_580:
 
 class Program_weight_tensor_parameter_581:
     name = "parameter_581"
+    original_name = "batch_norm2d_5.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-6.10813")
@@ -6386,6 +6968,7 @@ class Program_weight_tensor_parameter_581:
 
 class Program_weight_tensor_parameter_582:
     name = "parameter_582"
+    original_name = "conv2d_5.w_0"
     shape = [128, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.662406")
@@ -6397,6 +6980,7 @@ class Program_weight_tensor_parameter_582:
 
 class Program_weight_tensor_parameter_583:
     name = "parameter_583"
+    original_name = "batch_norm2d_4.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-4.80275")
@@ -6408,6 +6992,7 @@ class Program_weight_tensor_parameter_583:
 
 class Program_weight_tensor_parameter_584:
     name = "parameter_584"
+    original_name = "batch_norm2d_4.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.801288")
@@ -6419,6 +7004,7 @@ class Program_weight_tensor_parameter_584:
 
 class Program_weight_tensor_parameter_585:
     name = "parameter_585"
+    original_name = "batch_norm2d_4.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("10.3665")
@@ -6430,6 +7016,7 @@ class Program_weight_tensor_parameter_585:
 
 class Program_weight_tensor_parameter_586:
     name = "parameter_586"
+    original_name = "batch_norm2d_4.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-24.7532")
@@ -6441,6 +7028,7 @@ class Program_weight_tensor_parameter_586:
 
 class Program_weight_tensor_parameter_587:
     name = "parameter_587"
+    original_name = "conv2d_4.w_0"
     shape = [128, 32, 1, 1]
     dtype = "float32"
     min_val = float("-1.49226")
@@ -6452,6 +7040,7 @@ class Program_weight_tensor_parameter_587:
 
 class Program_weight_tensor_parameter_588:
     name = "parameter_588"
+    original_name = "batch_norm2d_3.b_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -6461,6 +7050,7 @@ class Program_weight_tensor_parameter_588:
 
 class Program_weight_tensor_parameter_589:
     name = "parameter_589"
+    original_name = "batch_norm2d_3.w_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -6470,6 +7060,7 @@ class Program_weight_tensor_parameter_589:
 
 class Program_weight_tensor_parameter_590:
     name = "parameter_590"
+    original_name = "batch_norm2d_3.w_2"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -6479,6 +7070,7 @@ class Program_weight_tensor_parameter_590:
 
 class Program_weight_tensor_parameter_591:
     name = "parameter_591"
+    original_name = "batch_norm2d_3.w_1"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -6488,6 +7080,7 @@ class Program_weight_tensor_parameter_591:
 
 class Program_weight_tensor_parameter_592:
     name = "parameter_592"
+    original_name = "conv2d_3.w_0"
     shape = [32, 96, 1, 1]
     dtype = "float32"
     min_val = float("-1.56537")
@@ -6499,6 +7092,7 @@ class Program_weight_tensor_parameter_592:
 
 class Program_weight_tensor_parameter_593:
     name = "parameter_593"
+    original_name = "batch_norm2d_2.b_0"
     shape = [96]
     dtype = "float32"
     min_val = float("-7.39713")
@@ -6510,6 +7104,7 @@ class Program_weight_tensor_parameter_593:
 
 class Program_weight_tensor_parameter_594:
     name = "parameter_594"
+    original_name = "batch_norm2d_2.w_0"
     shape = [96]
     dtype = "float32"
     min_val = float("0.61591")
@@ -6521,6 +7116,7 @@ class Program_weight_tensor_parameter_594:
 
 class Program_weight_tensor_parameter_595:
     name = "parameter_595"
+    original_name = "batch_norm2d_2.w_2"
     shape = [96]
     dtype = "float32"
     min_val = float("5.60519e-45")
@@ -6532,6 +7128,7 @@ class Program_weight_tensor_parameter_595:
 
 class Program_weight_tensor_parameter_596:
     name = "parameter_596"
+    original_name = "batch_norm2d_2.w_1"
     shape = [96]
     dtype = "float32"
     min_val = float("-1.10606")
@@ -6543,6 +7140,7 @@ class Program_weight_tensor_parameter_596:
 
 class Program_weight_tensor_parameter_597:
     name = "parameter_597"
+    original_name = "conv2d_2.w_0"
     shape = [96, 1, 3, 3]
     dtype = "float32"
     min_val = float("-1.30479")
@@ -6554,6 +7152,7 @@ class Program_weight_tensor_parameter_597:
 
 class Program_weight_tensor_parameter_598:
     name = "parameter_598"
+    original_name = "batch_norm2d_1.b_0"
     shape = [96]
     dtype = "float32"
     min_val = float("-4.33562")
@@ -6565,6 +7164,7 @@ class Program_weight_tensor_parameter_598:
 
 class Program_weight_tensor_parameter_599:
     name = "parameter_599"
+    original_name = "batch_norm2d_1.w_0"
     shape = [96]
     dtype = "float32"
     min_val = float("-0.0660904")
@@ -6576,6 +7176,7 @@ class Program_weight_tensor_parameter_599:
 
 class Program_weight_tensor_parameter_600:
     name = "parameter_600"
+    original_name = "batch_norm2d_1.w_2"
     shape = [96]
     dtype = "float32"
     min_val = float("5.60519e-45")
@@ -6587,6 +7188,7 @@ class Program_weight_tensor_parameter_600:
 
 class Program_weight_tensor_parameter_601:
     name = "parameter_601"
+    original_name = "batch_norm2d_1.w_1"
     shape = [96]
     dtype = "float32"
     min_val = float("-19.4011")
@@ -6598,6 +7200,7 @@ class Program_weight_tensor_parameter_601:
 
 class Program_weight_tensor_parameter_602:
     name = "parameter_602"
+    original_name = "conv2d_1.w_0"
     shape = [96, 32, 1, 1]
     dtype = "float32"
     min_val = float("-1.40999")
@@ -6609,6 +7212,7 @@ class Program_weight_tensor_parameter_602:
 
 class Program_weight_tensor_parameter_603:
     name = "parameter_603"
+    original_name = "batch_norm2d_0.b_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -6618,6 +7222,7 @@ class Program_weight_tensor_parameter_603:
 
 class Program_weight_tensor_parameter_604:
     name = "parameter_604"
+    original_name = "batch_norm2d_0.w_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -6627,6 +7232,7 @@ class Program_weight_tensor_parameter_604:
 
 class Program_weight_tensor_parameter_605:
     name = "parameter_605"
+    original_name = "batch_norm2d_0.w_2"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -6636,6 +7242,7 @@ class Program_weight_tensor_parameter_605:
 
 class Program_weight_tensor_parameter_606:
     name = "parameter_606"
+    original_name = "batch_norm2d_0.w_1"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -6645,6 +7252,7 @@ class Program_weight_tensor_parameter_606:
 
 class Program_weight_tensor_parameter_607:
     name = "parameter_607"
+    original_name = "conv2d_0.w_0"
     shape = [32, 3, 3, 3]
     dtype = "float32"
     min_val = float("-1.68376")

--- a/paddle_samples/PaddleX/SeaFormer_small/subgraph_1/input_meta.py
+++ b/paddle_samples/PaddleX/SeaFormer_small/subgraph_1/input_meta.py
@@ -1,5 +1,6 @@
 class Program_weight_tensor_data_0:
     name = "data_0"
+    original_name = "param_24"
     shape = [1, 96, 16]
     dtype = "float32"
     min_val = float("-0.365507")
@@ -11,6 +12,7 @@ class Program_weight_tensor_data_0:
 
 class Program_weight_tensor_data_1:
     name = "data_1"
+    original_name = "param_25"
     shape = [1, 96, 16]
     dtype = "float32"
     min_val = float("-0.386047")
@@ -22,6 +24,7 @@ class Program_weight_tensor_data_1:
 
 class Program_weight_tensor_data_2:
     name = "data_2"
+    original_name = "param_26"
     shape = [1, 96, 16]
     dtype = "float32"
     min_val = float("-0.328172")
@@ -33,6 +36,7 @@ class Program_weight_tensor_data_2:
 
 class Program_weight_tensor_data_3:
     name = "data_3"
+    original_name = "param_27"
     shape = [1, 96, 16]
     dtype = "float32"
     min_val = float("-0.386699")
@@ -44,6 +48,7 @@ class Program_weight_tensor_data_3:
 
 class Program_weight_tensor_data_4:
     name = "data_4"
+    original_name = "param_28"
     shape = [1, 96, 16]
     dtype = "float32"
     min_val = float("-0.114796")
@@ -55,6 +60,7 @@ class Program_weight_tensor_data_4:
 
 class Program_weight_tensor_data_5:
     name = "data_5"
+    original_name = "param_29"
     shape = [1, 96, 16]
     dtype = "float32"
     min_val = float("-0.165459")
@@ -66,6 +72,7 @@ class Program_weight_tensor_data_5:
 
 class Program_weight_tensor_data_6:
     name = "data_6"
+    original_name = "param_30"
     shape = [1, 96, 16]
     dtype = "float32"
     min_val = float("-0.0790651")
@@ -77,6 +84,7 @@ class Program_weight_tensor_data_6:
 
 class Program_weight_tensor_data_7:
     name = "data_7"
+    original_name = "param_31"
     shape = [1, 96, 16]
     dtype = "float32"
     min_val = float("-0.0682898")
@@ -88,6 +96,7 @@ class Program_weight_tensor_data_7:
 
 class Program_weight_tensor_data_8:
     name = "data_8"
+    original_name = "param_32"
     shape = [1, 96, 16]
     dtype = "float32"
     min_val = float("-0.205362")
@@ -99,6 +108,7 @@ class Program_weight_tensor_data_8:
 
 class Program_weight_tensor_data_9:
     name = "data_9"
+    original_name = "param_33"
     shape = [1, 96, 16]
     dtype = "float32"
     min_val = float("-0.106444")
@@ -110,6 +120,7 @@ class Program_weight_tensor_data_9:
 
 class Program_weight_tensor_data_10:
     name = "data_10"
+    original_name = "param_34"
     shape = [1, 96, 16]
     dtype = "float32"
     min_val = float("-0.1741")
@@ -121,6 +132,7 @@ class Program_weight_tensor_data_10:
 
 class Program_weight_tensor_data_11:
     name = "data_11"
+    original_name = "param_35"
     shape = [1, 96, 16]
     dtype = "float32"
     min_val = float("-0.0849838")
@@ -132,6 +144,7 @@ class Program_weight_tensor_data_11:
 
 class Program_weight_tensor_data_12:
     name = "data_12"
+    original_name = "param_36"
     shape = [1, 144, 16]
     dtype = "float32"
     min_val = float("-0.101095")
@@ -143,6 +156,7 @@ class Program_weight_tensor_data_12:
 
 class Program_weight_tensor_data_13:
     name = "data_13"
+    original_name = "param_37"
     shape = [1, 144, 16]
     dtype = "float32"
     min_val = float("-0.147527")
@@ -154,6 +168,7 @@ class Program_weight_tensor_data_13:
 
 class Program_weight_tensor_data_14:
     name = "data_14"
+    original_name = "param_38"
     shape = [1, 144, 16]
     dtype = "float32"
     min_val = float("-0.0587647")
@@ -165,6 +180,7 @@ class Program_weight_tensor_data_14:
 
 class Program_weight_tensor_data_15:
     name = "data_15"
+    original_name = "param_39"
     shape = [1, 144, 16]
     dtype = "float32"
     min_val = float("-0.0355509")
@@ -176,6 +192,7 @@ class Program_weight_tensor_data_15:
 
 class Program_weight_tensor_data_16:
     name = "data_16"
+    original_name = "param_40"
     shape = [1, 144, 16]
     dtype = "float32"
     min_val = float("-0.0761779")
@@ -187,6 +204,7 @@ class Program_weight_tensor_data_16:
 
 class Program_weight_tensor_data_17:
     name = "data_17"
+    original_name = "param_41"
     shape = [1, 144, 16]
     dtype = "float32"
     min_val = float("-0.08757")
@@ -198,6 +216,7 @@ class Program_weight_tensor_data_17:
 
 class Program_weight_tensor_data_18:
     name = "data_18"
+    original_name = "param_42"
     shape = [1, 144, 16]
     dtype = "float32"
     min_val = float("-0.0642873")
@@ -209,6 +228,7 @@ class Program_weight_tensor_data_18:
 
 class Program_weight_tensor_data_19:
     name = "data_19"
+    original_name = "param_43"
     shape = [1, 144, 16]
     dtype = "float32"
     min_val = float("-0.0313386")
@@ -220,6 +240,7 @@ class Program_weight_tensor_data_19:
 
 class Program_weight_tensor_data_20:
     name = "data_20"
+    original_name = "param_44"
     shape = [1, 144, 16]
     dtype = "float32"
     min_val = float("-0.07837")
@@ -231,6 +252,7 @@ class Program_weight_tensor_data_20:
 
 class Program_weight_tensor_data_21:
     name = "data_21"
+    original_name = "param_45"
     shape = [1, 144, 16]
     dtype = "float32"
     min_val = float("-0.0592643")
@@ -242,6 +264,7 @@ class Program_weight_tensor_data_21:
 
 class Program_weight_tensor_data_22:
     name = "data_22"
+    original_name = "param_46"
     shape = [1, 144, 16]
     dtype = "float32"
     min_val = float("-0.0344173")
@@ -253,6 +276,7 @@ class Program_weight_tensor_data_22:
 
 class Program_weight_tensor_data_23:
     name = "data_23"
+    original_name = "param_47"
     shape = [1, 144, 16]
     dtype = "float32"
     min_val = float("-0.0470819")
@@ -264,6 +288,7 @@ class Program_weight_tensor_data_23:
 
 class Program_weight_tensor_data_24:
     name = "data_24"
+    original_name = "var_563"
     shape = [2, 3, 512, 512]
     dtype = "float32"
     min_val = float("-1.0")

--- a/paddle_samples/PaddleX/SeaFormer_small/subgraph_1/weight_meta.py
+++ b/paddle_samples/PaddleX/SeaFormer_small/subgraph_1/weight_meta.py
@@ -1,5 +1,6 @@
 class Program_weight_tensor_parameter_0:
     name = "parameter_0"
+    original_name = "batch_norm2d_86.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.0853705")
@@ -11,6 +12,7 @@ class Program_weight_tensor_parameter_0:
 
 class Program_weight_tensor_parameter_1:
     name = "parameter_1"
+    original_name = "batch_norm2d_86.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("0.870519")
@@ -22,6 +24,7 @@ class Program_weight_tensor_parameter_1:
 
 class Program_weight_tensor_parameter_2:
     name = "parameter_2"
+    original_name = "batch_norm2d_86.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("0.00459293")
@@ -33,6 +36,7 @@ class Program_weight_tensor_parameter_2:
 
 class Program_weight_tensor_parameter_3:
     name = "parameter_3"
+    original_name = "batch_norm2d_86.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.212881")
@@ -44,6 +48,7 @@ class Program_weight_tensor_parameter_3:
 
 class Program_weight_tensor_parameter_4:
     name = "parameter_4"
+    original_name = "conv2d_92.w_0"
     shape = [192, 768, 1, 1]
     dtype = "float32"
     min_val = float("-0.193998")
@@ -55,6 +60,7 @@ class Program_weight_tensor_parameter_4:
 
 class Program_weight_tensor_parameter_5:
     name = "parameter_5"
+    original_name = "conv2d_91.b_0"
     shape = [768]
     dtype = "float32"
     min_val = float("-1.52866")
@@ -66,6 +72,7 @@ class Program_weight_tensor_parameter_5:
 
 class Program_weight_tensor_parameter_6:
     name = "parameter_6"
+    original_name = "conv2d_91.w_0"
     shape = [768, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.439912")
@@ -77,6 +84,7 @@ class Program_weight_tensor_parameter_6:
 
 class Program_weight_tensor_parameter_7:
     name = "parameter_7"
+    original_name = "batch_norm2d_85.b_0"
     shape = [768]
     dtype = "float32"
     min_val = float("-4.3305")
@@ -88,6 +96,7 @@ class Program_weight_tensor_parameter_7:
 
 class Program_weight_tensor_parameter_8:
     name = "parameter_8"
+    original_name = "batch_norm2d_85.w_0"
     shape = [768]
     dtype = "float32"
     min_val = float("0.22525")
@@ -99,6 +108,7 @@ class Program_weight_tensor_parameter_8:
 
 class Program_weight_tensor_parameter_9:
     name = "parameter_9"
+    original_name = "batch_norm2d_85.w_2"
     shape = [768]
     dtype = "float32"
     min_val = float("0.0591464")
@@ -110,6 +120,7 @@ class Program_weight_tensor_parameter_9:
 
 class Program_weight_tensor_parameter_10:
     name = "parameter_10"
+    original_name = "batch_norm2d_85.w_1"
     shape = [768]
     dtype = "float32"
     min_val = float("-0.335531")
@@ -121,6 +132,7 @@ class Program_weight_tensor_parameter_10:
 
 class Program_weight_tensor_parameter_11:
     name = "parameter_11"
+    original_name = "conv2d_90.w_0"
     shape = [768, 192, 1, 1]
     dtype = "float32"
     min_val = float("-0.285966")
@@ -132,6 +144,7 @@ class Program_weight_tensor_parameter_11:
 
 class Program_weight_tensor_parameter_12:
     name = "parameter_12"
+    original_name = "batch_norm2d_80.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-2.39766")
@@ -143,6 +156,7 @@ class Program_weight_tensor_parameter_12:
 
 class Program_weight_tensor_parameter_13:
     name = "parameter_13"
+    original_name = "batch_norm2d_80.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-1.83786")
@@ -154,6 +168,7 @@ class Program_weight_tensor_parameter_13:
 
 class Program_weight_tensor_parameter_14:
     name = "parameter_14"
+    original_name = "batch_norm2d_80.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("0.103635")
@@ -165,6 +180,7 @@ class Program_weight_tensor_parameter_14:
 
 class Program_weight_tensor_parameter_15:
     name = "parameter_15"
+    original_name = "batch_norm2d_80.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.337241")
@@ -176,6 +192,7 @@ class Program_weight_tensor_parameter_15:
 
 class Program_weight_tensor_parameter_16:
     name = "parameter_16"
+    original_name = "conv2d_85.w_0"
     shape = [192, 288, 1, 1]
     dtype = "float32"
     min_val = float("-0.290369")
@@ -187,6 +204,7 @@ class Program_weight_tensor_parameter_16:
 
 class Program_weight_tensor_parameter_17:
     name = "parameter_17"
+    original_name = "batch_norm2d_82.b_0"
     shape = [288]
     dtype = "float32"
     min_val = float("-1.226")
@@ -198,6 +216,7 @@ class Program_weight_tensor_parameter_17:
 
 class Program_weight_tensor_parameter_18:
     name = "parameter_18"
+    original_name = "batch_norm2d_82.w_0"
     shape = [288]
     dtype = "float32"
     min_val = float("-2.27401")
@@ -209,6 +228,7 @@ class Program_weight_tensor_parameter_18:
 
 class Program_weight_tensor_parameter_19:
     name = "parameter_19"
+    original_name = "batch_norm2d_82.w_2"
     shape = [288]
     dtype = "float32"
     min_val = float("0.000439859")
@@ -220,6 +240,7 @@ class Program_weight_tensor_parameter_19:
 
 class Program_weight_tensor_parameter_20:
     name = "parameter_20"
+    original_name = "batch_norm2d_82.w_1"
     shape = [288]
     dtype = "float32"
     min_val = float("-0.272969")
@@ -231,6 +252,7 @@ class Program_weight_tensor_parameter_20:
 
 class Program_weight_tensor_parameter_21:
     name = "parameter_21"
+    original_name = "conv2d_87.w_0"
     shape = [288, 288, 1, 1]
     dtype = "float32"
     min_val = float("-0.416905")
@@ -242,6 +264,7 @@ class Program_weight_tensor_parameter_21:
 
 class Program_weight_tensor_parameter_22:
     name = "parameter_22"
+    original_name = "batch_norm2d_81.b_0"
     shape = [288]
     dtype = "float32"
     min_val = float("-1.22601")
@@ -253,6 +276,7 @@ class Program_weight_tensor_parameter_22:
 
 class Program_weight_tensor_parameter_23:
     name = "parameter_23"
+    original_name = "batch_norm2d_81.w_0"
     shape = [288]
     dtype = "float32"
     min_val = float("-2.34439")
@@ -264,6 +288,7 @@ class Program_weight_tensor_parameter_23:
 
 class Program_weight_tensor_parameter_24:
     name = "parameter_24"
+    original_name = "batch_norm2d_81.w_2"
     shape = [288]
     dtype = "float32"
     min_val = float("0.000563082")
@@ -275,6 +300,7 @@ class Program_weight_tensor_parameter_24:
 
 class Program_weight_tensor_parameter_25:
     name = "parameter_25"
+    original_name = "batch_norm2d_81.w_1"
     shape = [288]
     dtype = "float32"
     min_val = float("-0.411988")
@@ -286,6 +312,7 @@ class Program_weight_tensor_parameter_25:
 
 class Program_weight_tensor_parameter_26:
     name = "parameter_26"
+    original_name = "conv2d_86.w_0"
     shape = [288, 288, 1, 1]
     dtype = "float32"
     min_val = float("-0.332253")
@@ -297,6 +324,7 @@ class Program_weight_tensor_parameter_26:
 
 class Program_weight_tensor_parameter_27:
     name = "parameter_27"
+    original_name = "batch_norm2d_84.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-2.6653")
@@ -308,6 +336,7 @@ class Program_weight_tensor_parameter_27:
 
 class Program_weight_tensor_parameter_28:
     name = "parameter_28"
+    original_name = "batch_norm2d_84.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("1.9815")
@@ -319,6 +348,7 @@ class Program_weight_tensor_parameter_28:
 
 class Program_weight_tensor_parameter_29:
     name = "parameter_29"
+    original_name = "batch_norm2d_84.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("0.0275175")
@@ -330,6 +360,7 @@ class Program_weight_tensor_parameter_29:
 
 class Program_weight_tensor_parameter_30:
     name = "parameter_30"
+    original_name = "batch_norm2d_84.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-1.05696")
@@ -341,6 +372,7 @@ class Program_weight_tensor_parameter_30:
 
 class Program_weight_tensor_parameter_31:
     name = "parameter_31"
+    original_name = "conv2d_89.w_0"
     shape = [192, 576, 1, 1]
     dtype = "float32"
     min_val = float("-0.256626")
@@ -352,6 +384,7 @@ class Program_weight_tensor_parameter_31:
 
 class Program_weight_tensor_parameter_32:
     name = "parameter_32"
+    original_name = "batch_norm2d_83.b_0"
     shape = [576]
     dtype = "float32"
     min_val = float("-3.77136")
@@ -363,6 +396,7 @@ class Program_weight_tensor_parameter_32:
 
 class Program_weight_tensor_parameter_33:
     name = "parameter_33"
+    original_name = "batch_norm2d_83.w_0"
     shape = [576]
     dtype = "float32"
     min_val = float("0.338616")
@@ -374,6 +408,7 @@ class Program_weight_tensor_parameter_33:
 
 class Program_weight_tensor_parameter_34:
     name = "parameter_34"
+    original_name = "batch_norm2d_83.w_2"
     shape = [576]
     dtype = "float32"
     min_val = float("0.00025252")
@@ -385,6 +420,7 @@ class Program_weight_tensor_parameter_34:
 
 class Program_weight_tensor_parameter_35:
     name = "parameter_35"
+    original_name = "batch_norm2d_83.w_1"
     shape = [576]
     dtype = "float32"
     min_val = float("-0.743757")
@@ -396,6 +432,7 @@ class Program_weight_tensor_parameter_35:
 
 class Program_weight_tensor_parameter_36:
     name = "parameter_36"
+    original_name = "conv2d_88.w_0"
     shape = [576, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.376982")
@@ -407,6 +444,7 @@ class Program_weight_tensor_parameter_36:
 
 class Program_weight_tensor_parameter_37:
     name = "parameter_37"
+    original_name = "batch_norm2d_79.b_0"
     shape = [288]
     dtype = "float32"
     min_val = float("-2.47511")
@@ -418,6 +456,7 @@ class Program_weight_tensor_parameter_37:
 
 class Program_weight_tensor_parameter_38:
     name = "parameter_38"
+    original_name = "batch_norm2d_79.w_0"
     shape = [288]
     dtype = "float32"
     min_val = float("0.204882")
@@ -429,6 +468,7 @@ class Program_weight_tensor_parameter_38:
 
 class Program_weight_tensor_parameter_39:
     name = "parameter_39"
+    original_name = "batch_norm2d_79.w_2"
     shape = [288]
     dtype = "float32"
     min_val = float("1.73789")
@@ -440,6 +480,7 @@ class Program_weight_tensor_parameter_39:
 
 class Program_weight_tensor_parameter_40:
     name = "parameter_40"
+    original_name = "batch_norm2d_79.w_1"
     shape = [288]
     dtype = "float32"
     min_val = float("-1.09087")
@@ -451,6 +492,7 @@ class Program_weight_tensor_parameter_40:
 
 class Program_weight_tensor_parameter_41:
     name = "parameter_41"
+    original_name = "conv2d_84.w_0"
     shape = [288, 192, 1, 1]
     dtype = "float32"
     min_val = float("-0.637711")
@@ -462,6 +504,7 @@ class Program_weight_tensor_parameter_41:
 
 class Program_weight_tensor_parameter_42:
     name = "parameter_42"
+    original_name = "batch_norm2d_78.b_0"
     shape = [144]
     dtype = "float32"
     min_val = float("-0.71185")
@@ -473,6 +516,7 @@ class Program_weight_tensor_parameter_42:
 
 class Program_weight_tensor_parameter_43:
     name = "parameter_43"
+    original_name = "batch_norm2d_78.w_0"
     shape = [144]
     dtype = "float32"
     min_val = float("0.0800748")
@@ -484,6 +528,7 @@ class Program_weight_tensor_parameter_43:
 
 class Program_weight_tensor_parameter_44:
     name = "parameter_44"
+    original_name = "batch_norm2d_78.w_2"
     shape = [144]
     dtype = "float32"
     min_val = float("1.07497")
@@ -495,6 +540,7 @@ class Program_weight_tensor_parameter_44:
 
 class Program_weight_tensor_parameter_45:
     name = "parameter_45"
+    original_name = "batch_norm2d_78.w_1"
     shape = [144]
     dtype = "float32"
     min_val = float("-0.315597")
@@ -506,6 +552,7 @@ class Program_weight_tensor_parameter_45:
 
 class Program_weight_tensor_parameter_46:
     name = "parameter_46"
+    original_name = "conv2d_83.w_0"
     shape = [144, 192, 1, 1]
     dtype = "float32"
     min_val = float("-0.390917")
@@ -517,6 +564,7 @@ class Program_weight_tensor_parameter_46:
 
 class Program_weight_tensor_parameter_47:
     name = "parameter_47"
+    original_name = "batch_norm2d_77.b_0"
     shape = [144]
     dtype = "float32"
     min_val = float("-0.907424")
@@ -528,6 +576,7 @@ class Program_weight_tensor_parameter_47:
 
 class Program_weight_tensor_parameter_48:
     name = "parameter_48"
+    original_name = "batch_norm2d_77.w_0"
     shape = [144]
     dtype = "float32"
     min_val = float("0.111522")
@@ -539,6 +588,7 @@ class Program_weight_tensor_parameter_48:
 
 class Program_weight_tensor_parameter_49:
     name = "parameter_49"
+    original_name = "batch_norm2d_77.w_2"
     shape = [144]
     dtype = "float32"
     min_val = float("1.03317")
@@ -550,6 +600,7 @@ class Program_weight_tensor_parameter_49:
 
 class Program_weight_tensor_parameter_50:
     name = "parameter_50"
+    original_name = "batch_norm2d_77.w_1"
     shape = [144]
     dtype = "float32"
     min_val = float("-0.344913")
@@ -561,6 +612,7 @@ class Program_weight_tensor_parameter_50:
 
 class Program_weight_tensor_parameter_51:
     name = "parameter_51"
+    original_name = "conv2d_82.w_0"
     shape = [144, 192, 1, 1]
     dtype = "float32"
     min_val = float("-0.174453")
@@ -572,6 +624,7 @@ class Program_weight_tensor_parameter_51:
 
 class Program_weight_tensor_parameter_52:
     name = "parameter_52"
+    original_name = "batch_norm2d_76.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-1.34212")
@@ -583,6 +636,7 @@ class Program_weight_tensor_parameter_52:
 
 class Program_weight_tensor_parameter_53:
     name = "parameter_53"
+    original_name = "batch_norm2d_76.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("0.746471")
@@ -594,6 +648,7 @@ class Program_weight_tensor_parameter_53:
 
 class Program_weight_tensor_parameter_54:
     name = "parameter_54"
+    original_name = "batch_norm2d_76.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("0.00237303")
@@ -605,6 +660,7 @@ class Program_weight_tensor_parameter_54:
 
 class Program_weight_tensor_parameter_55:
     name = "parameter_55"
+    original_name = "batch_norm2d_76.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.574975")
@@ -616,6 +672,7 @@ class Program_weight_tensor_parameter_55:
 
 class Program_weight_tensor_parameter_56:
     name = "parameter_56"
+    original_name = "conv2d_81.w_0"
     shape = [192, 768, 1, 1]
     dtype = "float32"
     min_val = float("-0.301184")
@@ -627,6 +684,7 @@ class Program_weight_tensor_parameter_56:
 
 class Program_weight_tensor_parameter_57:
     name = "parameter_57"
+    original_name = "conv2d_80.b_0"
     shape = [768]
     dtype = "float32"
     min_val = float("-2.08956")
@@ -638,6 +696,7 @@ class Program_weight_tensor_parameter_57:
 
 class Program_weight_tensor_parameter_58:
     name = "parameter_58"
+    original_name = "conv2d_80.w_0"
     shape = [768, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.495636")
@@ -649,6 +708,7 @@ class Program_weight_tensor_parameter_58:
 
 class Program_weight_tensor_parameter_59:
     name = "parameter_59"
+    original_name = "batch_norm2d_75.b_0"
     shape = [768]
     dtype = "float32"
     min_val = float("-4.41789")
@@ -660,6 +720,7 @@ class Program_weight_tensor_parameter_59:
 
 class Program_weight_tensor_parameter_60:
     name = "parameter_60"
+    original_name = "batch_norm2d_75.w_0"
     shape = [768]
     dtype = "float32"
     min_val = float("0.224732")
@@ -671,6 +732,7 @@ class Program_weight_tensor_parameter_60:
 
 class Program_weight_tensor_parameter_61:
     name = "parameter_61"
+    original_name = "batch_norm2d_75.w_2"
     shape = [768]
     dtype = "float32"
     min_val = float("1.14755")
@@ -682,6 +744,7 @@ class Program_weight_tensor_parameter_61:
 
 class Program_weight_tensor_parameter_62:
     name = "parameter_62"
+    original_name = "batch_norm2d_75.w_1"
     shape = [768]
     dtype = "float32"
     min_val = float("-0.68752")
@@ -693,6 +756,7 @@ class Program_weight_tensor_parameter_62:
 
 class Program_weight_tensor_parameter_63:
     name = "parameter_63"
+    original_name = "conv2d_79.w_0"
     shape = [768, 192, 1, 1]
     dtype = "float32"
     min_val = float("-0.331103")
@@ -704,6 +768,7 @@ class Program_weight_tensor_parameter_63:
 
 class Program_weight_tensor_parameter_64:
     name = "parameter_64"
+    original_name = "batch_norm2d_70.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-2.29881")
@@ -715,6 +780,7 @@ class Program_weight_tensor_parameter_64:
 
 class Program_weight_tensor_parameter_65:
     name = "parameter_65"
+    original_name = "batch_norm2d_70.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-3.47982")
@@ -726,6 +792,7 @@ class Program_weight_tensor_parameter_65:
 
 class Program_weight_tensor_parameter_66:
     name = "parameter_66"
+    original_name = "batch_norm2d_70.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("0.108865")
@@ -737,6 +804,7 @@ class Program_weight_tensor_parameter_66:
 
 class Program_weight_tensor_parameter_67:
     name = "parameter_67"
+    original_name = "batch_norm2d_70.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-1.02077")
@@ -748,6 +816,7 @@ class Program_weight_tensor_parameter_67:
 
 class Program_weight_tensor_parameter_68:
     name = "parameter_68"
+    original_name = "conv2d_74.w_0"
     shape = [192, 288, 1, 1]
     dtype = "float32"
     min_val = float("-0.307274")
@@ -759,6 +828,7 @@ class Program_weight_tensor_parameter_68:
 
 class Program_weight_tensor_parameter_69:
     name = "parameter_69"
+    original_name = "batch_norm2d_72.b_0"
     shape = [288]
     dtype = "float32"
     min_val = float("-1.79456")
@@ -770,6 +840,7 @@ class Program_weight_tensor_parameter_69:
 
 class Program_weight_tensor_parameter_70:
     name = "parameter_70"
+    original_name = "batch_norm2d_72.w_0"
     shape = [288]
     dtype = "float32"
     min_val = float("-1.68906")
@@ -781,6 +852,7 @@ class Program_weight_tensor_parameter_70:
 
 class Program_weight_tensor_parameter_71:
     name = "parameter_71"
+    original_name = "batch_norm2d_72.w_2"
     shape = [288]
     dtype = "float32"
     min_val = float("0.00140081")
@@ -792,6 +864,7 @@ class Program_weight_tensor_parameter_71:
 
 class Program_weight_tensor_parameter_72:
     name = "parameter_72"
+    original_name = "batch_norm2d_72.w_1"
     shape = [288]
     dtype = "float32"
     min_val = float("-0.406342")
@@ -803,6 +876,7 @@ class Program_weight_tensor_parameter_72:
 
 class Program_weight_tensor_parameter_73:
     name = "parameter_73"
+    original_name = "conv2d_76.w_0"
     shape = [288, 288, 1, 1]
     dtype = "float32"
     min_val = float("-0.168132")
@@ -814,6 +888,7 @@ class Program_weight_tensor_parameter_73:
 
 class Program_weight_tensor_parameter_74:
     name = "parameter_74"
+    original_name = "batch_norm2d_71.b_0"
     shape = [288]
     dtype = "float32"
     min_val = float("-1.79447")
@@ -825,6 +900,7 @@ class Program_weight_tensor_parameter_74:
 
 class Program_weight_tensor_parameter_75:
     name = "parameter_75"
+    original_name = "batch_norm2d_71.w_0"
     shape = [288]
     dtype = "float32"
     min_val = float("-1.59886")
@@ -836,6 +912,7 @@ class Program_weight_tensor_parameter_75:
 
 class Program_weight_tensor_parameter_76:
     name = "parameter_76"
+    original_name = "batch_norm2d_71.w_2"
     shape = [288]
     dtype = "float32"
     min_val = float("0.00139878")
@@ -847,6 +924,7 @@ class Program_weight_tensor_parameter_76:
 
 class Program_weight_tensor_parameter_77:
     name = "parameter_77"
+    original_name = "batch_norm2d_71.w_1"
     shape = [288]
     dtype = "float32"
     min_val = float("-0.651703")
@@ -858,6 +936,7 @@ class Program_weight_tensor_parameter_77:
 
 class Program_weight_tensor_parameter_78:
     name = "parameter_78"
+    original_name = "conv2d_75.w_0"
     shape = [288, 288, 1, 1]
     dtype = "float32"
     min_val = float("-0.202894")
@@ -869,6 +948,7 @@ class Program_weight_tensor_parameter_78:
 
 class Program_weight_tensor_parameter_79:
     name = "parameter_79"
+    original_name = "batch_norm2d_74.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-5.20017")
@@ -880,6 +960,7 @@ class Program_weight_tensor_parameter_79:
 
 class Program_weight_tensor_parameter_80:
     name = "parameter_80"
+    original_name = "batch_norm2d_74.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("1.34595")
@@ -891,6 +972,7 @@ class Program_weight_tensor_parameter_80:
 
 class Program_weight_tensor_parameter_81:
     name = "parameter_81"
+    original_name = "batch_norm2d_74.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("0.0132664")
@@ -902,6 +984,7 @@ class Program_weight_tensor_parameter_81:
 
 class Program_weight_tensor_parameter_82:
     name = "parameter_82"
+    original_name = "batch_norm2d_74.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.909312")
@@ -913,6 +996,7 @@ class Program_weight_tensor_parameter_82:
 
 class Program_weight_tensor_parameter_83:
     name = "parameter_83"
+    original_name = "conv2d_78.w_0"
     shape = [192, 576, 1, 1]
     dtype = "float32"
     min_val = float("-0.384472")
@@ -924,6 +1008,7 @@ class Program_weight_tensor_parameter_83:
 
 class Program_weight_tensor_parameter_84:
     name = "parameter_84"
+    original_name = "batch_norm2d_73.b_0"
     shape = [576]
     dtype = "float32"
     min_val = float("-4.89917")
@@ -935,6 +1020,7 @@ class Program_weight_tensor_parameter_84:
 
 class Program_weight_tensor_parameter_85:
     name = "parameter_85"
+    original_name = "batch_norm2d_73.w_0"
     shape = [576]
     dtype = "float32"
     min_val = float("0.219636")
@@ -946,6 +1032,7 @@ class Program_weight_tensor_parameter_85:
 
 class Program_weight_tensor_parameter_86:
     name = "parameter_86"
+    original_name = "batch_norm2d_73.w_2"
     shape = [576]
     dtype = "float32"
     min_val = float("0.000445306")
@@ -957,6 +1044,7 @@ class Program_weight_tensor_parameter_86:
 
 class Program_weight_tensor_parameter_87:
     name = "parameter_87"
+    original_name = "batch_norm2d_73.w_1"
     shape = [576]
     dtype = "float32"
     min_val = float("-1.08729")
@@ -968,6 +1056,7 @@ class Program_weight_tensor_parameter_87:
 
 class Program_weight_tensor_parameter_88:
     name = "parameter_88"
+    original_name = "conv2d_77.w_0"
     shape = [576, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.326283")
@@ -979,6 +1068,7 @@ class Program_weight_tensor_parameter_88:
 
 class Program_weight_tensor_parameter_89:
     name = "parameter_89"
+    original_name = "batch_norm2d_69.b_0"
     shape = [288]
     dtype = "float32"
     min_val = float("-3.02079")
@@ -990,6 +1080,7 @@ class Program_weight_tensor_parameter_89:
 
 class Program_weight_tensor_parameter_90:
     name = "parameter_90"
+    original_name = "batch_norm2d_69.w_0"
     shape = [288]
     dtype = "float32"
     min_val = float("0.271735")
@@ -1001,6 +1092,7 @@ class Program_weight_tensor_parameter_90:
 
 class Program_weight_tensor_parameter_91:
     name = "parameter_91"
+    original_name = "batch_norm2d_69.w_2"
     shape = [288]
     dtype = "float32"
     min_val = float("1.33199")
@@ -1012,6 +1104,7 @@ class Program_weight_tensor_parameter_91:
 
 class Program_weight_tensor_parameter_92:
     name = "parameter_92"
+    original_name = "batch_norm2d_69.w_1"
     shape = [288]
     dtype = "float32"
     min_val = float("-2.08313")
@@ -1023,6 +1116,7 @@ class Program_weight_tensor_parameter_92:
 
 class Program_weight_tensor_parameter_93:
     name = "parameter_93"
+    original_name = "conv2d_73.w_0"
     shape = [288, 192, 1, 1]
     dtype = "float32"
     min_val = float("-0.54308")
@@ -1034,6 +1128,7 @@ class Program_weight_tensor_parameter_93:
 
 class Program_weight_tensor_parameter_94:
     name = "parameter_94"
+    original_name = "batch_norm2d_68.b_0"
     shape = [144]
     dtype = "float32"
     min_val = float("-1.156")
@@ -1045,6 +1140,7 @@ class Program_weight_tensor_parameter_94:
 
 class Program_weight_tensor_parameter_95:
     name = "parameter_95"
+    original_name = "batch_norm2d_68.w_0"
     shape = [144]
     dtype = "float32"
     min_val = float("0.079053")
@@ -1056,6 +1152,7 @@ class Program_weight_tensor_parameter_95:
 
 class Program_weight_tensor_parameter_96:
     name = "parameter_96"
+    original_name = "batch_norm2d_68.w_2"
     shape = [144]
     dtype = "float32"
     min_val = float("1.06162")
@@ -1067,6 +1164,7 @@ class Program_weight_tensor_parameter_96:
 
 class Program_weight_tensor_parameter_97:
     name = "parameter_97"
+    original_name = "batch_norm2d_68.w_1"
     shape = [144]
     dtype = "float32"
     min_val = float("-1.29415")
@@ -1078,6 +1176,7 @@ class Program_weight_tensor_parameter_97:
 
 class Program_weight_tensor_parameter_98:
     name = "parameter_98"
+    original_name = "conv2d_72.w_0"
     shape = [144, 192, 1, 1]
     dtype = "float32"
     min_val = float("-0.253387")
@@ -1089,6 +1188,7 @@ class Program_weight_tensor_parameter_98:
 
 class Program_weight_tensor_parameter_99:
     name = "parameter_99"
+    original_name = "batch_norm2d_67.b_0"
     shape = [144]
     dtype = "float32"
     min_val = float("-1.51192")
@@ -1100,6 +1200,7 @@ class Program_weight_tensor_parameter_99:
 
 class Program_weight_tensor_parameter_100:
     name = "parameter_100"
+    original_name = "batch_norm2d_67.w_0"
     shape = [144]
     dtype = "float32"
     min_val = float("0.0953124")
@@ -1111,6 +1212,7 @@ class Program_weight_tensor_parameter_100:
 
 class Program_weight_tensor_parameter_101:
     name = "parameter_101"
+    original_name = "batch_norm2d_67.w_2"
     shape = [144]
     dtype = "float32"
     min_val = float("0.983242")
@@ -1122,6 +1224,7 @@ class Program_weight_tensor_parameter_101:
 
 class Program_weight_tensor_parameter_102:
     name = "parameter_102"
+    original_name = "batch_norm2d_67.w_1"
     shape = [144]
     dtype = "float32"
     min_val = float("-0.588233")
@@ -1133,6 +1236,7 @@ class Program_weight_tensor_parameter_102:
 
 class Program_weight_tensor_parameter_103:
     name = "parameter_103"
+    original_name = "conv2d_71.w_0"
     shape = [144, 192, 1, 1]
     dtype = "float32"
     min_val = float("-0.23439")
@@ -1144,6 +1248,7 @@ class Program_weight_tensor_parameter_103:
 
 class Program_weight_tensor_parameter_104:
     name = "parameter_104"
+    original_name = "batch_norm2d_66.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.908832")
@@ -1155,6 +1260,7 @@ class Program_weight_tensor_parameter_104:
 
 class Program_weight_tensor_parameter_105:
     name = "parameter_105"
+    original_name = "batch_norm2d_66.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("0.694269")
@@ -1166,6 +1272,7 @@ class Program_weight_tensor_parameter_105:
 
 class Program_weight_tensor_parameter_106:
     name = "parameter_106"
+    original_name = "batch_norm2d_66.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("0.00828547")
@@ -1177,6 +1284,7 @@ class Program_weight_tensor_parameter_106:
 
 class Program_weight_tensor_parameter_107:
     name = "parameter_107"
+    original_name = "batch_norm2d_66.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-1.42069")
@@ -1188,6 +1296,7 @@ class Program_weight_tensor_parameter_107:
 
 class Program_weight_tensor_parameter_108:
     name = "parameter_108"
+    original_name = "conv2d_70.w_0"
     shape = [192, 768, 1, 1]
     dtype = "float32"
     min_val = float("-0.32103")
@@ -1199,6 +1308,7 @@ class Program_weight_tensor_parameter_108:
 
 class Program_weight_tensor_parameter_109:
     name = "parameter_109"
+    original_name = "conv2d_69.b_0"
     shape = [768]
     dtype = "float32"
     min_val = float("-2.07493")
@@ -1210,6 +1320,7 @@ class Program_weight_tensor_parameter_109:
 
 class Program_weight_tensor_parameter_110:
     name = "parameter_110"
+    original_name = "conv2d_69.w_0"
     shape = [768, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.544484")
@@ -1221,6 +1332,7 @@ class Program_weight_tensor_parameter_110:
 
 class Program_weight_tensor_parameter_111:
     name = "parameter_111"
+    original_name = "batch_norm2d_65.b_0"
     shape = [768]
     dtype = "float32"
     min_val = float("-4.82954")
@@ -1232,6 +1344,7 @@ class Program_weight_tensor_parameter_111:
 
 class Program_weight_tensor_parameter_112:
     name = "parameter_112"
+    original_name = "batch_norm2d_65.w_0"
     shape = [768]
     dtype = "float32"
     min_val = float("0.463431")
@@ -1243,6 +1356,7 @@ class Program_weight_tensor_parameter_112:
 
 class Program_weight_tensor_parameter_113:
     name = "parameter_113"
+    original_name = "batch_norm2d_65.w_2"
     shape = [768]
     dtype = "float32"
     min_val = float("0.530927")
@@ -1254,6 +1368,7 @@ class Program_weight_tensor_parameter_113:
 
 class Program_weight_tensor_parameter_114:
     name = "parameter_114"
+    original_name = "batch_norm2d_65.w_1"
     shape = [768]
     dtype = "float32"
     min_val = float("-1.05081")
@@ -1265,6 +1380,7 @@ class Program_weight_tensor_parameter_114:
 
 class Program_weight_tensor_parameter_115:
     name = "parameter_115"
+    original_name = "conv2d_68.w_0"
     shape = [768, 192, 1, 1]
     dtype = "float32"
     min_val = float("-0.377738")
@@ -1276,6 +1392,7 @@ class Program_weight_tensor_parameter_115:
 
 class Program_weight_tensor_parameter_116:
     name = "parameter_116"
+    original_name = "batch_norm2d_60.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-2.677")
@@ -1287,6 +1404,7 @@ class Program_weight_tensor_parameter_116:
 
 class Program_weight_tensor_parameter_117:
     name = "parameter_117"
+    original_name = "batch_norm2d_60.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-2.12923")
@@ -1298,6 +1416,7 @@ class Program_weight_tensor_parameter_117:
 
 class Program_weight_tensor_parameter_118:
     name = "parameter_118"
+    original_name = "batch_norm2d_60.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("0.24745")
@@ -1309,6 +1428,7 @@ class Program_weight_tensor_parameter_118:
 
 class Program_weight_tensor_parameter_119:
     name = "parameter_119"
+    original_name = "batch_norm2d_60.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-1.30766")
@@ -1320,6 +1440,7 @@ class Program_weight_tensor_parameter_119:
 
 class Program_weight_tensor_parameter_120:
     name = "parameter_120"
+    original_name = "conv2d_63.w_0"
     shape = [192, 288, 1, 1]
     dtype = "float32"
     min_val = float("-0.320611")
@@ -1331,6 +1452,7 @@ class Program_weight_tensor_parameter_120:
 
 class Program_weight_tensor_parameter_121:
     name = "parameter_121"
+    original_name = "batch_norm2d_62.b_0"
     shape = [288]
     dtype = "float32"
     min_val = float("-1.76435")
@@ -1342,6 +1464,7 @@ class Program_weight_tensor_parameter_121:
 
 class Program_weight_tensor_parameter_122:
     name = "parameter_122"
+    original_name = "batch_norm2d_62.w_0"
     shape = [288]
     dtype = "float32"
     min_val = float("-1.73496")
@@ -1353,6 +1476,7 @@ class Program_weight_tensor_parameter_122:
 
 class Program_weight_tensor_parameter_123:
     name = "parameter_123"
+    original_name = "batch_norm2d_62.w_2"
     shape = [288]
     dtype = "float32"
     min_val = float("0.0101015")
@@ -1364,6 +1488,7 @@ class Program_weight_tensor_parameter_123:
 
 class Program_weight_tensor_parameter_124:
     name = "parameter_124"
+    original_name = "batch_norm2d_62.w_1"
     shape = [288]
     dtype = "float32"
     min_val = float("-0.477401")
@@ -1375,6 +1500,7 @@ class Program_weight_tensor_parameter_124:
 
 class Program_weight_tensor_parameter_125:
     name = "parameter_125"
+    original_name = "conv2d_65.w_0"
     shape = [288, 288, 1, 1]
     dtype = "float32"
     min_val = float("-0.259413")
@@ -1386,6 +1512,7 @@ class Program_weight_tensor_parameter_125:
 
 class Program_weight_tensor_parameter_126:
     name = "parameter_126"
+    original_name = "batch_norm2d_61.b_0"
     shape = [288]
     dtype = "float32"
     min_val = float("-1.7645")
@@ -1397,6 +1524,7 @@ class Program_weight_tensor_parameter_126:
 
 class Program_weight_tensor_parameter_127:
     name = "parameter_127"
+    original_name = "batch_norm2d_61.w_0"
     shape = [288]
     dtype = "float32"
     min_val = float("-2.42087")
@@ -1408,6 +1536,7 @@ class Program_weight_tensor_parameter_127:
 
 class Program_weight_tensor_parameter_128:
     name = "parameter_128"
+    original_name = "batch_norm2d_61.w_2"
     shape = [288]
     dtype = "float32"
     min_val = float("0.00976043")
@@ -1419,6 +1548,7 @@ class Program_weight_tensor_parameter_128:
 
 class Program_weight_tensor_parameter_129:
     name = "parameter_129"
+    original_name = "batch_norm2d_61.w_1"
     shape = [288]
     dtype = "float32"
     min_val = float("-0.407814")
@@ -1430,6 +1560,7 @@ class Program_weight_tensor_parameter_129:
 
 class Program_weight_tensor_parameter_130:
     name = "parameter_130"
+    original_name = "conv2d_64.w_0"
     shape = [288, 288, 1, 1]
     dtype = "float32"
     min_val = float("-0.274797")
@@ -1441,6 +1572,7 @@ class Program_weight_tensor_parameter_130:
 
 class Program_weight_tensor_parameter_131:
     name = "parameter_131"
+    original_name = "batch_norm2d_64.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-9.03609")
@@ -1452,6 +1584,7 @@ class Program_weight_tensor_parameter_131:
 
 class Program_weight_tensor_parameter_132:
     name = "parameter_132"
+    original_name = "batch_norm2d_64.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("1.11972")
@@ -1463,6 +1596,7 @@ class Program_weight_tensor_parameter_132:
 
 class Program_weight_tensor_parameter_133:
     name = "parameter_133"
+    original_name = "batch_norm2d_64.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("0.18299")
@@ -1474,6 +1608,7 @@ class Program_weight_tensor_parameter_133:
 
 class Program_weight_tensor_parameter_134:
     name = "parameter_134"
+    original_name = "batch_norm2d_64.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-2.4495")
@@ -1485,6 +1620,7 @@ class Program_weight_tensor_parameter_134:
 
 class Program_weight_tensor_parameter_135:
     name = "parameter_135"
+    original_name = "conv2d_67.w_0"
     shape = [192, 576, 1, 1]
     dtype = "float32"
     min_val = float("-0.322108")
@@ -1496,6 +1632,7 @@ class Program_weight_tensor_parameter_135:
 
 class Program_weight_tensor_parameter_136:
     name = "parameter_136"
+    original_name = "batch_norm2d_63.b_0"
     shape = [576]
     dtype = "float32"
     min_val = float("-4.40607")
@@ -1507,6 +1644,7 @@ class Program_weight_tensor_parameter_136:
 
 class Program_weight_tensor_parameter_137:
     name = "parameter_137"
+    original_name = "batch_norm2d_63.w_0"
     shape = [576]
     dtype = "float32"
     min_val = float("0.586436")
@@ -1518,6 +1656,7 @@ class Program_weight_tensor_parameter_137:
 
 class Program_weight_tensor_parameter_138:
     name = "parameter_138"
+    original_name = "batch_norm2d_63.w_2"
     shape = [576]
     dtype = "float32"
     min_val = float("0.000286212")
@@ -1529,6 +1668,7 @@ class Program_weight_tensor_parameter_138:
 
 class Program_weight_tensor_parameter_139:
     name = "parameter_139"
+    original_name = "batch_norm2d_63.w_1"
     shape = [576]
     dtype = "float32"
     min_val = float("-0.974102")
@@ -1540,6 +1680,7 @@ class Program_weight_tensor_parameter_139:
 
 class Program_weight_tensor_parameter_140:
     name = "parameter_140"
+    original_name = "conv2d_66.w_0"
     shape = [576, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.376213")
@@ -1551,6 +1692,7 @@ class Program_weight_tensor_parameter_140:
 
 class Program_weight_tensor_parameter_141:
     name = "parameter_141"
+    original_name = "batch_norm2d_59.b_0"
     shape = [288]
     dtype = "float32"
     min_val = float("-1.94753")
@@ -1562,6 +1704,7 @@ class Program_weight_tensor_parameter_141:
 
 class Program_weight_tensor_parameter_142:
     name = "parameter_142"
+    original_name = "batch_norm2d_59.w_0"
     shape = [288]
     dtype = "float32"
     min_val = float("0.48401")
@@ -1573,6 +1716,7 @@ class Program_weight_tensor_parameter_142:
 
 class Program_weight_tensor_parameter_143:
     name = "parameter_143"
+    original_name = "batch_norm2d_59.w_2"
     shape = [288]
     dtype = "float32"
     min_val = float("0.959203")
@@ -1584,6 +1728,7 @@ class Program_weight_tensor_parameter_143:
 
 class Program_weight_tensor_parameter_144:
     name = "parameter_144"
+    original_name = "batch_norm2d_59.w_1"
     shape = [288]
     dtype = "float32"
     min_val = float("-2.05565")
@@ -1595,6 +1740,7 @@ class Program_weight_tensor_parameter_144:
 
 class Program_weight_tensor_parameter_145:
     name = "parameter_145"
+    original_name = "conv2d_62.w_0"
     shape = [288, 192, 1, 1]
     dtype = "float32"
     min_val = float("-0.427304")
@@ -1606,6 +1752,7 @@ class Program_weight_tensor_parameter_145:
 
 class Program_weight_tensor_parameter_146:
     name = "parameter_146"
+    original_name = "batch_norm2d_58.b_0"
     shape = [144]
     dtype = "float32"
     min_val = float("-1.73447")
@@ -1617,6 +1764,7 @@ class Program_weight_tensor_parameter_146:
 
 class Program_weight_tensor_parameter_147:
     name = "parameter_147"
+    original_name = "batch_norm2d_58.w_0"
     shape = [144]
     dtype = "float32"
     min_val = float("0.0679161")
@@ -1628,6 +1776,7 @@ class Program_weight_tensor_parameter_147:
 
 class Program_weight_tensor_parameter_148:
     name = "parameter_148"
+    original_name = "batch_norm2d_58.w_2"
     shape = [144]
     dtype = "float32"
     min_val = float("0.56742")
@@ -1639,6 +1788,7 @@ class Program_weight_tensor_parameter_148:
 
 class Program_weight_tensor_parameter_149:
     name = "parameter_149"
+    original_name = "batch_norm2d_58.w_1"
     shape = [144]
     dtype = "float32"
     min_val = float("-1.98923")
@@ -1650,6 +1800,7 @@ class Program_weight_tensor_parameter_149:
 
 class Program_weight_tensor_parameter_150:
     name = "parameter_150"
+    original_name = "conv2d_61.w_0"
     shape = [144, 192, 1, 1]
     dtype = "float32"
     min_val = float("-0.272609")
@@ -1661,6 +1812,7 @@ class Program_weight_tensor_parameter_150:
 
 class Program_weight_tensor_parameter_151:
     name = "parameter_151"
+    original_name = "batch_norm2d_57.b_0"
     shape = [144]
     dtype = "float32"
     min_val = float("-2.30438")
@@ -1672,6 +1824,7 @@ class Program_weight_tensor_parameter_151:
 
 class Program_weight_tensor_parameter_152:
     name = "parameter_152"
+    original_name = "batch_norm2d_57.w_0"
     shape = [144]
     dtype = "float32"
     min_val = float("0.123505")
@@ -1683,6 +1836,7 @@ class Program_weight_tensor_parameter_152:
 
 class Program_weight_tensor_parameter_153:
     name = "parameter_153"
+    original_name = "batch_norm2d_57.w_2"
     shape = [144]
     dtype = "float32"
     min_val = float("0.533026")
@@ -1694,6 +1848,7 @@ class Program_weight_tensor_parameter_153:
 
 class Program_weight_tensor_parameter_154:
     name = "parameter_154"
+    original_name = "batch_norm2d_57.w_1"
     shape = [144]
     dtype = "float32"
     min_val = float("-1.56296")
@@ -1705,6 +1860,7 @@ class Program_weight_tensor_parameter_154:
 
 class Program_weight_tensor_parameter_155:
     name = "parameter_155"
+    original_name = "conv2d_60.w_0"
     shape = [144, 192, 1, 1]
     dtype = "float32"
     min_val = float("-0.227301")
@@ -1716,6 +1872,7 @@ class Program_weight_tensor_parameter_155:
 
 class Program_weight_tensor_parameter_156:
     name = "parameter_156"
+    original_name = "batch_norm2d_26.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.909262")
@@ -1727,6 +1884,7 @@ class Program_weight_tensor_parameter_156:
 
 class Program_weight_tensor_parameter_157:
     name = "parameter_157"
+    original_name = "batch_norm2d_26.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("1.23388")
@@ -1738,6 +1896,7 @@ class Program_weight_tensor_parameter_157:
 
 class Program_weight_tensor_parameter_158:
     name = "parameter_158"
+    original_name = "batch_norm2d_26.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("2.10325")
@@ -1749,6 +1908,7 @@ class Program_weight_tensor_parameter_158:
 
 class Program_weight_tensor_parameter_159:
     name = "parameter_159"
+    original_name = "batch_norm2d_26.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-14.9605")
@@ -1760,6 +1920,7 @@ class Program_weight_tensor_parameter_159:
 
 class Program_weight_tensor_parameter_160:
     name = "parameter_160"
+    original_name = "conv2d_26.w_0"
     shape = [192, 960, 1, 1]
     dtype = "float32"
     min_val = float("-0.399824")
@@ -1771,6 +1932,7 @@ class Program_weight_tensor_parameter_160:
 
 class Program_weight_tensor_parameter_161:
     name = "parameter_161"
+    original_name = "batch_norm2d_25.b_0"
     shape = [960]
     dtype = "float32"
     min_val = float("-4.83676")
@@ -1782,6 +1944,7 @@ class Program_weight_tensor_parameter_161:
 
 class Program_weight_tensor_parameter_162:
     name = "parameter_162"
+    original_name = "batch_norm2d_25.w_0"
     shape = [960]
     dtype = "float32"
     min_val = float("0.793353")
@@ -1793,6 +1956,7 @@ class Program_weight_tensor_parameter_162:
 
 class Program_weight_tensor_parameter_163:
     name = "parameter_163"
+    original_name = "batch_norm2d_25.w_2"
     shape = [960]
     dtype = "float32"
     min_val = float("5.60519e-45")
@@ -1804,6 +1968,7 @@ class Program_weight_tensor_parameter_163:
 
 class Program_weight_tensor_parameter_164:
     name = "parameter_164"
+    original_name = "batch_norm2d_25.w_1"
     shape = [960]
     dtype = "float32"
     min_val = float("-1.02269")
@@ -1815,6 +1980,7 @@ class Program_weight_tensor_parameter_164:
 
 class Program_weight_tensor_parameter_165:
     name = "parameter_165"
+    original_name = "conv2d_25.w_0"
     shape = [960, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.53791")
@@ -1826,6 +1992,7 @@ class Program_weight_tensor_parameter_165:
 
 class Program_weight_tensor_parameter_166:
     name = "parameter_166"
+    original_name = "batch_norm2d_24.b_0"
     shape = [960]
     dtype = "float32"
     min_val = float("-3.50168")
@@ -1837,6 +2004,7 @@ class Program_weight_tensor_parameter_166:
 
 class Program_weight_tensor_parameter_167:
     name = "parameter_167"
+    original_name = "batch_norm2d_24.w_0"
     shape = [960]
     dtype = "float32"
     min_val = float("-0.131154")
@@ -1848,6 +2016,7 @@ class Program_weight_tensor_parameter_167:
 
 class Program_weight_tensor_parameter_168:
     name = "parameter_168"
+    original_name = "batch_norm2d_24.w_2"
     shape = [960]
     dtype = "float32"
     min_val = float("5.60519e-45")
@@ -1859,6 +2028,7 @@ class Program_weight_tensor_parameter_168:
 
 class Program_weight_tensor_parameter_169:
     name = "parameter_169"
+    original_name = "batch_norm2d_24.w_1"
     shape = [960]
     dtype = "float32"
     min_val = float("-7.25633")
@@ -1870,6 +2040,7 @@ class Program_weight_tensor_parameter_169:
 
 class Program_weight_tensor_parameter_170:
     name = "parameter_170"
+    original_name = "conv2d_24.w_0"
     shape = [960, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.596027")
@@ -1881,6 +2052,7 @@ class Program_weight_tensor_parameter_170:
 
 class Program_weight_tensor_parameter_171:
     name = "parameter_171"
+    original_name = "batch_norm2d_56.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.491651")
@@ -1892,6 +2064,7 @@ class Program_weight_tensor_parameter_171:
 
 class Program_weight_tensor_parameter_172:
     name = "parameter_172"
+    original_name = "batch_norm2d_56.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.420618")
@@ -1903,6 +2076,7 @@ class Program_weight_tensor_parameter_172:
 
 class Program_weight_tensor_parameter_173:
     name = "parameter_173"
+    original_name = "batch_norm2d_56.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.00758491")
@@ -1914,6 +2088,7 @@ class Program_weight_tensor_parameter_173:
 
 class Program_weight_tensor_parameter_174:
     name = "parameter_174"
+    original_name = "batch_norm2d_56.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.351461")
@@ -1925,6 +2100,7 @@ class Program_weight_tensor_parameter_174:
 
 class Program_weight_tensor_parameter_175:
     name = "parameter_175"
+    original_name = "conv2d_59.w_0"
     shape = [160, 320, 1, 1]
     dtype = "float32"
     min_val = float("-0.659562")
@@ -1936,6 +2112,7 @@ class Program_weight_tensor_parameter_175:
 
 class Program_weight_tensor_parameter_176:
     name = "parameter_176"
+    original_name = "conv2d_58.b_0"
     shape = [320]
     dtype = "float32"
     min_val = float("-2.04704")
@@ -1947,6 +2124,7 @@ class Program_weight_tensor_parameter_176:
 
 class Program_weight_tensor_parameter_177:
     name = "parameter_177"
+    original_name = "conv2d_58.w_0"
     shape = [320, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.426622")
@@ -1958,6 +2136,7 @@ class Program_weight_tensor_parameter_177:
 
 class Program_weight_tensor_parameter_178:
     name = "parameter_178"
+    original_name = "batch_norm2d_55.b_0"
     shape = [320]
     dtype = "float32"
     min_val = float("-5.13079")
@@ -1969,6 +2148,7 @@ class Program_weight_tensor_parameter_178:
 
 class Program_weight_tensor_parameter_179:
     name = "parameter_179"
+    original_name = "batch_norm2d_55.w_0"
     shape = [320]
     dtype = "float32"
     min_val = float("0.489065")
@@ -1980,6 +2160,7 @@ class Program_weight_tensor_parameter_179:
 
 class Program_weight_tensor_parameter_180:
     name = "parameter_180"
+    original_name = "batch_norm2d_55.w_2"
     shape = [320]
     dtype = "float32"
     min_val = float("1.72001")
@@ -1991,6 +2172,7 @@ class Program_weight_tensor_parameter_180:
 
 class Program_weight_tensor_parameter_181:
     name = "parameter_181"
+    original_name = "batch_norm2d_55.w_1"
     shape = [320]
     dtype = "float32"
     min_val = float("-5.55958")
@@ -2002,6 +2184,7 @@ class Program_weight_tensor_parameter_181:
 
 class Program_weight_tensor_parameter_182:
     name = "parameter_182"
+    original_name = "conv2d_57.w_0"
     shape = [320, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.388769")
@@ -2013,6 +2196,7 @@ class Program_weight_tensor_parameter_182:
 
 class Program_weight_tensor_parameter_183:
     name = "parameter_183"
+    original_name = "batch_norm2d_50.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-3.8491")
@@ -2024,6 +2208,7 @@ class Program_weight_tensor_parameter_183:
 
 class Program_weight_tensor_parameter_184:
     name = "parameter_184"
+    original_name = "batch_norm2d_50.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-2.92557")
@@ -2035,6 +2220,7 @@ class Program_weight_tensor_parameter_184:
 
 class Program_weight_tensor_parameter_185:
     name = "parameter_185"
+    original_name = "batch_norm2d_50.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.0891018")
@@ -2046,6 +2232,7 @@ class Program_weight_tensor_parameter_185:
 
 class Program_weight_tensor_parameter_186:
     name = "parameter_186"
+    original_name = "batch_norm2d_50.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.889662")
@@ -2057,6 +2244,7 @@ class Program_weight_tensor_parameter_186:
 
 class Program_weight_tensor_parameter_187:
     name = "parameter_187"
+    original_name = "conv2d_52.w_0"
     shape = [160, 192, 1, 1]
     dtype = "float32"
     min_val = float("-0.341971")
@@ -2068,6 +2256,7 @@ class Program_weight_tensor_parameter_187:
 
 class Program_weight_tensor_parameter_188:
     name = "parameter_188"
+    original_name = "batch_norm2d_52.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-2.37504")
@@ -2079,6 +2268,7 @@ class Program_weight_tensor_parameter_188:
 
 class Program_weight_tensor_parameter_189:
     name = "parameter_189"
+    original_name = "batch_norm2d_52.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-1.30002")
@@ -2090,6 +2280,7 @@ class Program_weight_tensor_parameter_189:
 
 class Program_weight_tensor_parameter_190:
     name = "parameter_190"
+    original_name = "batch_norm2d_52.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("0.00872753")
@@ -2101,6 +2292,7 @@ class Program_weight_tensor_parameter_190:
 
 class Program_weight_tensor_parameter_191:
     name = "parameter_191"
+    original_name = "batch_norm2d_52.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.841789")
@@ -2112,6 +2304,7 @@ class Program_weight_tensor_parameter_191:
 
 class Program_weight_tensor_parameter_192:
     name = "parameter_192"
+    original_name = "conv2d_54.w_0"
     shape = [192, 192, 1, 1]
     dtype = "float32"
     min_val = float("-0.333505")
@@ -2123,6 +2316,7 @@ class Program_weight_tensor_parameter_192:
 
 class Program_weight_tensor_parameter_193:
     name = "parameter_193"
+    original_name = "batch_norm2d_51.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-2.37508")
@@ -2134,6 +2328,7 @@ class Program_weight_tensor_parameter_193:
 
 class Program_weight_tensor_parameter_194:
     name = "parameter_194"
+    original_name = "batch_norm2d_51.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-1.44722")
@@ -2145,6 +2340,7 @@ class Program_weight_tensor_parameter_194:
 
 class Program_weight_tensor_parameter_195:
     name = "parameter_195"
+    original_name = "batch_norm2d_51.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("0.00482623")
@@ -2156,6 +2352,7 @@ class Program_weight_tensor_parameter_195:
 
 class Program_weight_tensor_parameter_196:
     name = "parameter_196"
+    original_name = "batch_norm2d_51.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.82958")
@@ -2167,6 +2364,7 @@ class Program_weight_tensor_parameter_196:
 
 class Program_weight_tensor_parameter_197:
     name = "parameter_197"
+    original_name = "conv2d_53.w_0"
     shape = [192, 192, 1, 1]
     dtype = "float32"
     min_val = float("-0.302041")
@@ -2178,6 +2376,7 @@ class Program_weight_tensor_parameter_197:
 
 class Program_weight_tensor_parameter_198:
     name = "parameter_198"
+    original_name = "batch_norm2d_54.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-10.8761")
@@ -2189,6 +2388,7 @@ class Program_weight_tensor_parameter_198:
 
 class Program_weight_tensor_parameter_199:
     name = "parameter_199"
+    original_name = "batch_norm2d_54.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.681215")
@@ -2200,6 +2400,7 @@ class Program_weight_tensor_parameter_199:
 
 class Program_weight_tensor_parameter_200:
     name = "parameter_200"
+    original_name = "batch_norm2d_54.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.0782633")
@@ -2211,6 +2412,7 @@ class Program_weight_tensor_parameter_200:
 
 class Program_weight_tensor_parameter_201:
     name = "parameter_201"
+    original_name = "batch_norm2d_54.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.947607")
@@ -2222,6 +2424,7 @@ class Program_weight_tensor_parameter_201:
 
 class Program_weight_tensor_parameter_202:
     name = "parameter_202"
+    original_name = "conv2d_56.w_0"
     shape = [160, 384, 1, 1]
     dtype = "float32"
     min_val = float("-0.362102")
@@ -2233,6 +2436,7 @@ class Program_weight_tensor_parameter_202:
 
 class Program_weight_tensor_parameter_203:
     name = "parameter_203"
+    original_name = "batch_norm2d_53.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-3.87569")
@@ -2244,6 +2448,7 @@ class Program_weight_tensor_parameter_203:
 
 class Program_weight_tensor_parameter_204:
     name = "parameter_204"
+    original_name = "batch_norm2d_53.w_0"
     shape = [384]
     dtype = "float32"
     min_val = float("0.511665")
@@ -2255,6 +2460,7 @@ class Program_weight_tensor_parameter_204:
 
 class Program_weight_tensor_parameter_205:
     name = "parameter_205"
+    original_name = "batch_norm2d_53.w_2"
     shape = [384]
     dtype = "float32"
     min_val = float("0.000301414")
@@ -2266,6 +2472,7 @@ class Program_weight_tensor_parameter_205:
 
 class Program_weight_tensor_parameter_206:
     name = "parameter_206"
+    original_name = "batch_norm2d_53.w_1"
     shape = [384]
     dtype = "float32"
     min_val = float("-0.867054")
@@ -2277,6 +2484,7 @@ class Program_weight_tensor_parameter_206:
 
 class Program_weight_tensor_parameter_207:
     name = "parameter_207"
+    original_name = "conv2d_55.w_0"
     shape = [384, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.382248")
@@ -2288,6 +2496,7 @@ class Program_weight_tensor_parameter_207:
 
 class Program_weight_tensor_parameter_208:
     name = "parameter_208"
+    original_name = "batch_norm2d_49.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-1.76187")
@@ -2299,6 +2508,7 @@ class Program_weight_tensor_parameter_208:
 
 class Program_weight_tensor_parameter_209:
     name = "parameter_209"
+    original_name = "batch_norm2d_49.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("0.324269")
@@ -2310,6 +2520,7 @@ class Program_weight_tensor_parameter_209:
 
 class Program_weight_tensor_parameter_210:
     name = "parameter_210"
+    original_name = "batch_norm2d_49.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("3.06437")
@@ -2321,6 +2532,7 @@ class Program_weight_tensor_parameter_210:
 
 class Program_weight_tensor_parameter_211:
     name = "parameter_211"
+    original_name = "batch_norm2d_49.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-5.75436")
@@ -2332,6 +2544,7 @@ class Program_weight_tensor_parameter_211:
 
 class Program_weight_tensor_parameter_212:
     name = "parameter_212"
+    original_name = "conv2d_51.w_0"
     shape = [192, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.623411")
@@ -2343,6 +2556,7 @@ class Program_weight_tensor_parameter_212:
 
 class Program_weight_tensor_parameter_213:
     name = "parameter_213"
+    original_name = "batch_norm2d_48.b_0"
     shape = [96]
     dtype = "float32"
     min_val = float("-1.13031")
@@ -2354,6 +2568,7 @@ class Program_weight_tensor_parameter_213:
 
 class Program_weight_tensor_parameter_214:
     name = "parameter_214"
+    original_name = "batch_norm2d_48.w_0"
     shape = [96]
     dtype = "float32"
     min_val = float("0.108122")
@@ -2365,6 +2580,7 @@ class Program_weight_tensor_parameter_214:
 
 class Program_weight_tensor_parameter_215:
     name = "parameter_215"
+    original_name = "batch_norm2d_48.w_2"
     shape = [96]
     dtype = "float32"
     min_val = float("1.50696")
@@ -2376,6 +2592,7 @@ class Program_weight_tensor_parameter_215:
 
 class Program_weight_tensor_parameter_216:
     name = "parameter_216"
+    original_name = "batch_norm2d_48.w_1"
     shape = [96]
     dtype = "float32"
     min_val = float("-4.29504")
@@ -2387,6 +2604,7 @@ class Program_weight_tensor_parameter_216:
 
 class Program_weight_tensor_parameter_217:
     name = "parameter_217"
+    original_name = "conv2d_50.w_0"
     shape = [96, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.426308")
@@ -2398,6 +2616,7 @@ class Program_weight_tensor_parameter_217:
 
 class Program_weight_tensor_parameter_218:
     name = "parameter_218"
+    original_name = "batch_norm2d_47.b_0"
     shape = [96]
     dtype = "float32"
     min_val = float("-2.74204")
@@ -2409,6 +2628,7 @@ class Program_weight_tensor_parameter_218:
 
 class Program_weight_tensor_parameter_219:
     name = "parameter_219"
+    original_name = "batch_norm2d_47.w_0"
     shape = [96]
     dtype = "float32"
     min_val = float("0.0607976")
@@ -2420,6 +2640,7 @@ class Program_weight_tensor_parameter_219:
 
 class Program_weight_tensor_parameter_220:
     name = "parameter_220"
+    original_name = "batch_norm2d_47.w_2"
     shape = [96]
     dtype = "float32"
     min_val = float("1.62153")
@@ -2431,6 +2652,7 @@ class Program_weight_tensor_parameter_220:
 
 class Program_weight_tensor_parameter_221:
     name = "parameter_221"
+    original_name = "batch_norm2d_47.w_1"
     shape = [96]
     dtype = "float32"
     min_val = float("-3.10706")
@@ -2442,6 +2664,7 @@ class Program_weight_tensor_parameter_221:
 
 class Program_weight_tensor_parameter_222:
     name = "parameter_222"
+    original_name = "conv2d_49.w_0"
     shape = [96, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.378679")
@@ -2453,6 +2676,7 @@ class Program_weight_tensor_parameter_222:
 
 class Program_weight_tensor_parameter_223:
     name = "parameter_223"
+    original_name = "batch_norm2d_46.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-1.10904")
@@ -2464,6 +2688,7 @@ class Program_weight_tensor_parameter_223:
 
 class Program_weight_tensor_parameter_224:
     name = "parameter_224"
+    original_name = "batch_norm2d_46.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.252018")
@@ -2475,6 +2700,7 @@ class Program_weight_tensor_parameter_224:
 
 class Program_weight_tensor_parameter_225:
     name = "parameter_225"
+    original_name = "batch_norm2d_46.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.00990516")
@@ -2486,6 +2712,7 @@ class Program_weight_tensor_parameter_225:
 
 class Program_weight_tensor_parameter_226:
     name = "parameter_226"
+    original_name = "batch_norm2d_46.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.579024")
@@ -2497,6 +2724,7 @@ class Program_weight_tensor_parameter_226:
 
 class Program_weight_tensor_parameter_227:
     name = "parameter_227"
+    original_name = "conv2d_48.w_0"
     shape = [160, 320, 1, 1]
     dtype = "float32"
     min_val = float("-0.441261")
@@ -2508,6 +2736,7 @@ class Program_weight_tensor_parameter_227:
 
 class Program_weight_tensor_parameter_228:
     name = "parameter_228"
+    original_name = "conv2d_47.b_0"
     shape = [320]
     dtype = "float32"
     min_val = float("-3.72808")
@@ -2519,6 +2748,7 @@ class Program_weight_tensor_parameter_228:
 
 class Program_weight_tensor_parameter_229:
     name = "parameter_229"
+    original_name = "conv2d_47.w_0"
     shape = [320, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.484868")
@@ -2530,6 +2760,7 @@ class Program_weight_tensor_parameter_229:
 
 class Program_weight_tensor_parameter_230:
     name = "parameter_230"
+    original_name = "batch_norm2d_45.b_0"
     shape = [320]
     dtype = "float32"
     min_val = float("-4.42061")
@@ -2541,6 +2772,7 @@ class Program_weight_tensor_parameter_230:
 
 class Program_weight_tensor_parameter_231:
     name = "parameter_231"
+    original_name = "batch_norm2d_45.w_0"
     shape = [320]
     dtype = "float32"
     min_val = float("0.437423")
@@ -2552,6 +2784,7 @@ class Program_weight_tensor_parameter_231:
 
 class Program_weight_tensor_parameter_232:
     name = "parameter_232"
+    original_name = "batch_norm2d_45.w_2"
     shape = [320]
     dtype = "float32"
     min_val = float("1.80384")
@@ -2563,6 +2796,7 @@ class Program_weight_tensor_parameter_232:
 
 class Program_weight_tensor_parameter_233:
     name = "parameter_233"
+    original_name = "batch_norm2d_45.w_1"
     shape = [320]
     dtype = "float32"
     min_val = float("-3.76114")
@@ -2574,6 +2808,7 @@ class Program_weight_tensor_parameter_233:
 
 class Program_weight_tensor_parameter_234:
     name = "parameter_234"
+    original_name = "conv2d_46.w_0"
     shape = [320, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.562467")
@@ -2585,6 +2820,7 @@ class Program_weight_tensor_parameter_234:
 
 class Program_weight_tensor_parameter_235:
     name = "parameter_235"
+    original_name = "batch_norm2d_40.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-2.7042")
@@ -2596,6 +2832,7 @@ class Program_weight_tensor_parameter_235:
 
 class Program_weight_tensor_parameter_236:
     name = "parameter_236"
+    original_name = "batch_norm2d_40.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-2.64835")
@@ -2607,6 +2844,7 @@ class Program_weight_tensor_parameter_236:
 
 class Program_weight_tensor_parameter_237:
     name = "parameter_237"
+    original_name = "batch_norm2d_40.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.0989894")
@@ -2618,6 +2856,7 @@ class Program_weight_tensor_parameter_237:
 
 class Program_weight_tensor_parameter_238:
     name = "parameter_238"
+    original_name = "batch_norm2d_40.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.976287")
@@ -2629,6 +2868,7 @@ class Program_weight_tensor_parameter_238:
 
 class Program_weight_tensor_parameter_239:
     name = "parameter_239"
+    original_name = "conv2d_41.w_0"
     shape = [160, 192, 1, 1]
     dtype = "float32"
     min_val = float("-0.348199")
@@ -2640,6 +2880,7 @@ class Program_weight_tensor_parameter_239:
 
 class Program_weight_tensor_parameter_240:
     name = "parameter_240"
+    original_name = "batch_norm2d_42.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-2.47227")
@@ -2651,6 +2892,7 @@ class Program_weight_tensor_parameter_240:
 
 class Program_weight_tensor_parameter_241:
     name = "parameter_241"
+    original_name = "batch_norm2d_42.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-1.18387")
@@ -2662,6 +2904,7 @@ class Program_weight_tensor_parameter_241:
 
 class Program_weight_tensor_parameter_242:
     name = "parameter_242"
+    original_name = "batch_norm2d_42.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("0.00703715")
@@ -2673,6 +2916,7 @@ class Program_weight_tensor_parameter_242:
 
 class Program_weight_tensor_parameter_243:
     name = "parameter_243"
+    original_name = "batch_norm2d_42.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-1.15654")
@@ -2684,6 +2928,7 @@ class Program_weight_tensor_parameter_243:
 
 class Program_weight_tensor_parameter_244:
     name = "parameter_244"
+    original_name = "conv2d_43.w_0"
     shape = [192, 192, 1, 1]
     dtype = "float32"
     min_val = float("-0.335779")
@@ -2695,6 +2940,7 @@ class Program_weight_tensor_parameter_244:
 
 class Program_weight_tensor_parameter_245:
     name = "parameter_245"
+    original_name = "batch_norm2d_41.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-2.4724")
@@ -2706,6 +2952,7 @@ class Program_weight_tensor_parameter_245:
 
 class Program_weight_tensor_parameter_246:
     name = "parameter_246"
+    original_name = "batch_norm2d_41.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-1.56191")
@@ -2717,6 +2964,7 @@ class Program_weight_tensor_parameter_246:
 
 class Program_weight_tensor_parameter_247:
     name = "parameter_247"
+    original_name = "batch_norm2d_41.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("0.00511736")
@@ -2728,6 +2976,7 @@ class Program_weight_tensor_parameter_247:
 
 class Program_weight_tensor_parameter_248:
     name = "parameter_248"
+    original_name = "batch_norm2d_41.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.93404")
@@ -2739,6 +2988,7 @@ class Program_weight_tensor_parameter_248:
 
 class Program_weight_tensor_parameter_249:
     name = "parameter_249"
+    original_name = "conv2d_42.w_0"
     shape = [192, 192, 1, 1]
     dtype = "float32"
     min_val = float("-0.419101")
@@ -2750,6 +3000,7 @@ class Program_weight_tensor_parameter_249:
 
 class Program_weight_tensor_parameter_250:
     name = "parameter_250"
+    original_name = "batch_norm2d_44.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-9.5367")
@@ -2761,6 +3012,7 @@ class Program_weight_tensor_parameter_250:
 
 class Program_weight_tensor_parameter_251:
     name = "parameter_251"
+    original_name = "batch_norm2d_44.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.833508")
@@ -2772,6 +3024,7 @@ class Program_weight_tensor_parameter_251:
 
 class Program_weight_tensor_parameter_252:
     name = "parameter_252"
+    original_name = "batch_norm2d_44.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.102768")
@@ -2783,6 +3036,7 @@ class Program_weight_tensor_parameter_252:
 
 class Program_weight_tensor_parameter_253:
     name = "parameter_253"
+    original_name = "batch_norm2d_44.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.852297")
@@ -2794,6 +3048,7 @@ class Program_weight_tensor_parameter_253:
 
 class Program_weight_tensor_parameter_254:
     name = "parameter_254"
+    original_name = "conv2d_45.w_0"
     shape = [160, 384, 1, 1]
     dtype = "float32"
     min_val = float("-0.491285")
@@ -2805,6 +3060,7 @@ class Program_weight_tensor_parameter_254:
 
 class Program_weight_tensor_parameter_255:
     name = "parameter_255"
+    original_name = "batch_norm2d_43.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-4.60269")
@@ -2816,6 +3072,7 @@ class Program_weight_tensor_parameter_255:
 
 class Program_weight_tensor_parameter_256:
     name = "parameter_256"
+    original_name = "batch_norm2d_43.w_0"
     shape = [384]
     dtype = "float32"
     min_val = float("0.476992")
@@ -2827,6 +3084,7 @@ class Program_weight_tensor_parameter_256:
 
 class Program_weight_tensor_parameter_257:
     name = "parameter_257"
+    original_name = "batch_norm2d_43.w_2"
     shape = [384]
     dtype = "float32"
     min_val = float("0.000463212")
@@ -2838,6 +3096,7 @@ class Program_weight_tensor_parameter_257:
 
 class Program_weight_tensor_parameter_258:
     name = "parameter_258"
+    original_name = "batch_norm2d_43.w_1"
     shape = [384]
     dtype = "float32"
     min_val = float("-0.745419")
@@ -2849,6 +3108,7 @@ class Program_weight_tensor_parameter_258:
 
 class Program_weight_tensor_parameter_259:
     name = "parameter_259"
+    original_name = "conv2d_44.w_0"
     shape = [384, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.357631")
@@ -2860,6 +3120,7 @@ class Program_weight_tensor_parameter_259:
 
 class Program_weight_tensor_parameter_260:
     name = "parameter_260"
+    original_name = "batch_norm2d_39.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-1.39207")
@@ -2871,6 +3132,7 @@ class Program_weight_tensor_parameter_260:
 
 class Program_weight_tensor_parameter_261:
     name = "parameter_261"
+    original_name = "batch_norm2d_39.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("0.0656485")
@@ -2882,6 +3144,7 @@ class Program_weight_tensor_parameter_261:
 
 class Program_weight_tensor_parameter_262:
     name = "parameter_262"
+    original_name = "batch_norm2d_39.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("2.51654")
@@ -2893,6 +3156,7 @@ class Program_weight_tensor_parameter_262:
 
 class Program_weight_tensor_parameter_263:
     name = "parameter_263"
+    original_name = "batch_norm2d_39.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-7.52958")
@@ -2904,6 +3168,7 @@ class Program_weight_tensor_parameter_263:
 
 class Program_weight_tensor_parameter_264:
     name = "parameter_264"
+    original_name = "conv2d_40.w_0"
     shape = [192, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.717801")
@@ -2915,6 +3180,7 @@ class Program_weight_tensor_parameter_264:
 
 class Program_weight_tensor_parameter_265:
     name = "parameter_265"
+    original_name = "batch_norm2d_38.b_0"
     shape = [96]
     dtype = "float32"
     min_val = float("-1.22609")
@@ -2926,6 +3192,7 @@ class Program_weight_tensor_parameter_265:
 
 class Program_weight_tensor_parameter_266:
     name = "parameter_266"
+    original_name = "batch_norm2d_38.w_0"
     shape = [96]
     dtype = "float32"
     min_val = float("0.0709358")
@@ -2937,6 +3204,7 @@ class Program_weight_tensor_parameter_266:
 
 class Program_weight_tensor_parameter_267:
     name = "parameter_267"
+    original_name = "batch_norm2d_38.w_2"
     shape = [96]
     dtype = "float32"
     min_val = float("1.77002")
@@ -2948,6 +3216,7 @@ class Program_weight_tensor_parameter_267:
 
 class Program_weight_tensor_parameter_268:
     name = "parameter_268"
+    original_name = "batch_norm2d_38.w_1"
     shape = [96]
     dtype = "float32"
     min_val = float("-3.31063")
@@ -2959,6 +3228,7 @@ class Program_weight_tensor_parameter_268:
 
 class Program_weight_tensor_parameter_269:
     name = "parameter_269"
+    original_name = "conv2d_39.w_0"
     shape = [96, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.440663")
@@ -2970,6 +3240,7 @@ class Program_weight_tensor_parameter_269:
 
 class Program_weight_tensor_parameter_270:
     name = "parameter_270"
+    original_name = "batch_norm2d_37.b_0"
     shape = [96]
     dtype = "float32"
     min_val = float("-1.26974")
@@ -2981,6 +3252,7 @@ class Program_weight_tensor_parameter_270:
 
 class Program_weight_tensor_parameter_271:
     name = "parameter_271"
+    original_name = "batch_norm2d_37.w_0"
     shape = [96]
     dtype = "float32"
     min_val = float("0.115087")
@@ -2992,6 +3264,7 @@ class Program_weight_tensor_parameter_271:
 
 class Program_weight_tensor_parameter_272:
     name = "parameter_272"
+    original_name = "batch_norm2d_37.w_2"
     shape = [96]
     dtype = "float32"
     min_val = float("1.51623")
@@ -3003,6 +3276,7 @@ class Program_weight_tensor_parameter_272:
 
 class Program_weight_tensor_parameter_273:
     name = "parameter_273"
+    original_name = "batch_norm2d_37.w_1"
     shape = [96]
     dtype = "float32"
     min_val = float("-4.52321")
@@ -3014,6 +3288,7 @@ class Program_weight_tensor_parameter_273:
 
 class Program_weight_tensor_parameter_274:
     name = "parameter_274"
+    original_name = "conv2d_38.w_0"
     shape = [96, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.374328")
@@ -3025,6 +3300,7 @@ class Program_weight_tensor_parameter_274:
 
 class Program_weight_tensor_parameter_275:
     name = "parameter_275"
+    original_name = "batch_norm2d_36.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.00327022")
@@ -3036,6 +3312,7 @@ class Program_weight_tensor_parameter_275:
 
 class Program_weight_tensor_parameter_276:
     name = "parameter_276"
+    original_name = "batch_norm2d_36.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.387327")
@@ -3047,6 +3324,7 @@ class Program_weight_tensor_parameter_276:
 
 class Program_weight_tensor_parameter_277:
     name = "parameter_277"
+    original_name = "batch_norm2d_36.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.0416635")
@@ -3058,6 +3336,7 @@ class Program_weight_tensor_parameter_277:
 
 class Program_weight_tensor_parameter_278:
     name = "parameter_278"
+    original_name = "batch_norm2d_36.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.788108")
@@ -3069,6 +3348,7 @@ class Program_weight_tensor_parameter_278:
 
 class Program_weight_tensor_parameter_279:
     name = "parameter_279"
+    original_name = "conv2d_37.w_0"
     shape = [160, 320, 1, 1]
     dtype = "float32"
     min_val = float("-0.56769")
@@ -3080,6 +3360,7 @@ class Program_weight_tensor_parameter_279:
 
 class Program_weight_tensor_parameter_280:
     name = "parameter_280"
+    original_name = "conv2d_36.b_0"
     shape = [320]
     dtype = "float32"
     min_val = float("-3.51341")
@@ -3091,6 +3372,7 @@ class Program_weight_tensor_parameter_280:
 
 class Program_weight_tensor_parameter_281:
     name = "parameter_281"
+    original_name = "conv2d_36.w_0"
     shape = [320, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.549087")
@@ -3102,6 +3384,7 @@ class Program_weight_tensor_parameter_281:
 
 class Program_weight_tensor_parameter_282:
     name = "parameter_282"
+    original_name = "batch_norm2d_35.b_0"
     shape = [320]
     dtype = "float32"
     min_val = float("-3.94091")
@@ -3113,6 +3396,7 @@ class Program_weight_tensor_parameter_282:
 
 class Program_weight_tensor_parameter_283:
     name = "parameter_283"
+    original_name = "batch_norm2d_35.w_0"
     shape = [320]
     dtype = "float32"
     min_val = float("0.901889")
@@ -3124,6 +3408,7 @@ class Program_weight_tensor_parameter_283:
 
 class Program_weight_tensor_parameter_284:
     name = "parameter_284"
+    original_name = "batch_norm2d_35.w_2"
     shape = [320]
     dtype = "float32"
     min_val = float("1.20738")
@@ -3135,6 +3420,7 @@ class Program_weight_tensor_parameter_284:
 
 class Program_weight_tensor_parameter_285:
     name = "parameter_285"
+    original_name = "batch_norm2d_35.w_1"
     shape = [320]
     dtype = "float32"
     min_val = float("-5.92147")
@@ -3146,6 +3432,7 @@ class Program_weight_tensor_parameter_285:
 
 class Program_weight_tensor_parameter_286:
     name = "parameter_286"
+    original_name = "conv2d_35.w_0"
     shape = [320, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.734099")
@@ -3157,6 +3444,7 @@ class Program_weight_tensor_parameter_286:
 
 class Program_weight_tensor_parameter_287:
     name = "parameter_287"
+    original_name = "batch_norm2d_30.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-2.48405")
@@ -3168,6 +3456,7 @@ class Program_weight_tensor_parameter_287:
 
 class Program_weight_tensor_parameter_288:
     name = "parameter_288"
+    original_name = "batch_norm2d_30.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-2.18063")
@@ -3179,6 +3468,7 @@ class Program_weight_tensor_parameter_288:
 
 class Program_weight_tensor_parameter_289:
     name = "parameter_289"
+    original_name = "batch_norm2d_30.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.0928075")
@@ -3190,6 +3480,7 @@ class Program_weight_tensor_parameter_289:
 
 class Program_weight_tensor_parameter_290:
     name = "parameter_290"
+    original_name = "batch_norm2d_30.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-1.47036")
@@ -3201,6 +3492,7 @@ class Program_weight_tensor_parameter_290:
 
 class Program_weight_tensor_parameter_291:
     name = "parameter_291"
+    original_name = "conv2d_30.w_0"
     shape = [160, 192, 1, 1]
     dtype = "float32"
     min_val = float("-0.717852")
@@ -3212,6 +3504,7 @@ class Program_weight_tensor_parameter_291:
 
 class Program_weight_tensor_parameter_292:
     name = "parameter_292"
+    original_name = "batch_norm2d_32.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-5.65278")
@@ -3223,6 +3516,7 @@ class Program_weight_tensor_parameter_292:
 
 class Program_weight_tensor_parameter_293:
     name = "parameter_293"
+    original_name = "batch_norm2d_32.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-2.98867")
@@ -3234,6 +3528,7 @@ class Program_weight_tensor_parameter_293:
 
 class Program_weight_tensor_parameter_294:
     name = "parameter_294"
+    original_name = "batch_norm2d_32.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("0.0298566")
@@ -3245,6 +3540,7 @@ class Program_weight_tensor_parameter_294:
 
 class Program_weight_tensor_parameter_295:
     name = "parameter_295"
+    original_name = "batch_norm2d_32.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-1.59128")
@@ -3256,6 +3552,7 @@ class Program_weight_tensor_parameter_295:
 
 class Program_weight_tensor_parameter_296:
     name = "parameter_296"
+    original_name = "conv2d_32.w_0"
     shape = [192, 192, 1, 1]
     dtype = "float32"
     min_val = float("-0.535143")
@@ -3267,6 +3564,7 @@ class Program_weight_tensor_parameter_296:
 
 class Program_weight_tensor_parameter_297:
     name = "parameter_297"
+    original_name = "batch_norm2d_31.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-5.65277")
@@ -3278,6 +3576,7 @@ class Program_weight_tensor_parameter_297:
 
 class Program_weight_tensor_parameter_298:
     name = "parameter_298"
+    original_name = "batch_norm2d_31.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-2.37812")
@@ -3289,6 +3588,7 @@ class Program_weight_tensor_parameter_298:
 
 class Program_weight_tensor_parameter_299:
     name = "parameter_299"
+    original_name = "batch_norm2d_31.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("0.0171108")
@@ -3300,6 +3600,7 @@ class Program_weight_tensor_parameter_299:
 
 class Program_weight_tensor_parameter_300:
     name = "parameter_300"
+    original_name = "batch_norm2d_31.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-1.91704")
@@ -3311,6 +3612,7 @@ class Program_weight_tensor_parameter_300:
 
 class Program_weight_tensor_parameter_301:
     name = "parameter_301"
+    original_name = "conv2d_31.w_0"
     shape = [192, 192, 1, 1]
     dtype = "float32"
     min_val = float("-0.654884")
@@ -3322,6 +3624,7 @@ class Program_weight_tensor_parameter_301:
 
 class Program_weight_tensor_parameter_302:
     name = "parameter_302"
+    original_name = "batch_norm2d_34.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-13.9114")
@@ -3333,6 +3636,7 @@ class Program_weight_tensor_parameter_302:
 
 class Program_weight_tensor_parameter_303:
     name = "parameter_303"
+    original_name = "batch_norm2d_34.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.637045")
@@ -3344,6 +3648,7 @@ class Program_weight_tensor_parameter_303:
 
 class Program_weight_tensor_parameter_304:
     name = "parameter_304"
+    original_name = "batch_norm2d_34.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.250958")
@@ -3355,6 +3660,7 @@ class Program_weight_tensor_parameter_304:
 
 class Program_weight_tensor_parameter_305:
     name = "parameter_305"
+    original_name = "batch_norm2d_34.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-5.07249")
@@ -3366,6 +3672,7 @@ class Program_weight_tensor_parameter_305:
 
 class Program_weight_tensor_parameter_306:
     name = "parameter_306"
+    original_name = "conv2d_34.w_0"
     shape = [160, 384, 1, 1]
     dtype = "float32"
     min_val = float("-0.871533")
@@ -3377,6 +3684,7 @@ class Program_weight_tensor_parameter_306:
 
 class Program_weight_tensor_parameter_307:
     name = "parameter_307"
+    original_name = "batch_norm2d_33.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-5.3433")
@@ -3388,6 +3696,7 @@ class Program_weight_tensor_parameter_307:
 
 class Program_weight_tensor_parameter_308:
     name = "parameter_308"
+    original_name = "batch_norm2d_33.w_0"
     shape = [384]
     dtype = "float32"
     min_val = float("0.531147")
@@ -3399,6 +3708,7 @@ class Program_weight_tensor_parameter_308:
 
 class Program_weight_tensor_parameter_309:
     name = "parameter_309"
+    original_name = "batch_norm2d_33.w_2"
     shape = [384]
     dtype = "float32"
     min_val = float("0.000515588")
@@ -3410,6 +3720,7 @@ class Program_weight_tensor_parameter_309:
 
 class Program_weight_tensor_parameter_310:
     name = "parameter_310"
+    original_name = "batch_norm2d_33.w_1"
     shape = [384]
     dtype = "float32"
     min_val = float("-4.573")
@@ -3421,6 +3732,7 @@ class Program_weight_tensor_parameter_310:
 
 class Program_weight_tensor_parameter_311:
     name = "parameter_311"
+    original_name = "conv2d_33.w_0"
     shape = [384, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.715493")
@@ -3432,6 +3744,7 @@ class Program_weight_tensor_parameter_311:
 
 class Program_weight_tensor_parameter_312:
     name = "parameter_312"
+    original_name = "batch_norm2d_29.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-4.69529")
@@ -3443,6 +3756,7 @@ class Program_weight_tensor_parameter_312:
 
 class Program_weight_tensor_parameter_313:
     name = "parameter_313"
+    original_name = "batch_norm2d_29.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("0.0920039")
@@ -3454,6 +3768,7 @@ class Program_weight_tensor_parameter_313:
 
 class Program_weight_tensor_parameter_314:
     name = "parameter_314"
+    original_name = "batch_norm2d_29.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("1.59648")
@@ -3465,6 +3780,7 @@ class Program_weight_tensor_parameter_314:
 
 class Program_weight_tensor_parameter_315:
     name = "parameter_315"
+    original_name = "batch_norm2d_29.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.00427836")
@@ -3476,6 +3792,7 @@ class Program_weight_tensor_parameter_315:
 
 class Program_weight_tensor_parameter_316:
     name = "parameter_316"
+    original_name = "conv2d_29.w_0"
     shape = [192, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.987647")
@@ -3487,6 +3804,7 @@ class Program_weight_tensor_parameter_316:
 
 class Program_weight_tensor_parameter_317:
     name = "parameter_317"
+    original_name = "batch_norm2d_28.b_0"
     shape = [96]
     dtype = "float32"
     min_val = float("-1.77747")
@@ -3498,6 +3816,7 @@ class Program_weight_tensor_parameter_317:
 
 class Program_weight_tensor_parameter_318:
     name = "parameter_318"
+    original_name = "batch_norm2d_28.w_0"
     shape = [96]
     dtype = "float32"
     min_val = float("0.0523727")
@@ -3509,6 +3828,7 @@ class Program_weight_tensor_parameter_318:
 
 class Program_weight_tensor_parameter_319:
     name = "parameter_319"
+    original_name = "batch_norm2d_28.w_2"
     shape = [96]
     dtype = "float32"
     min_val = float("1.08635")
@@ -3520,6 +3840,7 @@ class Program_weight_tensor_parameter_319:
 
 class Program_weight_tensor_parameter_320:
     name = "parameter_320"
+    original_name = "batch_norm2d_28.w_1"
     shape = [96]
     dtype = "float32"
     min_val = float("-0.00258461")
@@ -3531,6 +3852,7 @@ class Program_weight_tensor_parameter_320:
 
 class Program_weight_tensor_parameter_321:
     name = "parameter_321"
+    original_name = "conv2d_28.w_0"
     shape = [96, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.71674")
@@ -3542,6 +3864,7 @@ class Program_weight_tensor_parameter_321:
 
 class Program_weight_tensor_parameter_322:
     name = "parameter_322"
+    original_name = "batch_norm2d_27.b_0"
     shape = [96]
     dtype = "float32"
     min_val = float("-12.031")
@@ -3553,6 +3876,7 @@ class Program_weight_tensor_parameter_322:
 
 class Program_weight_tensor_parameter_323:
     name = "parameter_323"
+    original_name = "batch_norm2d_27.w_0"
     shape = [96]
     dtype = "float32"
     min_val = float("0.0869672")
@@ -3564,6 +3888,7 @@ class Program_weight_tensor_parameter_323:
 
 class Program_weight_tensor_parameter_324:
     name = "parameter_324"
+    original_name = "batch_norm2d_27.w_2"
     shape = [96]
     dtype = "float32"
     min_val = float("1.15927")
@@ -3575,6 +3900,7 @@ class Program_weight_tensor_parameter_324:
 
 class Program_weight_tensor_parameter_325:
     name = "parameter_325"
+    original_name = "batch_norm2d_27.w_1"
     shape = [96]
     dtype = "float32"
     min_val = float("-0.00258741")
@@ -3586,6 +3912,7 @@ class Program_weight_tensor_parameter_325:
 
 class Program_weight_tensor_parameter_326:
     name = "parameter_326"
+    original_name = "conv2d_27.w_0"
     shape = [96, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.840882")
@@ -3597,6 +3924,7 @@ class Program_weight_tensor_parameter_326:
 
 class Program_weight_tensor_parameter_327:
     name = "parameter_327"
+    original_name = "batch_norm2d_23.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.00496585")
@@ -3608,6 +3936,7 @@ class Program_weight_tensor_parameter_327:
 
 class Program_weight_tensor_parameter_328:
     name = "parameter_328"
+    original_name = "batch_norm2d_23.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("0.847523")
@@ -3619,6 +3948,7 @@ class Program_weight_tensor_parameter_328:
 
 class Program_weight_tensor_parameter_329:
     name = "parameter_329"
+    original_name = "batch_norm2d_23.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("2.44071")
@@ -3630,6 +3960,7 @@ class Program_weight_tensor_parameter_329:
 
 class Program_weight_tensor_parameter_330:
     name = "parameter_330"
+    original_name = "batch_norm2d_23.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-13.2659")
@@ -3641,6 +3972,7 @@ class Program_weight_tensor_parameter_330:
 
 class Program_weight_tensor_parameter_331:
     name = "parameter_331"
+    original_name = "conv2d_23.w_0"
     shape = [160, 384, 1, 1]
     dtype = "float32"
     min_val = float("-0.939962")
@@ -3652,6 +3984,7 @@ class Program_weight_tensor_parameter_331:
 
 class Program_weight_tensor_parameter_332:
     name = "parameter_332"
+    original_name = "batch_norm2d_22.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-8.01603")
@@ -3663,6 +3996,7 @@ class Program_weight_tensor_parameter_332:
 
 class Program_weight_tensor_parameter_333:
     name = "parameter_333"
+    original_name = "batch_norm2d_22.w_0"
     shape = [384]
     dtype = "float32"
     min_val = float("1.08085")
@@ -3674,6 +4008,7 @@ class Program_weight_tensor_parameter_333:
 
 class Program_weight_tensor_parameter_334:
     name = "parameter_334"
+    original_name = "batch_norm2d_22.w_2"
     shape = [384]
     dtype = "float32"
     min_val = float("5.60519e-45")
@@ -3685,6 +4020,7 @@ class Program_weight_tensor_parameter_334:
 
 class Program_weight_tensor_parameter_335:
     name = "parameter_335"
+    original_name = "batch_norm2d_22.w_1"
     shape = [384]
     dtype = "float32"
     min_val = float("-2.65927")
@@ -3696,6 +4032,7 @@ class Program_weight_tensor_parameter_335:
 
 class Program_weight_tensor_parameter_336:
     name = "parameter_336"
+    original_name = "conv2d_22.w_0"
     shape = [384, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.401214")
@@ -3707,6 +4044,7 @@ class Program_weight_tensor_parameter_336:
 
 class Program_weight_tensor_parameter_337:
     name = "parameter_337"
+    original_name = "batch_norm2d_21.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-4.22972")
@@ -3718,6 +4056,7 @@ class Program_weight_tensor_parameter_337:
 
 class Program_weight_tensor_parameter_338:
     name = "parameter_338"
+    original_name = "batch_norm2d_21.w_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-0.009879")
@@ -3729,6 +4068,7 @@ class Program_weight_tensor_parameter_338:
 
 class Program_weight_tensor_parameter_339:
     name = "parameter_339"
+    original_name = "batch_norm2d_21.w_2"
     shape = [384]
     dtype = "float32"
     min_val = float("5.60519e-45")
@@ -3740,6 +4080,7 @@ class Program_weight_tensor_parameter_339:
 
 class Program_weight_tensor_parameter_340:
     name = "parameter_340"
+    original_name = "batch_norm2d_21.w_1"
     shape = [384]
     dtype = "float32"
     min_val = float("-0.00357057")
@@ -3751,6 +4092,7 @@ class Program_weight_tensor_parameter_340:
 
 class Program_weight_tensor_parameter_341:
     name = "parameter_341"
+    original_name = "conv2d_21.w_0"
     shape = [384, 96, 1, 1]
     dtype = "float32"
     min_val = float("-0.745157")
@@ -3762,6 +4104,7 @@ class Program_weight_tensor_parameter_341:
 
 class Program_weight_tensor_parameter_342:
     name = "parameter_342"
+    original_name = "batch_norm2d_20.b_0"
     shape = [96]
     dtype = "float32"
     min_val = float("-0.00147919")
@@ -3773,6 +4116,7 @@ class Program_weight_tensor_parameter_342:
 
 class Program_weight_tensor_parameter_343:
     name = "parameter_343"
+    original_name = "batch_norm2d_20.w_0"
     shape = [96]
     dtype = "float32"
     min_val = float("1.00368")
@@ -3784,6 +4128,7 @@ class Program_weight_tensor_parameter_343:
 
 class Program_weight_tensor_parameter_344:
     name = "parameter_344"
+    original_name = "batch_norm2d_20.w_2"
     shape = [96]
     dtype = "float32"
     min_val = float("0.894153")
@@ -3795,6 +4140,7 @@ class Program_weight_tensor_parameter_344:
 
 class Program_weight_tensor_parameter_345:
     name = "parameter_345"
+    original_name = "batch_norm2d_20.w_1"
     shape = [96]
     dtype = "float32"
     min_val = float("-7.50301")
@@ -3806,6 +4152,7 @@ class Program_weight_tensor_parameter_345:
 
 class Program_weight_tensor_parameter_346:
     name = "parameter_346"
+    original_name = "conv2d_20.w_0"
     shape = [96, 288, 1, 1]
     dtype = "float32"
     min_val = float("-0.484845")
@@ -3817,6 +4164,7 @@ class Program_weight_tensor_parameter_346:
 
 class Program_weight_tensor_parameter_347:
     name = "parameter_347"
+    original_name = "batch_norm2d_19.b_0"
     shape = [288]
     dtype = "float32"
     min_val = float("-9.05633")
@@ -3828,6 +4176,7 @@ class Program_weight_tensor_parameter_347:
 
 class Program_weight_tensor_parameter_348:
     name = "parameter_348"
+    original_name = "batch_norm2d_19.w_0"
     shape = [288]
     dtype = "float32"
     min_val = float("0.722175")
@@ -3839,6 +4188,7 @@ class Program_weight_tensor_parameter_348:
 
 class Program_weight_tensor_parameter_349:
     name = "parameter_349"
+    original_name = "batch_norm2d_19.w_2"
     shape = [288]
     dtype = "float32"
     min_val = float("5.60519e-45")
@@ -3850,6 +4200,7 @@ class Program_weight_tensor_parameter_349:
 
 class Program_weight_tensor_parameter_350:
     name = "parameter_350"
+    original_name = "batch_norm2d_19.w_1"
     shape = [288]
     dtype = "float32"
     min_val = float("-9.26525")
@@ -3861,6 +4212,7 @@ class Program_weight_tensor_parameter_350:
 
 class Program_weight_tensor_parameter_351:
     name = "parameter_351"
+    original_name = "conv2d_19.w_0"
     shape = [288, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.685085")
@@ -3872,6 +4224,7 @@ class Program_weight_tensor_parameter_351:
 
 class Program_weight_tensor_parameter_352:
     name = "parameter_352"
+    original_name = "batch_norm2d_18.b_0"
     shape = [288]
     dtype = "float32"
     min_val = float("-2.97378")
@@ -3883,6 +4236,7 @@ class Program_weight_tensor_parameter_352:
 
 class Program_weight_tensor_parameter_353:
     name = "parameter_353"
+    original_name = "batch_norm2d_18.w_0"
     shape = [288]
     dtype = "float32"
     min_val = float("0.177668")
@@ -3894,6 +4248,7 @@ class Program_weight_tensor_parameter_353:
 
 class Program_weight_tensor_parameter_354:
     name = "parameter_354"
+    original_name = "batch_norm2d_18.w_2"
     shape = [288]
     dtype = "float32"
     min_val = float("5.60519e-45")
@@ -3905,6 +4260,7 @@ class Program_weight_tensor_parameter_354:
 
 class Program_weight_tensor_parameter_355:
     name = "parameter_355"
+    original_name = "batch_norm2d_18.w_1"
     shape = [288]
     dtype = "float32"
     min_val = float("-0.00338306")
@@ -3916,6 +4272,7 @@ class Program_weight_tensor_parameter_355:
 
 class Program_weight_tensor_parameter_356:
     name = "parameter_356"
+    original_name = "conv2d_18.w_0"
     shape = [288, 96, 1, 1]
     dtype = "float32"
     min_val = float("-0.461763")
@@ -3927,6 +4284,7 @@ class Program_weight_tensor_parameter_356:
 
 class Program_weight_tensor_parameter_357:
     name = "parameter_357"
+    original_name = "batch_norm2d_17.b_0"
     shape = [96]
     dtype = "float32"
     min_val = float("-0.00322852")
@@ -3938,6 +4296,7 @@ class Program_weight_tensor_parameter_357:
 
 class Program_weight_tensor_parameter_358:
     name = "parameter_358"
+    original_name = "batch_norm2d_17.w_0"
     shape = [96]
     dtype = "float32"
     min_val = float("1.37513")
@@ -3949,6 +4308,7 @@ class Program_weight_tensor_parameter_358:
 
 class Program_weight_tensor_parameter_359:
     name = "parameter_359"
+    original_name = "batch_norm2d_17.w_2"
     shape = [96]
     dtype = "float32"
     min_val = float("1.93075")
@@ -3960,6 +4320,7 @@ class Program_weight_tensor_parameter_359:
 
 class Program_weight_tensor_parameter_360:
     name = "parameter_360"
+    original_name = "batch_norm2d_17.w_1"
     shape = [96]
     dtype = "float32"
     min_val = float("-19.3165")
@@ -3971,6 +4332,7 @@ class Program_weight_tensor_parameter_360:
 
 class Program_weight_tensor_parameter_361:
     name = "parameter_361"
+    original_name = "conv2d_17.w_0"
     shape = [96, 144, 1, 1]
     dtype = "float32"
     min_val = float("-0.906756")
@@ -3982,6 +4344,7 @@ class Program_weight_tensor_parameter_361:
 
 class Program_weight_tensor_parameter_362:
     name = "parameter_362"
+    original_name = "batch_norm2d_16.b_0"
     shape = [144]
     dtype = "float32"
     min_val = float("-3.34992")
@@ -3993,6 +4356,7 @@ class Program_weight_tensor_parameter_362:
 
 class Program_weight_tensor_parameter_363:
     name = "parameter_363"
+    original_name = "batch_norm2d_16.w_0"
     shape = [144]
     dtype = "float32"
     min_val = float("1.41069")
@@ -4004,6 +4368,7 @@ class Program_weight_tensor_parameter_363:
 
 class Program_weight_tensor_parameter_364:
     name = "parameter_364"
+    original_name = "batch_norm2d_16.w_2"
     shape = [144]
     dtype = "float32"
     min_val = float("0.103286")
@@ -4015,6 +4380,7 @@ class Program_weight_tensor_parameter_364:
 
 class Program_weight_tensor_parameter_365:
     name = "parameter_365"
+    original_name = "batch_norm2d_16.w_1"
     shape = [144]
     dtype = "float32"
     min_val = float("-4.14255")
@@ -4026,6 +4392,7 @@ class Program_weight_tensor_parameter_365:
 
 class Program_weight_tensor_parameter_366:
     name = "parameter_366"
+    original_name = "conv2d_16.w_0"
     shape = [144, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.353054")
@@ -4037,6 +4404,7 @@ class Program_weight_tensor_parameter_366:
 
 class Program_weight_tensor_parameter_367:
     name = "parameter_367"
+    original_name = "batch_norm2d_15.b_0"
     shape = [144]
     dtype = "float32"
     min_val = float("-3.34908")
@@ -4048,6 +4416,7 @@ class Program_weight_tensor_parameter_367:
 
 class Program_weight_tensor_parameter_368:
     name = "parameter_368"
+    original_name = "batch_norm2d_15.w_0"
     shape = [144]
     dtype = "float32"
     min_val = float("0.576562")
@@ -4059,6 +4428,7 @@ class Program_weight_tensor_parameter_368:
 
 class Program_weight_tensor_parameter_369:
     name = "parameter_369"
+    original_name = "batch_norm2d_15.w_2"
     shape = [144]
     dtype = "float32"
     min_val = float("13.9541")
@@ -4070,6 +4440,7 @@ class Program_weight_tensor_parameter_369:
 
 class Program_weight_tensor_parameter_370:
     name = "parameter_370"
+    original_name = "batch_norm2d_15.w_1"
     shape = [144]
     dtype = "float32"
     min_val = float("-0.0050809")
@@ -4081,6 +4452,7 @@ class Program_weight_tensor_parameter_370:
 
 class Program_weight_tensor_parameter_371:
     name = "parameter_371"
+    original_name = "conv2d_15.w_0"
     shape = [144, 48, 1, 1]
     dtype = "float32"
     min_val = float("-1.40546")
@@ -4092,6 +4464,7 @@ class Program_weight_tensor_parameter_371:
 
 class Program_weight_tensor_parameter_372:
     name = "parameter_372"
+    original_name = "batch_norm2d_14.b_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -4101,6 +4474,7 @@ class Program_weight_tensor_parameter_372:
 
 class Program_weight_tensor_parameter_373:
     name = "parameter_373"
+    original_name = "batch_norm2d_14.w_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -4110,6 +4484,7 @@ class Program_weight_tensor_parameter_373:
 
 class Program_weight_tensor_parameter_374:
     name = "parameter_374"
+    original_name = "batch_norm2d_14.w_2"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -4119,6 +4494,7 @@ class Program_weight_tensor_parameter_374:
 
 class Program_weight_tensor_parameter_375:
     name = "parameter_375"
+    original_name = "batch_norm2d_14.w_1"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -4128,6 +4504,7 @@ class Program_weight_tensor_parameter_375:
 
 class Program_weight_tensor_parameter_376:
     name = "parameter_376"
+    original_name = "conv2d_14.w_0"
     shape = [48, 144, 1, 1]
     dtype = "float32"
     min_val = float("-0.732577")
@@ -4139,6 +4516,7 @@ class Program_weight_tensor_parameter_376:
 
 class Program_weight_tensor_parameter_377:
     name = "parameter_377"
+    original_name = "batch_norm2d_13.b_0"
     shape = [144]
     dtype = "float32"
     min_val = float("-5.56949")
@@ -4150,6 +4528,7 @@ class Program_weight_tensor_parameter_377:
 
 class Program_weight_tensor_parameter_378:
     name = "parameter_378"
+    original_name = "batch_norm2d_13.w_0"
     shape = [144]
     dtype = "float32"
     min_val = float("1.17849")
@@ -4161,6 +4540,7 @@ class Program_weight_tensor_parameter_378:
 
 class Program_weight_tensor_parameter_379:
     name = "parameter_379"
+    original_name = "batch_norm2d_13.w_2"
     shape = [144]
     dtype = "float32"
     min_val = float("5.60519e-45")
@@ -4172,6 +4552,7 @@ class Program_weight_tensor_parameter_379:
 
 class Program_weight_tensor_parameter_380:
     name = "parameter_380"
+    original_name = "batch_norm2d_13.w_1"
     shape = [144]
     dtype = "float32"
     min_val = float("-4.45721")
@@ -4183,6 +4564,7 @@ class Program_weight_tensor_parameter_380:
 
 class Program_weight_tensor_parameter_381:
     name = "parameter_381"
+    original_name = "conv2d_13.w_0"
     shape = [144, 1, 5, 5]
     dtype = "float32"
     min_val = float("-1.01605")
@@ -4194,6 +4576,7 @@ class Program_weight_tensor_parameter_381:
 
 class Program_weight_tensor_parameter_382:
     name = "parameter_382"
+    original_name = "batch_norm2d_12.b_0"
     shape = [144]
     dtype = "float32"
     min_val = float("-5.37509")
@@ -4205,6 +4588,7 @@ class Program_weight_tensor_parameter_382:
 
 class Program_weight_tensor_parameter_383:
     name = "parameter_383"
+    original_name = "batch_norm2d_12.w_0"
     shape = [144]
     dtype = "float32"
     min_val = float("0.196069")
@@ -4216,6 +4600,7 @@ class Program_weight_tensor_parameter_383:
 
 class Program_weight_tensor_parameter_384:
     name = "parameter_384"
+    original_name = "batch_norm2d_12.w_2"
     shape = [144]
     dtype = "float32"
     min_val = float("5.60519e-45")
@@ -4227,6 +4612,7 @@ class Program_weight_tensor_parameter_384:
 
 class Program_weight_tensor_parameter_385:
     name = "parameter_385"
+    original_name = "batch_norm2d_12.w_1"
     shape = [144]
     dtype = "float32"
     min_val = float("-0.00357625")
@@ -4238,6 +4624,7 @@ class Program_weight_tensor_parameter_385:
 
 class Program_weight_tensor_parameter_386:
     name = "parameter_386"
+    original_name = "conv2d_12.w_0"
     shape = [144, 48, 1, 1]
     dtype = "float32"
     min_val = float("-0.97904")
@@ -4249,6 +4636,7 @@ class Program_weight_tensor_parameter_386:
 
 class Program_weight_tensor_parameter_387:
     name = "parameter_387"
+    original_name = "batch_norm2d_11.b_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -4258,6 +4646,7 @@ class Program_weight_tensor_parameter_387:
 
 class Program_weight_tensor_parameter_388:
     name = "parameter_388"
+    original_name = "batch_norm2d_11.w_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -4267,6 +4656,7 @@ class Program_weight_tensor_parameter_388:
 
 class Program_weight_tensor_parameter_389:
     name = "parameter_389"
+    original_name = "batch_norm2d_11.w_2"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -4276,6 +4666,7 @@ class Program_weight_tensor_parameter_389:
 
 class Program_weight_tensor_parameter_390:
     name = "parameter_390"
+    original_name = "batch_norm2d_11.w_1"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -4285,6 +4676,7 @@ class Program_weight_tensor_parameter_390:
 
 class Program_weight_tensor_parameter_391:
     name = "parameter_391"
+    original_name = "conv2d_11.w_0"
     shape = [48, 72, 1, 1]
     dtype = "float32"
     min_val = float("-1.05076")
@@ -4296,6 +4688,7 @@ class Program_weight_tensor_parameter_391:
 
 class Program_weight_tensor_parameter_392:
     name = "parameter_392"
+    original_name = "batch_norm2d_10.b_0"
     shape = [72]
     dtype = "float32"
     min_val = float("-1.67977")
@@ -4307,6 +4700,7 @@ class Program_weight_tensor_parameter_392:
 
 class Program_weight_tensor_parameter_393:
     name = "parameter_393"
+    original_name = "batch_norm2d_10.w_0"
     shape = [72]
     dtype = "float32"
     min_val = float("1.58305")
@@ -4318,6 +4712,7 @@ class Program_weight_tensor_parameter_393:
 
 class Program_weight_tensor_parameter_394:
     name = "parameter_394"
+    original_name = "batch_norm2d_10.w_2"
     shape = [72]
     dtype = "float32"
     min_val = float("0.0376316")
@@ -4329,6 +4724,7 @@ class Program_weight_tensor_parameter_394:
 
 class Program_weight_tensor_parameter_395:
     name = "parameter_395"
+    original_name = "batch_norm2d_10.w_1"
     shape = [72]
     dtype = "float32"
     min_val = float("-6.72116")
@@ -4340,6 +4736,7 @@ class Program_weight_tensor_parameter_395:
 
 class Program_weight_tensor_parameter_396:
     name = "parameter_396"
+    original_name = "conv2d_10.w_0"
     shape = [72, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.547218")
@@ -4351,6 +4748,7 @@ class Program_weight_tensor_parameter_396:
 
 class Program_weight_tensor_parameter_397:
     name = "parameter_397"
+    original_name = "batch_norm2d_9.b_0"
     shape = [72]
     dtype = "float32"
     min_val = float("-6.08463")
@@ -4362,6 +4760,7 @@ class Program_weight_tensor_parameter_397:
 
 class Program_weight_tensor_parameter_398:
     name = "parameter_398"
+    original_name = "batch_norm2d_9.w_0"
     shape = [72]
     dtype = "float32"
     min_val = float("1.23275")
@@ -4373,6 +4772,7 @@ class Program_weight_tensor_parameter_398:
 
 class Program_weight_tensor_parameter_399:
     name = "parameter_399"
+    original_name = "batch_norm2d_9.w_2"
     shape = [72]
     dtype = "float32"
     min_val = float("25.3683")
@@ -4384,6 +4784,7 @@ class Program_weight_tensor_parameter_399:
 
 class Program_weight_tensor_parameter_400:
     name = "parameter_400"
+    original_name = "batch_norm2d_9.w_1"
     shape = [72]
     dtype = "float32"
     min_val = float("-0.0182682")
@@ -4395,6 +4796,7 @@ class Program_weight_tensor_parameter_400:
 
 class Program_weight_tensor_parameter_401:
     name = "parameter_401"
+    original_name = "conv2d_9.w_0"
     shape = [72, 24, 1, 1]
     dtype = "float32"
     min_val = float("-1.67165")
@@ -4406,6 +4808,7 @@ class Program_weight_tensor_parameter_401:
 
 class Program_weight_tensor_parameter_402:
     name = "parameter_402"
+    original_name = "batch_norm2d_8.b_0"
     shape = [24]
     dtype = "float32"
     min_val = float("0")
@@ -4415,6 +4818,7 @@ class Program_weight_tensor_parameter_402:
 
 class Program_weight_tensor_parameter_403:
     name = "parameter_403"
+    original_name = "batch_norm2d_8.w_0"
     shape = [24]
     dtype = "float32"
     min_val = float("0")
@@ -4424,6 +4828,7 @@ class Program_weight_tensor_parameter_403:
 
 class Program_weight_tensor_parameter_404:
     name = "parameter_404"
+    original_name = "batch_norm2d_8.w_2"
     shape = [24]
     dtype = "float32"
     min_val = float("0")
@@ -4433,6 +4838,7 @@ class Program_weight_tensor_parameter_404:
 
 class Program_weight_tensor_parameter_405:
     name = "parameter_405"
+    original_name = "batch_norm2d_8.w_1"
     shape = [24]
     dtype = "float32"
     min_val = float("0")
@@ -4442,6 +4848,7 @@ class Program_weight_tensor_parameter_405:
 
 class Program_weight_tensor_parameter_406:
     name = "parameter_406"
+    original_name = "conv2d_8.w_0"
     shape = [24, 72, 1, 1]
     dtype = "float32"
     min_val = float("-1.2266")
@@ -4453,6 +4860,7 @@ class Program_weight_tensor_parameter_406:
 
 class Program_weight_tensor_parameter_407:
     name = "parameter_407"
+    original_name = "batch_norm2d_7.b_0"
     shape = [72]
     dtype = "float32"
     min_val = float("-7.6693")
@@ -4464,6 +4872,7 @@ class Program_weight_tensor_parameter_407:
 
 class Program_weight_tensor_parameter_408:
     name = "parameter_408"
+    original_name = "batch_norm2d_7.w_0"
     shape = [72]
     dtype = "float32"
     min_val = float("0.92717")
@@ -4475,6 +4884,7 @@ class Program_weight_tensor_parameter_408:
 
 class Program_weight_tensor_parameter_409:
     name = "parameter_409"
+    original_name = "batch_norm2d_7.w_2"
     shape = [72]
     dtype = "float32"
     min_val = float("5.60519e-45")
@@ -4486,6 +4896,7 @@ class Program_weight_tensor_parameter_409:
 
 class Program_weight_tensor_parameter_410:
     name = "parameter_410"
+    original_name = "batch_norm2d_7.w_1"
     shape = [72]
     dtype = "float32"
     min_val = float("-2.59014")
@@ -4497,6 +4908,7 @@ class Program_weight_tensor_parameter_410:
 
 class Program_weight_tensor_parameter_411:
     name = "parameter_411"
+    original_name = "conv2d_7.w_0"
     shape = [72, 1, 3, 3]
     dtype = "float32"
     min_val = float("-1.32627")
@@ -4508,6 +4920,7 @@ class Program_weight_tensor_parameter_411:
 
 class Program_weight_tensor_parameter_412:
     name = "parameter_412"
+    original_name = "batch_norm2d_6.b_0"
     shape = [72]
     dtype = "float32"
     min_val = float("-4.85285")
@@ -4519,6 +4932,7 @@ class Program_weight_tensor_parameter_412:
 
 class Program_weight_tensor_parameter_413:
     name = "parameter_413"
+    original_name = "batch_norm2d_6.w_0"
     shape = [72]
     dtype = "float32"
     min_val = float("0.393199")
@@ -4530,6 +4944,7 @@ class Program_weight_tensor_parameter_413:
 
 class Program_weight_tensor_parameter_414:
     name = "parameter_414"
+    original_name = "batch_norm2d_6.w_2"
     shape = [72]
     dtype = "float32"
     min_val = float("5.60519e-45")
@@ -4541,6 +4956,7 @@ class Program_weight_tensor_parameter_414:
 
 class Program_weight_tensor_parameter_415:
     name = "parameter_415"
+    original_name = "batch_norm2d_6.w_1"
     shape = [72]
     dtype = "float32"
     min_val = float("-0.00934683")
@@ -4552,6 +4968,7 @@ class Program_weight_tensor_parameter_415:
 
 class Program_weight_tensor_parameter_416:
     name = "parameter_416"
+    original_name = "conv2d_6.w_0"
     shape = [72, 24, 1, 1]
     dtype = "float32"
     min_val = float("-1.52299")
@@ -4563,6 +4980,7 @@ class Program_weight_tensor_parameter_416:
 
 class Program_weight_tensor_parameter_417:
     name = "parameter_417"
+    original_name = "batch_norm2d_5.b_0"
     shape = [24]
     dtype = "float32"
     min_val = float("0")
@@ -4572,6 +4990,7 @@ class Program_weight_tensor_parameter_417:
 
 class Program_weight_tensor_parameter_418:
     name = "parameter_418"
+    original_name = "batch_norm2d_5.w_0"
     shape = [24]
     dtype = "float32"
     min_val = float("0")
@@ -4581,6 +5000,7 @@ class Program_weight_tensor_parameter_418:
 
 class Program_weight_tensor_parameter_419:
     name = "parameter_419"
+    original_name = "batch_norm2d_5.w_2"
     shape = [24]
     dtype = "float32"
     min_val = float("0")
@@ -4590,6 +5010,7 @@ class Program_weight_tensor_parameter_419:
 
 class Program_weight_tensor_parameter_420:
     name = "parameter_420"
+    original_name = "batch_norm2d_5.w_1"
     shape = [24]
     dtype = "float32"
     min_val = float("0")
@@ -4599,6 +5020,7 @@ class Program_weight_tensor_parameter_420:
 
 class Program_weight_tensor_parameter_421:
     name = "parameter_421"
+    original_name = "conv2d_5.w_0"
     shape = [24, 64, 1, 1]
     dtype = "float32"
     min_val = float("-1.26639")
@@ -4610,6 +5032,7 @@ class Program_weight_tensor_parameter_421:
 
 class Program_weight_tensor_parameter_422:
     name = "parameter_422"
+    original_name = "batch_norm2d_4.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -4619,6 +5042,7 @@ class Program_weight_tensor_parameter_422:
 
 class Program_weight_tensor_parameter_423:
     name = "parameter_423"
+    original_name = "batch_norm2d_4.w_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -4628,6 +5052,7 @@ class Program_weight_tensor_parameter_423:
 
 class Program_weight_tensor_parameter_424:
     name = "parameter_424"
+    original_name = "batch_norm2d_4.w_2"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -4637,6 +5062,7 @@ class Program_weight_tensor_parameter_424:
 
 class Program_weight_tensor_parameter_425:
     name = "parameter_425"
+    original_name = "batch_norm2d_4.w_1"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -4646,6 +5072,7 @@ class Program_weight_tensor_parameter_425:
 
 class Program_weight_tensor_parameter_426:
     name = "parameter_426"
+    original_name = "conv2d_4.w_0"
     shape = [64, 1, 3, 3]
     dtype = "float32"
     min_val = float("-1.26075")
@@ -4657,6 +5084,7 @@ class Program_weight_tensor_parameter_426:
 
 class Program_weight_tensor_parameter_427:
     name = "parameter_427"
+    original_name = "batch_norm2d_3.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -4666,6 +5094,7 @@ class Program_weight_tensor_parameter_427:
 
 class Program_weight_tensor_parameter_428:
     name = "parameter_428"
+    original_name = "batch_norm2d_3.w_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -4675,6 +5104,7 @@ class Program_weight_tensor_parameter_428:
 
 class Program_weight_tensor_parameter_429:
     name = "parameter_429"
+    original_name = "batch_norm2d_3.w_2"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -4684,6 +5114,7 @@ class Program_weight_tensor_parameter_429:
 
 class Program_weight_tensor_parameter_430:
     name = "parameter_430"
+    original_name = "batch_norm2d_3.w_1"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -4693,6 +5124,7 @@ class Program_weight_tensor_parameter_430:
 
 class Program_weight_tensor_parameter_431:
     name = "parameter_431"
+    original_name = "conv2d_3.w_0"
     shape = [64, 16, 1, 1]
     dtype = "float32"
     min_val = float("-1.7517")
@@ -4704,6 +5136,7 @@ class Program_weight_tensor_parameter_431:
 
 class Program_weight_tensor_parameter_432:
     name = "parameter_432"
+    original_name = "batch_norm2d_2.b_0"
     shape = [16]
     dtype = "float32"
     min_val = float("0")
@@ -4713,6 +5146,7 @@ class Program_weight_tensor_parameter_432:
 
 class Program_weight_tensor_parameter_433:
     name = "parameter_433"
+    original_name = "batch_norm2d_2.w_0"
     shape = [16]
     dtype = "float32"
     min_val = float("0")
@@ -4722,6 +5156,7 @@ class Program_weight_tensor_parameter_433:
 
 class Program_weight_tensor_parameter_434:
     name = "parameter_434"
+    original_name = "batch_norm2d_2.w_2"
     shape = [16]
     dtype = "float32"
     min_val = float("0")
@@ -4731,6 +5166,7 @@ class Program_weight_tensor_parameter_434:
 
 class Program_weight_tensor_parameter_435:
     name = "parameter_435"
+    original_name = "batch_norm2d_2.w_1"
     shape = [16]
     dtype = "float32"
     min_val = float("0")
@@ -4740,6 +5176,7 @@ class Program_weight_tensor_parameter_435:
 
 class Program_weight_tensor_parameter_436:
     name = "parameter_436"
+    original_name = "conv2d_2.w_0"
     shape = [16, 16, 1, 1]
     dtype = "float32"
     min_val = float("-1.53536")
@@ -4751,6 +5188,7 @@ class Program_weight_tensor_parameter_436:
 
 class Program_weight_tensor_parameter_437:
     name = "parameter_437"
+    original_name = "batch_norm2d_1.b_0"
     shape = [16]
     dtype = "float32"
     min_val = float("0")
@@ -4760,6 +5198,7 @@ class Program_weight_tensor_parameter_437:
 
 class Program_weight_tensor_parameter_438:
     name = "parameter_438"
+    original_name = "batch_norm2d_1.w_0"
     shape = [16]
     dtype = "float32"
     min_val = float("0")
@@ -4769,6 +5208,7 @@ class Program_weight_tensor_parameter_438:
 
 class Program_weight_tensor_parameter_439:
     name = "parameter_439"
+    original_name = "batch_norm2d_1.w_2"
     shape = [16]
     dtype = "float32"
     min_val = float("0")
@@ -4778,6 +5218,7 @@ class Program_weight_tensor_parameter_439:
 
 class Program_weight_tensor_parameter_440:
     name = "parameter_440"
+    original_name = "batch_norm2d_1.w_1"
     shape = [16]
     dtype = "float32"
     min_val = float("0")
@@ -4787,6 +5228,7 @@ class Program_weight_tensor_parameter_440:
 
 class Program_weight_tensor_parameter_441:
     name = "parameter_441"
+    original_name = "conv2d_1.w_0"
     shape = [16, 1, 3, 3]
     dtype = "float32"
     min_val = float("-1.44212")
@@ -4798,6 +5240,7 @@ class Program_weight_tensor_parameter_441:
 
 class Program_weight_tensor_parameter_442:
     name = "parameter_442"
+    original_name = "batch_norm2d_0.b_0"
     shape = [16]
     dtype = "float32"
     min_val = float("0")
@@ -4807,6 +5250,7 @@ class Program_weight_tensor_parameter_442:
 
 class Program_weight_tensor_parameter_443:
     name = "parameter_443"
+    original_name = "batch_norm2d_0.w_0"
     shape = [16]
     dtype = "float32"
     min_val = float("0")
@@ -4816,6 +5260,7 @@ class Program_weight_tensor_parameter_443:
 
 class Program_weight_tensor_parameter_444:
     name = "parameter_444"
+    original_name = "batch_norm2d_0.w_2"
     shape = [16]
     dtype = "float32"
     min_val = float("0")
@@ -4825,6 +5270,7 @@ class Program_weight_tensor_parameter_444:
 
 class Program_weight_tensor_parameter_445:
     name = "parameter_445"
+    original_name = "batch_norm2d_0.w_1"
     shape = [16]
     dtype = "float32"
     min_val = float("0")
@@ -4834,6 +5280,7 @@ class Program_weight_tensor_parameter_445:
 
 class Program_weight_tensor_parameter_446:
     name = "parameter_446"
+    original_name = "conv2d_0.w_0"
     shape = [16, 3, 3, 3]
     dtype = "float32"
     min_val = float("-2.228")

--- a/paddle_samples/PaddleX/SeaFormer_tiny/subgraph_1/input_meta.py
+++ b/paddle_samples/PaddleX/SeaFormer_tiny/subgraph_1/input_meta.py
@@ -1,5 +1,6 @@
 class Program_weight_tensor_data_0:
     name = "data_0"
+    original_name = "param_16"
     shape = [1, 64, 16]
     dtype = "float32"
     min_val = float("-0.232804")
@@ -11,6 +12,7 @@ class Program_weight_tensor_data_0:
 
 class Program_weight_tensor_data_1:
     name = "data_1"
+    original_name = "param_17"
     shape = [1, 64, 16]
     dtype = "float32"
     min_val = float("-0.275247")
@@ -22,6 +24,7 @@ class Program_weight_tensor_data_1:
 
 class Program_weight_tensor_data_2:
     name = "data_2"
+    original_name = "param_18"
     shape = [1, 64, 16]
     dtype = "float32"
     min_val = float("-0.231688")
@@ -33,6 +36,7 @@ class Program_weight_tensor_data_2:
 
 class Program_weight_tensor_data_3:
     name = "data_3"
+    original_name = "param_19"
     shape = [1, 64, 16]
     dtype = "float32"
     min_val = float("-0.221527")
@@ -44,6 +48,7 @@ class Program_weight_tensor_data_3:
 
 class Program_weight_tensor_data_4:
     name = "data_4"
+    original_name = "param_20"
     shape = [1, 64, 16]
     dtype = "float32"
     min_val = float("-0.236935")
@@ -55,6 +60,7 @@ class Program_weight_tensor_data_4:
 
 class Program_weight_tensor_data_5:
     name = "data_5"
+    original_name = "param_21"
     shape = [1, 64, 16]
     dtype = "float32"
     min_val = float("-0.251175")
@@ -66,6 +72,7 @@ class Program_weight_tensor_data_5:
 
 class Program_weight_tensor_data_6:
     name = "data_6"
+    original_name = "param_22"
     shape = [1, 64, 16]
     dtype = "float32"
     min_val = float("-0.147883")
@@ -77,6 +84,7 @@ class Program_weight_tensor_data_6:
 
 class Program_weight_tensor_data_7:
     name = "data_7"
+    original_name = "param_23"
     shape = [1, 64, 16]
     dtype = "float32"
     min_val = float("-0.290828")
@@ -88,6 +96,7 @@ class Program_weight_tensor_data_7:
 
 class Program_weight_tensor_data_8:
     name = "data_8"
+    original_name = "param_24"
     shape = [1, 96, 16]
     dtype = "float32"
     min_val = float("-0.228242")
@@ -99,6 +108,7 @@ class Program_weight_tensor_data_8:
 
 class Program_weight_tensor_data_9:
     name = "data_9"
+    original_name = "param_25"
     shape = [1, 96, 16]
     dtype = "float32"
     min_val = float("-0.263307")
@@ -110,6 +120,7 @@ class Program_weight_tensor_data_9:
 
 class Program_weight_tensor_data_10:
     name = "data_10"
+    original_name = "param_26"
     shape = [1, 96, 16]
     dtype = "float32"
     min_val = float("-0.0823531")
@@ -121,6 +132,7 @@ class Program_weight_tensor_data_10:
 
 class Program_weight_tensor_data_11:
     name = "data_11"
+    original_name = "param_27"
     shape = [1, 96, 16]
     dtype = "float32"
     min_val = float("-0.0820232")
@@ -132,6 +144,7 @@ class Program_weight_tensor_data_11:
 
 class Program_weight_tensor_data_12:
     name = "data_12"
+    original_name = "param_28"
     shape = [1, 96, 16]
     dtype = "float32"
     min_val = float("-0.17863")
@@ -143,6 +156,7 @@ class Program_weight_tensor_data_12:
 
 class Program_weight_tensor_data_13:
     name = "data_13"
+    original_name = "param_29"
     shape = [1, 96, 16]
     dtype = "float32"
     min_val = float("-0.0831355")
@@ -154,6 +168,7 @@ class Program_weight_tensor_data_13:
 
 class Program_weight_tensor_data_14:
     name = "data_14"
+    original_name = "param_30"
     shape = [1, 96, 16]
     dtype = "float32"
     min_val = float("-0.0695174")
@@ -165,6 +180,7 @@ class Program_weight_tensor_data_14:
 
 class Program_weight_tensor_data_15:
     name = "data_15"
+    original_name = "param_31"
     shape = [1, 96, 16]
     dtype = "float32"
     min_val = float("-0.0380223")
@@ -176,6 +192,7 @@ class Program_weight_tensor_data_15:
 
 class Program_weight_tensor_data_16:
     name = "data_16"
+    original_name = "var_393"
     shape = [2, 3, 512, 512]
     dtype = "float32"
     min_val = float("-1.0")

--- a/paddle_samples/PaddleX/SeaFormer_tiny/subgraph_1/weight_meta.py
+++ b/paddle_samples/PaddleX/SeaFormer_tiny/subgraph_1/weight_meta.py
@@ -1,5 +1,6 @@
 class Program_weight_tensor_parameter_0:
     name = "parameter_0"
+    original_name = "batch_norm2d_66.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.225851")
@@ -11,6 +12,7 @@ class Program_weight_tensor_parameter_0:
 
 class Program_weight_tensor_parameter_1:
     name = "parameter_1"
+    original_name = "batch_norm2d_66.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("1.07996")
@@ -22,6 +24,7 @@ class Program_weight_tensor_parameter_1:
 
 class Program_weight_tensor_parameter_2:
     name = "parameter_2"
+    original_name = "batch_norm2d_66.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.0197816")
@@ -33,6 +36,7 @@ class Program_weight_tensor_parameter_2:
 
 class Program_weight_tensor_parameter_3:
     name = "parameter_3"
+    original_name = "batch_norm2d_66.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.224814")
@@ -44,6 +48,7 @@ class Program_weight_tensor_parameter_3:
 
 class Program_weight_tensor_parameter_4:
     name = "parameter_4"
+    original_name = "conv2d_70.w_0"
     shape = [160, 640, 1, 1]
     dtype = "float32"
     min_val = float("-0.249843")
@@ -55,6 +60,7 @@ class Program_weight_tensor_parameter_4:
 
 class Program_weight_tensor_parameter_5:
     name = "parameter_5"
+    original_name = "conv2d_69.b_0"
     shape = [640]
     dtype = "float32"
     min_val = float("-1.72581")
@@ -66,6 +72,7 @@ class Program_weight_tensor_parameter_5:
 
 class Program_weight_tensor_parameter_6:
     name = "parameter_6"
+    original_name = "conv2d_69.w_0"
     shape = [640, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.509448")
@@ -77,6 +84,7 @@ class Program_weight_tensor_parameter_6:
 
 class Program_weight_tensor_parameter_7:
     name = "parameter_7"
+    original_name = "batch_norm2d_65.b_0"
     shape = [640]
     dtype = "float32"
     min_val = float("-5.87959")
@@ -88,6 +96,7 @@ class Program_weight_tensor_parameter_7:
 
 class Program_weight_tensor_parameter_8:
     name = "parameter_8"
+    original_name = "batch_norm2d_65.w_0"
     shape = [640]
     dtype = "float32"
     min_val = float("-0.97277")
@@ -99,6 +108,7 @@ class Program_weight_tensor_parameter_8:
 
 class Program_weight_tensor_parameter_9:
     name = "parameter_9"
+    original_name = "batch_norm2d_65.w_2"
     shape = [640]
     dtype = "float32"
     min_val = float("1.32389")
@@ -110,6 +120,7 @@ class Program_weight_tensor_parameter_9:
 
 class Program_weight_tensor_parameter_10:
     name = "parameter_10"
+    original_name = "batch_norm2d_65.w_1"
     shape = [640]
     dtype = "float32"
     min_val = float("-0.332256")
@@ -121,6 +132,7 @@ class Program_weight_tensor_parameter_10:
 
 class Program_weight_tensor_parameter_11:
     name = "parameter_11"
+    original_name = "conv2d_68.w_0"
     shape = [640, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.375757")
@@ -132,6 +144,7 @@ class Program_weight_tensor_parameter_11:
 
 class Program_weight_tensor_parameter_12:
     name = "parameter_12"
+    original_name = "batch_norm2d_60.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-2.29156")
@@ -143,6 +156,7 @@ class Program_weight_tensor_parameter_12:
 
 class Program_weight_tensor_parameter_13:
     name = "parameter_13"
+    original_name = "batch_norm2d_60.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-2.1294")
@@ -154,6 +168,7 @@ class Program_weight_tensor_parameter_13:
 
 class Program_weight_tensor_parameter_14:
     name = "parameter_14"
+    original_name = "batch_norm2d_60.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.39775")
@@ -165,6 +180,7 @@ class Program_weight_tensor_parameter_14:
 
 class Program_weight_tensor_parameter_15:
     name = "parameter_15"
+    original_name = "batch_norm2d_60.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-1.37098")
@@ -176,6 +192,7 @@ class Program_weight_tensor_parameter_15:
 
 class Program_weight_tensor_parameter_16:
     name = "parameter_16"
+    original_name = "conv2d_63.w_0"
     shape = [160, 192, 1, 1]
     dtype = "float32"
     min_val = float("-0.223415")
@@ -187,6 +204,7 @@ class Program_weight_tensor_parameter_16:
 
 class Program_weight_tensor_parameter_17:
     name = "parameter_17"
+    original_name = "batch_norm2d_62.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-1.5326")
@@ -198,6 +216,7 @@ class Program_weight_tensor_parameter_17:
 
 class Program_weight_tensor_parameter_18:
     name = "parameter_18"
+    original_name = "batch_norm2d_62.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-2.51238")
@@ -209,6 +228,7 @@ class Program_weight_tensor_parameter_18:
 
 class Program_weight_tensor_parameter_19:
     name = "parameter_19"
+    original_name = "batch_norm2d_62.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("0.00192051")
@@ -220,6 +240,7 @@ class Program_weight_tensor_parameter_19:
 
 class Program_weight_tensor_parameter_20:
     name = "parameter_20"
+    original_name = "batch_norm2d_62.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.319825")
@@ -231,6 +252,7 @@ class Program_weight_tensor_parameter_20:
 
 class Program_weight_tensor_parameter_21:
     name = "parameter_21"
+    original_name = "conv2d_65.w_0"
     shape = [192, 192, 1, 1]
     dtype = "float32"
     min_val = float("-0.165221")
@@ -242,6 +264,7 @@ class Program_weight_tensor_parameter_21:
 
 class Program_weight_tensor_parameter_22:
     name = "parameter_22"
+    original_name = "batch_norm2d_61.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-1.53264")
@@ -253,6 +276,7 @@ class Program_weight_tensor_parameter_22:
 
 class Program_weight_tensor_parameter_23:
     name = "parameter_23"
+    original_name = "batch_norm2d_61.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-2.22181")
@@ -264,6 +288,7 @@ class Program_weight_tensor_parameter_23:
 
 class Program_weight_tensor_parameter_24:
     name = "parameter_24"
+    original_name = "batch_norm2d_61.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("0.00259331")
@@ -275,6 +300,7 @@ class Program_weight_tensor_parameter_24:
 
 class Program_weight_tensor_parameter_25:
     name = "parameter_25"
+    original_name = "batch_norm2d_61.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.30262")
@@ -286,6 +312,7 @@ class Program_weight_tensor_parameter_25:
 
 class Program_weight_tensor_parameter_26:
     name = "parameter_26"
+    original_name = "conv2d_64.w_0"
     shape = [192, 192, 1, 1]
     dtype = "float32"
     min_val = float("-0.257147")
@@ -297,6 +324,7 @@ class Program_weight_tensor_parameter_26:
 
 class Program_weight_tensor_parameter_27:
     name = "parameter_27"
+    original_name = "batch_norm2d_64.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-3.1358")
@@ -308,6 +336,7 @@ class Program_weight_tensor_parameter_27:
 
 class Program_weight_tensor_parameter_28:
     name = "parameter_28"
+    original_name = "batch_norm2d_64.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("1.98039")
@@ -319,6 +348,7 @@ class Program_weight_tensor_parameter_28:
 
 class Program_weight_tensor_parameter_29:
     name = "parameter_29"
+    original_name = "batch_norm2d_64.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.0427999")
@@ -330,6 +360,7 @@ class Program_weight_tensor_parameter_29:
 
 class Program_weight_tensor_parameter_30:
     name = "parameter_30"
+    original_name = "batch_norm2d_64.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.315733")
@@ -341,6 +372,7 @@ class Program_weight_tensor_parameter_30:
 
 class Program_weight_tensor_parameter_31:
     name = "parameter_31"
+    original_name = "conv2d_67.w_0"
     shape = [160, 384, 1, 1]
     dtype = "float32"
     min_val = float("-0.296159")
@@ -352,6 +384,7 @@ class Program_weight_tensor_parameter_31:
 
 class Program_weight_tensor_parameter_32:
     name = "parameter_32"
+    original_name = "batch_norm2d_63.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-4.94135")
@@ -363,6 +396,7 @@ class Program_weight_tensor_parameter_32:
 
 class Program_weight_tensor_parameter_33:
     name = "parameter_33"
+    original_name = "batch_norm2d_63.w_0"
     shape = [384]
     dtype = "float32"
     min_val = float("0.34756")
@@ -374,6 +408,7 @@ class Program_weight_tensor_parameter_33:
 
 class Program_weight_tensor_parameter_34:
     name = "parameter_34"
+    original_name = "batch_norm2d_63.w_2"
     shape = [384]
     dtype = "float32"
     min_val = float("0.000307026")
@@ -385,6 +420,7 @@ class Program_weight_tensor_parameter_34:
 
 class Program_weight_tensor_parameter_35:
     name = "parameter_35"
+    original_name = "batch_norm2d_63.w_1"
     shape = [384]
     dtype = "float32"
     min_val = float("-1.18213")
@@ -396,6 +432,7 @@ class Program_weight_tensor_parameter_35:
 
 class Program_weight_tensor_parameter_36:
     name = "parameter_36"
+    original_name = "conv2d_66.w_0"
     shape = [384, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.364734")
@@ -407,6 +444,7 @@ class Program_weight_tensor_parameter_36:
 
 class Program_weight_tensor_parameter_37:
     name = "parameter_37"
+    original_name = "batch_norm2d_59.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-3.20071")
@@ -418,6 +456,7 @@ class Program_weight_tensor_parameter_37:
 
 class Program_weight_tensor_parameter_38:
     name = "parameter_38"
+    original_name = "batch_norm2d_59.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("0.31292")
@@ -429,6 +468,7 @@ class Program_weight_tensor_parameter_38:
 
 class Program_weight_tensor_parameter_39:
     name = "parameter_39"
+    original_name = "batch_norm2d_59.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("3.59878")
@@ -440,6 +480,7 @@ class Program_weight_tensor_parameter_39:
 
 class Program_weight_tensor_parameter_40:
     name = "parameter_40"
+    original_name = "batch_norm2d_59.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.781005")
@@ -451,6 +492,7 @@ class Program_weight_tensor_parameter_40:
 
 class Program_weight_tensor_parameter_41:
     name = "parameter_41"
+    original_name = "conv2d_62.w_0"
     shape = [192, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.513961")
@@ -462,6 +504,7 @@ class Program_weight_tensor_parameter_41:
 
 class Program_weight_tensor_parameter_42:
     name = "parameter_42"
+    original_name = "batch_norm2d_58.b_0"
     shape = [96]
     dtype = "float32"
     min_val = float("-1.17739")
@@ -473,6 +516,7 @@ class Program_weight_tensor_parameter_42:
 
 class Program_weight_tensor_parameter_43:
     name = "parameter_43"
+    original_name = "batch_norm2d_58.w_0"
     shape = [96]
     dtype = "float32"
     min_val = float("-0.0816752")
@@ -484,6 +528,7 @@ class Program_weight_tensor_parameter_43:
 
 class Program_weight_tensor_parameter_44:
     name = "parameter_44"
+    original_name = "batch_norm2d_58.w_2"
     shape = [96]
     dtype = "float32"
     min_val = float("2.72273")
@@ -495,6 +540,7 @@ class Program_weight_tensor_parameter_44:
 
 class Program_weight_tensor_parameter_45:
     name = "parameter_45"
+    original_name = "batch_norm2d_58.w_1"
     shape = [96]
     dtype = "float32"
     min_val = float("-0.457936")
@@ -506,6 +552,7 @@ class Program_weight_tensor_parameter_45:
 
 class Program_weight_tensor_parameter_46:
     name = "parameter_46"
+    original_name = "conv2d_61.w_0"
     shape = [96, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.260112")
@@ -517,6 +564,7 @@ class Program_weight_tensor_parameter_46:
 
 class Program_weight_tensor_parameter_47:
     name = "parameter_47"
+    original_name = "batch_norm2d_57.b_0"
     shape = [96]
     dtype = "float32"
     min_val = float("-1.198")
@@ -528,6 +576,7 @@ class Program_weight_tensor_parameter_47:
 
 class Program_weight_tensor_parameter_48:
     name = "parameter_48"
+    original_name = "batch_norm2d_57.w_0"
     shape = [96]
     dtype = "float32"
     min_val = float("0.0601328")
@@ -539,6 +588,7 @@ class Program_weight_tensor_parameter_48:
 
 class Program_weight_tensor_parameter_49:
     name = "parameter_49"
+    original_name = "batch_norm2d_57.w_2"
     shape = [96]
     dtype = "float32"
     min_val = float("2.67173")
@@ -550,6 +600,7 @@ class Program_weight_tensor_parameter_49:
 
 class Program_weight_tensor_parameter_50:
     name = "parameter_50"
+    original_name = "batch_norm2d_57.w_1"
     shape = [96]
     dtype = "float32"
     min_val = float("-0.351198")
@@ -561,6 +612,7 @@ class Program_weight_tensor_parameter_50:
 
 class Program_weight_tensor_parameter_51:
     name = "parameter_51"
+    original_name = "conv2d_60.w_0"
     shape = [96, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.261431")
@@ -572,6 +624,7 @@ class Program_weight_tensor_parameter_51:
 
 class Program_weight_tensor_parameter_52:
     name = "parameter_52"
+    original_name = "batch_norm2d_56.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.869375")
@@ -583,6 +636,7 @@ class Program_weight_tensor_parameter_52:
 
 class Program_weight_tensor_parameter_53:
     name = "parameter_53"
+    original_name = "batch_norm2d_56.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("1.29965")
@@ -594,6 +648,7 @@ class Program_weight_tensor_parameter_53:
 
 class Program_weight_tensor_parameter_54:
     name = "parameter_54"
+    original_name = "batch_norm2d_56.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.0374577")
@@ -605,6 +660,7 @@ class Program_weight_tensor_parameter_54:
 
 class Program_weight_tensor_parameter_55:
     name = "parameter_55"
+    original_name = "batch_norm2d_56.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.137166")
@@ -616,6 +672,7 @@ class Program_weight_tensor_parameter_55:
 
 class Program_weight_tensor_parameter_56:
     name = "parameter_56"
+    original_name = "conv2d_59.w_0"
     shape = [160, 640, 1, 1]
     dtype = "float32"
     min_val = float("-0.3027")
@@ -627,6 +684,7 @@ class Program_weight_tensor_parameter_56:
 
 class Program_weight_tensor_parameter_57:
     name = "parameter_57"
+    original_name = "conv2d_58.b_0"
     shape = [640]
     dtype = "float32"
     min_val = float("-2.15076")
@@ -638,6 +696,7 @@ class Program_weight_tensor_parameter_57:
 
 class Program_weight_tensor_parameter_58:
     name = "parameter_58"
+    original_name = "conv2d_58.w_0"
     shape = [640, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.577908")
@@ -649,6 +708,7 @@ class Program_weight_tensor_parameter_58:
 
 class Program_weight_tensor_parameter_59:
     name = "parameter_59"
+    original_name = "batch_norm2d_55.b_0"
     shape = [640]
     dtype = "float32"
     min_val = float("-5.44385")
@@ -660,6 +720,7 @@ class Program_weight_tensor_parameter_59:
 
 class Program_weight_tensor_parameter_60:
     name = "parameter_60"
+    original_name = "batch_norm2d_55.w_0"
     shape = [640]
     dtype = "float32"
     min_val = float("0.923652")
@@ -671,6 +732,7 @@ class Program_weight_tensor_parameter_60:
 
 class Program_weight_tensor_parameter_61:
     name = "parameter_61"
+    original_name = "batch_norm2d_55.w_2"
     shape = [640]
     dtype = "float32"
     min_val = float("1.84506")
@@ -682,6 +744,7 @@ class Program_weight_tensor_parameter_61:
 
 class Program_weight_tensor_parameter_62:
     name = "parameter_62"
+    original_name = "batch_norm2d_55.w_1"
     shape = [640]
     dtype = "float32"
     min_val = float("-1.084")
@@ -693,6 +756,7 @@ class Program_weight_tensor_parameter_62:
 
 class Program_weight_tensor_parameter_63:
     name = "parameter_63"
+    original_name = "conv2d_57.w_0"
     shape = [640, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.347156")
@@ -704,6 +768,7 @@ class Program_weight_tensor_parameter_63:
 
 class Program_weight_tensor_parameter_64:
     name = "parameter_64"
+    original_name = "batch_norm2d_50.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-3.16468")
@@ -715,6 +780,7 @@ class Program_weight_tensor_parameter_64:
 
 class Program_weight_tensor_parameter_65:
     name = "parameter_65"
+    original_name = "batch_norm2d_50.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-3.2556")
@@ -726,6 +792,7 @@ class Program_weight_tensor_parameter_65:
 
 class Program_weight_tensor_parameter_66:
     name = "parameter_66"
+    original_name = "batch_norm2d_50.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.423531")
@@ -737,6 +804,7 @@ class Program_weight_tensor_parameter_66:
 
 class Program_weight_tensor_parameter_67:
     name = "parameter_67"
+    original_name = "batch_norm2d_50.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-2.0289")
@@ -748,6 +816,7 @@ class Program_weight_tensor_parameter_67:
 
 class Program_weight_tensor_parameter_68:
     name = "parameter_68"
+    original_name = "conv2d_52.w_0"
     shape = [160, 192, 1, 1]
     dtype = "float32"
     min_val = float("-0.371344")
@@ -759,6 +828,7 @@ class Program_weight_tensor_parameter_68:
 
 class Program_weight_tensor_parameter_69:
     name = "parameter_69"
+    original_name = "batch_norm2d_52.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-2.05746")
@@ -770,6 +840,7 @@ class Program_weight_tensor_parameter_69:
 
 class Program_weight_tensor_parameter_70:
     name = "parameter_70"
+    original_name = "batch_norm2d_52.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-4.10247")
@@ -781,6 +852,7 @@ class Program_weight_tensor_parameter_70:
 
 class Program_weight_tensor_parameter_71:
     name = "parameter_71"
+    original_name = "batch_norm2d_52.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("0.0188222")
@@ -792,6 +864,7 @@ class Program_weight_tensor_parameter_71:
 
 class Program_weight_tensor_parameter_72:
     name = "parameter_72"
+    original_name = "batch_norm2d_52.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.861745")
@@ -803,6 +876,7 @@ class Program_weight_tensor_parameter_72:
 
 class Program_weight_tensor_parameter_73:
     name = "parameter_73"
+    original_name = "conv2d_54.w_0"
     shape = [192, 192, 1, 1]
     dtype = "float32"
     min_val = float("-0.361256")
@@ -814,6 +888,7 @@ class Program_weight_tensor_parameter_73:
 
 class Program_weight_tensor_parameter_74:
     name = "parameter_74"
+    original_name = "batch_norm2d_51.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-2.05739")
@@ -825,6 +900,7 @@ class Program_weight_tensor_parameter_74:
 
 class Program_weight_tensor_parameter_75:
     name = "parameter_75"
+    original_name = "batch_norm2d_51.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-3.23892")
@@ -836,6 +912,7 @@ class Program_weight_tensor_parameter_75:
 
 class Program_weight_tensor_parameter_76:
     name = "parameter_76"
+    original_name = "batch_norm2d_51.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("0.0160168")
@@ -847,6 +924,7 @@ class Program_weight_tensor_parameter_76:
 
 class Program_weight_tensor_parameter_77:
     name = "parameter_77"
+    original_name = "batch_norm2d_51.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.981247")
@@ -858,6 +936,7 @@ class Program_weight_tensor_parameter_77:
 
 class Program_weight_tensor_parameter_78:
     name = "parameter_78"
+    original_name = "conv2d_53.w_0"
     shape = [192, 192, 1, 1]
     dtype = "float32"
     min_val = float("-0.353439")
@@ -869,6 +948,7 @@ class Program_weight_tensor_parameter_78:
 
 class Program_weight_tensor_parameter_79:
     name = "parameter_79"
+    original_name = "batch_norm2d_54.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-6.52632")
@@ -880,6 +960,7 @@ class Program_weight_tensor_parameter_79:
 
 class Program_weight_tensor_parameter_80:
     name = "parameter_80"
+    original_name = "batch_norm2d_54.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("1.4005")
@@ -891,6 +972,7 @@ class Program_weight_tensor_parameter_80:
 
 class Program_weight_tensor_parameter_81:
     name = "parameter_81"
+    original_name = "batch_norm2d_54.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("0.373405")
@@ -902,6 +984,7 @@ class Program_weight_tensor_parameter_81:
 
 class Program_weight_tensor_parameter_82:
     name = "parameter_82"
+    original_name = "batch_norm2d_54.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-1.26314")
@@ -913,6 +996,7 @@ class Program_weight_tensor_parameter_82:
 
 class Program_weight_tensor_parameter_83:
     name = "parameter_83"
+    original_name = "conv2d_56.w_0"
     shape = [160, 384, 1, 1]
     dtype = "float32"
     min_val = float("-0.439908")
@@ -924,6 +1008,7 @@ class Program_weight_tensor_parameter_83:
 
 class Program_weight_tensor_parameter_84:
     name = "parameter_84"
+    original_name = "batch_norm2d_53.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-4.40772")
@@ -935,6 +1020,7 @@ class Program_weight_tensor_parameter_84:
 
 class Program_weight_tensor_parameter_85:
     name = "parameter_85"
+    original_name = "batch_norm2d_53.w_0"
     shape = [384]
     dtype = "float32"
     min_val = float("0.665998")
@@ -946,6 +1032,7 @@ class Program_weight_tensor_parameter_85:
 
 class Program_weight_tensor_parameter_86:
     name = "parameter_86"
+    original_name = "batch_norm2d_53.w_2"
     shape = [384]
     dtype = "float32"
     min_val = float("0.000240712")
@@ -957,6 +1044,7 @@ class Program_weight_tensor_parameter_86:
 
 class Program_weight_tensor_parameter_87:
     name = "parameter_87"
+    original_name = "batch_norm2d_53.w_1"
     shape = [384]
     dtype = "float32"
     min_val = float("-1.19388")
@@ -968,6 +1056,7 @@ class Program_weight_tensor_parameter_87:
 
 class Program_weight_tensor_parameter_88:
     name = "parameter_88"
+    original_name = "conv2d_55.w_0"
     shape = [384, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.481068")
@@ -979,6 +1068,7 @@ class Program_weight_tensor_parameter_88:
 
 class Program_weight_tensor_parameter_89:
     name = "parameter_89"
+    original_name = "batch_norm2d_49.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-3.06677")
@@ -990,6 +1080,7 @@ class Program_weight_tensor_parameter_89:
 
 class Program_weight_tensor_parameter_90:
     name = "parameter_90"
+    original_name = "batch_norm2d_49.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("0.555852")
@@ -1001,6 +1092,7 @@ class Program_weight_tensor_parameter_90:
 
 class Program_weight_tensor_parameter_91:
     name = "parameter_91"
+    original_name = "batch_norm2d_49.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("2.32359")
@@ -1012,6 +1104,7 @@ class Program_weight_tensor_parameter_91:
 
 class Program_weight_tensor_parameter_92:
     name = "parameter_92"
+    original_name = "batch_norm2d_49.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-2.4427")
@@ -1023,6 +1116,7 @@ class Program_weight_tensor_parameter_92:
 
 class Program_weight_tensor_parameter_93:
     name = "parameter_93"
+    original_name = "conv2d_51.w_0"
     shape = [192, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.504903")
@@ -1034,6 +1128,7 @@ class Program_weight_tensor_parameter_93:
 
 class Program_weight_tensor_parameter_94:
     name = "parameter_94"
+    original_name = "batch_norm2d_48.b_0"
     shape = [96]
     dtype = "float32"
     min_val = float("-1.68501")
@@ -1045,6 +1140,7 @@ class Program_weight_tensor_parameter_94:
 
 class Program_weight_tensor_parameter_95:
     name = "parameter_95"
+    original_name = "batch_norm2d_48.w_0"
     shape = [96]
     dtype = "float32"
     min_val = float("0.0496471")
@@ -1056,6 +1152,7 @@ class Program_weight_tensor_parameter_95:
 
 class Program_weight_tensor_parameter_96:
     name = "parameter_96"
+    original_name = "batch_norm2d_48.w_2"
     shape = [96]
     dtype = "float32"
     min_val = float("1.11938")
@@ -1067,6 +1164,7 @@ class Program_weight_tensor_parameter_96:
 
 class Program_weight_tensor_parameter_97:
     name = "parameter_97"
+    original_name = "batch_norm2d_48.w_1"
     shape = [96]
     dtype = "float32"
     min_val = float("-1.41462")
@@ -1078,6 +1176,7 @@ class Program_weight_tensor_parameter_97:
 
 class Program_weight_tensor_parameter_98:
     name = "parameter_98"
+    original_name = "conv2d_50.w_0"
     shape = [96, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.587386")
@@ -1089,6 +1188,7 @@ class Program_weight_tensor_parameter_98:
 
 class Program_weight_tensor_parameter_99:
     name = "parameter_99"
+    original_name = "batch_norm2d_47.b_0"
     shape = [96]
     dtype = "float32"
     min_val = float("-2.84615")
@@ -1100,6 +1200,7 @@ class Program_weight_tensor_parameter_99:
 
 class Program_weight_tensor_parameter_100:
     name = "parameter_100"
+    original_name = "batch_norm2d_47.w_0"
     shape = [96]
     dtype = "float32"
     min_val = float("0.0482252")
@@ -1111,6 +1212,7 @@ class Program_weight_tensor_parameter_100:
 
 class Program_weight_tensor_parameter_101:
     name = "parameter_101"
+    original_name = "batch_norm2d_47.w_2"
     shape = [96]
     dtype = "float32"
     min_val = float("1.01655")
@@ -1122,6 +1224,7 @@ class Program_weight_tensor_parameter_101:
 
 class Program_weight_tensor_parameter_102:
     name = "parameter_102"
+    original_name = "batch_norm2d_47.w_1"
     shape = [96]
     dtype = "float32"
     min_val = float("-0.990652")
@@ -1133,6 +1236,7 @@ class Program_weight_tensor_parameter_102:
 
 class Program_weight_tensor_parameter_103:
     name = "parameter_103"
+    original_name = "conv2d_49.w_0"
     shape = [96, 160, 1, 1]
     dtype = "float32"
     min_val = float("-0.315133")
@@ -1144,6 +1248,7 @@ class Program_weight_tensor_parameter_103:
 
 class Program_weight_tensor_parameter_104:
     name = "parameter_104"
+    original_name = "batch_norm2d_26.b_0"
     shape = [160]
     dtype = "float32"
     min_val = float("-0.871859")
@@ -1155,6 +1260,7 @@ class Program_weight_tensor_parameter_104:
 
 class Program_weight_tensor_parameter_105:
     name = "parameter_105"
+    original_name = "batch_norm2d_26.w_0"
     shape = [160]
     dtype = "float32"
     min_val = float("1.46044")
@@ -1166,6 +1272,7 @@ class Program_weight_tensor_parameter_105:
 
 class Program_weight_tensor_parameter_106:
     name = "parameter_106"
+    original_name = "batch_norm2d_26.w_2"
     shape = [160]
     dtype = "float32"
     min_val = float("5.39117")
@@ -1177,6 +1284,7 @@ class Program_weight_tensor_parameter_106:
 
 class Program_weight_tensor_parameter_107:
     name = "parameter_107"
+    original_name = "batch_norm2d_26.w_1"
     shape = [160]
     dtype = "float32"
     min_val = float("-16.1519")
@@ -1188,6 +1296,7 @@ class Program_weight_tensor_parameter_107:
 
 class Program_weight_tensor_parameter_108:
     name = "parameter_108"
+    original_name = "conv2d_26.w_0"
     shape = [160, 768, 1, 1]
     dtype = "float32"
     min_val = float("-0.743618")
@@ -1199,6 +1308,7 @@ class Program_weight_tensor_parameter_108:
 
 class Program_weight_tensor_parameter_109:
     name = "parameter_109"
+    original_name = "batch_norm2d_25.b_0"
     shape = [768]
     dtype = "float32"
     min_val = float("-6.01793")
@@ -1210,6 +1320,7 @@ class Program_weight_tensor_parameter_109:
 
 class Program_weight_tensor_parameter_110:
     name = "parameter_110"
+    original_name = "batch_norm2d_25.w_0"
     shape = [768]
     dtype = "float32"
     min_val = float("0.808304")
@@ -1221,6 +1332,7 @@ class Program_weight_tensor_parameter_110:
 
 class Program_weight_tensor_parameter_111:
     name = "parameter_111"
+    original_name = "batch_norm2d_25.w_2"
     shape = [768]
     dtype = "float32"
     min_val = float("5.60519e-45")
@@ -1232,6 +1344,7 @@ class Program_weight_tensor_parameter_111:
 
 class Program_weight_tensor_parameter_112:
     name = "parameter_112"
+    original_name = "batch_norm2d_25.w_1"
     shape = [768]
     dtype = "float32"
     min_val = float("-2.13854")
@@ -1243,6 +1356,7 @@ class Program_weight_tensor_parameter_112:
 
 class Program_weight_tensor_parameter_113:
     name = "parameter_113"
+    original_name = "conv2d_25.w_0"
     shape = [768, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.277844")
@@ -1254,6 +1368,7 @@ class Program_weight_tensor_parameter_113:
 
 class Program_weight_tensor_parameter_114:
     name = "parameter_114"
+    original_name = "batch_norm2d_24.b_0"
     shape = [768]
     dtype = "float32"
     min_val = float("-4.77029")
@@ -1265,6 +1380,7 @@ class Program_weight_tensor_parameter_114:
 
 class Program_weight_tensor_parameter_115:
     name = "parameter_115"
+    original_name = "batch_norm2d_24.w_0"
     shape = [768]
     dtype = "float32"
     min_val = float("-0.26054")
@@ -1276,6 +1392,7 @@ class Program_weight_tensor_parameter_115:
 
 class Program_weight_tensor_parameter_116:
     name = "parameter_116"
+    original_name = "batch_norm2d_24.w_2"
     shape = [768]
     dtype = "float32"
     min_val = float("5.60519e-45")
@@ -1287,6 +1404,7 @@ class Program_weight_tensor_parameter_116:
 
 class Program_weight_tensor_parameter_117:
     name = "parameter_117"
+    original_name = "batch_norm2d_24.w_1"
     shape = [768]
     dtype = "float32"
     min_val = float("-6.67108")
@@ -1298,6 +1416,7 @@ class Program_weight_tensor_parameter_117:
 
 class Program_weight_tensor_parameter_118:
     name = "parameter_118"
+    original_name = "conv2d_24.w_0"
     shape = [768, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.584392")
@@ -1309,6 +1428,7 @@ class Program_weight_tensor_parameter_118:
 
 class Program_weight_tensor_parameter_119:
     name = "parameter_119"
+    original_name = "batch_norm2d_46.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.01521")
@@ -1320,6 +1440,7 @@ class Program_weight_tensor_parameter_119:
 
 class Program_weight_tensor_parameter_120:
     name = "parameter_120"
+    original_name = "batch_norm2d_46.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.310142")
@@ -1331,6 +1452,7 @@ class Program_weight_tensor_parameter_120:
 
 class Program_weight_tensor_parameter_121:
     name = "parameter_121"
+    original_name = "batch_norm2d_46.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.0225761")
@@ -1342,6 +1464,7 @@ class Program_weight_tensor_parameter_121:
 
 class Program_weight_tensor_parameter_122:
     name = "parameter_122"
+    original_name = "batch_norm2d_46.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.15196")
@@ -1353,6 +1476,7 @@ class Program_weight_tensor_parameter_122:
 
 class Program_weight_tensor_parameter_123:
     name = "parameter_123"
+    original_name = "conv2d_48.w_0"
     shape = [128, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.449055")
@@ -1364,6 +1488,7 @@ class Program_weight_tensor_parameter_123:
 
 class Program_weight_tensor_parameter_124:
     name = "parameter_124"
+    original_name = "conv2d_47.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-2.83855")
@@ -1375,6 +1500,7 @@ class Program_weight_tensor_parameter_124:
 
 class Program_weight_tensor_parameter_125:
     name = "parameter_125"
+    original_name = "conv2d_47.w_0"
     shape = [256, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.541175")
@@ -1386,6 +1512,7 @@ class Program_weight_tensor_parameter_125:
 
 class Program_weight_tensor_parameter_126:
     name = "parameter_126"
+    original_name = "batch_norm2d_45.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-4.747")
@@ -1397,6 +1524,7 @@ class Program_weight_tensor_parameter_126:
 
 class Program_weight_tensor_parameter_127:
     name = "parameter_127"
+    original_name = "batch_norm2d_45.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.722462")
@@ -1408,6 +1536,7 @@ class Program_weight_tensor_parameter_127:
 
 class Program_weight_tensor_parameter_128:
     name = "parameter_128"
+    original_name = "batch_norm2d_45.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("3.0133")
@@ -1419,6 +1548,7 @@ class Program_weight_tensor_parameter_128:
 
 class Program_weight_tensor_parameter_129:
     name = "parameter_129"
+    original_name = "batch_norm2d_45.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-6.49916")
@@ -1430,6 +1560,7 @@ class Program_weight_tensor_parameter_129:
 
 class Program_weight_tensor_parameter_130:
     name = "parameter_130"
+    original_name = "conv2d_46.w_0"
     shape = [256, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.509698")
@@ -1441,6 +1572,7 @@ class Program_weight_tensor_parameter_130:
 
 class Program_weight_tensor_parameter_131:
     name = "parameter_131"
+    original_name = "batch_norm2d_40.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-3.81977")
@@ -1452,6 +1584,7 @@ class Program_weight_tensor_parameter_131:
 
 class Program_weight_tensor_parameter_132:
     name = "parameter_132"
+    original_name = "batch_norm2d_40.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-3.33733")
@@ -1463,6 +1596,7 @@ class Program_weight_tensor_parameter_132:
 
 class Program_weight_tensor_parameter_133:
     name = "parameter_133"
+    original_name = "batch_norm2d_40.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.16678")
@@ -1474,6 +1608,7 @@ class Program_weight_tensor_parameter_133:
 
 class Program_weight_tensor_parameter_134:
     name = "parameter_134"
+    original_name = "batch_norm2d_40.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.8673")
@@ -1485,6 +1620,7 @@ class Program_weight_tensor_parameter_134:
 
 class Program_weight_tensor_parameter_135:
     name = "parameter_135"
+    original_name = "conv2d_41.w_0"
     shape = [128, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.463887")
@@ -1496,6 +1632,7 @@ class Program_weight_tensor_parameter_135:
 
 class Program_weight_tensor_parameter_136:
     name = "parameter_136"
+    original_name = "batch_norm2d_42.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-2.57039")
@@ -1507,6 +1644,7 @@ class Program_weight_tensor_parameter_136:
 
 class Program_weight_tensor_parameter_137:
     name = "parameter_137"
+    original_name = "batch_norm2d_42.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.8269")
@@ -1518,6 +1656,7 @@ class Program_weight_tensor_parameter_137:
 
 class Program_weight_tensor_parameter_138:
     name = "parameter_138"
+    original_name = "batch_norm2d_42.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.0233131")
@@ -1529,6 +1668,7 @@ class Program_weight_tensor_parameter_138:
 
 class Program_weight_tensor_parameter_139:
     name = "parameter_139"
+    original_name = "batch_norm2d_42.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.1859")
@@ -1540,6 +1680,7 @@ class Program_weight_tensor_parameter_139:
 
 class Program_weight_tensor_parameter_140:
     name = "parameter_140"
+    original_name = "conv2d_43.w_0"
     shape = [128, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.484306")
@@ -1551,6 +1692,7 @@ class Program_weight_tensor_parameter_140:
 
 class Program_weight_tensor_parameter_141:
     name = "parameter_141"
+    original_name = "batch_norm2d_41.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-2.57062")
@@ -1562,6 +1704,7 @@ class Program_weight_tensor_parameter_141:
 
 class Program_weight_tensor_parameter_142:
     name = "parameter_142"
+    original_name = "batch_norm2d_41.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.73667")
@@ -1573,6 +1716,7 @@ class Program_weight_tensor_parameter_142:
 
 class Program_weight_tensor_parameter_143:
     name = "parameter_143"
+    original_name = "batch_norm2d_41.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.0164409")
@@ -1584,6 +1728,7 @@ class Program_weight_tensor_parameter_143:
 
 class Program_weight_tensor_parameter_144:
     name = "parameter_144"
+    original_name = "batch_norm2d_41.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.02746")
@@ -1595,6 +1740,7 @@ class Program_weight_tensor_parameter_144:
 
 class Program_weight_tensor_parameter_145:
     name = "parameter_145"
+    original_name = "conv2d_42.w_0"
     shape = [128, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.481643")
@@ -1606,6 +1752,7 @@ class Program_weight_tensor_parameter_145:
 
 class Program_weight_tensor_parameter_146:
     name = "parameter_146"
+    original_name = "batch_norm2d_44.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-10.3948")
@@ -1617,6 +1764,7 @@ class Program_weight_tensor_parameter_146:
 
 class Program_weight_tensor_parameter_147:
     name = "parameter_147"
+    original_name = "batch_norm2d_44.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("1.08673")
@@ -1628,6 +1776,7 @@ class Program_weight_tensor_parameter_147:
 
 class Program_weight_tensor_parameter_148:
     name = "parameter_148"
+    original_name = "batch_norm2d_44.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.177571")
@@ -1639,6 +1788,7 @@ class Program_weight_tensor_parameter_148:
 
 class Program_weight_tensor_parameter_149:
     name = "parameter_149"
+    original_name = "batch_norm2d_44.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-2.03986")
@@ -1650,6 +1800,7 @@ class Program_weight_tensor_parameter_149:
 
 class Program_weight_tensor_parameter_150:
     name = "parameter_150"
+    original_name = "conv2d_45.w_0"
     shape = [128, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.478104")
@@ -1661,6 +1812,7 @@ class Program_weight_tensor_parameter_150:
 
 class Program_weight_tensor_parameter_151:
     name = "parameter_151"
+    original_name = "batch_norm2d_43.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-4.08936")
@@ -1672,6 +1824,7 @@ class Program_weight_tensor_parameter_151:
 
 class Program_weight_tensor_parameter_152:
     name = "parameter_152"
+    original_name = "batch_norm2d_43.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.704063")
@@ -1683,6 +1836,7 @@ class Program_weight_tensor_parameter_152:
 
 class Program_weight_tensor_parameter_153:
     name = "parameter_153"
+    original_name = "batch_norm2d_43.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.0003586")
@@ -1694,6 +1848,7 @@ class Program_weight_tensor_parameter_153:
 
 class Program_weight_tensor_parameter_154:
     name = "parameter_154"
+    original_name = "batch_norm2d_43.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.7159")
@@ -1705,6 +1860,7 @@ class Program_weight_tensor_parameter_154:
 
 class Program_weight_tensor_parameter_155:
     name = "parameter_155"
+    original_name = "conv2d_44.w_0"
     shape = [256, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.571032")
@@ -1716,6 +1872,7 @@ class Program_weight_tensor_parameter_155:
 
 class Program_weight_tensor_parameter_156:
     name = "parameter_156"
+    original_name = "batch_norm2d_39.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.74399")
@@ -1727,6 +1884,7 @@ class Program_weight_tensor_parameter_156:
 
 class Program_weight_tensor_parameter_157:
     name = "parameter_157"
+    original_name = "batch_norm2d_39.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.545582")
@@ -1738,6 +1896,7 @@ class Program_weight_tensor_parameter_157:
 
 class Program_weight_tensor_parameter_158:
     name = "parameter_158"
+    original_name = "batch_norm2d_39.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("5.04063")
@@ -1749,6 +1908,7 @@ class Program_weight_tensor_parameter_158:
 
 class Program_weight_tensor_parameter_159:
     name = "parameter_159"
+    original_name = "batch_norm2d_39.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-7.50572")
@@ -1760,6 +1920,7 @@ class Program_weight_tensor_parameter_159:
 
 class Program_weight_tensor_parameter_160:
     name = "parameter_160"
+    original_name = "conv2d_40.w_0"
     shape = [128, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.605532")
@@ -1771,6 +1932,7 @@ class Program_weight_tensor_parameter_160:
 
 class Program_weight_tensor_parameter_161:
     name = "parameter_161"
+    original_name = "batch_norm2d_38.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -1780,6 +1942,7 @@ class Program_weight_tensor_parameter_161:
 
 class Program_weight_tensor_parameter_162:
     name = "parameter_162"
+    original_name = "batch_norm2d_38.w_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -1789,6 +1952,7 @@ class Program_weight_tensor_parameter_162:
 
 class Program_weight_tensor_parameter_163:
     name = "parameter_163"
+    original_name = "batch_norm2d_38.w_2"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -1798,6 +1962,7 @@ class Program_weight_tensor_parameter_163:
 
 class Program_weight_tensor_parameter_164:
     name = "parameter_164"
+    original_name = "batch_norm2d_38.w_1"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -1807,6 +1972,7 @@ class Program_weight_tensor_parameter_164:
 
 class Program_weight_tensor_parameter_165:
     name = "parameter_165"
+    original_name = "conv2d_39.w_0"
     shape = [64, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.493914")
@@ -1818,6 +1984,7 @@ class Program_weight_tensor_parameter_165:
 
 class Program_weight_tensor_parameter_166:
     name = "parameter_166"
+    original_name = "batch_norm2d_37.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -1827,6 +1994,7 @@ class Program_weight_tensor_parameter_166:
 
 class Program_weight_tensor_parameter_167:
     name = "parameter_167"
+    original_name = "batch_norm2d_37.w_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -1836,6 +2004,7 @@ class Program_weight_tensor_parameter_167:
 
 class Program_weight_tensor_parameter_168:
     name = "parameter_168"
+    original_name = "batch_norm2d_37.w_2"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -1845,6 +2014,7 @@ class Program_weight_tensor_parameter_168:
 
 class Program_weight_tensor_parameter_169:
     name = "parameter_169"
+    original_name = "batch_norm2d_37.w_1"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -1854,6 +2024,7 @@ class Program_weight_tensor_parameter_169:
 
 class Program_weight_tensor_parameter_170:
     name = "parameter_170"
+    original_name = "conv2d_38.w_0"
     shape = [64, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.716293")
@@ -1865,6 +2036,7 @@ class Program_weight_tensor_parameter_170:
 
 class Program_weight_tensor_parameter_171:
     name = "parameter_171"
+    original_name = "batch_norm2d_36.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.00472084")
@@ -1876,6 +2048,7 @@ class Program_weight_tensor_parameter_171:
 
 class Program_weight_tensor_parameter_172:
     name = "parameter_172"
+    original_name = "batch_norm2d_36.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.706161")
@@ -1887,6 +2060,7 @@ class Program_weight_tensor_parameter_172:
 
 class Program_weight_tensor_parameter_173:
     name = "parameter_173"
+    original_name = "batch_norm2d_36.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.0937137")
@@ -1898,6 +2072,7 @@ class Program_weight_tensor_parameter_173:
 
 class Program_weight_tensor_parameter_174:
     name = "parameter_174"
+    original_name = "batch_norm2d_36.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.92886")
@@ -1909,6 +2084,7 @@ class Program_weight_tensor_parameter_174:
 
 class Program_weight_tensor_parameter_175:
     name = "parameter_175"
+    original_name = "conv2d_37.w_0"
     shape = [128, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.480067")
@@ -1920,6 +2096,7 @@ class Program_weight_tensor_parameter_175:
 
 class Program_weight_tensor_parameter_176:
     name = "parameter_176"
+    original_name = "conv2d_36.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-3.50279")
@@ -1931,6 +2108,7 @@ class Program_weight_tensor_parameter_176:
 
 class Program_weight_tensor_parameter_177:
     name = "parameter_177"
+    original_name = "conv2d_36.w_0"
     shape = [256, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.660249")
@@ -1942,6 +2120,7 @@ class Program_weight_tensor_parameter_177:
 
 class Program_weight_tensor_parameter_178:
     name = "parameter_178"
+    original_name = "batch_norm2d_35.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-5.5199")
@@ -1953,6 +2132,7 @@ class Program_weight_tensor_parameter_178:
 
 class Program_weight_tensor_parameter_179:
     name = "parameter_179"
+    original_name = "batch_norm2d_35.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.799696")
@@ -1964,6 +2144,7 @@ class Program_weight_tensor_parameter_179:
 
 class Program_weight_tensor_parameter_180:
     name = "parameter_180"
+    original_name = "batch_norm2d_35.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("2.67299")
@@ -1975,6 +2156,7 @@ class Program_weight_tensor_parameter_180:
 
 class Program_weight_tensor_parameter_181:
     name = "parameter_181"
+    original_name = "batch_norm2d_35.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-9.73847")
@@ -1986,6 +2168,7 @@ class Program_weight_tensor_parameter_181:
 
 class Program_weight_tensor_parameter_182:
     name = "parameter_182"
+    original_name = "conv2d_35.w_0"
     shape = [256, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.826677")
@@ -1997,6 +2180,7 @@ class Program_weight_tensor_parameter_182:
 
 class Program_weight_tensor_parameter_183:
     name = "parameter_183"
+    original_name = "batch_norm2d_30.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-3.86312")
@@ -2008,6 +2192,7 @@ class Program_weight_tensor_parameter_183:
 
 class Program_weight_tensor_parameter_184:
     name = "parameter_184"
+    original_name = "batch_norm2d_30.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-2.83802")
@@ -2019,6 +2204,7 @@ class Program_weight_tensor_parameter_184:
 
 class Program_weight_tensor_parameter_185:
     name = "parameter_185"
+    original_name = "batch_norm2d_30.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.124922")
@@ -2030,6 +2216,7 @@ class Program_weight_tensor_parameter_185:
 
 class Program_weight_tensor_parameter_186:
     name = "parameter_186"
+    original_name = "batch_norm2d_30.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-2.55733")
@@ -2041,6 +2228,7 @@ class Program_weight_tensor_parameter_186:
 
 class Program_weight_tensor_parameter_187:
     name = "parameter_187"
+    original_name = "conv2d_30.w_0"
     shape = [128, 128, 1, 1]
     dtype = "float32"
     min_val = float("-1.2806")
@@ -2052,6 +2240,7 @@ class Program_weight_tensor_parameter_187:
 
 class Program_weight_tensor_parameter_188:
     name = "parameter_188"
+    original_name = "batch_norm2d_32.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-8.41947")
@@ -2063,6 +2252,7 @@ class Program_weight_tensor_parameter_188:
 
 class Program_weight_tensor_parameter_189:
     name = "parameter_189"
+    original_name = "batch_norm2d_32.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-2.52565")
@@ -2074,6 +2264,7 @@ class Program_weight_tensor_parameter_189:
 
 class Program_weight_tensor_parameter_190:
     name = "parameter_190"
+    original_name = "batch_norm2d_32.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.0296406")
@@ -2085,6 +2276,7 @@ class Program_weight_tensor_parameter_190:
 
 class Program_weight_tensor_parameter_191:
     name = "parameter_191"
+    original_name = "batch_norm2d_32.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-2.25006")
@@ -2096,6 +2288,7 @@ class Program_weight_tensor_parameter_191:
 
 class Program_weight_tensor_parameter_192:
     name = "parameter_192"
+    original_name = "conv2d_32.w_0"
     shape = [128, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.623142")
@@ -2107,6 +2300,7 @@ class Program_weight_tensor_parameter_192:
 
 class Program_weight_tensor_parameter_193:
     name = "parameter_193"
+    original_name = "batch_norm2d_31.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-8.41982")
@@ -2118,6 +2312,7 @@ class Program_weight_tensor_parameter_193:
 
 class Program_weight_tensor_parameter_194:
     name = "parameter_194"
+    original_name = "batch_norm2d_31.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-3.69915")
@@ -2129,6 +2324,7 @@ class Program_weight_tensor_parameter_194:
 
 class Program_weight_tensor_parameter_195:
     name = "parameter_195"
+    original_name = "batch_norm2d_31.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.043276")
@@ -2140,6 +2336,7 @@ class Program_weight_tensor_parameter_195:
 
 class Program_weight_tensor_parameter_196:
     name = "parameter_196"
+    original_name = "batch_norm2d_31.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-2.20421")
@@ -2151,6 +2348,7 @@ class Program_weight_tensor_parameter_196:
 
 class Program_weight_tensor_parameter_197:
     name = "parameter_197"
+    original_name = "conv2d_31.w_0"
     shape = [128, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.721786")
@@ -2162,6 +2360,7 @@ class Program_weight_tensor_parameter_197:
 
 class Program_weight_tensor_parameter_198:
     name = "parameter_198"
+    original_name = "batch_norm2d_34.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-20.1528")
@@ -2173,6 +2372,7 @@ class Program_weight_tensor_parameter_198:
 
 class Program_weight_tensor_parameter_199:
     name = "parameter_199"
+    original_name = "batch_norm2d_34.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("1.02736")
@@ -2184,6 +2384,7 @@ class Program_weight_tensor_parameter_199:
 
 class Program_weight_tensor_parameter_200:
     name = "parameter_200"
+    original_name = "batch_norm2d_34.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.412703")
@@ -2195,6 +2396,7 @@ class Program_weight_tensor_parameter_200:
 
 class Program_weight_tensor_parameter_201:
     name = "parameter_201"
+    original_name = "batch_norm2d_34.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-7.28169")
@@ -2206,6 +2408,7 @@ class Program_weight_tensor_parameter_201:
 
 class Program_weight_tensor_parameter_202:
     name = "parameter_202"
+    original_name = "conv2d_34.w_0"
     shape = [128, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.782075")
@@ -2217,6 +2420,7 @@ class Program_weight_tensor_parameter_202:
 
 class Program_weight_tensor_parameter_203:
     name = "parameter_203"
+    original_name = "batch_norm2d_33.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-4.32566")
@@ -2228,6 +2432,7 @@ class Program_weight_tensor_parameter_203:
 
 class Program_weight_tensor_parameter_204:
     name = "parameter_204"
+    original_name = "batch_norm2d_33.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.720327")
@@ -2239,6 +2444,7 @@ class Program_weight_tensor_parameter_204:
 
 class Program_weight_tensor_parameter_205:
     name = "parameter_205"
+    original_name = "batch_norm2d_33.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.00023333")
@@ -2250,6 +2456,7 @@ class Program_weight_tensor_parameter_205:
 
 class Program_weight_tensor_parameter_206:
     name = "parameter_206"
+    original_name = "batch_norm2d_33.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-4.3104")
@@ -2261,6 +2468,7 @@ class Program_weight_tensor_parameter_206:
 
 class Program_weight_tensor_parameter_207:
     name = "parameter_207"
+    original_name = "conv2d_33.w_0"
     shape = [256, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.746652")
@@ -2272,6 +2480,7 @@ class Program_weight_tensor_parameter_207:
 
 class Program_weight_tensor_parameter_208:
     name = "parameter_208"
+    original_name = "batch_norm2d_29.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-8.63109")
@@ -2283,6 +2492,7 @@ class Program_weight_tensor_parameter_208:
 
 class Program_weight_tensor_parameter_209:
     name = "parameter_209"
+    original_name = "batch_norm2d_29.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.0986718")
@@ -2294,6 +2504,7 @@ class Program_weight_tensor_parameter_209:
 
 class Program_weight_tensor_parameter_210:
     name = "parameter_210"
+    original_name = "batch_norm2d_29.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("2.77536")
@@ -2305,6 +2516,7 @@ class Program_weight_tensor_parameter_210:
 
 class Program_weight_tensor_parameter_211:
     name = "parameter_211"
+    original_name = "batch_norm2d_29.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.0064576")
@@ -2316,6 +2528,7 @@ class Program_weight_tensor_parameter_211:
 
 class Program_weight_tensor_parameter_212:
     name = "parameter_212"
+    original_name = "conv2d_29.w_0"
     shape = [128, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.868917")
@@ -2327,6 +2540,7 @@ class Program_weight_tensor_parameter_212:
 
 class Program_weight_tensor_parameter_213:
     name = "parameter_213"
+    original_name = "batch_norm2d_28.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -2336,6 +2550,7 @@ class Program_weight_tensor_parameter_213:
 
 class Program_weight_tensor_parameter_214:
     name = "parameter_214"
+    original_name = "batch_norm2d_28.w_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -2345,6 +2560,7 @@ class Program_weight_tensor_parameter_214:
 
 class Program_weight_tensor_parameter_215:
     name = "parameter_215"
+    original_name = "batch_norm2d_28.w_2"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -2354,6 +2570,7 @@ class Program_weight_tensor_parameter_215:
 
 class Program_weight_tensor_parameter_216:
     name = "parameter_216"
+    original_name = "batch_norm2d_28.w_1"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -2363,6 +2580,7 @@ class Program_weight_tensor_parameter_216:
 
 class Program_weight_tensor_parameter_217:
     name = "parameter_217"
+    original_name = "conv2d_28.w_0"
     shape = [64, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.758681")
@@ -2374,6 +2592,7 @@ class Program_weight_tensor_parameter_217:
 
 class Program_weight_tensor_parameter_218:
     name = "parameter_218"
+    original_name = "batch_norm2d_27.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -2383,6 +2602,7 @@ class Program_weight_tensor_parameter_218:
 
 class Program_weight_tensor_parameter_219:
     name = "parameter_219"
+    original_name = "batch_norm2d_27.w_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -2392,6 +2612,7 @@ class Program_weight_tensor_parameter_219:
 
 class Program_weight_tensor_parameter_220:
     name = "parameter_220"
+    original_name = "batch_norm2d_27.w_2"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -2401,6 +2622,7 @@ class Program_weight_tensor_parameter_220:
 
 class Program_weight_tensor_parameter_221:
     name = "parameter_221"
+    original_name = "batch_norm2d_27.w_1"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -2410,6 +2632,7 @@ class Program_weight_tensor_parameter_221:
 
 class Program_weight_tensor_parameter_222:
     name = "parameter_222"
+    original_name = "conv2d_27.w_0"
     shape = [64, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.506924")
@@ -2421,6 +2644,7 @@ class Program_weight_tensor_parameter_222:
 
 class Program_weight_tensor_parameter_223:
     name = "parameter_223"
+    original_name = "batch_norm2d_23.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.00602357")
@@ -2432,6 +2656,7 @@ class Program_weight_tensor_parameter_223:
 
 class Program_weight_tensor_parameter_224:
     name = "parameter_224"
+    original_name = "batch_norm2d_23.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("1.03124")
@@ -2443,6 +2668,7 @@ class Program_weight_tensor_parameter_224:
 
 class Program_weight_tensor_parameter_225:
     name = "parameter_225"
+    original_name = "batch_norm2d_23.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("5.22742")
@@ -2454,6 +2680,7 @@ class Program_weight_tensor_parameter_225:
 
 class Program_weight_tensor_parameter_226:
     name = "parameter_226"
+    original_name = "batch_norm2d_23.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-18.7199")
@@ -2465,6 +2692,7 @@ class Program_weight_tensor_parameter_226:
 
 class Program_weight_tensor_parameter_227:
     name = "parameter_227"
+    original_name = "conv2d_23.w_0"
     shape = [128, 192, 1, 1]
     dtype = "float32"
     min_val = float("-1.01798")
@@ -2476,6 +2704,7 @@ class Program_weight_tensor_parameter_227:
 
 class Program_weight_tensor_parameter_228:
     name = "parameter_228"
+    original_name = "batch_norm2d_22.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-5.18269")
@@ -2487,6 +2716,7 @@ class Program_weight_tensor_parameter_228:
 
 class Program_weight_tensor_parameter_229:
     name = "parameter_229"
+    original_name = "batch_norm2d_22.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("1.67873")
@@ -2498,6 +2728,7 @@ class Program_weight_tensor_parameter_229:
 
 class Program_weight_tensor_parameter_230:
     name = "parameter_230"
+    original_name = "batch_norm2d_22.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("0.005973")
@@ -2509,6 +2740,7 @@ class Program_weight_tensor_parameter_230:
 
 class Program_weight_tensor_parameter_231:
     name = "parameter_231"
+    original_name = "batch_norm2d_22.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-12.3714")
@@ -2520,6 +2752,7 @@ class Program_weight_tensor_parameter_231:
 
 class Program_weight_tensor_parameter_232:
     name = "parameter_232"
+    original_name = "conv2d_22.w_0"
     shape = [192, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.444745")
@@ -2531,6 +2764,7 @@ class Program_weight_tensor_parameter_232:
 
 class Program_weight_tensor_parameter_233:
     name = "parameter_233"
+    original_name = "batch_norm2d_21.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-4.2057")
@@ -2542,6 +2776,7 @@ class Program_weight_tensor_parameter_233:
 
 class Program_weight_tensor_parameter_234:
     name = "parameter_234"
+    original_name = "batch_norm2d_21.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("0.801897")
@@ -2553,6 +2788,7 @@ class Program_weight_tensor_parameter_234:
 
 class Program_weight_tensor_parameter_235:
     name = "parameter_235"
+    original_name = "batch_norm2d_21.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("18.4489")
@@ -2564,6 +2800,7 @@ class Program_weight_tensor_parameter_235:
 
 class Program_weight_tensor_parameter_236:
     name = "parameter_236"
+    original_name = "batch_norm2d_21.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.00530442")
@@ -2575,6 +2812,7 @@ class Program_weight_tensor_parameter_236:
 
 class Program_weight_tensor_parameter_237:
     name = "parameter_237"
+    original_name = "conv2d_21.w_0"
     shape = [192, 64, 1, 1]
     dtype = "float32"
     min_val = float("-1.12028")
@@ -2586,6 +2824,7 @@ class Program_weight_tensor_parameter_237:
 
 class Program_weight_tensor_parameter_238:
     name = "parameter_238"
+    original_name = "batch_norm2d_20.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -2595,6 +2834,7 @@ class Program_weight_tensor_parameter_238:
 
 class Program_weight_tensor_parameter_239:
     name = "parameter_239"
+    original_name = "batch_norm2d_20.w_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -2604,6 +2844,7 @@ class Program_weight_tensor_parameter_239:
 
 class Program_weight_tensor_parameter_240:
     name = "parameter_240"
+    original_name = "batch_norm2d_20.w_2"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -2613,6 +2854,7 @@ class Program_weight_tensor_parameter_240:
 
 class Program_weight_tensor_parameter_241:
     name = "parameter_241"
+    original_name = "batch_norm2d_20.w_1"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -2622,6 +2864,7 @@ class Program_weight_tensor_parameter_241:
 
 class Program_weight_tensor_parameter_242:
     name = "parameter_242"
+    original_name = "conv2d_20.w_0"
     shape = [64, 192, 1, 1]
     dtype = "float32"
     min_val = float("-0.632773")
@@ -2633,6 +2876,7 @@ class Program_weight_tensor_parameter_242:
 
 class Program_weight_tensor_parameter_243:
     name = "parameter_243"
+    original_name = "batch_norm2d_19.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-13.6491")
@@ -2644,6 +2888,7 @@ class Program_weight_tensor_parameter_243:
 
 class Program_weight_tensor_parameter_244:
     name = "parameter_244"
+    original_name = "batch_norm2d_19.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("0.668165")
@@ -2655,6 +2900,7 @@ class Program_weight_tensor_parameter_244:
 
 class Program_weight_tensor_parameter_245:
     name = "parameter_245"
+    original_name = "batch_norm2d_19.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("5.60519e-45")
@@ -2666,6 +2912,7 @@ class Program_weight_tensor_parameter_245:
 
 class Program_weight_tensor_parameter_246:
     name = "parameter_246"
+    original_name = "batch_norm2d_19.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-2.76653")
@@ -2677,6 +2924,7 @@ class Program_weight_tensor_parameter_246:
 
 class Program_weight_tensor_parameter_247:
     name = "parameter_247"
+    original_name = "conv2d_19.w_0"
     shape = [192, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.780393")
@@ -2688,6 +2936,7 @@ class Program_weight_tensor_parameter_247:
 
 class Program_weight_tensor_parameter_248:
     name = "parameter_248"
+    original_name = "batch_norm2d_18.b_0"
     shape = [192]
     dtype = "float32"
     min_val = float("-4.29947")
@@ -2699,6 +2948,7 @@ class Program_weight_tensor_parameter_248:
 
 class Program_weight_tensor_parameter_249:
     name = "parameter_249"
+    original_name = "batch_norm2d_18.w_0"
     shape = [192]
     dtype = "float32"
     min_val = float("0.268987")
@@ -2710,6 +2960,7 @@ class Program_weight_tensor_parameter_249:
 
 class Program_weight_tensor_parameter_250:
     name = "parameter_250"
+    original_name = "batch_norm2d_18.w_2"
     shape = [192]
     dtype = "float32"
     min_val = float("5.60519e-45")
@@ -2721,6 +2972,7 @@ class Program_weight_tensor_parameter_250:
 
 class Program_weight_tensor_parameter_251:
     name = "parameter_251"
+    original_name = "batch_norm2d_18.w_1"
     shape = [192]
     dtype = "float32"
     min_val = float("-0.00334471")
@@ -2732,6 +2984,7 @@ class Program_weight_tensor_parameter_251:
 
 class Program_weight_tensor_parameter_252:
     name = "parameter_252"
+    original_name = "conv2d_18.w_0"
     shape = [192, 64, 1, 1]
     dtype = "float32"
     min_val = float("-0.504243")
@@ -2743,6 +2996,7 @@ class Program_weight_tensor_parameter_252:
 
 class Program_weight_tensor_parameter_253:
     name = "parameter_253"
+    original_name = "batch_norm2d_17.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -2752,6 +3006,7 @@ class Program_weight_tensor_parameter_253:
 
 class Program_weight_tensor_parameter_254:
     name = "parameter_254"
+    original_name = "batch_norm2d_17.w_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -2761,6 +3016,7 @@ class Program_weight_tensor_parameter_254:
 
 class Program_weight_tensor_parameter_255:
     name = "parameter_255"
+    original_name = "batch_norm2d_17.w_2"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -2770,6 +3026,7 @@ class Program_weight_tensor_parameter_255:
 
 class Program_weight_tensor_parameter_256:
     name = "parameter_256"
+    original_name = "batch_norm2d_17.w_1"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -2779,6 +3036,7 @@ class Program_weight_tensor_parameter_256:
 
 class Program_weight_tensor_parameter_257:
     name = "parameter_257"
+    original_name = "conv2d_17.w_0"
     shape = [64, 96, 1, 1]
     dtype = "float32"
     min_val = float("-1.02697")
@@ -2790,6 +3048,7 @@ class Program_weight_tensor_parameter_257:
 
 class Program_weight_tensor_parameter_258:
     name = "parameter_258"
+    original_name = "batch_norm2d_16.b_0"
     shape = [96]
     dtype = "float32"
     min_val = float("-1.49743")
@@ -2801,6 +3060,7 @@ class Program_weight_tensor_parameter_258:
 
 class Program_weight_tensor_parameter_259:
     name = "parameter_259"
+    original_name = "batch_norm2d_16.w_0"
     shape = [96]
     dtype = "float32"
     min_val = float("1.55576")
@@ -2812,6 +3072,7 @@ class Program_weight_tensor_parameter_259:
 
 class Program_weight_tensor_parameter_260:
     name = "parameter_260"
+    original_name = "batch_norm2d_16.w_2"
     shape = [96]
     dtype = "float32"
     min_val = float("0.227324")
@@ -2823,6 +3084,7 @@ class Program_weight_tensor_parameter_260:
 
 class Program_weight_tensor_parameter_261:
     name = "parameter_261"
+    original_name = "batch_norm2d_16.w_1"
     shape = [96]
     dtype = "float32"
     min_val = float("-5.5259")
@@ -2834,6 +3096,7 @@ class Program_weight_tensor_parameter_261:
 
 class Program_weight_tensor_parameter_262:
     name = "parameter_262"
+    original_name = "conv2d_16.w_0"
     shape = [96, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.440958")
@@ -2845,6 +3108,7 @@ class Program_weight_tensor_parameter_262:
 
 class Program_weight_tensor_parameter_263:
     name = "parameter_263"
+    original_name = "batch_norm2d_15.b_0"
     shape = [96]
     dtype = "float32"
     min_val = float("-4.8853")
@@ -2856,6 +3120,7 @@ class Program_weight_tensor_parameter_263:
 
 class Program_weight_tensor_parameter_264:
     name = "parameter_264"
+    original_name = "batch_norm2d_15.w_0"
     shape = [96]
     dtype = "float32"
     min_val = float("0.407317")
@@ -2867,6 +3132,7 @@ class Program_weight_tensor_parameter_264:
 
 class Program_weight_tensor_parameter_265:
     name = "parameter_265"
+    original_name = "batch_norm2d_15.w_2"
     shape = [96]
     dtype = "float32"
     min_val = float("31.4588")
@@ -2878,6 +3144,7 @@ class Program_weight_tensor_parameter_265:
 
 class Program_weight_tensor_parameter_266:
     name = "parameter_266"
+    original_name = "batch_norm2d_15.w_1"
     shape = [96]
     dtype = "float32"
     min_val = float("-0.0099081")
@@ -2889,6 +3156,7 @@ class Program_weight_tensor_parameter_266:
 
 class Program_weight_tensor_parameter_267:
     name = "parameter_267"
+    original_name = "conv2d_15.w_0"
     shape = [96, 32, 1, 1]
     dtype = "float32"
     min_val = float("-1.3588")
@@ -2900,6 +3168,7 @@ class Program_weight_tensor_parameter_267:
 
 class Program_weight_tensor_parameter_268:
     name = "parameter_268"
+    original_name = "batch_norm2d_14.b_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -2909,6 +3178,7 @@ class Program_weight_tensor_parameter_268:
 
 class Program_weight_tensor_parameter_269:
     name = "parameter_269"
+    original_name = "batch_norm2d_14.w_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -2918,6 +3188,7 @@ class Program_weight_tensor_parameter_269:
 
 class Program_weight_tensor_parameter_270:
     name = "parameter_270"
+    original_name = "batch_norm2d_14.w_2"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -2927,6 +3198,7 @@ class Program_weight_tensor_parameter_270:
 
 class Program_weight_tensor_parameter_271:
     name = "parameter_271"
+    original_name = "batch_norm2d_14.w_1"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -2936,6 +3208,7 @@ class Program_weight_tensor_parameter_271:
 
 class Program_weight_tensor_parameter_272:
     name = "parameter_272"
+    original_name = "conv2d_14.w_0"
     shape = [32, 96, 1, 1]
     dtype = "float32"
     min_val = float("-0.899369")
@@ -2947,6 +3220,7 @@ class Program_weight_tensor_parameter_272:
 
 class Program_weight_tensor_parameter_273:
     name = "parameter_273"
+    original_name = "batch_norm2d_13.b_0"
     shape = [96]
     dtype = "float32"
     min_val = float("-14.7657")
@@ -2958,6 +3232,7 @@ class Program_weight_tensor_parameter_273:
 
 class Program_weight_tensor_parameter_274:
     name = "parameter_274"
+    original_name = "batch_norm2d_13.w_0"
     shape = [96]
     dtype = "float32"
     min_val = float("1.05511")
@@ -2969,6 +3244,7 @@ class Program_weight_tensor_parameter_274:
 
 class Program_weight_tensor_parameter_275:
     name = "parameter_275"
+    original_name = "batch_norm2d_13.w_2"
     shape = [96]
     dtype = "float32"
     min_val = float("0.285256")
@@ -2980,6 +3256,7 @@ class Program_weight_tensor_parameter_275:
 
 class Program_weight_tensor_parameter_276:
     name = "parameter_276"
+    original_name = "batch_norm2d_13.w_1"
     shape = [96]
     dtype = "float32"
     min_val = float("-21.2036")
@@ -2991,6 +3268,7 @@ class Program_weight_tensor_parameter_276:
 
 class Program_weight_tensor_parameter_277:
     name = "parameter_277"
+    original_name = "conv2d_13.w_0"
     shape = [96, 1, 5, 5]
     dtype = "float32"
     min_val = float("-1.73834")
@@ -3002,6 +3280,7 @@ class Program_weight_tensor_parameter_277:
 
 class Program_weight_tensor_parameter_278:
     name = "parameter_278"
+    original_name = "batch_norm2d_12.b_0"
     shape = [96]
     dtype = "float32"
     min_val = float("-2.14764")
@@ -3013,6 +3292,7 @@ class Program_weight_tensor_parameter_278:
 
 class Program_weight_tensor_parameter_279:
     name = "parameter_279"
+    original_name = "batch_norm2d_12.w_0"
     shape = [96]
     dtype = "float32"
     min_val = float("0.71409")
@@ -3024,6 +3304,7 @@ class Program_weight_tensor_parameter_279:
 
 class Program_weight_tensor_parameter_280:
     name = "parameter_280"
+    original_name = "batch_norm2d_12.w_2"
     shape = [96]
     dtype = "float32"
     min_val = float("14.8876")
@@ -3035,6 +3316,7 @@ class Program_weight_tensor_parameter_280:
 
 class Program_weight_tensor_parameter_281:
     name = "parameter_281"
+    original_name = "batch_norm2d_12.w_1"
     shape = [96]
     dtype = "float32"
     min_val = float("-0.0043112")
@@ -3046,6 +3328,7 @@ class Program_weight_tensor_parameter_281:
 
 class Program_weight_tensor_parameter_282:
     name = "parameter_282"
+    original_name = "conv2d_12.w_0"
     shape = [96, 32, 1, 1]
     dtype = "float32"
     min_val = float("-0.958433")
@@ -3057,6 +3340,7 @@ class Program_weight_tensor_parameter_282:
 
 class Program_weight_tensor_parameter_283:
     name = "parameter_283"
+    original_name = "batch_norm2d_11.b_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -3066,6 +3350,7 @@ class Program_weight_tensor_parameter_283:
 
 class Program_weight_tensor_parameter_284:
     name = "parameter_284"
+    original_name = "batch_norm2d_11.w_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -3075,6 +3360,7 @@ class Program_weight_tensor_parameter_284:
 
 class Program_weight_tensor_parameter_285:
     name = "parameter_285"
+    original_name = "batch_norm2d_11.w_2"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -3084,6 +3370,7 @@ class Program_weight_tensor_parameter_285:
 
 class Program_weight_tensor_parameter_286:
     name = "parameter_286"
+    original_name = "batch_norm2d_11.w_1"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -3093,6 +3380,7 @@ class Program_weight_tensor_parameter_286:
 
 class Program_weight_tensor_parameter_287:
     name = "parameter_287"
+    original_name = "conv2d_11.w_0"
     shape = [32, 48, 1, 1]
     dtype = "float32"
     min_val = float("-1.19436")
@@ -3104,6 +3392,7 @@ class Program_weight_tensor_parameter_287:
 
 class Program_weight_tensor_parameter_288:
     name = "parameter_288"
+    original_name = "batch_norm2d_10.b_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -3113,6 +3402,7 @@ class Program_weight_tensor_parameter_288:
 
 class Program_weight_tensor_parameter_289:
     name = "parameter_289"
+    original_name = "batch_norm2d_10.w_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -3122,6 +3412,7 @@ class Program_weight_tensor_parameter_289:
 
 class Program_weight_tensor_parameter_290:
     name = "parameter_290"
+    original_name = "batch_norm2d_10.w_2"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -3131,6 +3422,7 @@ class Program_weight_tensor_parameter_290:
 
 class Program_weight_tensor_parameter_291:
     name = "parameter_291"
+    original_name = "batch_norm2d_10.w_1"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -3140,6 +3432,7 @@ class Program_weight_tensor_parameter_291:
 
 class Program_weight_tensor_parameter_292:
     name = "parameter_292"
+    original_name = "conv2d_10.w_0"
     shape = [48, 1, 5, 5]
     dtype = "float32"
     min_val = float("-0.711676")
@@ -3151,6 +3444,7 @@ class Program_weight_tensor_parameter_292:
 
 class Program_weight_tensor_parameter_293:
     name = "parameter_293"
+    original_name = "batch_norm2d_9.b_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -3160,6 +3454,7 @@ class Program_weight_tensor_parameter_293:
 
 class Program_weight_tensor_parameter_294:
     name = "parameter_294"
+    original_name = "batch_norm2d_9.w_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -3169,6 +3464,7 @@ class Program_weight_tensor_parameter_294:
 
 class Program_weight_tensor_parameter_295:
     name = "parameter_295"
+    original_name = "batch_norm2d_9.w_2"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -3178,6 +3474,7 @@ class Program_weight_tensor_parameter_295:
 
 class Program_weight_tensor_parameter_296:
     name = "parameter_296"
+    original_name = "batch_norm2d_9.w_1"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -3187,6 +3484,7 @@ class Program_weight_tensor_parameter_296:
 
 class Program_weight_tensor_parameter_297:
     name = "parameter_297"
+    original_name = "conv2d_9.w_0"
     shape = [48, 16, 1, 1]
     dtype = "float32"
     min_val = float("-1.94587")
@@ -3198,6 +3496,7 @@ class Program_weight_tensor_parameter_297:
 
 class Program_weight_tensor_parameter_298:
     name = "parameter_298"
+    original_name = "batch_norm2d_8.b_0"
     shape = [16]
     dtype = "float32"
     min_val = float("0")
@@ -3207,6 +3506,7 @@ class Program_weight_tensor_parameter_298:
 
 class Program_weight_tensor_parameter_299:
     name = "parameter_299"
+    original_name = "batch_norm2d_8.w_0"
     shape = [16]
     dtype = "float32"
     min_val = float("0")
@@ -3216,6 +3516,7 @@ class Program_weight_tensor_parameter_299:
 
 class Program_weight_tensor_parameter_300:
     name = "parameter_300"
+    original_name = "batch_norm2d_8.w_2"
     shape = [16]
     dtype = "float32"
     min_val = float("0")
@@ -3225,6 +3526,7 @@ class Program_weight_tensor_parameter_300:
 
 class Program_weight_tensor_parameter_301:
     name = "parameter_301"
+    original_name = "batch_norm2d_8.w_1"
     shape = [16]
     dtype = "float32"
     min_val = float("0")
@@ -3234,6 +3536,7 @@ class Program_weight_tensor_parameter_301:
 
 class Program_weight_tensor_parameter_302:
     name = "parameter_302"
+    original_name = "conv2d_8.w_0"
     shape = [16, 48, 1, 1]
     dtype = "float32"
     min_val = float("-0.993618")
@@ -3245,6 +3548,7 @@ class Program_weight_tensor_parameter_302:
 
 class Program_weight_tensor_parameter_303:
     name = "parameter_303"
+    original_name = "batch_norm2d_7.b_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -3254,6 +3558,7 @@ class Program_weight_tensor_parameter_303:
 
 class Program_weight_tensor_parameter_304:
     name = "parameter_304"
+    original_name = "batch_norm2d_7.w_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -3263,6 +3568,7 @@ class Program_weight_tensor_parameter_304:
 
 class Program_weight_tensor_parameter_305:
     name = "parameter_305"
+    original_name = "batch_norm2d_7.w_2"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -3272,6 +3578,7 @@ class Program_weight_tensor_parameter_305:
 
 class Program_weight_tensor_parameter_306:
     name = "parameter_306"
+    original_name = "batch_norm2d_7.w_1"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -3281,6 +3588,7 @@ class Program_weight_tensor_parameter_306:
 
 class Program_weight_tensor_parameter_307:
     name = "parameter_307"
+    original_name = "conv2d_7.w_0"
     shape = [48, 1, 3, 3]
     dtype = "float32"
     min_val = float("-1.5169")
@@ -3292,6 +3600,7 @@ class Program_weight_tensor_parameter_307:
 
 class Program_weight_tensor_parameter_308:
     name = "parameter_308"
+    original_name = "batch_norm2d_6.b_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -3301,6 +3610,7 @@ class Program_weight_tensor_parameter_308:
 
 class Program_weight_tensor_parameter_309:
     name = "parameter_309"
+    original_name = "batch_norm2d_6.w_0"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -3310,6 +3620,7 @@ class Program_weight_tensor_parameter_309:
 
 class Program_weight_tensor_parameter_310:
     name = "parameter_310"
+    original_name = "batch_norm2d_6.w_2"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -3319,6 +3630,7 @@ class Program_weight_tensor_parameter_310:
 
 class Program_weight_tensor_parameter_311:
     name = "parameter_311"
+    original_name = "batch_norm2d_6.w_1"
     shape = [48]
     dtype = "float32"
     min_val = float("0")
@@ -3328,6 +3640,7 @@ class Program_weight_tensor_parameter_311:
 
 class Program_weight_tensor_parameter_312:
     name = "parameter_312"
+    original_name = "conv2d_6.w_0"
     shape = [48, 16, 1, 1]
     dtype = "float32"
     min_val = float("-0.996491")
@@ -3339,6 +3652,7 @@ class Program_weight_tensor_parameter_312:
 
 class Program_weight_tensor_parameter_313:
     name = "parameter_313"
+    original_name = "batch_norm2d_5.b_0"
     shape = [16]
     dtype = "float32"
     min_val = float("0")
@@ -3348,6 +3662,7 @@ class Program_weight_tensor_parameter_313:
 
 class Program_weight_tensor_parameter_314:
     name = "parameter_314"
+    original_name = "batch_norm2d_5.w_0"
     shape = [16]
     dtype = "float32"
     min_val = float("0")
@@ -3357,6 +3672,7 @@ class Program_weight_tensor_parameter_314:
 
 class Program_weight_tensor_parameter_315:
     name = "parameter_315"
+    original_name = "batch_norm2d_5.w_2"
     shape = [16]
     dtype = "float32"
     min_val = float("0")
@@ -3366,6 +3682,7 @@ class Program_weight_tensor_parameter_315:
 
 class Program_weight_tensor_parameter_316:
     name = "parameter_316"
+    original_name = "batch_norm2d_5.w_1"
     shape = [16]
     dtype = "float32"
     min_val = float("0")
@@ -3375,6 +3692,7 @@ class Program_weight_tensor_parameter_316:
 
 class Program_weight_tensor_parameter_317:
     name = "parameter_317"
+    original_name = "conv2d_5.w_0"
     shape = [16, 64, 1, 1]
     dtype = "float32"
     min_val = float("-1.29513")
@@ -3386,6 +3704,7 @@ class Program_weight_tensor_parameter_317:
 
 class Program_weight_tensor_parameter_318:
     name = "parameter_318"
+    original_name = "batch_norm2d_4.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -3395,6 +3714,7 @@ class Program_weight_tensor_parameter_318:
 
 class Program_weight_tensor_parameter_319:
     name = "parameter_319"
+    original_name = "batch_norm2d_4.w_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -3404,6 +3724,7 @@ class Program_weight_tensor_parameter_319:
 
 class Program_weight_tensor_parameter_320:
     name = "parameter_320"
+    original_name = "batch_norm2d_4.w_2"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -3413,6 +3734,7 @@ class Program_weight_tensor_parameter_320:
 
 class Program_weight_tensor_parameter_321:
     name = "parameter_321"
+    original_name = "batch_norm2d_4.w_1"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -3422,6 +3744,7 @@ class Program_weight_tensor_parameter_321:
 
 class Program_weight_tensor_parameter_322:
     name = "parameter_322"
+    original_name = "conv2d_4.w_0"
     shape = [64, 1, 3, 3]
     dtype = "float32"
     min_val = float("-0.751809")
@@ -3433,6 +3756,7 @@ class Program_weight_tensor_parameter_322:
 
 class Program_weight_tensor_parameter_323:
     name = "parameter_323"
+    original_name = "batch_norm2d_3.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -3442,6 +3766,7 @@ class Program_weight_tensor_parameter_323:
 
 class Program_weight_tensor_parameter_324:
     name = "parameter_324"
+    original_name = "batch_norm2d_3.w_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -3451,6 +3776,7 @@ class Program_weight_tensor_parameter_324:
 
 class Program_weight_tensor_parameter_325:
     name = "parameter_325"
+    original_name = "batch_norm2d_3.w_2"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -3460,6 +3786,7 @@ class Program_weight_tensor_parameter_325:
 
 class Program_weight_tensor_parameter_326:
     name = "parameter_326"
+    original_name = "batch_norm2d_3.w_1"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -3469,6 +3796,7 @@ class Program_weight_tensor_parameter_326:
 
 class Program_weight_tensor_parameter_327:
     name = "parameter_327"
+    original_name = "conv2d_3.w_0"
     shape = [64, 16, 1, 1]
     dtype = "float32"
     min_val = float("-1.53297")
@@ -3480,6 +3808,7 @@ class Program_weight_tensor_parameter_327:
 
 class Program_weight_tensor_parameter_328:
     name = "parameter_328"
+    original_name = "batch_norm2d_2.b_0"
     shape = [16]
     dtype = "float32"
     min_val = float("0")
@@ -3489,6 +3818,7 @@ class Program_weight_tensor_parameter_328:
 
 class Program_weight_tensor_parameter_329:
     name = "parameter_329"
+    original_name = "batch_norm2d_2.w_0"
     shape = [16]
     dtype = "float32"
     min_val = float("0")
@@ -3498,6 +3828,7 @@ class Program_weight_tensor_parameter_329:
 
 class Program_weight_tensor_parameter_330:
     name = "parameter_330"
+    original_name = "batch_norm2d_2.w_2"
     shape = [16]
     dtype = "float32"
     min_val = float("0")
@@ -3507,6 +3838,7 @@ class Program_weight_tensor_parameter_330:
 
 class Program_weight_tensor_parameter_331:
     name = "parameter_331"
+    original_name = "batch_norm2d_2.w_1"
     shape = [16]
     dtype = "float32"
     min_val = float("0")
@@ -3516,6 +3848,7 @@ class Program_weight_tensor_parameter_331:
 
 class Program_weight_tensor_parameter_332:
     name = "parameter_332"
+    original_name = "conv2d_2.w_0"
     shape = [16, 16, 1, 1]
     dtype = "float32"
     min_val = float("-1.83577")
@@ -3527,6 +3860,7 @@ class Program_weight_tensor_parameter_332:
 
 class Program_weight_tensor_parameter_333:
     name = "parameter_333"
+    original_name = "batch_norm2d_1.b_0"
     shape = [16]
     dtype = "float32"
     min_val = float("0")
@@ -3536,6 +3870,7 @@ class Program_weight_tensor_parameter_333:
 
 class Program_weight_tensor_parameter_334:
     name = "parameter_334"
+    original_name = "batch_norm2d_1.w_0"
     shape = [16]
     dtype = "float32"
     min_val = float("0")
@@ -3545,6 +3880,7 @@ class Program_weight_tensor_parameter_334:
 
 class Program_weight_tensor_parameter_335:
     name = "parameter_335"
+    original_name = "batch_norm2d_1.w_2"
     shape = [16]
     dtype = "float32"
     min_val = float("0")
@@ -3554,6 +3890,7 @@ class Program_weight_tensor_parameter_335:
 
 class Program_weight_tensor_parameter_336:
     name = "parameter_336"
+    original_name = "batch_norm2d_1.w_1"
     shape = [16]
     dtype = "float32"
     min_val = float("0")
@@ -3563,6 +3900,7 @@ class Program_weight_tensor_parameter_336:
 
 class Program_weight_tensor_parameter_337:
     name = "parameter_337"
+    original_name = "conv2d_1.w_0"
     shape = [16, 1, 3, 3]
     dtype = "float32"
     min_val = float("-2.52589")
@@ -3574,6 +3912,7 @@ class Program_weight_tensor_parameter_337:
 
 class Program_weight_tensor_parameter_338:
     name = "parameter_338"
+    original_name = "batch_norm2d_0.b_0"
     shape = [16]
     dtype = "float32"
     min_val = float("0")
@@ -3583,6 +3922,7 @@ class Program_weight_tensor_parameter_338:
 
 class Program_weight_tensor_parameter_339:
     name = "parameter_339"
+    original_name = "batch_norm2d_0.w_0"
     shape = [16]
     dtype = "float32"
     min_val = float("0")
@@ -3592,6 +3932,7 @@ class Program_weight_tensor_parameter_339:
 
 class Program_weight_tensor_parameter_340:
     name = "parameter_340"
+    original_name = "batch_norm2d_0.w_2"
     shape = [16]
     dtype = "float32"
     min_val = float("0")
@@ -3601,6 +3942,7 @@ class Program_weight_tensor_parameter_340:
 
 class Program_weight_tensor_parameter_341:
     name = "parameter_341"
+    original_name = "batch_norm2d_0.w_1"
     shape = [16]
     dtype = "float32"
     min_val = float("0")
@@ -3610,6 +3952,7 @@ class Program_weight_tensor_parameter_341:
 
 class Program_weight_tensor_parameter_342:
     name = "parameter_342"
+    original_name = "conv2d_0.w_0"
     shape = [16, 3, 3, 3]
     dtype = "float32"
     min_val = float("-2.52696")

--- a/paddle_samples/PaddleX/StarNet-S2/subgraph_1/input_meta.py
+++ b/paddle_samples/PaddleX/StarNet-S2/subgraph_1/input_meta.py
@@ -1,5 +1,6 @@
 class Program_weight_tensor_data_0:
     name = "data_0"
+    original_name = "var_197"
     shape = [124, 3, 224, 224]
     dtype = "float32"
     min_val = float("-5.18906")

--- a/paddle_samples/PaddleX/StarNet-S2/subgraph_1/weight_meta.py
+++ b/paddle_samples/PaddleX/StarNet-S2/subgraph_1/weight_meta.py
@@ -1,5 +1,6 @@
 class Program_weight_tensor_parameter_0:
     name = "parameter_0"
+    original_name = "linear_0.b_0"
     shape = [102]
     dtype = "float32"
     min_val = float("-0.00233931")
@@ -11,6 +12,7 @@ class Program_weight_tensor_parameter_0:
 
 class Program_weight_tensor_parameter_1:
     name = "parameter_1"
+    original_name = "linear_0.w_0"
     shape = [256, 102]
     dtype = "float32"
     min_val = float("-0.132036")
@@ -22,6 +24,7 @@ class Program_weight_tensor_parameter_1:
 
 class Program_weight_tensor_parameter_2:
     name = "parameter_2"
+    original_name = "batch_norm2d_27.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.0878273")
@@ -33,6 +36,7 @@ class Program_weight_tensor_parameter_2:
 
 class Program_weight_tensor_parameter_3:
     name = "parameter_3"
+    original_name = "batch_norm2d_27.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("1.0058")
@@ -44,6 +48,7 @@ class Program_weight_tensor_parameter_3:
 
 class Program_weight_tensor_parameter_4:
     name = "parameter_4"
+    original_name = "batch_norm2d_27.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("1.06077")
@@ -55,6 +60,7 @@ class Program_weight_tensor_parameter_4:
 
 class Program_weight_tensor_parameter_5:
     name = "parameter_5"
+    original_name = "batch_norm2d_27.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.23049")
@@ -66,6 +72,7 @@ class Program_weight_tensor_parameter_5:
 
 class Program_weight_tensor_parameter_6:
     name = "parameter_6"
+    original_name = "conv2d_59.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.908746")
@@ -77,6 +84,7 @@ class Program_weight_tensor_parameter_6:
 
 class Program_weight_tensor_parameter_7:
     name = "parameter_7"
+    original_name = "conv2d_59.w_0"
     shape = [256, 1, 7, 7]
     dtype = "float32"
     min_val = float("-0.336553")
@@ -88,6 +96,7 @@ class Program_weight_tensor_parameter_7:
 
 class Program_weight_tensor_parameter_8:
     name = "parameter_8"
+    original_name = "batch_norm2d_26.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.514132")
@@ -99,6 +108,7 @@ class Program_weight_tensor_parameter_8:
 
 class Program_weight_tensor_parameter_9:
     name = "parameter_9"
+    original_name = "batch_norm2d_26.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.714781")
@@ -110,6 +120,7 @@ class Program_weight_tensor_parameter_9:
 
 class Program_weight_tensor_parameter_10:
     name = "parameter_10"
+    original_name = "batch_norm2d_26.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("10.1869")
@@ -121,6 +132,7 @@ class Program_weight_tensor_parameter_10:
 
 class Program_weight_tensor_parameter_11:
     name = "parameter_11"
+    original_name = "batch_norm2d_26.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.511038")
@@ -132,6 +144,7 @@ class Program_weight_tensor_parameter_11:
 
 class Program_weight_tensor_parameter_12:
     name = "parameter_12"
+    original_name = "conv2d_58.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.0338517")
@@ -143,6 +156,7 @@ class Program_weight_tensor_parameter_12:
 
 class Program_weight_tensor_parameter_13:
     name = "parameter_13"
+    original_name = "conv2d_58.w_0"
     shape = [256, 1024, 1, 1]
     dtype = "float32"
     min_val = float("-0.369144")
@@ -154,6 +168,7 @@ class Program_weight_tensor_parameter_13:
 
 class Program_weight_tensor_parameter_14:
     name = "parameter_14"
+    original_name = "conv2d_57.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-2.79521")
@@ -165,6 +180,7 @@ class Program_weight_tensor_parameter_14:
 
 class Program_weight_tensor_parameter_15:
     name = "parameter_15"
+    original_name = "conv2d_57.w_0"
     shape = [1024, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.422909")
@@ -176,6 +192,7 @@ class Program_weight_tensor_parameter_15:
 
 class Program_weight_tensor_parameter_16:
     name = "parameter_16"
+    original_name = "conv2d_56.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-4.61809")
@@ -187,6 +204,7 @@ class Program_weight_tensor_parameter_16:
 
 class Program_weight_tensor_parameter_17:
     name = "parameter_17"
+    original_name = "conv2d_56.w_0"
     shape = [1024, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.624475")
@@ -198,6 +216,7 @@ class Program_weight_tensor_parameter_17:
 
 class Program_weight_tensor_parameter_18:
     name = "parameter_18"
+    original_name = "batch_norm2d_25.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.445868")
@@ -209,6 +228,7 @@ class Program_weight_tensor_parameter_18:
 
 class Program_weight_tensor_parameter_19:
     name = "parameter_19"
+    original_name = "batch_norm2d_25.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.651284")
@@ -220,6 +240,7 @@ class Program_weight_tensor_parameter_19:
 
 class Program_weight_tensor_parameter_20:
     name = "parameter_20"
+    original_name = "batch_norm2d_25.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.16308")
@@ -231,6 +252,7 @@ class Program_weight_tensor_parameter_20:
 
 class Program_weight_tensor_parameter_21:
     name = "parameter_21"
+    original_name = "batch_norm2d_25.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.54971")
@@ -242,6 +264,7 @@ class Program_weight_tensor_parameter_21:
 
 class Program_weight_tensor_parameter_22:
     name = "parameter_22"
+    original_name = "conv2d_55.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.140657")
@@ -253,6 +276,7 @@ class Program_weight_tensor_parameter_22:
 
 class Program_weight_tensor_parameter_23:
     name = "parameter_23"
+    original_name = "conv2d_55.w_0"
     shape = [256, 1, 7, 7]
     dtype = "float32"
     min_val = float("-1.24917")
@@ -264,6 +288,7 @@ class Program_weight_tensor_parameter_23:
 
 class Program_weight_tensor_parameter_24:
     name = "parameter_24"
+    original_name = "conv2d_54.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.86511")
@@ -275,6 +300,7 @@ class Program_weight_tensor_parameter_24:
 
 class Program_weight_tensor_parameter_25:
     name = "parameter_25"
+    original_name = "conv2d_54.w_0"
     shape = [256, 1, 7, 7]
     dtype = "float32"
     min_val = float("-0.434331")
@@ -286,6 +312,7 @@ class Program_weight_tensor_parameter_25:
 
 class Program_weight_tensor_parameter_26:
     name = "parameter_26"
+    original_name = "batch_norm2d_24.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.740494")
@@ -297,6 +324,7 @@ class Program_weight_tensor_parameter_26:
 
 class Program_weight_tensor_parameter_27:
     name = "parameter_27"
+    original_name = "batch_norm2d_24.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.582338")
@@ -308,6 +336,7 @@ class Program_weight_tensor_parameter_27:
 
 class Program_weight_tensor_parameter_28:
     name = "parameter_28"
+    original_name = "batch_norm2d_24.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.237891")
@@ -319,6 +348,7 @@ class Program_weight_tensor_parameter_28:
 
 class Program_weight_tensor_parameter_29:
     name = "parameter_29"
+    original_name = "batch_norm2d_24.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.353966")
@@ -330,6 +360,7 @@ class Program_weight_tensor_parameter_29:
 
 class Program_weight_tensor_parameter_30:
     name = "parameter_30"
+    original_name = "conv2d_53.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.0367665")
@@ -341,6 +372,7 @@ class Program_weight_tensor_parameter_30:
 
 class Program_weight_tensor_parameter_31:
     name = "parameter_31"
+    original_name = "conv2d_53.w_0"
     shape = [256, 1024, 1, 1]
     dtype = "float32"
     min_val = float("-0.660603")
@@ -352,6 +384,7 @@ class Program_weight_tensor_parameter_31:
 
 class Program_weight_tensor_parameter_32:
     name = "parameter_32"
+    original_name = "conv2d_52.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-2.97243")
@@ -363,6 +396,7 @@ class Program_weight_tensor_parameter_32:
 
 class Program_weight_tensor_parameter_33:
     name = "parameter_33"
+    original_name = "conv2d_52.w_0"
     shape = [1024, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.533367")
@@ -374,6 +408,7 @@ class Program_weight_tensor_parameter_33:
 
 class Program_weight_tensor_parameter_34:
     name = "parameter_34"
+    original_name = "conv2d_51.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-3.21651")
@@ -385,6 +420,7 @@ class Program_weight_tensor_parameter_34:
 
 class Program_weight_tensor_parameter_35:
     name = "parameter_35"
+    original_name = "conv2d_51.w_0"
     shape = [1024, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.679708")
@@ -396,6 +432,7 @@ class Program_weight_tensor_parameter_35:
 
 class Program_weight_tensor_parameter_36:
     name = "parameter_36"
+    original_name = "batch_norm2d_23.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.384991")
@@ -407,6 +444,7 @@ class Program_weight_tensor_parameter_36:
 
 class Program_weight_tensor_parameter_37:
     name = "parameter_37"
+    original_name = "batch_norm2d_23.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.296544")
@@ -418,6 +456,7 @@ class Program_weight_tensor_parameter_37:
 
 class Program_weight_tensor_parameter_38:
     name = "parameter_38"
+    original_name = "batch_norm2d_23.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.00184919")
@@ -429,6 +468,7 @@ class Program_weight_tensor_parameter_38:
 
 class Program_weight_tensor_parameter_39:
     name = "parameter_39"
+    original_name = "batch_norm2d_23.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.53622")
@@ -440,6 +480,7 @@ class Program_weight_tensor_parameter_39:
 
 class Program_weight_tensor_parameter_40:
     name = "parameter_40"
+    original_name = "conv2d_50.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.148166")
@@ -451,6 +492,7 @@ class Program_weight_tensor_parameter_40:
 
 class Program_weight_tensor_parameter_41:
     name = "parameter_41"
+    original_name = "conv2d_50.w_0"
     shape = [256, 1, 7, 7]
     dtype = "float32"
     min_val = float("-1.16219")
@@ -462,6 +504,7 @@ class Program_weight_tensor_parameter_41:
 
 class Program_weight_tensor_parameter_42:
     name = "parameter_42"
+    original_name = "batch_norm2d_22.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.1428")
@@ -473,6 +516,7 @@ class Program_weight_tensor_parameter_42:
 
 class Program_weight_tensor_parameter_43:
     name = "parameter_43"
+    original_name = "batch_norm2d_22.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.1121")
@@ -484,6 +528,7 @@ class Program_weight_tensor_parameter_43:
 
 class Program_weight_tensor_parameter_44:
     name = "parameter_44"
+    original_name = "batch_norm2d_22.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("178.346")
@@ -495,6 +540,7 @@ class Program_weight_tensor_parameter_44:
 
 class Program_weight_tensor_parameter_45:
     name = "parameter_45"
+    original_name = "batch_norm2d_22.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-28.5218")
@@ -506,6 +552,7 @@ class Program_weight_tensor_parameter_45:
 
 class Program_weight_tensor_parameter_46:
     name = "parameter_46"
+    original_name = "conv2d_49.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.0292519")
@@ -517,6 +564,7 @@ class Program_weight_tensor_parameter_46:
 
 class Program_weight_tensor_parameter_47:
     name = "parameter_47"
+    original_name = "conv2d_49.w_0"
     shape = [256, 128, 3, 3]
     dtype = "float32"
     min_val = float("-0.834351")
@@ -528,6 +576,7 @@ class Program_weight_tensor_parameter_47:
 
 class Program_weight_tensor_parameter_48:
     name = "parameter_48"
+    original_name = "conv2d_48.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.835992")
@@ -539,6 +588,7 @@ class Program_weight_tensor_parameter_48:
 
 class Program_weight_tensor_parameter_49:
     name = "parameter_49"
+    original_name = "conv2d_48.w_0"
     shape = [128, 1, 7, 7]
     dtype = "float32"
     min_val = float("-0.403569")
@@ -550,6 +600,7 @@ class Program_weight_tensor_parameter_49:
 
 class Program_weight_tensor_parameter_50:
     name = "parameter_50"
+    original_name = "batch_norm2d_21.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.740669")
@@ -561,6 +612,7 @@ class Program_weight_tensor_parameter_50:
 
 class Program_weight_tensor_parameter_51:
     name = "parameter_51"
+    original_name = "batch_norm2d_21.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.67716")
@@ -572,6 +624,7 @@ class Program_weight_tensor_parameter_51:
 
 class Program_weight_tensor_parameter_52:
     name = "parameter_52"
+    original_name = "batch_norm2d_21.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("2.18299")
@@ -583,6 +636,7 @@ class Program_weight_tensor_parameter_52:
 
 class Program_weight_tensor_parameter_53:
     name = "parameter_53"
+    original_name = "batch_norm2d_21.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.80159")
@@ -594,6 +648,7 @@ class Program_weight_tensor_parameter_53:
 
 class Program_weight_tensor_parameter_54:
     name = "parameter_54"
+    original_name = "conv2d_47.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.0444162")
@@ -605,6 +660,7 @@ class Program_weight_tensor_parameter_54:
 
 class Program_weight_tensor_parameter_55:
     name = "parameter_55"
+    original_name = "conv2d_47.w_0"
     shape = [128, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.915283")
@@ -616,6 +672,7 @@ class Program_weight_tensor_parameter_55:
 
 class Program_weight_tensor_parameter_56:
     name = "parameter_56"
+    original_name = "conv2d_46.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-3.56282")
@@ -627,6 +684,7 @@ class Program_weight_tensor_parameter_56:
 
 class Program_weight_tensor_parameter_57:
     name = "parameter_57"
+    original_name = "conv2d_46.w_0"
     shape = [512, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.495574")
@@ -638,6 +696,7 @@ class Program_weight_tensor_parameter_57:
 
 class Program_weight_tensor_parameter_58:
     name = "parameter_58"
+    original_name = "conv2d_45.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-4.168")
@@ -649,6 +708,7 @@ class Program_weight_tensor_parameter_58:
 
 class Program_weight_tensor_parameter_59:
     name = "parameter_59"
+    original_name = "conv2d_45.w_0"
     shape = [512, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.547667")
@@ -660,6 +720,7 @@ class Program_weight_tensor_parameter_59:
 
 class Program_weight_tensor_parameter_60:
     name = "parameter_60"
+    original_name = "batch_norm2d_20.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.84318")
@@ -671,6 +732,7 @@ class Program_weight_tensor_parameter_60:
 
 class Program_weight_tensor_parameter_61:
     name = "parameter_61"
+    original_name = "batch_norm2d_20.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.79951")
@@ -682,6 +744,7 @@ class Program_weight_tensor_parameter_61:
 
 class Program_weight_tensor_parameter_62:
     name = "parameter_62"
+    original_name = "batch_norm2d_20.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.251798")
@@ -693,6 +756,7 @@ class Program_weight_tensor_parameter_62:
 
 class Program_weight_tensor_parameter_63:
     name = "parameter_63"
+    original_name = "batch_norm2d_20.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-4.97195")
@@ -704,6 +768,7 @@ class Program_weight_tensor_parameter_63:
 
 class Program_weight_tensor_parameter_64:
     name = "parameter_64"
+    original_name = "conv2d_44.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.150097")
@@ -715,6 +780,7 @@ class Program_weight_tensor_parameter_64:
 
 class Program_weight_tensor_parameter_65:
     name = "parameter_65"
+    original_name = "conv2d_44.w_0"
     shape = [128, 1, 7, 7]
     dtype = "float32"
     min_val = float("-1.15659")
@@ -726,6 +792,7 @@ class Program_weight_tensor_parameter_65:
 
 class Program_weight_tensor_parameter_66:
     name = "parameter_66"
+    original_name = "conv2d_43.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-2.71152")
@@ -737,6 +804,7 @@ class Program_weight_tensor_parameter_66:
 
 class Program_weight_tensor_parameter_67:
     name = "parameter_67"
+    original_name = "conv2d_43.w_0"
     shape = [128, 1, 7, 7]
     dtype = "float32"
     min_val = float("-0.424465")
@@ -748,6 +816,7 @@ class Program_weight_tensor_parameter_67:
 
 class Program_weight_tensor_parameter_68:
     name = "parameter_68"
+    original_name = "batch_norm2d_19.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.08382")
@@ -759,6 +828,7 @@ class Program_weight_tensor_parameter_68:
 
 class Program_weight_tensor_parameter_69:
     name = "parameter_69"
+    original_name = "batch_norm2d_19.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.744099")
@@ -770,6 +840,7 @@ class Program_weight_tensor_parameter_69:
 
 class Program_weight_tensor_parameter_70:
     name = "parameter_70"
+    original_name = "batch_norm2d_19.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.585264")
@@ -781,6 +852,7 @@ class Program_weight_tensor_parameter_70:
 
 class Program_weight_tensor_parameter_71:
     name = "parameter_71"
+    original_name = "batch_norm2d_19.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.246574")
@@ -792,6 +864,7 @@ class Program_weight_tensor_parameter_71:
 
 class Program_weight_tensor_parameter_72:
     name = "parameter_72"
+    original_name = "conv2d_42.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.0439543")
@@ -803,6 +876,7 @@ class Program_weight_tensor_parameter_72:
 
 class Program_weight_tensor_parameter_73:
     name = "parameter_73"
+    original_name = "conv2d_42.w_0"
     shape = [128, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.59657")
@@ -814,6 +888,7 @@ class Program_weight_tensor_parameter_73:
 
 class Program_weight_tensor_parameter_74:
     name = "parameter_74"
+    original_name = "conv2d_41.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-2.01386")
@@ -825,6 +900,7 @@ class Program_weight_tensor_parameter_74:
 
 class Program_weight_tensor_parameter_75:
     name = "parameter_75"
+    original_name = "conv2d_41.w_0"
     shape = [512, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.578804")
@@ -836,6 +912,7 @@ class Program_weight_tensor_parameter_75:
 
 class Program_weight_tensor_parameter_76:
     name = "parameter_76"
+    original_name = "conv2d_40.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-3.51683")
@@ -847,6 +924,7 @@ class Program_weight_tensor_parameter_76:
 
 class Program_weight_tensor_parameter_77:
     name = "parameter_77"
+    original_name = "conv2d_40.w_0"
     shape = [512, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.905559")
@@ -858,6 +936,7 @@ class Program_weight_tensor_parameter_77:
 
 class Program_weight_tensor_parameter_78:
     name = "parameter_78"
+    original_name = "batch_norm2d_18.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.597058")
@@ -869,6 +948,7 @@ class Program_weight_tensor_parameter_78:
 
 class Program_weight_tensor_parameter_79:
     name = "parameter_79"
+    original_name = "batch_norm2d_18.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.322838")
@@ -880,6 +960,7 @@ class Program_weight_tensor_parameter_79:
 
 class Program_weight_tensor_parameter_80:
     name = "parameter_80"
+    original_name = "batch_norm2d_18.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.0106017")
@@ -891,6 +972,7 @@ class Program_weight_tensor_parameter_80:
 
 class Program_weight_tensor_parameter_81:
     name = "parameter_81"
+    original_name = "batch_norm2d_18.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-4.7409")
@@ -902,6 +984,7 @@ class Program_weight_tensor_parameter_81:
 
 class Program_weight_tensor_parameter_82:
     name = "parameter_82"
+    original_name = "conv2d_39.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.152566")
@@ -913,6 +996,7 @@ class Program_weight_tensor_parameter_82:
 
 class Program_weight_tensor_parameter_83:
     name = "parameter_83"
+    original_name = "conv2d_39.w_0"
     shape = [128, 1, 7, 7]
     dtype = "float32"
     min_val = float("-1.23439")
@@ -924,6 +1008,7 @@ class Program_weight_tensor_parameter_83:
 
 class Program_weight_tensor_parameter_84:
     name = "parameter_84"
+    original_name = "conv2d_38.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.73719")
@@ -935,6 +1020,7 @@ class Program_weight_tensor_parameter_84:
 
 class Program_weight_tensor_parameter_85:
     name = "parameter_85"
+    original_name = "conv2d_38.w_0"
     shape = [128, 1, 7, 7]
     dtype = "float32"
     min_val = float("-0.591918")
@@ -946,6 +1032,7 @@ class Program_weight_tensor_parameter_85:
 
 class Program_weight_tensor_parameter_86:
     name = "parameter_86"
+    original_name = "batch_norm2d_17.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.37839")
@@ -957,6 +1044,7 @@ class Program_weight_tensor_parameter_86:
 
 class Program_weight_tensor_parameter_87:
     name = "parameter_87"
+    original_name = "batch_norm2d_17.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.244617")
@@ -968,6 +1056,7 @@ class Program_weight_tensor_parameter_87:
 
 class Program_weight_tensor_parameter_88:
     name = "parameter_88"
+    original_name = "batch_norm2d_17.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("3.40967")
@@ -979,6 +1068,7 @@ class Program_weight_tensor_parameter_88:
 
 class Program_weight_tensor_parameter_89:
     name = "parameter_89"
+    original_name = "batch_norm2d_17.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.52641")
@@ -990,6 +1080,7 @@ class Program_weight_tensor_parameter_89:
 
 class Program_weight_tensor_parameter_90:
     name = "parameter_90"
+    original_name = "conv2d_37.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.0515101")
@@ -1001,6 +1092,7 @@ class Program_weight_tensor_parameter_90:
 
 class Program_weight_tensor_parameter_91:
     name = "parameter_91"
+    original_name = "conv2d_37.w_0"
     shape = [128, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.778381")
@@ -1012,6 +1104,7 @@ class Program_weight_tensor_parameter_91:
 
 class Program_weight_tensor_parameter_92:
     name = "parameter_92"
+    original_name = "conv2d_36.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-4.41659")
@@ -1023,6 +1116,7 @@ class Program_weight_tensor_parameter_92:
 
 class Program_weight_tensor_parameter_93:
     name = "parameter_93"
+    original_name = "conv2d_36.w_0"
     shape = [512, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.625329")
@@ -1034,6 +1128,7 @@ class Program_weight_tensor_parameter_93:
 
 class Program_weight_tensor_parameter_94:
     name = "parameter_94"
+    original_name = "conv2d_35.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-4.42537")
@@ -1045,6 +1140,7 @@ class Program_weight_tensor_parameter_94:
 
 class Program_weight_tensor_parameter_95:
     name = "parameter_95"
+    original_name = "conv2d_35.w_0"
     shape = [512, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.74207")
@@ -1056,6 +1152,7 @@ class Program_weight_tensor_parameter_95:
 
 class Program_weight_tensor_parameter_96:
     name = "parameter_96"
+    original_name = "batch_norm2d_16.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.726014")
@@ -1067,6 +1164,7 @@ class Program_weight_tensor_parameter_96:
 
 class Program_weight_tensor_parameter_97:
     name = "parameter_97"
+    original_name = "batch_norm2d_16.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("1.00134")
@@ -1078,6 +1176,7 @@ class Program_weight_tensor_parameter_97:
 
 class Program_weight_tensor_parameter_98:
     name = "parameter_98"
+    original_name = "batch_norm2d_16.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.0164105")
@@ -1089,6 +1188,7 @@ class Program_weight_tensor_parameter_98:
 
 class Program_weight_tensor_parameter_99:
     name = "parameter_99"
+    original_name = "batch_norm2d_16.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-3.54612")
@@ -1100,6 +1200,7 @@ class Program_weight_tensor_parameter_99:
 
 class Program_weight_tensor_parameter_100:
     name = "parameter_100"
+    original_name = "conv2d_34.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.142311")
@@ -1111,6 +1212,7 @@ class Program_weight_tensor_parameter_100:
 
 class Program_weight_tensor_parameter_101:
     name = "parameter_101"
+    original_name = "conv2d_34.w_0"
     shape = [128, 1, 7, 7]
     dtype = "float32"
     min_val = float("-1.71507")
@@ -1122,6 +1224,7 @@ class Program_weight_tensor_parameter_101:
 
 class Program_weight_tensor_parameter_102:
     name = "parameter_102"
+    original_name = "conv2d_33.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.65373")
@@ -1133,6 +1236,7 @@ class Program_weight_tensor_parameter_102:
 
 class Program_weight_tensor_parameter_103:
     name = "parameter_103"
+    original_name = "conv2d_33.w_0"
     shape = [128, 1, 7, 7]
     dtype = "float32"
     min_val = float("-0.524429")
@@ -1144,6 +1248,7 @@ class Program_weight_tensor_parameter_103:
 
 class Program_weight_tensor_parameter_104:
     name = "parameter_104"
+    original_name = "batch_norm2d_15.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.658526")
@@ -1155,6 +1260,7 @@ class Program_weight_tensor_parameter_104:
 
 class Program_weight_tensor_parameter_105:
     name = "parameter_105"
+    original_name = "batch_norm2d_15.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.117359")
@@ -1166,6 +1272,7 @@ class Program_weight_tensor_parameter_105:
 
 class Program_weight_tensor_parameter_106:
     name = "parameter_106"
+    original_name = "batch_norm2d_15.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("3.40517")
@@ -1177,6 +1284,7 @@ class Program_weight_tensor_parameter_106:
 
 class Program_weight_tensor_parameter_107:
     name = "parameter_107"
+    original_name = "batch_norm2d_15.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-2.94718")
@@ -1188,6 +1296,7 @@ class Program_weight_tensor_parameter_107:
 
 class Program_weight_tensor_parameter_108:
     name = "parameter_108"
+    original_name = "conv2d_32.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.0441185")
@@ -1199,6 +1308,7 @@ class Program_weight_tensor_parameter_108:
 
 class Program_weight_tensor_parameter_109:
     name = "parameter_109"
+    original_name = "conv2d_32.w_0"
     shape = [128, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.611755")
@@ -1210,6 +1320,7 @@ class Program_weight_tensor_parameter_109:
 
 class Program_weight_tensor_parameter_110:
     name = "parameter_110"
+    original_name = "conv2d_31.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-3.9848")
@@ -1221,6 +1332,7 @@ class Program_weight_tensor_parameter_110:
 
 class Program_weight_tensor_parameter_111:
     name = "parameter_111"
+    original_name = "conv2d_31.w_0"
     shape = [512, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.65656")
@@ -1232,6 +1344,7 @@ class Program_weight_tensor_parameter_111:
 
 class Program_weight_tensor_parameter_112:
     name = "parameter_112"
+    original_name = "conv2d_30.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-3.92676")
@@ -1243,6 +1356,7 @@ class Program_weight_tensor_parameter_112:
 
 class Program_weight_tensor_parameter_113:
     name = "parameter_113"
+    original_name = "conv2d_30.w_0"
     shape = [512, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.839348")
@@ -1254,6 +1368,7 @@ class Program_weight_tensor_parameter_113:
 
 class Program_weight_tensor_parameter_114:
     name = "parameter_114"
+    original_name = "batch_norm2d_14.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.862711")
@@ -1265,6 +1380,7 @@ class Program_weight_tensor_parameter_114:
 
 class Program_weight_tensor_parameter_115:
     name = "parameter_115"
+    original_name = "batch_norm2d_14.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("1.14891")
@@ -1276,6 +1392,7 @@ class Program_weight_tensor_parameter_115:
 
 class Program_weight_tensor_parameter_116:
     name = "parameter_116"
+    original_name = "batch_norm2d_14.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.000901697")
@@ -1287,6 +1404,7 @@ class Program_weight_tensor_parameter_116:
 
 class Program_weight_tensor_parameter_117:
     name = "parameter_117"
+    original_name = "batch_norm2d_14.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.96333")
@@ -1298,6 +1416,7 @@ class Program_weight_tensor_parameter_117:
 
 class Program_weight_tensor_parameter_118:
     name = "parameter_118"
+    original_name = "conv2d_29.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.153374")
@@ -1309,6 +1428,7 @@ class Program_weight_tensor_parameter_118:
 
 class Program_weight_tensor_parameter_119:
     name = "parameter_119"
+    original_name = "conv2d_29.w_0"
     shape = [128, 1, 7, 7]
     dtype = "float32"
     min_val = float("-0.788707")
@@ -1320,6 +1440,7 @@ class Program_weight_tensor_parameter_119:
 
 class Program_weight_tensor_parameter_120:
     name = "parameter_120"
+    original_name = "conv2d_28.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-2.61781")
@@ -1331,6 +1452,7 @@ class Program_weight_tensor_parameter_120:
 
 class Program_weight_tensor_parameter_121:
     name = "parameter_121"
+    original_name = "conv2d_28.w_0"
     shape = [128, 1, 7, 7]
     dtype = "float32"
     min_val = float("-0.542714")
@@ -1342,6 +1464,7 @@ class Program_weight_tensor_parameter_121:
 
 class Program_weight_tensor_parameter_122:
     name = "parameter_122"
+    original_name = "batch_norm2d_13.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.49443")
@@ -1353,6 +1476,7 @@ class Program_weight_tensor_parameter_122:
 
 class Program_weight_tensor_parameter_123:
     name = "parameter_123"
+    original_name = "batch_norm2d_13.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.0700347")
@@ -1364,6 +1488,7 @@ class Program_weight_tensor_parameter_123:
 
 class Program_weight_tensor_parameter_124:
     name = "parameter_124"
+    original_name = "batch_norm2d_13.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("3.91169")
@@ -1375,6 +1500,7 @@ class Program_weight_tensor_parameter_124:
 
 class Program_weight_tensor_parameter_125:
     name = "parameter_125"
+    original_name = "batch_norm2d_13.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.74765")
@@ -1386,6 +1512,7 @@ class Program_weight_tensor_parameter_125:
 
 class Program_weight_tensor_parameter_126:
     name = "parameter_126"
+    original_name = "conv2d_27.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.0522467")
@@ -1397,6 +1524,7 @@ class Program_weight_tensor_parameter_126:
 
 class Program_weight_tensor_parameter_127:
     name = "parameter_127"
+    original_name = "conv2d_27.w_0"
     shape = [128, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.757348")
@@ -1408,6 +1536,7 @@ class Program_weight_tensor_parameter_127:
 
 class Program_weight_tensor_parameter_128:
     name = "parameter_128"
+    original_name = "conv2d_26.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-6.60289")
@@ -1419,6 +1548,7 @@ class Program_weight_tensor_parameter_128:
 
 class Program_weight_tensor_parameter_129:
     name = "parameter_129"
+    original_name = "conv2d_26.w_0"
     shape = [512, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.738971")
@@ -1430,6 +1560,7 @@ class Program_weight_tensor_parameter_129:
 
 class Program_weight_tensor_parameter_130:
     name = "parameter_130"
+    original_name = "conv2d_25.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-4.05918")
@@ -1441,6 +1572,7 @@ class Program_weight_tensor_parameter_130:
 
 class Program_weight_tensor_parameter_131:
     name = "parameter_131"
+    original_name = "conv2d_25.w_0"
     shape = [512, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.967555")
@@ -1452,6 +1584,7 @@ class Program_weight_tensor_parameter_131:
 
 class Program_weight_tensor_parameter_132:
     name = "parameter_132"
+    original_name = "batch_norm2d_12.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.635508")
@@ -1463,6 +1596,7 @@ class Program_weight_tensor_parameter_132:
 
 class Program_weight_tensor_parameter_133:
     name = "parameter_133"
+    original_name = "batch_norm2d_12.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.91248")
@@ -1474,6 +1608,7 @@ class Program_weight_tensor_parameter_133:
 
 class Program_weight_tensor_parameter_134:
     name = "parameter_134"
+    original_name = "batch_norm2d_12.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("6.84357e-05")
@@ -1485,6 +1620,7 @@ class Program_weight_tensor_parameter_134:
 
 class Program_weight_tensor_parameter_135:
     name = "parameter_135"
+    original_name = "batch_norm2d_12.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-3.99446")
@@ -1496,6 +1632,7 @@ class Program_weight_tensor_parameter_135:
 
 class Program_weight_tensor_parameter_136:
     name = "parameter_136"
+    original_name = "conv2d_24.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.245245")
@@ -1507,6 +1644,7 @@ class Program_weight_tensor_parameter_136:
 
 class Program_weight_tensor_parameter_137:
     name = "parameter_137"
+    original_name = "conv2d_24.w_0"
     shape = [128, 1, 7, 7]
     dtype = "float32"
     min_val = float("-1.41617")
@@ -1518,6 +1656,7 @@ class Program_weight_tensor_parameter_137:
 
 class Program_weight_tensor_parameter_138:
     name = "parameter_138"
+    original_name = "conv2d_23.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.815377")
@@ -1529,6 +1668,7 @@ class Program_weight_tensor_parameter_138:
 
 class Program_weight_tensor_parameter_139:
     name = "parameter_139"
+    original_name = "conv2d_23.w_0"
     shape = [128, 1, 7, 7]
     dtype = "float32"
     min_val = float("-1.23056")
@@ -1540,6 +1680,7 @@ class Program_weight_tensor_parameter_139:
 
 class Program_weight_tensor_parameter_140:
     name = "parameter_140"
+    original_name = "batch_norm2d_11.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.522269")
@@ -1551,6 +1692,7 @@ class Program_weight_tensor_parameter_140:
 
 class Program_weight_tensor_parameter_141:
     name = "parameter_141"
+    original_name = "batch_norm2d_11.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.0245394")
@@ -1562,6 +1704,7 @@ class Program_weight_tensor_parameter_141:
 
 class Program_weight_tensor_parameter_142:
     name = "parameter_142"
+    original_name = "batch_norm2d_11.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("4.87278")
@@ -1573,6 +1716,7 @@ class Program_weight_tensor_parameter_142:
 
 class Program_weight_tensor_parameter_143:
     name = "parameter_143"
+    original_name = "batch_norm2d_11.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-2.94185")
@@ -1584,6 +1728,7 @@ class Program_weight_tensor_parameter_143:
 
 class Program_weight_tensor_parameter_144:
     name = "parameter_144"
+    original_name = "conv2d_22.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.0447659")
@@ -1595,6 +1740,7 @@ class Program_weight_tensor_parameter_144:
 
 class Program_weight_tensor_parameter_145:
     name = "parameter_145"
+    original_name = "conv2d_22.w_0"
     shape = [128, 512, 1, 1]
     dtype = "float32"
     min_val = float("-1.27223")
@@ -1606,6 +1752,7 @@ class Program_weight_tensor_parameter_145:
 
 class Program_weight_tensor_parameter_146:
     name = "parameter_146"
+    original_name = "conv2d_21.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-4.55436")
@@ -1617,6 +1764,7 @@ class Program_weight_tensor_parameter_146:
 
 class Program_weight_tensor_parameter_147:
     name = "parameter_147"
+    original_name = "conv2d_21.w_0"
     shape = [512, 128, 1, 1]
     dtype = "float32"
     min_val = float("-1.00472")
@@ -1628,6 +1776,7 @@ class Program_weight_tensor_parameter_147:
 
 class Program_weight_tensor_parameter_148:
     name = "parameter_148"
+    original_name = "conv2d_20.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-4.97443")
@@ -1639,6 +1788,7 @@ class Program_weight_tensor_parameter_148:
 
 class Program_weight_tensor_parameter_149:
     name = "parameter_149"
+    original_name = "conv2d_20.w_0"
     shape = [512, 128, 1, 1]
     dtype = "float32"
     min_val = float("-1.16504")
@@ -1650,6 +1800,7 @@ class Program_weight_tensor_parameter_149:
 
 class Program_weight_tensor_parameter_150:
     name = "parameter_150"
+    original_name = "batch_norm2d_10.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.648151")
@@ -1661,6 +1812,7 @@ class Program_weight_tensor_parameter_150:
 
 class Program_weight_tensor_parameter_151:
     name = "parameter_151"
+    original_name = "batch_norm2d_10.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.90469")
@@ -1672,6 +1824,7 @@ class Program_weight_tensor_parameter_151:
 
 class Program_weight_tensor_parameter_152:
     name = "parameter_152"
+    original_name = "batch_norm2d_10.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("1.8788e-05")
@@ -1683,6 +1836,7 @@ class Program_weight_tensor_parameter_152:
 
 class Program_weight_tensor_parameter_153:
     name = "parameter_153"
+    original_name = "batch_norm2d_10.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.82624")
@@ -1694,6 +1848,7 @@ class Program_weight_tensor_parameter_153:
 
 class Program_weight_tensor_parameter_154:
     name = "parameter_154"
+    original_name = "conv2d_19.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.298377")
@@ -1705,6 +1860,7 @@ class Program_weight_tensor_parameter_154:
 
 class Program_weight_tensor_parameter_155:
     name = "parameter_155"
+    original_name = "conv2d_19.w_0"
     shape = [128, 1, 7, 7]
     dtype = "float32"
     min_val = float("-1.35766")
@@ -1716,6 +1872,7 @@ class Program_weight_tensor_parameter_155:
 
 class Program_weight_tensor_parameter_156:
     name = "parameter_156"
+    original_name = "batch_norm2d_9.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-2.04523")
@@ -1727,6 +1884,7 @@ class Program_weight_tensor_parameter_156:
 
 class Program_weight_tensor_parameter_157:
     name = "parameter_157"
+    original_name = "batch_norm2d_9.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.0035501")
@@ -1738,6 +1896,7 @@ class Program_weight_tensor_parameter_157:
 
 class Program_weight_tensor_parameter_158:
     name = "parameter_158"
+    original_name = "batch_norm2d_9.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("17.2691")
@@ -1749,6 +1908,7 @@ class Program_weight_tensor_parameter_158:
 
 class Program_weight_tensor_parameter_159:
     name = "parameter_159"
+    original_name = "batch_norm2d_9.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-9.96033")
@@ -1760,6 +1920,7 @@ class Program_weight_tensor_parameter_159:
 
 class Program_weight_tensor_parameter_160:
     name = "parameter_160"
+    original_name = "conv2d_18.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.0453472")
@@ -1771,6 +1932,7 @@ class Program_weight_tensor_parameter_160:
 
 class Program_weight_tensor_parameter_161:
     name = "parameter_161"
+    original_name = "conv2d_18.w_0"
     shape = [128, 64, 3, 3]
     dtype = "float32"
     min_val = float("-0.812689")
@@ -1782,6 +1944,7 @@ class Program_weight_tensor_parameter_161:
 
 class Program_weight_tensor_parameter_162:
     name = "parameter_162"
+    original_name = "conv2d_17.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -1791,6 +1954,7 @@ class Program_weight_tensor_parameter_162:
 
 class Program_weight_tensor_parameter_163:
     name = "parameter_163"
+    original_name = "conv2d_17.w_0"
     shape = [64, 1, 7, 7]
     dtype = "float32"
     min_val = float("-0.43281")
@@ -1802,6 +1966,7 @@ class Program_weight_tensor_parameter_163:
 
 class Program_weight_tensor_parameter_164:
     name = "parameter_164"
+    original_name = "batch_norm2d_8.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -1811,6 +1976,7 @@ class Program_weight_tensor_parameter_164:
 
 class Program_weight_tensor_parameter_165:
     name = "parameter_165"
+    original_name = "batch_norm2d_8.w_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -1820,6 +1986,7 @@ class Program_weight_tensor_parameter_165:
 
 class Program_weight_tensor_parameter_166:
     name = "parameter_166"
+    original_name = "batch_norm2d_8.w_2"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -1829,6 +1996,7 @@ class Program_weight_tensor_parameter_166:
 
 class Program_weight_tensor_parameter_167:
     name = "parameter_167"
+    original_name = "batch_norm2d_8.w_1"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -1838,6 +2006,7 @@ class Program_weight_tensor_parameter_167:
 
 class Program_weight_tensor_parameter_168:
     name = "parameter_168"
+    original_name = "conv2d_16.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -1847,6 +2016,7 @@ class Program_weight_tensor_parameter_168:
 
 class Program_weight_tensor_parameter_169:
     name = "parameter_169"
+    original_name = "conv2d_16.w_0"
     shape = [64, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.694975")
@@ -1858,6 +2028,7 @@ class Program_weight_tensor_parameter_169:
 
 class Program_weight_tensor_parameter_170:
     name = "parameter_170"
+    original_name = "conv2d_15.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-3.30619")
@@ -1869,6 +2040,7 @@ class Program_weight_tensor_parameter_170:
 
 class Program_weight_tensor_parameter_171:
     name = "parameter_171"
+    original_name = "conv2d_15.w_0"
     shape = [256, 64, 1, 1]
     dtype = "float32"
     min_val = float("-0.584892")
@@ -1880,6 +2052,7 @@ class Program_weight_tensor_parameter_171:
 
 class Program_weight_tensor_parameter_172:
     name = "parameter_172"
+    original_name = "conv2d_14.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-3.54543")
@@ -1891,6 +2064,7 @@ class Program_weight_tensor_parameter_172:
 
 class Program_weight_tensor_parameter_173:
     name = "parameter_173"
+    original_name = "conv2d_14.w_0"
     shape = [256, 64, 1, 1]
     dtype = "float32"
     min_val = float("-0.766964")
@@ -1902,6 +2076,7 @@ class Program_weight_tensor_parameter_173:
 
 class Program_weight_tensor_parameter_174:
     name = "parameter_174"
+    original_name = "batch_norm2d_7.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -1911,6 +2086,7 @@ class Program_weight_tensor_parameter_174:
 
 class Program_weight_tensor_parameter_175:
     name = "parameter_175"
+    original_name = "batch_norm2d_7.w_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -1920,6 +2096,7 @@ class Program_weight_tensor_parameter_175:
 
 class Program_weight_tensor_parameter_176:
     name = "parameter_176"
+    original_name = "batch_norm2d_7.w_2"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -1929,6 +2106,7 @@ class Program_weight_tensor_parameter_176:
 
 class Program_weight_tensor_parameter_177:
     name = "parameter_177"
+    original_name = "batch_norm2d_7.w_1"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -1938,6 +2116,7 @@ class Program_weight_tensor_parameter_177:
 
 class Program_weight_tensor_parameter_178:
     name = "parameter_178"
+    original_name = "conv2d_13.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -1947,6 +2126,7 @@ class Program_weight_tensor_parameter_178:
 
 class Program_weight_tensor_parameter_179:
     name = "parameter_179"
+    original_name = "conv2d_13.w_0"
     shape = [64, 1, 7, 7]
     dtype = "float32"
     min_val = float("-0.92599")
@@ -1958,6 +2138,7 @@ class Program_weight_tensor_parameter_179:
 
 class Program_weight_tensor_parameter_180:
     name = "parameter_180"
+    original_name = "conv2d_12.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -1967,6 +2148,7 @@ class Program_weight_tensor_parameter_180:
 
 class Program_weight_tensor_parameter_181:
     name = "parameter_181"
+    original_name = "conv2d_12.w_0"
     shape = [64, 1, 7, 7]
     dtype = "float32"
     min_val = float("-0.604516")
@@ -1978,6 +2160,7 @@ class Program_weight_tensor_parameter_181:
 
 class Program_weight_tensor_parameter_182:
     name = "parameter_182"
+    original_name = "batch_norm2d_6.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -1987,6 +2170,7 @@ class Program_weight_tensor_parameter_182:
 
 class Program_weight_tensor_parameter_183:
     name = "parameter_183"
+    original_name = "batch_norm2d_6.w_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -1996,6 +2180,7 @@ class Program_weight_tensor_parameter_183:
 
 class Program_weight_tensor_parameter_184:
     name = "parameter_184"
+    original_name = "batch_norm2d_6.w_2"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -2005,6 +2190,7 @@ class Program_weight_tensor_parameter_184:
 
 class Program_weight_tensor_parameter_185:
     name = "parameter_185"
+    original_name = "batch_norm2d_6.w_1"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -2014,6 +2200,7 @@ class Program_weight_tensor_parameter_185:
 
 class Program_weight_tensor_parameter_186:
     name = "parameter_186"
+    original_name = "conv2d_11.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -2023,6 +2210,7 @@ class Program_weight_tensor_parameter_186:
 
 class Program_weight_tensor_parameter_187:
     name = "parameter_187"
+    original_name = "conv2d_11.w_0"
     shape = [64, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.834753")
@@ -2034,6 +2222,7 @@ class Program_weight_tensor_parameter_187:
 
 class Program_weight_tensor_parameter_188:
     name = "parameter_188"
+    original_name = "conv2d_10.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-4.31178")
@@ -2045,6 +2234,7 @@ class Program_weight_tensor_parameter_188:
 
 class Program_weight_tensor_parameter_189:
     name = "parameter_189"
+    original_name = "conv2d_10.w_0"
     shape = [256, 64, 1, 1]
     dtype = "float32"
     min_val = float("-0.738591")
@@ -2056,6 +2246,7 @@ class Program_weight_tensor_parameter_189:
 
 class Program_weight_tensor_parameter_190:
     name = "parameter_190"
+    original_name = "conv2d_9.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-5.68517")
@@ -2067,6 +2258,7 @@ class Program_weight_tensor_parameter_190:
 
 class Program_weight_tensor_parameter_191:
     name = "parameter_191"
+    original_name = "conv2d_9.w_0"
     shape = [256, 64, 1, 1]
     dtype = "float32"
     min_val = float("-0.910064")
@@ -2078,6 +2270,7 @@ class Program_weight_tensor_parameter_191:
 
 class Program_weight_tensor_parameter_192:
     name = "parameter_192"
+    original_name = "batch_norm2d_5.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -2087,6 +2280,7 @@ class Program_weight_tensor_parameter_192:
 
 class Program_weight_tensor_parameter_193:
     name = "parameter_193"
+    original_name = "batch_norm2d_5.w_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -2096,6 +2290,7 @@ class Program_weight_tensor_parameter_193:
 
 class Program_weight_tensor_parameter_194:
     name = "parameter_194"
+    original_name = "batch_norm2d_5.w_2"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -2105,6 +2300,7 @@ class Program_weight_tensor_parameter_194:
 
 class Program_weight_tensor_parameter_195:
     name = "parameter_195"
+    original_name = "batch_norm2d_5.w_1"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -2114,6 +2310,7 @@ class Program_weight_tensor_parameter_195:
 
 class Program_weight_tensor_parameter_196:
     name = "parameter_196"
+    original_name = "conv2d_8.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -2123,6 +2320,7 @@ class Program_weight_tensor_parameter_196:
 
 class Program_weight_tensor_parameter_197:
     name = "parameter_197"
+    original_name = "conv2d_8.w_0"
     shape = [64, 1, 7, 7]
     dtype = "float32"
     min_val = float("-1.72537")
@@ -2134,6 +2332,7 @@ class Program_weight_tensor_parameter_197:
 
 class Program_weight_tensor_parameter_198:
     name = "parameter_198"
+    original_name = "batch_norm2d_4.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -2143,6 +2342,7 @@ class Program_weight_tensor_parameter_198:
 
 class Program_weight_tensor_parameter_199:
     name = "parameter_199"
+    original_name = "batch_norm2d_4.w_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -2152,6 +2352,7 @@ class Program_weight_tensor_parameter_199:
 
 class Program_weight_tensor_parameter_200:
     name = "parameter_200"
+    original_name = "batch_norm2d_4.w_2"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -2161,6 +2362,7 @@ class Program_weight_tensor_parameter_200:
 
 class Program_weight_tensor_parameter_201:
     name = "parameter_201"
+    original_name = "batch_norm2d_4.w_1"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -2170,6 +2372,7 @@ class Program_weight_tensor_parameter_201:
 
 class Program_weight_tensor_parameter_202:
     name = "parameter_202"
+    original_name = "conv2d_7.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -2179,6 +2382,7 @@ class Program_weight_tensor_parameter_202:
 
 class Program_weight_tensor_parameter_203:
     name = "parameter_203"
+    original_name = "conv2d_7.w_0"
     shape = [64, 32, 3, 3]
     dtype = "float32"
     min_val = float("-0.982435")
@@ -2190,6 +2394,7 @@ class Program_weight_tensor_parameter_203:
 
 class Program_weight_tensor_parameter_204:
     name = "parameter_204"
+    original_name = "conv2d_6.b_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -2199,6 +2404,7 @@ class Program_weight_tensor_parameter_204:
 
 class Program_weight_tensor_parameter_205:
     name = "parameter_205"
+    original_name = "conv2d_6.w_0"
     shape = [32, 1, 7, 7]
     dtype = "float32"
     min_val = float("-0.440817")
@@ -2210,6 +2416,7 @@ class Program_weight_tensor_parameter_205:
 
 class Program_weight_tensor_parameter_206:
     name = "parameter_206"
+    original_name = "batch_norm2d_3.b_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -2219,6 +2426,7 @@ class Program_weight_tensor_parameter_206:
 
 class Program_weight_tensor_parameter_207:
     name = "parameter_207"
+    original_name = "batch_norm2d_3.w_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -2228,6 +2436,7 @@ class Program_weight_tensor_parameter_207:
 
 class Program_weight_tensor_parameter_208:
     name = "parameter_208"
+    original_name = "batch_norm2d_3.w_2"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -2237,6 +2446,7 @@ class Program_weight_tensor_parameter_208:
 
 class Program_weight_tensor_parameter_209:
     name = "parameter_209"
+    original_name = "batch_norm2d_3.w_1"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -2246,6 +2456,7 @@ class Program_weight_tensor_parameter_209:
 
 class Program_weight_tensor_parameter_210:
     name = "parameter_210"
+    original_name = "conv2d_5.b_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -2255,6 +2466,7 @@ class Program_weight_tensor_parameter_210:
 
 class Program_weight_tensor_parameter_211:
     name = "parameter_211"
+    original_name = "conv2d_5.w_0"
     shape = [32, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.534437")
@@ -2266,6 +2478,7 @@ class Program_weight_tensor_parameter_211:
 
 class Program_weight_tensor_parameter_212:
     name = "parameter_212"
+    original_name = "conv2d_4.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-3.35493")
@@ -2277,6 +2490,7 @@ class Program_weight_tensor_parameter_212:
 
 class Program_weight_tensor_parameter_213:
     name = "parameter_213"
+    original_name = "conv2d_4.w_0"
     shape = [128, 32, 1, 1]
     dtype = "float32"
     min_val = float("-0.398431")
@@ -2288,6 +2502,7 @@ class Program_weight_tensor_parameter_213:
 
 class Program_weight_tensor_parameter_214:
     name = "parameter_214"
+    original_name = "conv2d_3.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.06343")
@@ -2299,6 +2514,7 @@ class Program_weight_tensor_parameter_214:
 
 class Program_weight_tensor_parameter_215:
     name = "parameter_215"
+    original_name = "conv2d_3.w_0"
     shape = [128, 32, 1, 1]
     dtype = "float32"
     min_val = float("-0.459826")
@@ -2310,6 +2526,7 @@ class Program_weight_tensor_parameter_215:
 
 class Program_weight_tensor_parameter_216:
     name = "parameter_216"
+    original_name = "batch_norm2d_2.b_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -2319,6 +2536,7 @@ class Program_weight_tensor_parameter_216:
 
 class Program_weight_tensor_parameter_217:
     name = "parameter_217"
+    original_name = "batch_norm2d_2.w_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -2328,6 +2546,7 @@ class Program_weight_tensor_parameter_217:
 
 class Program_weight_tensor_parameter_218:
     name = "parameter_218"
+    original_name = "batch_norm2d_2.w_2"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -2337,6 +2556,7 @@ class Program_weight_tensor_parameter_218:
 
 class Program_weight_tensor_parameter_219:
     name = "parameter_219"
+    original_name = "batch_norm2d_2.w_1"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -2346,6 +2566,7 @@ class Program_weight_tensor_parameter_219:
 
 class Program_weight_tensor_parameter_220:
     name = "parameter_220"
+    original_name = "conv2d_2.b_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -2355,6 +2576,7 @@ class Program_weight_tensor_parameter_220:
 
 class Program_weight_tensor_parameter_221:
     name = "parameter_221"
+    original_name = "conv2d_2.w_0"
     shape = [32, 1, 7, 7]
     dtype = "float32"
     min_val = float("-1.74532")
@@ -2366,6 +2588,7 @@ class Program_weight_tensor_parameter_221:
 
 class Program_weight_tensor_parameter_222:
     name = "parameter_222"
+    original_name = "batch_norm2d_1.b_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -2375,6 +2598,7 @@ class Program_weight_tensor_parameter_222:
 
 class Program_weight_tensor_parameter_223:
     name = "parameter_223"
+    original_name = "batch_norm2d_1.w_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -2384,6 +2608,7 @@ class Program_weight_tensor_parameter_223:
 
 class Program_weight_tensor_parameter_224:
     name = "parameter_224"
+    original_name = "batch_norm2d_1.w_2"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -2393,6 +2618,7 @@ class Program_weight_tensor_parameter_224:
 
 class Program_weight_tensor_parameter_225:
     name = "parameter_225"
+    original_name = "batch_norm2d_1.w_1"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -2402,6 +2628,7 @@ class Program_weight_tensor_parameter_225:
 
 class Program_weight_tensor_parameter_226:
     name = "parameter_226"
+    original_name = "conv2d_1.b_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -2411,6 +2638,7 @@ class Program_weight_tensor_parameter_226:
 
 class Program_weight_tensor_parameter_227:
     name = "parameter_227"
+    original_name = "conv2d_1.w_0"
     shape = [32, 32, 3, 3]
     dtype = "float32"
     min_val = float("-0.828529")
@@ -2422,6 +2650,7 @@ class Program_weight_tensor_parameter_227:
 
 class Program_weight_tensor_parameter_228:
     name = "parameter_228"
+    original_name = "batch_norm2d_0.b_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -2431,6 +2660,7 @@ class Program_weight_tensor_parameter_228:
 
 class Program_weight_tensor_parameter_229:
     name = "parameter_229"
+    original_name = "batch_norm2d_0.w_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -2440,6 +2670,7 @@ class Program_weight_tensor_parameter_229:
 
 class Program_weight_tensor_parameter_230:
     name = "parameter_230"
+    original_name = "batch_norm2d_0.w_2"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -2449,6 +2680,7 @@ class Program_weight_tensor_parameter_230:
 
 class Program_weight_tensor_parameter_231:
     name = "parameter_231"
+    original_name = "batch_norm2d_0.w_1"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -2458,6 +2690,7 @@ class Program_weight_tensor_parameter_231:
 
 class Program_weight_tensor_parameter_232:
     name = "parameter_232"
+    original_name = "conv2d_0.b_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -2467,6 +2700,7 @@ class Program_weight_tensor_parameter_232:
 
 class Program_weight_tensor_parameter_233:
     name = "parameter_233"
+    original_name = "conv2d_0.w_0"
     shape = [32, 3, 3, 3]
     dtype = "float32"
     min_val = float("-0.163911")

--- a/paddle_samples/PaddleX/StarNet-S3/subgraph_2/input_meta.py
+++ b/paddle_samples/PaddleX/StarNet-S3/subgraph_2/input_meta.py
@@ -1,5 +1,6 @@
 class Program_weight_tensor_data_0:
     name = "data_0"
+    original_name = "var_282"
     shape = [124, 3, 224, 224]
     dtype = "float32"
     min_val = float("-5.18906")

--- a/paddle_samples/PaddleX/StarNet-S3/subgraph_2/weight_meta.py
+++ b/paddle_samples/PaddleX/StarNet-S3/subgraph_2/weight_meta.py
@@ -1,5 +1,6 @@
 class Program_weight_tensor_parameter_0:
     name = "parameter_0"
+    original_name = "linear_0.b_0"
     shape = [102]
     dtype = "float32"
     min_val = float("-0.00233045")
@@ -11,6 +12,7 @@ class Program_weight_tensor_parameter_0:
 
 class Program_weight_tensor_parameter_1:
     name = "parameter_1"
+    original_name = "linear_0.w_0"
     shape = [256, 102]
     dtype = "float32"
     min_val = float("-0.132559")
@@ -22,6 +24,7 @@ class Program_weight_tensor_parameter_1:
 
 class Program_weight_tensor_parameter_2:
     name = "parameter_2"
+    original_name = "batch_norm2d_37.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.0561386")
@@ -33,6 +36,7 @@ class Program_weight_tensor_parameter_2:
 
 class Program_weight_tensor_parameter_3:
     name = "parameter_3"
+    original_name = "batch_norm2d_37.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.890972")
@@ -44,6 +48,7 @@ class Program_weight_tensor_parameter_3:
 
 class Program_weight_tensor_parameter_4:
     name = "parameter_4"
+    original_name = "batch_norm2d_37.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("4.02122")
@@ -55,6 +60,7 @@ class Program_weight_tensor_parameter_4:
 
 class Program_weight_tensor_parameter_5:
     name = "parameter_5"
+    original_name = "batch_norm2d_37.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-3.63124")
@@ -66,6 +72,7 @@ class Program_weight_tensor_parameter_5:
 
 class Program_weight_tensor_parameter_6:
     name = "parameter_6"
+    original_name = "conv2d_84.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-3.66322")
@@ -77,6 +84,7 @@ class Program_weight_tensor_parameter_6:
 
 class Program_weight_tensor_parameter_7:
     name = "parameter_7"
+    original_name = "conv2d_84.w_0"
     shape = [256, 1, 7, 7]
     dtype = "float32"
     min_val = float("-0.440126")
@@ -88,6 +96,7 @@ class Program_weight_tensor_parameter_7:
 
 class Program_weight_tensor_parameter_8:
     name = "parameter_8"
+    original_name = "batch_norm2d_36.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.03231")
@@ -99,6 +108,7 @@ class Program_weight_tensor_parameter_8:
 
 class Program_weight_tensor_parameter_9:
     name = "parameter_9"
+    original_name = "batch_norm2d_36.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("1.24139")
@@ -110,6 +120,7 @@ class Program_weight_tensor_parameter_9:
 
 class Program_weight_tensor_parameter_10:
     name = "parameter_10"
+    original_name = "batch_norm2d_36.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("5.80405")
@@ -121,6 +132,7 @@ class Program_weight_tensor_parameter_10:
 
 class Program_weight_tensor_parameter_11:
     name = "parameter_11"
+    original_name = "batch_norm2d_36.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.597064")
@@ -132,6 +144,7 @@ class Program_weight_tensor_parameter_11:
 
 class Program_weight_tensor_parameter_12:
     name = "parameter_12"
+    original_name = "conv2d_83.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.0317467")
@@ -143,6 +156,7 @@ class Program_weight_tensor_parameter_12:
 
 class Program_weight_tensor_parameter_13:
     name = "parameter_13"
+    original_name = "conv2d_83.w_0"
     shape = [256, 1024, 1, 1]
     dtype = "float32"
     min_val = float("-0.33943")
@@ -154,6 +168,7 @@ class Program_weight_tensor_parameter_13:
 
 class Program_weight_tensor_parameter_14:
     name = "parameter_14"
+    original_name = "conv2d_82.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-3.22128")
@@ -165,6 +180,7 @@ class Program_weight_tensor_parameter_14:
 
 class Program_weight_tensor_parameter_15:
     name = "parameter_15"
+    original_name = "conv2d_82.w_0"
     shape = [1024, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.398198")
@@ -176,6 +192,7 @@ class Program_weight_tensor_parameter_15:
 
 class Program_weight_tensor_parameter_16:
     name = "parameter_16"
+    original_name = "conv2d_81.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-3.85551")
@@ -187,6 +204,7 @@ class Program_weight_tensor_parameter_16:
 
 class Program_weight_tensor_parameter_17:
     name = "parameter_17"
+    original_name = "conv2d_81.w_0"
     shape = [1024, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.545266")
@@ -198,6 +216,7 @@ class Program_weight_tensor_parameter_17:
 
 class Program_weight_tensor_parameter_18:
     name = "parameter_18"
+    original_name = "batch_norm2d_35.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.276122")
@@ -209,6 +228,7 @@ class Program_weight_tensor_parameter_18:
 
 class Program_weight_tensor_parameter_19:
     name = "parameter_19"
+    original_name = "batch_norm2d_35.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.683637")
@@ -220,6 +240,7 @@ class Program_weight_tensor_parameter_19:
 
 class Program_weight_tensor_parameter_20:
     name = "parameter_20"
+    original_name = "batch_norm2d_35.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.291851")
@@ -231,6 +252,7 @@ class Program_weight_tensor_parameter_20:
 
 class Program_weight_tensor_parameter_21:
     name = "parameter_21"
+    original_name = "batch_norm2d_35.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-3.07819")
@@ -242,6 +264,7 @@ class Program_weight_tensor_parameter_21:
 
 class Program_weight_tensor_parameter_22:
     name = "parameter_22"
+    original_name = "conv2d_80.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.146225")
@@ -253,6 +276,7 @@ class Program_weight_tensor_parameter_22:
 
 class Program_weight_tensor_parameter_23:
     name = "parameter_23"
+    original_name = "conv2d_80.w_0"
     shape = [256, 1, 7, 7]
     dtype = "float32"
     min_val = float("-1.30314")
@@ -264,6 +288,7 @@ class Program_weight_tensor_parameter_23:
 
 class Program_weight_tensor_parameter_24:
     name = "parameter_24"
+    original_name = "conv2d_79.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.46717")
@@ -275,6 +300,7 @@ class Program_weight_tensor_parameter_24:
 
 class Program_weight_tensor_parameter_25:
     name = "parameter_25"
+    original_name = "conv2d_79.w_0"
     shape = [256, 1, 7, 7]
     dtype = "float32"
     min_val = float("-0.482618")
@@ -286,6 +312,7 @@ class Program_weight_tensor_parameter_25:
 
 class Program_weight_tensor_parameter_26:
     name = "parameter_26"
+    original_name = "batch_norm2d_34.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.53139")
@@ -297,6 +324,7 @@ class Program_weight_tensor_parameter_26:
 
 class Program_weight_tensor_parameter_27:
     name = "parameter_27"
+    original_name = "batch_norm2d_34.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.58445")
@@ -308,6 +336,7 @@ class Program_weight_tensor_parameter_27:
 
 class Program_weight_tensor_parameter_28:
     name = "parameter_28"
+    original_name = "batch_norm2d_34.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("2.89021")
@@ -319,6 +348,7 @@ class Program_weight_tensor_parameter_28:
 
 class Program_weight_tensor_parameter_29:
     name = "parameter_29"
+    original_name = "batch_norm2d_34.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-2.28964")
@@ -330,6 +360,7 @@ class Program_weight_tensor_parameter_29:
 
 class Program_weight_tensor_parameter_30:
     name = "parameter_30"
+    original_name = "conv2d_78.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.0309575")
@@ -341,6 +372,7 @@ class Program_weight_tensor_parameter_30:
 
 class Program_weight_tensor_parameter_31:
     name = "parameter_31"
+    original_name = "conv2d_78.w_0"
     shape = [256, 1024, 1, 1]
     dtype = "float32"
     min_val = float("-0.535152")
@@ -352,6 +384,7 @@ class Program_weight_tensor_parameter_31:
 
 class Program_weight_tensor_parameter_32:
     name = "parameter_32"
+    original_name = "conv2d_77.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-3.9016")
@@ -363,6 +396,7 @@ class Program_weight_tensor_parameter_32:
 
 class Program_weight_tensor_parameter_33:
     name = "parameter_33"
+    original_name = "conv2d_77.w_0"
     shape = [1024, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.530493")
@@ -374,6 +408,7 @@ class Program_weight_tensor_parameter_33:
 
 class Program_weight_tensor_parameter_34:
     name = "parameter_34"
+    original_name = "conv2d_76.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-4.28149")
@@ -385,6 +420,7 @@ class Program_weight_tensor_parameter_34:
 
 class Program_weight_tensor_parameter_35:
     name = "parameter_35"
+    original_name = "conv2d_76.w_0"
     shape = [1024, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.71682")
@@ -396,6 +432,7 @@ class Program_weight_tensor_parameter_35:
 
 class Program_weight_tensor_parameter_36:
     name = "parameter_36"
+    original_name = "batch_norm2d_33.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.614193")
@@ -407,6 +444,7 @@ class Program_weight_tensor_parameter_36:
 
 class Program_weight_tensor_parameter_37:
     name = "parameter_37"
+    original_name = "batch_norm2d_33.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.705196")
@@ -418,6 +456,7 @@ class Program_weight_tensor_parameter_37:
 
 class Program_weight_tensor_parameter_38:
     name = "parameter_38"
+    original_name = "batch_norm2d_33.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.0506259")
@@ -429,6 +468,7 @@ class Program_weight_tensor_parameter_38:
 
 class Program_weight_tensor_parameter_39:
     name = "parameter_39"
+    original_name = "batch_norm2d_33.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-2.24612")
@@ -440,6 +480,7 @@ class Program_weight_tensor_parameter_39:
 
 class Program_weight_tensor_parameter_40:
     name = "parameter_40"
+    original_name = "conv2d_75.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.147245")
@@ -451,6 +492,7 @@ class Program_weight_tensor_parameter_40:
 
 class Program_weight_tensor_parameter_41:
     name = "parameter_41"
+    original_name = "conv2d_75.w_0"
     shape = [256, 1, 7, 7]
     dtype = "float32"
     min_val = float("-1.23064")
@@ -462,6 +504,7 @@ class Program_weight_tensor_parameter_41:
 
 class Program_weight_tensor_parameter_42:
     name = "parameter_42"
+    original_name = "conv2d_74.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.58954")
@@ -473,6 +516,7 @@ class Program_weight_tensor_parameter_42:
 
 class Program_weight_tensor_parameter_43:
     name = "parameter_43"
+    original_name = "conv2d_74.w_0"
     shape = [256, 1, 7, 7]
     dtype = "float32"
     min_val = float("-0.424051")
@@ -484,6 +528,7 @@ class Program_weight_tensor_parameter_43:
 
 class Program_weight_tensor_parameter_44:
     name = "parameter_44"
+    original_name = "batch_norm2d_32.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.761258")
@@ -495,6 +540,7 @@ class Program_weight_tensor_parameter_44:
 
 class Program_weight_tensor_parameter_45:
     name = "parameter_45"
+    original_name = "batch_norm2d_32.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.514096")
@@ -506,6 +552,7 @@ class Program_weight_tensor_parameter_45:
 
 class Program_weight_tensor_parameter_46:
     name = "parameter_46"
+    original_name = "batch_norm2d_32.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.190183")
@@ -517,6 +564,7 @@ class Program_weight_tensor_parameter_46:
 
 class Program_weight_tensor_parameter_47:
     name = "parameter_47"
+    original_name = "batch_norm2d_32.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.261583")
@@ -528,6 +576,7 @@ class Program_weight_tensor_parameter_47:
 
 class Program_weight_tensor_parameter_48:
     name = "parameter_48"
+    original_name = "conv2d_73.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.0410902")
@@ -539,6 +588,7 @@ class Program_weight_tensor_parameter_48:
 
 class Program_weight_tensor_parameter_49:
     name = "parameter_49"
+    original_name = "conv2d_73.w_0"
     shape = [256, 1024, 1, 1]
     dtype = "float32"
     min_val = float("-0.415123")
@@ -550,6 +600,7 @@ class Program_weight_tensor_parameter_49:
 
 class Program_weight_tensor_parameter_50:
     name = "parameter_50"
+    original_name = "conv2d_72.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-2.50556")
@@ -561,6 +612,7 @@ class Program_weight_tensor_parameter_50:
 
 class Program_weight_tensor_parameter_51:
     name = "parameter_51"
+    original_name = "conv2d_72.w_0"
     shape = [1024, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.467946")
@@ -572,6 +624,7 @@ class Program_weight_tensor_parameter_51:
 
 class Program_weight_tensor_parameter_52:
     name = "parameter_52"
+    original_name = "conv2d_71.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-3.49211")
@@ -583,6 +636,7 @@ class Program_weight_tensor_parameter_52:
 
 class Program_weight_tensor_parameter_53:
     name = "parameter_53"
+    original_name = "conv2d_71.w_0"
     shape = [1024, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.402429")
@@ -594,6 +648,7 @@ class Program_weight_tensor_parameter_53:
 
 class Program_weight_tensor_parameter_54:
     name = "parameter_54"
+    original_name = "batch_norm2d_31.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.440309")
@@ -605,6 +660,7 @@ class Program_weight_tensor_parameter_54:
 
 class Program_weight_tensor_parameter_55:
     name = "parameter_55"
+    original_name = "batch_norm2d_31.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.383512")
@@ -616,6 +672,7 @@ class Program_weight_tensor_parameter_55:
 
 class Program_weight_tensor_parameter_56:
     name = "parameter_56"
+    original_name = "batch_norm2d_31.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.00575162")
@@ -627,6 +684,7 @@ class Program_weight_tensor_parameter_56:
 
 class Program_weight_tensor_parameter_57:
     name = "parameter_57"
+    original_name = "batch_norm2d_31.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.1902")
@@ -638,6 +696,7 @@ class Program_weight_tensor_parameter_57:
 
 class Program_weight_tensor_parameter_58:
     name = "parameter_58"
+    original_name = "conv2d_70.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.141155")
@@ -649,6 +708,7 @@ class Program_weight_tensor_parameter_58:
 
 class Program_weight_tensor_parameter_59:
     name = "parameter_59"
+    original_name = "conv2d_70.w_0"
     shape = [256, 1, 7, 7]
     dtype = "float32"
     min_val = float("-1.21193")
@@ -660,6 +720,7 @@ class Program_weight_tensor_parameter_59:
 
 class Program_weight_tensor_parameter_60:
     name = "parameter_60"
+    original_name = "conv2d_69.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.883891")
@@ -671,6 +732,7 @@ class Program_weight_tensor_parameter_60:
 
 class Program_weight_tensor_parameter_61:
     name = "parameter_61"
+    original_name = "conv2d_69.w_0"
     shape = [256, 1, 7, 7]
     dtype = "float32"
     min_val = float("-0.492697")
@@ -682,6 +744,7 @@ class Program_weight_tensor_parameter_61:
 
 class Program_weight_tensor_parameter_62:
     name = "parameter_62"
+    original_name = "batch_norm2d_30.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.604547")
@@ -693,6 +756,7 @@ class Program_weight_tensor_parameter_62:
 
 class Program_weight_tensor_parameter_63:
     name = "parameter_63"
+    original_name = "batch_norm2d_30.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.140901")
@@ -704,6 +768,7 @@ class Program_weight_tensor_parameter_63:
 
 class Program_weight_tensor_parameter_64:
     name = "parameter_64"
+    original_name = "batch_norm2d_30.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("3.76509")
@@ -715,6 +780,7 @@ class Program_weight_tensor_parameter_64:
 
 class Program_weight_tensor_parameter_65:
     name = "parameter_65"
+    original_name = "batch_norm2d_30.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-2.12518")
@@ -726,6 +792,7 @@ class Program_weight_tensor_parameter_65:
 
 class Program_weight_tensor_parameter_66:
     name = "parameter_66"
+    original_name = "conv2d_68.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.0321002")
@@ -737,6 +804,7 @@ class Program_weight_tensor_parameter_66:
 
 class Program_weight_tensor_parameter_67:
     name = "parameter_67"
+    original_name = "conv2d_68.w_0"
     shape = [256, 1024, 1, 1]
     dtype = "float32"
     min_val = float("-1.30983")
@@ -748,6 +816,7 @@ class Program_weight_tensor_parameter_67:
 
 class Program_weight_tensor_parameter_68:
     name = "parameter_68"
+    original_name = "conv2d_67.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-3.25328")
@@ -759,6 +828,7 @@ class Program_weight_tensor_parameter_68:
 
 class Program_weight_tensor_parameter_69:
     name = "parameter_69"
+    original_name = "conv2d_67.w_0"
     shape = [1024, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.48854")
@@ -770,6 +840,7 @@ class Program_weight_tensor_parameter_69:
 
 class Program_weight_tensor_parameter_70:
     name = "parameter_70"
+    original_name = "conv2d_66.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-3.47365")
@@ -781,6 +852,7 @@ class Program_weight_tensor_parameter_70:
 
 class Program_weight_tensor_parameter_71:
     name = "parameter_71"
+    original_name = "conv2d_66.w_0"
     shape = [1024, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.742085")
@@ -792,6 +864,7 @@ class Program_weight_tensor_parameter_71:
 
 class Program_weight_tensor_parameter_72:
     name = "parameter_72"
+    original_name = "batch_norm2d_29.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.36682")
@@ -803,6 +876,7 @@ class Program_weight_tensor_parameter_72:
 
 class Program_weight_tensor_parameter_73:
     name = "parameter_73"
+    original_name = "batch_norm2d_29.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.377704")
@@ -814,6 +888,7 @@ class Program_weight_tensor_parameter_73:
 
 class Program_weight_tensor_parameter_74:
     name = "parameter_74"
+    original_name = "batch_norm2d_29.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.000284832")
@@ -825,6 +900,7 @@ class Program_weight_tensor_parameter_74:
 
 class Program_weight_tensor_parameter_75:
     name = "parameter_75"
+    original_name = "batch_norm2d_29.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.48211")
@@ -836,6 +912,7 @@ class Program_weight_tensor_parameter_75:
 
 class Program_weight_tensor_parameter_76:
     name = "parameter_76"
+    original_name = "conv2d_65.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.160146")
@@ -847,6 +924,7 @@ class Program_weight_tensor_parameter_76:
 
 class Program_weight_tensor_parameter_77:
     name = "parameter_77"
+    original_name = "conv2d_65.w_0"
     shape = [256, 1, 7, 7]
     dtype = "float32"
     min_val = float("-1.30011")
@@ -858,6 +936,7 @@ class Program_weight_tensor_parameter_77:
 
 class Program_weight_tensor_parameter_78:
     name = "parameter_78"
+    original_name = "batch_norm2d_28.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.50363")
@@ -869,6 +948,7 @@ class Program_weight_tensor_parameter_78:
 
 class Program_weight_tensor_parameter_79:
     name = "parameter_79"
+    original_name = "batch_norm2d_28.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.0369259")
@@ -880,6 +960,7 @@ class Program_weight_tensor_parameter_79:
 
 class Program_weight_tensor_parameter_80:
     name = "parameter_80"
+    original_name = "batch_norm2d_28.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("183.293")
@@ -891,6 +972,7 @@ class Program_weight_tensor_parameter_80:
 
 class Program_weight_tensor_parameter_81:
     name = "parameter_81"
+    original_name = "batch_norm2d_28.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-40.9087")
@@ -902,6 +984,7 @@ class Program_weight_tensor_parameter_81:
 
 class Program_weight_tensor_parameter_82:
     name = "parameter_82"
+    original_name = "conv2d_64.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.0301259")
@@ -913,6 +996,7 @@ class Program_weight_tensor_parameter_82:
 
 class Program_weight_tensor_parameter_83:
     name = "parameter_83"
+    original_name = "conv2d_64.w_0"
     shape = [256, 128, 3, 3]
     dtype = "float32"
     min_val = float("-0.566927")
@@ -924,6 +1008,7 @@ class Program_weight_tensor_parameter_83:
 
 class Program_weight_tensor_parameter_84:
     name = "parameter_84"
+    original_name = "conv2d_63.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.2933")
@@ -935,6 +1020,7 @@ class Program_weight_tensor_parameter_84:
 
 class Program_weight_tensor_parameter_85:
     name = "parameter_85"
+    original_name = "conv2d_63.w_0"
     shape = [128, 1, 7, 7]
     dtype = "float32"
     min_val = float("-0.43076")
@@ -946,6 +1032,7 @@ class Program_weight_tensor_parameter_85:
 
 class Program_weight_tensor_parameter_86:
     name = "parameter_86"
+    original_name = "batch_norm2d_27.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.954806")
@@ -957,6 +1044,7 @@ class Program_weight_tensor_parameter_86:
 
 class Program_weight_tensor_parameter_87:
     name = "parameter_87"
+    original_name = "batch_norm2d_27.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("1.01519")
@@ -968,6 +1056,7 @@ class Program_weight_tensor_parameter_87:
 
 class Program_weight_tensor_parameter_88:
     name = "parameter_88"
+    original_name = "batch_norm2d_27.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("1.63993")
@@ -979,6 +1068,7 @@ class Program_weight_tensor_parameter_88:
 
 class Program_weight_tensor_parameter_89:
     name = "parameter_89"
+    original_name = "batch_norm2d_27.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.654706")
@@ -990,6 +1080,7 @@ class Program_weight_tensor_parameter_89:
 
 class Program_weight_tensor_parameter_90:
     name = "parameter_90"
+    original_name = "conv2d_62.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.0469711")
@@ -1001,6 +1092,7 @@ class Program_weight_tensor_parameter_90:
 
 class Program_weight_tensor_parameter_91:
     name = "parameter_91"
+    original_name = "conv2d_62.w_0"
     shape = [128, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.48279")
@@ -1012,6 +1104,7 @@ class Program_weight_tensor_parameter_91:
 
 class Program_weight_tensor_parameter_92:
     name = "parameter_92"
+    original_name = "conv2d_61.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-2.47469")
@@ -1023,6 +1116,7 @@ class Program_weight_tensor_parameter_92:
 
 class Program_weight_tensor_parameter_93:
     name = "parameter_93"
+    original_name = "conv2d_61.w_0"
     shape = [512, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.869892")
@@ -1034,6 +1128,7 @@ class Program_weight_tensor_parameter_93:
 
 class Program_weight_tensor_parameter_94:
     name = "parameter_94"
+    original_name = "conv2d_60.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-3.42549")
@@ -1045,6 +1140,7 @@ class Program_weight_tensor_parameter_94:
 
 class Program_weight_tensor_parameter_95:
     name = "parameter_95"
+    original_name = "conv2d_60.w_0"
     shape = [512, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.662584")
@@ -1056,6 +1152,7 @@ class Program_weight_tensor_parameter_95:
 
 class Program_weight_tensor_parameter_96:
     name = "parameter_96"
+    original_name = "batch_norm2d_26.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.38206")
@@ -1067,6 +1164,7 @@ class Program_weight_tensor_parameter_96:
 
 class Program_weight_tensor_parameter_97:
     name = "parameter_97"
+    original_name = "batch_norm2d_26.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.471461")
@@ -1078,6 +1176,7 @@ class Program_weight_tensor_parameter_97:
 
 class Program_weight_tensor_parameter_98:
     name = "parameter_98"
+    original_name = "batch_norm2d_26.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.243651")
@@ -1089,6 +1188,7 @@ class Program_weight_tensor_parameter_98:
 
 class Program_weight_tensor_parameter_99:
     name = "parameter_99"
+    original_name = "batch_norm2d_26.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-9.37839")
@@ -1100,6 +1200,7 @@ class Program_weight_tensor_parameter_99:
 
 class Program_weight_tensor_parameter_100:
     name = "parameter_100"
+    original_name = "conv2d_59.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.15132")
@@ -1111,6 +1212,7 @@ class Program_weight_tensor_parameter_100:
 
 class Program_weight_tensor_parameter_101:
     name = "parameter_101"
+    original_name = "conv2d_59.w_0"
     shape = [128, 1, 7, 7]
     dtype = "float32"
     min_val = float("-1.27416")
@@ -1122,6 +1224,7 @@ class Program_weight_tensor_parameter_101:
 
 class Program_weight_tensor_parameter_102:
     name = "parameter_102"
+    original_name = "conv2d_58.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.97451")
@@ -1133,6 +1236,7 @@ class Program_weight_tensor_parameter_102:
 
 class Program_weight_tensor_parameter_103:
     name = "parameter_103"
+    original_name = "conv2d_58.w_0"
     shape = [128, 1, 7, 7]
     dtype = "float32"
     min_val = float("-0.536383")
@@ -1144,6 +1248,7 @@ class Program_weight_tensor_parameter_103:
 
 class Program_weight_tensor_parameter_104:
     name = "parameter_104"
+    original_name = "batch_norm2d_25.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.814996")
@@ -1155,6 +1260,7 @@ class Program_weight_tensor_parameter_104:
 
 class Program_weight_tensor_parameter_105:
     name = "parameter_105"
+    original_name = "batch_norm2d_25.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.791455")
@@ -1166,6 +1272,7 @@ class Program_weight_tensor_parameter_105:
 
 class Program_weight_tensor_parameter_106:
     name = "parameter_106"
+    original_name = "batch_norm2d_25.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("1.52333")
@@ -1177,6 +1284,7 @@ class Program_weight_tensor_parameter_106:
 
 class Program_weight_tensor_parameter_107:
     name = "parameter_107"
+    original_name = "batch_norm2d_25.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.44374")
@@ -1188,6 +1296,7 @@ class Program_weight_tensor_parameter_107:
 
 class Program_weight_tensor_parameter_108:
     name = "parameter_108"
+    original_name = "conv2d_57.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.0457165")
@@ -1199,6 +1308,7 @@ class Program_weight_tensor_parameter_108:
 
 class Program_weight_tensor_parameter_109:
     name = "parameter_109"
+    original_name = "conv2d_57.w_0"
     shape = [128, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.73107")
@@ -1210,6 +1320,7 @@ class Program_weight_tensor_parameter_109:
 
 class Program_weight_tensor_parameter_110:
     name = "parameter_110"
+    original_name = "conv2d_56.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-2.54361")
@@ -1221,6 +1332,7 @@ class Program_weight_tensor_parameter_110:
 
 class Program_weight_tensor_parameter_111:
     name = "parameter_111"
+    original_name = "conv2d_56.w_0"
     shape = [512, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.687036")
@@ -1232,6 +1344,7 @@ class Program_weight_tensor_parameter_111:
 
 class Program_weight_tensor_parameter_112:
     name = "parameter_112"
+    original_name = "conv2d_55.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-3.45046")
@@ -1243,6 +1356,7 @@ class Program_weight_tensor_parameter_112:
 
 class Program_weight_tensor_parameter_113:
     name = "parameter_113"
+    original_name = "conv2d_55.w_0"
     shape = [512, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.534049")
@@ -1254,6 +1368,7 @@ class Program_weight_tensor_parameter_113:
 
 class Program_weight_tensor_parameter_114:
     name = "parameter_114"
+    original_name = "batch_norm2d_24.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.54339")
@@ -1265,6 +1380,7 @@ class Program_weight_tensor_parameter_114:
 
 class Program_weight_tensor_parameter_115:
     name = "parameter_115"
+    original_name = "batch_norm2d_24.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.493415")
@@ -1276,6 +1392,7 @@ class Program_weight_tensor_parameter_115:
 
 class Program_weight_tensor_parameter_116:
     name = "parameter_116"
+    original_name = "batch_norm2d_24.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.104599")
@@ -1287,6 +1404,7 @@ class Program_weight_tensor_parameter_116:
 
 class Program_weight_tensor_parameter_117:
     name = "parameter_117"
+    original_name = "batch_norm2d_24.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-5.42021")
@@ -1298,6 +1416,7 @@ class Program_weight_tensor_parameter_117:
 
 class Program_weight_tensor_parameter_118:
     name = "parameter_118"
+    original_name = "conv2d_54.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.144834")
@@ -1309,6 +1428,7 @@ class Program_weight_tensor_parameter_118:
 
 class Program_weight_tensor_parameter_119:
     name = "parameter_119"
+    original_name = "conv2d_54.w_0"
     shape = [128, 1, 7, 7]
     dtype = "float32"
     min_val = float("-1.23214")
@@ -1320,6 +1440,7 @@ class Program_weight_tensor_parameter_119:
 
 class Program_weight_tensor_parameter_120:
     name = "parameter_120"
+    original_name = "conv2d_53.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.735427")
@@ -1331,6 +1452,7 @@ class Program_weight_tensor_parameter_120:
 
 class Program_weight_tensor_parameter_121:
     name = "parameter_121"
+    original_name = "conv2d_53.w_0"
     shape = [128, 1, 7, 7]
     dtype = "float32"
     min_val = float("-0.450108")
@@ -1342,6 +1464,7 @@ class Program_weight_tensor_parameter_121:
 
 class Program_weight_tensor_parameter_122:
     name = "parameter_122"
+    original_name = "batch_norm2d_23.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.357018")
@@ -1353,6 +1476,7 @@ class Program_weight_tensor_parameter_122:
 
 class Program_weight_tensor_parameter_123:
     name = "parameter_123"
+    original_name = "batch_norm2d_23.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.01141")
@@ -1364,6 +1488,7 @@ class Program_weight_tensor_parameter_123:
 
 class Program_weight_tensor_parameter_124:
     name = "parameter_124"
+    original_name = "batch_norm2d_23.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("2.34595")
@@ -1375,6 +1500,7 @@ class Program_weight_tensor_parameter_124:
 
 class Program_weight_tensor_parameter_125:
     name = "parameter_125"
+    original_name = "batch_norm2d_23.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-2.27135")
@@ -1386,6 +1512,7 @@ class Program_weight_tensor_parameter_125:
 
 class Program_weight_tensor_parameter_126:
     name = "parameter_126"
+    original_name = "conv2d_52.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.0458994")
@@ -1397,6 +1524,7 @@ class Program_weight_tensor_parameter_126:
 
 class Program_weight_tensor_parameter_127:
     name = "parameter_127"
+    original_name = "conv2d_52.w_0"
     shape = [128, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.509232")
@@ -1408,6 +1536,7 @@ class Program_weight_tensor_parameter_127:
 
 class Program_weight_tensor_parameter_128:
     name = "parameter_128"
+    original_name = "conv2d_51.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-3.97613")
@@ -1419,6 +1548,7 @@ class Program_weight_tensor_parameter_128:
 
 class Program_weight_tensor_parameter_129:
     name = "parameter_129"
+    original_name = "conv2d_51.w_0"
     shape = [512, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.596044")
@@ -1430,6 +1560,7 @@ class Program_weight_tensor_parameter_129:
 
 class Program_weight_tensor_parameter_130:
     name = "parameter_130"
+    original_name = "conv2d_50.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-3.32622")
@@ -1441,6 +1572,7 @@ class Program_weight_tensor_parameter_130:
 
 class Program_weight_tensor_parameter_131:
     name = "parameter_131"
+    original_name = "conv2d_50.w_0"
     shape = [512, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.568842")
@@ -1452,6 +1584,7 @@ class Program_weight_tensor_parameter_131:
 
 class Program_weight_tensor_parameter_132:
     name = "parameter_132"
+    original_name = "batch_norm2d_22.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.473745")
@@ -1463,6 +1596,7 @@ class Program_weight_tensor_parameter_132:
 
 class Program_weight_tensor_parameter_133:
     name = "parameter_133"
+    original_name = "batch_norm2d_22.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.681585")
@@ -1474,6 +1608,7 @@ class Program_weight_tensor_parameter_133:
 
 class Program_weight_tensor_parameter_134:
     name = "parameter_134"
+    original_name = "batch_norm2d_22.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.0167681")
@@ -1485,6 +1620,7 @@ class Program_weight_tensor_parameter_134:
 
 class Program_weight_tensor_parameter_135:
     name = "parameter_135"
+    original_name = "batch_norm2d_22.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-3.92119")
@@ -1496,6 +1632,7 @@ class Program_weight_tensor_parameter_135:
 
 class Program_weight_tensor_parameter_136:
     name = "parameter_136"
+    original_name = "conv2d_49.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.140654")
@@ -1507,6 +1644,7 @@ class Program_weight_tensor_parameter_136:
 
 class Program_weight_tensor_parameter_137:
     name = "parameter_137"
+    original_name = "conv2d_49.w_0"
     shape = [128, 1, 7, 7]
     dtype = "float32"
     min_val = float("-0.852262")
@@ -1518,6 +1656,7 @@ class Program_weight_tensor_parameter_137:
 
 class Program_weight_tensor_parameter_138:
     name = "parameter_138"
+    original_name = "conv2d_48.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-2.66205")
@@ -1529,6 +1668,7 @@ class Program_weight_tensor_parameter_138:
 
 class Program_weight_tensor_parameter_139:
     name = "parameter_139"
+    original_name = "conv2d_48.w_0"
     shape = [128, 1, 7, 7]
     dtype = "float32"
     min_val = float("-0.567334")
@@ -1540,6 +1680,7 @@ class Program_weight_tensor_parameter_139:
 
 class Program_weight_tensor_parameter_140:
     name = "parameter_140"
+    original_name = "batch_norm2d_21.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.741623")
@@ -1551,6 +1692,7 @@ class Program_weight_tensor_parameter_140:
 
 class Program_weight_tensor_parameter_141:
     name = "parameter_141"
+    original_name = "batch_norm2d_21.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.158602")
@@ -1562,6 +1704,7 @@ class Program_weight_tensor_parameter_141:
 
 class Program_weight_tensor_parameter_142:
     name = "parameter_142"
+    original_name = "batch_norm2d_21.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("1.37738")
@@ -1573,6 +1716,7 @@ class Program_weight_tensor_parameter_142:
 
 class Program_weight_tensor_parameter_143:
     name = "parameter_143"
+    original_name = "batch_norm2d_21.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.15714")
@@ -1584,6 +1728,7 @@ class Program_weight_tensor_parameter_143:
 
 class Program_weight_tensor_parameter_144:
     name = "parameter_144"
+    original_name = "conv2d_47.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.0470889")
@@ -1595,6 +1740,7 @@ class Program_weight_tensor_parameter_144:
 
 class Program_weight_tensor_parameter_145:
     name = "parameter_145"
+    original_name = "conv2d_47.w_0"
     shape = [128, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.532501")
@@ -1606,6 +1752,7 @@ class Program_weight_tensor_parameter_145:
 
 class Program_weight_tensor_parameter_146:
     name = "parameter_146"
+    original_name = "conv2d_46.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-3.29959")
@@ -1617,6 +1764,7 @@ class Program_weight_tensor_parameter_146:
 
 class Program_weight_tensor_parameter_147:
     name = "parameter_147"
+    original_name = "conv2d_46.w_0"
     shape = [512, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.774191")
@@ -1628,6 +1776,7 @@ class Program_weight_tensor_parameter_147:
 
 class Program_weight_tensor_parameter_148:
     name = "parameter_148"
+    original_name = "conv2d_45.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-4.33839")
@@ -1639,6 +1788,7 @@ class Program_weight_tensor_parameter_148:
 
 class Program_weight_tensor_parameter_149:
     name = "parameter_149"
+    original_name = "conv2d_45.w_0"
     shape = [512, 128, 1, 1]
     dtype = "float32"
     min_val = float("-1.21034")
@@ -1650,6 +1800,7 @@ class Program_weight_tensor_parameter_149:
 
 class Program_weight_tensor_parameter_150:
     name = "parameter_150"
+    original_name = "batch_norm2d_20.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.782105")
@@ -1661,6 +1812,7 @@ class Program_weight_tensor_parameter_150:
 
 class Program_weight_tensor_parameter_151:
     name = "parameter_151"
+    original_name = "batch_norm2d_20.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.830842")
@@ -1672,6 +1824,7 @@ class Program_weight_tensor_parameter_151:
 
 class Program_weight_tensor_parameter_152:
     name = "parameter_152"
+    original_name = "batch_norm2d_20.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.00747972")
@@ -1683,6 +1836,7 @@ class Program_weight_tensor_parameter_152:
 
 class Program_weight_tensor_parameter_153:
     name = "parameter_153"
+    original_name = "batch_norm2d_20.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-3.33865")
@@ -1694,6 +1848,7 @@ class Program_weight_tensor_parameter_153:
 
 class Program_weight_tensor_parameter_154:
     name = "parameter_154"
+    original_name = "conv2d_44.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.146192")
@@ -1705,6 +1860,7 @@ class Program_weight_tensor_parameter_154:
 
 class Program_weight_tensor_parameter_155:
     name = "parameter_155"
+    original_name = "conv2d_44.w_0"
     shape = [128, 1, 7, 7]
     dtype = "float32"
     min_val = float("-1.55611")
@@ -1716,6 +1872,7 @@ class Program_weight_tensor_parameter_155:
 
 class Program_weight_tensor_parameter_156:
     name = "parameter_156"
+    original_name = "conv2d_43.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.83444")
@@ -1727,6 +1884,7 @@ class Program_weight_tensor_parameter_156:
 
 class Program_weight_tensor_parameter_157:
     name = "parameter_157"
+    original_name = "conv2d_43.w_0"
     shape = [128, 1, 7, 7]
     dtype = "float32"
     min_val = float("-0.53853")
@@ -1738,6 +1896,7 @@ class Program_weight_tensor_parameter_157:
 
 class Program_weight_tensor_parameter_158:
     name = "parameter_158"
+    original_name = "batch_norm2d_19.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.522073")
@@ -1749,6 +1908,7 @@ class Program_weight_tensor_parameter_158:
 
 class Program_weight_tensor_parameter_159:
     name = "parameter_159"
+    original_name = "batch_norm2d_19.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.11696")
@@ -1760,6 +1920,7 @@ class Program_weight_tensor_parameter_159:
 
 class Program_weight_tensor_parameter_160:
     name = "parameter_160"
+    original_name = "batch_norm2d_19.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("1.57934")
@@ -1771,6 +1932,7 @@ class Program_weight_tensor_parameter_160:
 
 class Program_weight_tensor_parameter_161:
     name = "parameter_161"
+    original_name = "batch_norm2d_19.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.19534")
@@ -1782,6 +1944,7 @@ class Program_weight_tensor_parameter_161:
 
 class Program_weight_tensor_parameter_162:
     name = "parameter_162"
+    original_name = "conv2d_42.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.0436405")
@@ -1793,6 +1956,7 @@ class Program_weight_tensor_parameter_162:
 
 class Program_weight_tensor_parameter_163:
     name = "parameter_163"
+    original_name = "conv2d_42.w_0"
     shape = [128, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.96654")
@@ -1804,6 +1968,7 @@ class Program_weight_tensor_parameter_163:
 
 class Program_weight_tensor_parameter_164:
     name = "parameter_164"
+    original_name = "conv2d_41.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-2.93958")
@@ -1815,6 +1980,7 @@ class Program_weight_tensor_parameter_164:
 
 class Program_weight_tensor_parameter_165:
     name = "parameter_165"
+    original_name = "conv2d_41.w_0"
     shape = [512, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.894595")
@@ -1826,6 +1992,7 @@ class Program_weight_tensor_parameter_165:
 
 class Program_weight_tensor_parameter_166:
     name = "parameter_166"
+    original_name = "conv2d_40.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-3.35702")
@@ -1837,6 +2004,7 @@ class Program_weight_tensor_parameter_166:
 
 class Program_weight_tensor_parameter_167:
     name = "parameter_167"
+    original_name = "conv2d_40.w_0"
     shape = [512, 128, 1, 1]
     dtype = "float32"
     min_val = float("-1.0906")
@@ -1848,6 +2016,7 @@ class Program_weight_tensor_parameter_167:
 
 class Program_weight_tensor_parameter_168:
     name = "parameter_168"
+    original_name = "batch_norm2d_18.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.01429")
@@ -1859,6 +2028,7 @@ class Program_weight_tensor_parameter_168:
 
 class Program_weight_tensor_parameter_169:
     name = "parameter_169"
+    original_name = "batch_norm2d_18.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.801231")
@@ -1870,6 +2040,7 @@ class Program_weight_tensor_parameter_169:
 
 class Program_weight_tensor_parameter_170:
     name = "parameter_170"
+    original_name = "batch_norm2d_18.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.00213181")
@@ -1881,6 +2052,7 @@ class Program_weight_tensor_parameter_170:
 
 class Program_weight_tensor_parameter_171:
     name = "parameter_171"
+    original_name = "batch_norm2d_18.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.15034")
@@ -1892,6 +2064,7 @@ class Program_weight_tensor_parameter_171:
 
 class Program_weight_tensor_parameter_172:
     name = "parameter_172"
+    original_name = "conv2d_39.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.151715")
@@ -1903,6 +2076,7 @@ class Program_weight_tensor_parameter_172:
 
 class Program_weight_tensor_parameter_173:
     name = "parameter_173"
+    original_name = "conv2d_39.w_0"
     shape = [128, 1, 7, 7]
     dtype = "float32"
     min_val = float("-1.3129")
@@ -1914,6 +2088,7 @@ class Program_weight_tensor_parameter_173:
 
 class Program_weight_tensor_parameter_174:
     name = "parameter_174"
+    original_name = "conv2d_38.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.687397")
@@ -1925,6 +2100,7 @@ class Program_weight_tensor_parameter_174:
 
 class Program_weight_tensor_parameter_175:
     name = "parameter_175"
+    original_name = "conv2d_38.w_0"
     shape = [128, 1, 7, 7]
     dtype = "float32"
     min_val = float("-0.603528")
@@ -1936,6 +2112,7 @@ class Program_weight_tensor_parameter_175:
 
 class Program_weight_tensor_parameter_176:
     name = "parameter_176"
+    original_name = "batch_norm2d_17.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.733037")
@@ -1947,6 +2124,7 @@ class Program_weight_tensor_parameter_176:
 
 class Program_weight_tensor_parameter_177:
     name = "parameter_177"
+    original_name = "batch_norm2d_17.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.0790904")
@@ -1958,6 +2136,7 @@ class Program_weight_tensor_parameter_177:
 
 class Program_weight_tensor_parameter_178:
     name = "parameter_178"
+    original_name = "batch_norm2d_17.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("3.2093")
@@ -1969,6 +2148,7 @@ class Program_weight_tensor_parameter_178:
 
 class Program_weight_tensor_parameter_179:
     name = "parameter_179"
+    original_name = "batch_norm2d_17.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.97124")
@@ -1980,6 +2160,7 @@ class Program_weight_tensor_parameter_179:
 
 class Program_weight_tensor_parameter_180:
     name = "parameter_180"
+    original_name = "conv2d_37.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.0446616")
@@ -1991,6 +2172,7 @@ class Program_weight_tensor_parameter_180:
 
 class Program_weight_tensor_parameter_181:
     name = "parameter_181"
+    original_name = "conv2d_37.w_0"
     shape = [128, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.820741")
@@ -2002,6 +2184,7 @@ class Program_weight_tensor_parameter_181:
 
 class Program_weight_tensor_parameter_182:
     name = "parameter_182"
+    original_name = "conv2d_36.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-4.73811")
@@ -2013,6 +2196,7 @@ class Program_weight_tensor_parameter_182:
 
 class Program_weight_tensor_parameter_183:
     name = "parameter_183"
+    original_name = "conv2d_36.w_0"
     shape = [512, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.741076")
@@ -2024,6 +2208,7 @@ class Program_weight_tensor_parameter_183:
 
 class Program_weight_tensor_parameter_184:
     name = "parameter_184"
+    original_name = "conv2d_35.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-5.24675")
@@ -2035,6 +2220,7 @@ class Program_weight_tensor_parameter_184:
 
 class Program_weight_tensor_parameter_185:
     name = "parameter_185"
+    original_name = "conv2d_35.w_0"
     shape = [512, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.852535")
@@ -2046,6 +2232,7 @@ class Program_weight_tensor_parameter_185:
 
 class Program_weight_tensor_parameter_186:
     name = "parameter_186"
+    original_name = "batch_norm2d_16.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.608736")
@@ -2057,6 +2244,7 @@ class Program_weight_tensor_parameter_186:
 
 class Program_weight_tensor_parameter_187:
     name = "parameter_187"
+    original_name = "batch_norm2d_16.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.803377")
@@ -2068,6 +2256,7 @@ class Program_weight_tensor_parameter_187:
 
 class Program_weight_tensor_parameter_188:
     name = "parameter_188"
+    original_name = "batch_norm2d_16.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.000354775")
@@ -2079,6 +2268,7 @@ class Program_weight_tensor_parameter_188:
 
 class Program_weight_tensor_parameter_189:
     name = "parameter_189"
+    original_name = "batch_norm2d_16.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.55534")
@@ -2090,6 +2280,7 @@ class Program_weight_tensor_parameter_189:
 
 class Program_weight_tensor_parameter_190:
     name = "parameter_190"
+    original_name = "conv2d_34.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.190776")
@@ -2101,6 +2292,7 @@ class Program_weight_tensor_parameter_190:
 
 class Program_weight_tensor_parameter_191:
     name = "parameter_191"
+    original_name = "conv2d_34.w_0"
     shape = [128, 1, 7, 7]
     dtype = "float32"
     min_val = float("-1.54169")
@@ -2112,6 +2304,7 @@ class Program_weight_tensor_parameter_191:
 
 class Program_weight_tensor_parameter_192:
     name = "parameter_192"
+    original_name = "conv2d_33.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.82233")
@@ -2123,6 +2316,7 @@ class Program_weight_tensor_parameter_192:
 
 class Program_weight_tensor_parameter_193:
     name = "parameter_193"
+    original_name = "conv2d_33.w_0"
     shape = [128, 1, 7, 7]
     dtype = "float32"
     min_val = float("-0.522098")
@@ -2134,6 +2328,7 @@ class Program_weight_tensor_parameter_193:
 
 class Program_weight_tensor_parameter_194:
     name = "parameter_194"
+    original_name = "batch_norm2d_15.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.18518")
@@ -2145,6 +2340,7 @@ class Program_weight_tensor_parameter_194:
 
 class Program_weight_tensor_parameter_195:
     name = "parameter_195"
+    original_name = "batch_norm2d_15.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.0397242")
@@ -2156,6 +2352,7 @@ class Program_weight_tensor_parameter_195:
 
 class Program_weight_tensor_parameter_196:
     name = "parameter_196"
+    original_name = "batch_norm2d_15.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("4.83714")
@@ -2167,6 +2364,7 @@ class Program_weight_tensor_parameter_196:
 
 class Program_weight_tensor_parameter_197:
     name = "parameter_197"
+    original_name = "batch_norm2d_15.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-3.40834")
@@ -2178,6 +2376,7 @@ class Program_weight_tensor_parameter_197:
 
 class Program_weight_tensor_parameter_198:
     name = "parameter_198"
+    original_name = "conv2d_32.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.0500022")
@@ -2189,6 +2388,7 @@ class Program_weight_tensor_parameter_198:
 
 class Program_weight_tensor_parameter_199:
     name = "parameter_199"
+    original_name = "conv2d_32.w_0"
     shape = [128, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.823636")
@@ -2200,6 +2400,7 @@ class Program_weight_tensor_parameter_199:
 
 class Program_weight_tensor_parameter_200:
     name = "parameter_200"
+    original_name = "conv2d_31.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-5.224")
@@ -2211,6 +2412,7 @@ class Program_weight_tensor_parameter_200:
 
 class Program_weight_tensor_parameter_201:
     name = "parameter_201"
+    original_name = "conv2d_31.w_0"
     shape = [512, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.779076")
@@ -2222,6 +2424,7 @@ class Program_weight_tensor_parameter_201:
 
 class Program_weight_tensor_parameter_202:
     name = "parameter_202"
+    original_name = "conv2d_30.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-3.17885")
@@ -2233,6 +2436,7 @@ class Program_weight_tensor_parameter_202:
 
 class Program_weight_tensor_parameter_203:
     name = "parameter_203"
+    original_name = "conv2d_30.w_0"
     shape = [512, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.886523")
@@ -2244,6 +2448,7 @@ class Program_weight_tensor_parameter_203:
 
 class Program_weight_tensor_parameter_204:
     name = "parameter_204"
+    original_name = "batch_norm2d_14.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.735672")
@@ -2255,6 +2460,7 @@ class Program_weight_tensor_parameter_204:
 
 class Program_weight_tensor_parameter_205:
     name = "parameter_205"
+    original_name = "batch_norm2d_14.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.751067")
@@ -2266,6 +2472,7 @@ class Program_weight_tensor_parameter_205:
 
 class Program_weight_tensor_parameter_206:
     name = "parameter_206"
+    original_name = "batch_norm2d_14.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("4.49702e-05")
@@ -2277,6 +2484,7 @@ class Program_weight_tensor_parameter_206:
 
 class Program_weight_tensor_parameter_207:
     name = "parameter_207"
+    original_name = "batch_norm2d_14.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-2.61811")
@@ -2288,6 +2496,7 @@ class Program_weight_tensor_parameter_207:
 
 class Program_weight_tensor_parameter_208:
     name = "parameter_208"
+    original_name = "conv2d_29.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.211909")
@@ -2299,6 +2508,7 @@ class Program_weight_tensor_parameter_208:
 
 class Program_weight_tensor_parameter_209:
     name = "parameter_209"
+    original_name = "conv2d_29.w_0"
     shape = [128, 1, 7, 7]
     dtype = "float32"
     min_val = float("-0.931733")
@@ -2310,6 +2520,7 @@ class Program_weight_tensor_parameter_209:
 
 class Program_weight_tensor_parameter_210:
     name = "parameter_210"
+    original_name = "conv2d_28.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.932001")
@@ -2321,6 +2532,7 @@ class Program_weight_tensor_parameter_210:
 
 class Program_weight_tensor_parameter_211:
     name = "parameter_211"
+    original_name = "conv2d_28.w_0"
     shape = [128, 1, 7, 7]
     dtype = "float32"
     min_val = float("-0.586012")
@@ -2332,6 +2544,7 @@ class Program_weight_tensor_parameter_211:
 
 class Program_weight_tensor_parameter_212:
     name = "parameter_212"
+    original_name = "batch_norm2d_13.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.795953")
@@ -2343,6 +2556,7 @@ class Program_weight_tensor_parameter_212:
 
 class Program_weight_tensor_parameter_213:
     name = "parameter_213"
+    original_name = "batch_norm2d_13.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.0151424")
@@ -2354,6 +2568,7 @@ class Program_weight_tensor_parameter_213:
 
 class Program_weight_tensor_parameter_214:
     name = "parameter_214"
+    original_name = "batch_norm2d_13.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("3.0954")
@@ -2365,6 +2580,7 @@ class Program_weight_tensor_parameter_214:
 
 class Program_weight_tensor_parameter_215:
     name = "parameter_215"
+    original_name = "batch_norm2d_13.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-2.57355")
@@ -2376,6 +2592,7 @@ class Program_weight_tensor_parameter_215:
 
 class Program_weight_tensor_parameter_216:
     name = "parameter_216"
+    original_name = "conv2d_27.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.0478978")
@@ -2387,6 +2604,7 @@ class Program_weight_tensor_parameter_216:
 
 class Program_weight_tensor_parameter_217:
     name = "parameter_217"
+    original_name = "conv2d_27.w_0"
     shape = [128, 512, 1, 1]
     dtype = "float32"
     min_val = float("-1.12895")
@@ -2398,6 +2616,7 @@ class Program_weight_tensor_parameter_217:
 
 class Program_weight_tensor_parameter_218:
     name = "parameter_218"
+    original_name = "conv2d_26.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-3.84246")
@@ -2409,6 +2628,7 @@ class Program_weight_tensor_parameter_218:
 
 class Program_weight_tensor_parameter_219:
     name = "parameter_219"
+    original_name = "conv2d_26.w_0"
     shape = [512, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.642186")
@@ -2420,6 +2640,7 @@ class Program_weight_tensor_parameter_219:
 
 class Program_weight_tensor_parameter_220:
     name = "parameter_220"
+    original_name = "conv2d_25.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-3.49728")
@@ -2431,6 +2652,7 @@ class Program_weight_tensor_parameter_220:
 
 class Program_weight_tensor_parameter_221:
     name = "parameter_221"
+    original_name = "conv2d_25.w_0"
     shape = [512, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.831621")
@@ -2442,6 +2664,7 @@ class Program_weight_tensor_parameter_221:
 
 class Program_weight_tensor_parameter_222:
     name = "parameter_222"
+    original_name = "batch_norm2d_12.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.563247")
@@ -2453,6 +2676,7 @@ class Program_weight_tensor_parameter_222:
 
 class Program_weight_tensor_parameter_223:
     name = "parameter_223"
+    original_name = "batch_norm2d_12.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.762424")
@@ -2464,6 +2688,7 @@ class Program_weight_tensor_parameter_223:
 
 class Program_weight_tensor_parameter_224:
     name = "parameter_224"
+    original_name = "batch_norm2d_12.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("1.9506e-05")
@@ -2475,6 +2700,7 @@ class Program_weight_tensor_parameter_224:
 
 class Program_weight_tensor_parameter_225:
     name = "parameter_225"
+    original_name = "batch_norm2d_12.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.45353")
@@ -2486,6 +2712,7 @@ class Program_weight_tensor_parameter_225:
 
 class Program_weight_tensor_parameter_226:
     name = "parameter_226"
+    original_name = "conv2d_24.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.25757")
@@ -2497,6 +2724,7 @@ class Program_weight_tensor_parameter_226:
 
 class Program_weight_tensor_parameter_227:
     name = "parameter_227"
+    original_name = "conv2d_24.w_0"
     shape = [128, 1, 7, 7]
     dtype = "float32"
     min_val = float("-1.48411")
@@ -2508,6 +2736,7 @@ class Program_weight_tensor_parameter_227:
 
 class Program_weight_tensor_parameter_228:
     name = "parameter_228"
+    original_name = "batch_norm2d_11.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.90235")
@@ -2519,6 +2748,7 @@ class Program_weight_tensor_parameter_228:
 
 class Program_weight_tensor_parameter_229:
     name = "parameter_229"
+    original_name = "batch_norm2d_11.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.00511136")
@@ -2530,6 +2760,7 @@ class Program_weight_tensor_parameter_229:
 
 class Program_weight_tensor_parameter_230:
     name = "parameter_230"
+    original_name = "batch_norm2d_11.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("14.4718")
@@ -2541,6 +2772,7 @@ class Program_weight_tensor_parameter_230:
 
 class Program_weight_tensor_parameter_231:
     name = "parameter_231"
+    original_name = "batch_norm2d_11.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-9.16758")
@@ -2552,6 +2784,7 @@ class Program_weight_tensor_parameter_231:
 
 class Program_weight_tensor_parameter_232:
     name = "parameter_232"
+    original_name = "conv2d_23.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.0478414")
@@ -2563,6 +2796,7 @@ class Program_weight_tensor_parameter_232:
 
 class Program_weight_tensor_parameter_233:
     name = "parameter_233"
+    original_name = "conv2d_23.w_0"
     shape = [128, 64, 3, 3]
     dtype = "float32"
     min_val = float("-1.43086")
@@ -2574,6 +2808,7 @@ class Program_weight_tensor_parameter_233:
 
 class Program_weight_tensor_parameter_234:
     name = "parameter_234"
+    original_name = "conv2d_22.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -2583,6 +2818,7 @@ class Program_weight_tensor_parameter_234:
 
 class Program_weight_tensor_parameter_235:
     name = "parameter_235"
+    original_name = "conv2d_22.w_0"
     shape = [64, 1, 7, 7]
     dtype = "float32"
     min_val = float("-0.448925")
@@ -2594,6 +2830,7 @@ class Program_weight_tensor_parameter_235:
 
 class Program_weight_tensor_parameter_236:
     name = "parameter_236"
+    original_name = "batch_norm2d_10.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -2603,6 +2840,7 @@ class Program_weight_tensor_parameter_236:
 
 class Program_weight_tensor_parameter_237:
     name = "parameter_237"
+    original_name = "batch_norm2d_10.w_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -2612,6 +2850,7 @@ class Program_weight_tensor_parameter_237:
 
 class Program_weight_tensor_parameter_238:
     name = "parameter_238"
+    original_name = "batch_norm2d_10.w_2"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -2621,6 +2860,7 @@ class Program_weight_tensor_parameter_238:
 
 class Program_weight_tensor_parameter_239:
     name = "parameter_239"
+    original_name = "batch_norm2d_10.w_1"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -2630,6 +2870,7 @@ class Program_weight_tensor_parameter_239:
 
 class Program_weight_tensor_parameter_240:
     name = "parameter_240"
+    original_name = "conv2d_21.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -2639,6 +2880,7 @@ class Program_weight_tensor_parameter_240:
 
 class Program_weight_tensor_parameter_241:
     name = "parameter_241"
+    original_name = "conv2d_21.w_0"
     shape = [64, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.634365")
@@ -2650,6 +2892,7 @@ class Program_weight_tensor_parameter_241:
 
 class Program_weight_tensor_parameter_242:
     name = "parameter_242"
+    original_name = "conv2d_20.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-3.42503")
@@ -2661,6 +2904,7 @@ class Program_weight_tensor_parameter_242:
 
 class Program_weight_tensor_parameter_243:
     name = "parameter_243"
+    original_name = "conv2d_20.w_0"
     shape = [256, 64, 1, 1]
     dtype = "float32"
     min_val = float("-0.613943")
@@ -2672,6 +2916,7 @@ class Program_weight_tensor_parameter_243:
 
 class Program_weight_tensor_parameter_244:
     name = "parameter_244"
+    original_name = "conv2d_19.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-2.82363")
@@ -2683,6 +2928,7 @@ class Program_weight_tensor_parameter_244:
 
 class Program_weight_tensor_parameter_245:
     name = "parameter_245"
+    original_name = "conv2d_19.w_0"
     shape = [256, 64, 1, 1]
     dtype = "float32"
     min_val = float("-0.488491")
@@ -2694,6 +2940,7 @@ class Program_weight_tensor_parameter_245:
 
 class Program_weight_tensor_parameter_246:
     name = "parameter_246"
+    original_name = "batch_norm2d_9.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -2703,6 +2950,7 @@ class Program_weight_tensor_parameter_246:
 
 class Program_weight_tensor_parameter_247:
     name = "parameter_247"
+    original_name = "batch_norm2d_9.w_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -2712,6 +2960,7 @@ class Program_weight_tensor_parameter_247:
 
 class Program_weight_tensor_parameter_248:
     name = "parameter_248"
+    original_name = "batch_norm2d_9.w_2"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -2721,6 +2970,7 @@ class Program_weight_tensor_parameter_248:
 
 class Program_weight_tensor_parameter_249:
     name = "parameter_249"
+    original_name = "batch_norm2d_9.w_1"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -2730,6 +2980,7 @@ class Program_weight_tensor_parameter_249:
 
 class Program_weight_tensor_parameter_250:
     name = "parameter_250"
+    original_name = "conv2d_18.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -2739,6 +2990,7 @@ class Program_weight_tensor_parameter_250:
 
 class Program_weight_tensor_parameter_251:
     name = "parameter_251"
+    original_name = "conv2d_18.w_0"
     shape = [64, 1, 7, 7]
     dtype = "float32"
     min_val = float("-1.27112")
@@ -2750,6 +3002,7 @@ class Program_weight_tensor_parameter_251:
 
 class Program_weight_tensor_parameter_252:
     name = "parameter_252"
+    original_name = "conv2d_17.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -2759,6 +3012,7 @@ class Program_weight_tensor_parameter_252:
 
 class Program_weight_tensor_parameter_253:
     name = "parameter_253"
+    original_name = "conv2d_17.w_0"
     shape = [64, 1, 7, 7]
     dtype = "float32"
     min_val = float("-0.54643")
@@ -2770,6 +3024,7 @@ class Program_weight_tensor_parameter_253:
 
 class Program_weight_tensor_parameter_254:
     name = "parameter_254"
+    original_name = "batch_norm2d_8.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -2779,6 +3034,7 @@ class Program_weight_tensor_parameter_254:
 
 class Program_weight_tensor_parameter_255:
     name = "parameter_255"
+    original_name = "batch_norm2d_8.w_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -2788,6 +3044,7 @@ class Program_weight_tensor_parameter_255:
 
 class Program_weight_tensor_parameter_256:
     name = "parameter_256"
+    original_name = "batch_norm2d_8.w_2"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -2797,6 +3054,7 @@ class Program_weight_tensor_parameter_256:
 
 class Program_weight_tensor_parameter_257:
     name = "parameter_257"
+    original_name = "batch_norm2d_8.w_1"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -2806,6 +3064,7 @@ class Program_weight_tensor_parameter_257:
 
 class Program_weight_tensor_parameter_258:
     name = "parameter_258"
+    original_name = "conv2d_16.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -2815,6 +3074,7 @@ class Program_weight_tensor_parameter_258:
 
 class Program_weight_tensor_parameter_259:
     name = "parameter_259"
+    original_name = "conv2d_16.w_0"
     shape = [64, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.616802")
@@ -2826,6 +3086,7 @@ class Program_weight_tensor_parameter_259:
 
 class Program_weight_tensor_parameter_260:
     name = "parameter_260"
+    original_name = "conv2d_15.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-4.08191")
@@ -2837,6 +3098,7 @@ class Program_weight_tensor_parameter_260:
 
 class Program_weight_tensor_parameter_261:
     name = "parameter_261"
+    original_name = "conv2d_15.w_0"
     shape = [256, 64, 1, 1]
     dtype = "float32"
     min_val = float("-0.672566")
@@ -2848,6 +3110,7 @@ class Program_weight_tensor_parameter_261:
 
 class Program_weight_tensor_parameter_262:
     name = "parameter_262"
+    original_name = "conv2d_14.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-4.93584")
@@ -2859,6 +3122,7 @@ class Program_weight_tensor_parameter_262:
 
 class Program_weight_tensor_parameter_263:
     name = "parameter_263"
+    original_name = "conv2d_14.w_0"
     shape = [256, 64, 1, 1]
     dtype = "float32"
     min_val = float("-0.737905")
@@ -2870,6 +3134,7 @@ class Program_weight_tensor_parameter_263:
 
 class Program_weight_tensor_parameter_264:
     name = "parameter_264"
+    original_name = "batch_norm2d_7.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -2879,6 +3144,7 @@ class Program_weight_tensor_parameter_264:
 
 class Program_weight_tensor_parameter_265:
     name = "parameter_265"
+    original_name = "batch_norm2d_7.w_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -2888,6 +3154,7 @@ class Program_weight_tensor_parameter_265:
 
 class Program_weight_tensor_parameter_266:
     name = "parameter_266"
+    original_name = "batch_norm2d_7.w_2"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -2897,6 +3164,7 @@ class Program_weight_tensor_parameter_266:
 
 class Program_weight_tensor_parameter_267:
     name = "parameter_267"
+    original_name = "batch_norm2d_7.w_1"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -2906,6 +3174,7 @@ class Program_weight_tensor_parameter_267:
 
 class Program_weight_tensor_parameter_268:
     name = "parameter_268"
+    original_name = "conv2d_13.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -2915,6 +3184,7 @@ class Program_weight_tensor_parameter_268:
 
 class Program_weight_tensor_parameter_269:
     name = "parameter_269"
+    original_name = "conv2d_13.w_0"
     shape = [64, 1, 7, 7]
     dtype = "float32"
     min_val = float("-1.32945")
@@ -2926,6 +3196,7 @@ class Program_weight_tensor_parameter_269:
 
 class Program_weight_tensor_parameter_270:
     name = "parameter_270"
+    original_name = "batch_norm2d_6.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -2935,6 +3206,7 @@ class Program_weight_tensor_parameter_270:
 
 class Program_weight_tensor_parameter_271:
     name = "parameter_271"
+    original_name = "batch_norm2d_6.w_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -2944,6 +3216,7 @@ class Program_weight_tensor_parameter_271:
 
 class Program_weight_tensor_parameter_272:
     name = "parameter_272"
+    original_name = "batch_norm2d_6.w_2"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -2953,6 +3226,7 @@ class Program_weight_tensor_parameter_272:
 
 class Program_weight_tensor_parameter_273:
     name = "parameter_273"
+    original_name = "batch_norm2d_6.w_1"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -2962,6 +3236,7 @@ class Program_weight_tensor_parameter_273:
 
 class Program_weight_tensor_parameter_274:
     name = "parameter_274"
+    original_name = "conv2d_12.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -2971,6 +3246,7 @@ class Program_weight_tensor_parameter_274:
 
 class Program_weight_tensor_parameter_275:
     name = "parameter_275"
+    original_name = "conv2d_12.w_0"
     shape = [64, 32, 3, 3]
     dtype = "float32"
     min_val = float("-1.18057")
@@ -2982,6 +3258,7 @@ class Program_weight_tensor_parameter_275:
 
 class Program_weight_tensor_parameter_276:
     name = "parameter_276"
+    original_name = "conv2d_11.b_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -2991,6 +3268,7 @@ class Program_weight_tensor_parameter_276:
 
 class Program_weight_tensor_parameter_277:
     name = "parameter_277"
+    original_name = "conv2d_11.w_0"
     shape = [32, 1, 7, 7]
     dtype = "float32"
     min_val = float("-0.354859")
@@ -3002,6 +3280,7 @@ class Program_weight_tensor_parameter_277:
 
 class Program_weight_tensor_parameter_278:
     name = "parameter_278"
+    original_name = "batch_norm2d_5.b_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -3011,6 +3290,7 @@ class Program_weight_tensor_parameter_278:
 
 class Program_weight_tensor_parameter_279:
     name = "parameter_279"
+    original_name = "batch_norm2d_5.w_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -3020,6 +3300,7 @@ class Program_weight_tensor_parameter_279:
 
 class Program_weight_tensor_parameter_280:
     name = "parameter_280"
+    original_name = "batch_norm2d_5.w_2"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -3029,6 +3310,7 @@ class Program_weight_tensor_parameter_280:
 
 class Program_weight_tensor_parameter_281:
     name = "parameter_281"
+    original_name = "batch_norm2d_5.w_1"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -3038,6 +3320,7 @@ class Program_weight_tensor_parameter_281:
 
 class Program_weight_tensor_parameter_282:
     name = "parameter_282"
+    original_name = "conv2d_10.b_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -3047,6 +3330,7 @@ class Program_weight_tensor_parameter_282:
 
 class Program_weight_tensor_parameter_283:
     name = "parameter_283"
+    original_name = "conv2d_10.w_0"
     shape = [32, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.655816")
@@ -3058,6 +3342,7 @@ class Program_weight_tensor_parameter_283:
 
 class Program_weight_tensor_parameter_284:
     name = "parameter_284"
+    original_name = "conv2d_9.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-2.74111")
@@ -3069,6 +3354,7 @@ class Program_weight_tensor_parameter_284:
 
 class Program_weight_tensor_parameter_285:
     name = "parameter_285"
+    original_name = "conv2d_9.w_0"
     shape = [128, 32, 1, 1]
     dtype = "float32"
     min_val = float("-0.415445")
@@ -3080,6 +3366,7 @@ class Program_weight_tensor_parameter_285:
 
 class Program_weight_tensor_parameter_286:
     name = "parameter_286"
+    original_name = "conv2d_8.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.872147")
@@ -3091,6 +3378,7 @@ class Program_weight_tensor_parameter_286:
 
 class Program_weight_tensor_parameter_287:
     name = "parameter_287"
+    original_name = "conv2d_8.w_0"
     shape = [128, 32, 1, 1]
     dtype = "float32"
     min_val = float("-0.468106")
@@ -3102,6 +3390,7 @@ class Program_weight_tensor_parameter_287:
 
 class Program_weight_tensor_parameter_288:
     name = "parameter_288"
+    original_name = "batch_norm2d_4.b_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -3111,6 +3400,7 @@ class Program_weight_tensor_parameter_288:
 
 class Program_weight_tensor_parameter_289:
     name = "parameter_289"
+    original_name = "batch_norm2d_4.w_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -3120,6 +3410,7 @@ class Program_weight_tensor_parameter_289:
 
 class Program_weight_tensor_parameter_290:
     name = "parameter_290"
+    original_name = "batch_norm2d_4.w_2"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -3129,6 +3420,7 @@ class Program_weight_tensor_parameter_290:
 
 class Program_weight_tensor_parameter_291:
     name = "parameter_291"
+    original_name = "batch_norm2d_4.w_1"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -3138,6 +3430,7 @@ class Program_weight_tensor_parameter_291:
 
 class Program_weight_tensor_parameter_292:
     name = "parameter_292"
+    original_name = "conv2d_7.b_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -3147,6 +3440,7 @@ class Program_weight_tensor_parameter_292:
 
 class Program_weight_tensor_parameter_293:
     name = "parameter_293"
+    original_name = "conv2d_7.w_0"
     shape = [32, 1, 7, 7]
     dtype = "float32"
     min_val = float("-0.606701")
@@ -3158,6 +3452,7 @@ class Program_weight_tensor_parameter_293:
 
 class Program_weight_tensor_parameter_294:
     name = "parameter_294"
+    original_name = "conv2d_6.b_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -3167,6 +3462,7 @@ class Program_weight_tensor_parameter_294:
 
 class Program_weight_tensor_parameter_295:
     name = "parameter_295"
+    original_name = "conv2d_6.w_0"
     shape = [32, 1, 7, 7]
     dtype = "float32"
     min_val = float("-0.464884")
@@ -3178,6 +3474,7 @@ class Program_weight_tensor_parameter_295:
 
 class Program_weight_tensor_parameter_296:
     name = "parameter_296"
+    original_name = "batch_norm2d_3.b_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -3187,6 +3484,7 @@ class Program_weight_tensor_parameter_296:
 
 class Program_weight_tensor_parameter_297:
     name = "parameter_297"
+    original_name = "batch_norm2d_3.w_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -3196,6 +3494,7 @@ class Program_weight_tensor_parameter_297:
 
 class Program_weight_tensor_parameter_298:
     name = "parameter_298"
+    original_name = "batch_norm2d_3.w_2"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -3205,6 +3504,7 @@ class Program_weight_tensor_parameter_298:
 
 class Program_weight_tensor_parameter_299:
     name = "parameter_299"
+    original_name = "batch_norm2d_3.w_1"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -3214,6 +3514,7 @@ class Program_weight_tensor_parameter_299:
 
 class Program_weight_tensor_parameter_300:
     name = "parameter_300"
+    original_name = "conv2d_5.b_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -3223,6 +3524,7 @@ class Program_weight_tensor_parameter_300:
 
 class Program_weight_tensor_parameter_301:
     name = "parameter_301"
+    original_name = "conv2d_5.w_0"
     shape = [32, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.7162")
@@ -3234,6 +3536,7 @@ class Program_weight_tensor_parameter_301:
 
 class Program_weight_tensor_parameter_302:
     name = "parameter_302"
+    original_name = "conv2d_4.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-2.86647")
@@ -3245,6 +3548,7 @@ class Program_weight_tensor_parameter_302:
 
 class Program_weight_tensor_parameter_303:
     name = "parameter_303"
+    original_name = "conv2d_4.w_0"
     shape = [128, 32, 1, 1]
     dtype = "float32"
     min_val = float("-0.498038")
@@ -3256,6 +3560,7 @@ class Program_weight_tensor_parameter_303:
 
 class Program_weight_tensor_parameter_304:
     name = "parameter_304"
+    original_name = "conv2d_3.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.253909")
@@ -3267,6 +3572,7 @@ class Program_weight_tensor_parameter_304:
 
 class Program_weight_tensor_parameter_305:
     name = "parameter_305"
+    original_name = "conv2d_3.w_0"
     shape = [128, 32, 1, 1]
     dtype = "float32"
     min_val = float("-0.60379")
@@ -3278,6 +3584,7 @@ class Program_weight_tensor_parameter_305:
 
 class Program_weight_tensor_parameter_306:
     name = "parameter_306"
+    original_name = "batch_norm2d_2.b_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -3287,6 +3594,7 @@ class Program_weight_tensor_parameter_306:
 
 class Program_weight_tensor_parameter_307:
     name = "parameter_307"
+    original_name = "batch_norm2d_2.w_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -3296,6 +3604,7 @@ class Program_weight_tensor_parameter_307:
 
 class Program_weight_tensor_parameter_308:
     name = "parameter_308"
+    original_name = "batch_norm2d_2.w_2"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -3305,6 +3614,7 @@ class Program_weight_tensor_parameter_308:
 
 class Program_weight_tensor_parameter_309:
     name = "parameter_309"
+    original_name = "batch_norm2d_2.w_1"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -3314,6 +3624,7 @@ class Program_weight_tensor_parameter_309:
 
 class Program_weight_tensor_parameter_310:
     name = "parameter_310"
+    original_name = "conv2d_2.b_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -3323,6 +3634,7 @@ class Program_weight_tensor_parameter_310:
 
 class Program_weight_tensor_parameter_311:
     name = "parameter_311"
+    original_name = "conv2d_2.w_0"
     shape = [32, 1, 7, 7]
     dtype = "float32"
     min_val = float("-2.18855")
@@ -3334,6 +3646,7 @@ class Program_weight_tensor_parameter_311:
 
 class Program_weight_tensor_parameter_312:
     name = "parameter_312"
+    original_name = "batch_norm2d_1.b_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -3343,6 +3656,7 @@ class Program_weight_tensor_parameter_312:
 
 class Program_weight_tensor_parameter_313:
     name = "parameter_313"
+    original_name = "batch_norm2d_1.w_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -3352,6 +3666,7 @@ class Program_weight_tensor_parameter_313:
 
 class Program_weight_tensor_parameter_314:
     name = "parameter_314"
+    original_name = "batch_norm2d_1.w_2"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -3361,6 +3676,7 @@ class Program_weight_tensor_parameter_314:
 
 class Program_weight_tensor_parameter_315:
     name = "parameter_315"
+    original_name = "batch_norm2d_1.w_1"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -3370,6 +3686,7 @@ class Program_weight_tensor_parameter_315:
 
 class Program_weight_tensor_parameter_316:
     name = "parameter_316"
+    original_name = "conv2d_1.b_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -3379,6 +3696,7 @@ class Program_weight_tensor_parameter_316:
 
 class Program_weight_tensor_parameter_317:
     name = "parameter_317"
+    original_name = "conv2d_1.w_0"
     shape = [32, 32, 3, 3]
     dtype = "float32"
     min_val = float("-0.905919")
@@ -3390,6 +3708,7 @@ class Program_weight_tensor_parameter_317:
 
 class Program_weight_tensor_parameter_318:
     name = "parameter_318"
+    original_name = "batch_norm2d_0.b_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -3399,6 +3718,7 @@ class Program_weight_tensor_parameter_318:
 
 class Program_weight_tensor_parameter_319:
     name = "parameter_319"
+    original_name = "batch_norm2d_0.w_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -3408,6 +3728,7 @@ class Program_weight_tensor_parameter_319:
 
 class Program_weight_tensor_parameter_320:
     name = "parameter_320"
+    original_name = "batch_norm2d_0.w_2"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -3417,6 +3738,7 @@ class Program_weight_tensor_parameter_320:
 
 class Program_weight_tensor_parameter_321:
     name = "parameter_321"
+    original_name = "batch_norm2d_0.w_1"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -3426,6 +3748,7 @@ class Program_weight_tensor_parameter_321:
 
 class Program_weight_tensor_parameter_322:
     name = "parameter_322"
+    original_name = "conv2d_0.b_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -3435,6 +3758,7 @@ class Program_weight_tensor_parameter_322:
 
 class Program_weight_tensor_parameter_323:
     name = "parameter_323"
+    original_name = "conv2d_0.w_0"
     shape = [32, 3, 3, 3]
     dtype = "float32"
     min_val = float("-0.224888")

--- a/paddle_samples/PaddleX/StarNet-S4/subgraph_2/input_meta.py
+++ b/paddle_samples/PaddleX/StarNet-S4/subgraph_2/input_meta.py
@@ -1,5 +1,6 @@
 class Program_weight_tensor_data_0:
     name = "data_0"
+    original_name = "var_401"
     shape = [124, 3, 224, 224]
     dtype = "float32"
     min_val = float("-5.18906")

--- a/paddle_samples/PaddleX/StarNet-S4/subgraph_2/weight_meta.py
+++ b/paddle_samples/PaddleX/StarNet-S4/subgraph_2/weight_meta.py
@@ -1,5 +1,6 @@
 class Program_weight_tensor_parameter_0:
     name = "parameter_0"
+    original_name = "linear_0.b_0"
     shape = [102]
     dtype = "float32"
     min_val = float("-0.00224202")
@@ -11,6 +12,7 @@ class Program_weight_tensor_parameter_0:
 
 class Program_weight_tensor_parameter_1:
     name = "parameter_1"
+    original_name = "linear_0.w_0"
     shape = [256, 102]
     dtype = "float32"
     min_val = float("-0.132778")
@@ -22,6 +24,7 @@ class Program_weight_tensor_parameter_1:
 
 class Program_weight_tensor_parameter_2:
     name = "parameter_2"
+    original_name = "batch_norm2d_51.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.0935415")
@@ -33,6 +36,7 @@ class Program_weight_tensor_parameter_2:
 
 class Program_weight_tensor_parameter_3:
     name = "parameter_3"
+    original_name = "batch_norm2d_51.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.862541")
@@ -44,6 +48,7 @@ class Program_weight_tensor_parameter_3:
 
 class Program_weight_tensor_parameter_4:
     name = "parameter_4"
+    original_name = "batch_norm2d_51.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("3.77081")
@@ -55,6 +60,7 @@ class Program_weight_tensor_parameter_4:
 
 class Program_weight_tensor_parameter_5:
     name = "parameter_5"
+    original_name = "batch_norm2d_51.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-5.68923")
@@ -66,6 +72,7 @@ class Program_weight_tensor_parameter_5:
 
 class Program_weight_tensor_parameter_6:
     name = "parameter_6"
+    original_name = "conv2d_119.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.84662")
@@ -77,6 +84,7 @@ class Program_weight_tensor_parameter_6:
 
 class Program_weight_tensor_parameter_7:
     name = "parameter_7"
+    original_name = "conv2d_119.w_0"
     shape = [256, 1, 7, 7]
     dtype = "float32"
     min_val = float("-0.451804")
@@ -88,6 +96,7 @@ class Program_weight_tensor_parameter_7:
 
 class Program_weight_tensor_parameter_8:
     name = "parameter_8"
+    original_name = "batch_norm2d_50.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.788301")
@@ -99,6 +108,7 @@ class Program_weight_tensor_parameter_8:
 
 class Program_weight_tensor_parameter_9:
     name = "parameter_9"
+    original_name = "batch_norm2d_50.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.940692")
@@ -110,6 +120,7 @@ class Program_weight_tensor_parameter_9:
 
 class Program_weight_tensor_parameter_10:
     name = "parameter_10"
+    original_name = "batch_norm2d_50.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("8.76602")
@@ -121,6 +132,7 @@ class Program_weight_tensor_parameter_10:
 
 class Program_weight_tensor_parameter_11:
     name = "parameter_11"
+    original_name = "batch_norm2d_50.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.585623")
@@ -132,6 +144,7 @@ class Program_weight_tensor_parameter_11:
 
 class Program_weight_tensor_parameter_12:
     name = "parameter_12"
+    original_name = "conv2d_118.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.0312176")
@@ -143,6 +156,7 @@ class Program_weight_tensor_parameter_12:
 
 class Program_weight_tensor_parameter_13:
     name = "parameter_13"
+    original_name = "conv2d_118.w_0"
     shape = [256, 1024, 1, 1]
     dtype = "float32"
     min_val = float("-0.345988")
@@ -154,6 +168,7 @@ class Program_weight_tensor_parameter_13:
 
 class Program_weight_tensor_parameter_14:
     name = "parameter_14"
+    original_name = "conv2d_117.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-3.01852")
@@ -165,6 +180,7 @@ class Program_weight_tensor_parameter_14:
 
 class Program_weight_tensor_parameter_15:
     name = "parameter_15"
+    original_name = "conv2d_117.w_0"
     shape = [1024, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.859317")
@@ -176,6 +192,7 @@ class Program_weight_tensor_parameter_15:
 
 class Program_weight_tensor_parameter_16:
     name = "parameter_16"
+    original_name = "conv2d_116.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-3.9927")
@@ -187,6 +204,7 @@ class Program_weight_tensor_parameter_16:
 
 class Program_weight_tensor_parameter_17:
     name = "parameter_17"
+    original_name = "conv2d_116.w_0"
     shape = [1024, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.414521")
@@ -198,6 +216,7 @@ class Program_weight_tensor_parameter_17:
 
 class Program_weight_tensor_parameter_18:
     name = "parameter_18"
+    original_name = "batch_norm2d_49.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.590918")
@@ -209,6 +228,7 @@ class Program_weight_tensor_parameter_18:
 
 class Program_weight_tensor_parameter_19:
     name = "parameter_19"
+    original_name = "batch_norm2d_49.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.825816")
@@ -220,6 +240,7 @@ class Program_weight_tensor_parameter_19:
 
 class Program_weight_tensor_parameter_20:
     name = "parameter_20"
+    original_name = "batch_norm2d_49.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.20266")
@@ -231,6 +252,7 @@ class Program_weight_tensor_parameter_20:
 
 class Program_weight_tensor_parameter_21:
     name = "parameter_21"
+    original_name = "batch_norm2d_49.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-5.83376")
@@ -242,6 +264,7 @@ class Program_weight_tensor_parameter_21:
 
 class Program_weight_tensor_parameter_22:
     name = "parameter_22"
+    original_name = "conv2d_115.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.150682")
@@ -253,6 +276,7 @@ class Program_weight_tensor_parameter_22:
 
 class Program_weight_tensor_parameter_23:
     name = "parameter_23"
+    original_name = "conv2d_115.w_0"
     shape = [256, 1, 7, 7]
     dtype = "float32"
     min_val = float("-1.31005")
@@ -264,6 +288,7 @@ class Program_weight_tensor_parameter_23:
 
 class Program_weight_tensor_parameter_24:
     name = "parameter_24"
+    original_name = "conv2d_114.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.995149")
@@ -275,6 +300,7 @@ class Program_weight_tensor_parameter_24:
 
 class Program_weight_tensor_parameter_25:
     name = "parameter_25"
+    original_name = "conv2d_114.w_0"
     shape = [256, 1, 7, 7]
     dtype = "float32"
     min_val = float("-0.474546")
@@ -286,6 +312,7 @@ class Program_weight_tensor_parameter_25:
 
 class Program_weight_tensor_parameter_26:
     name = "parameter_26"
+    original_name = "batch_norm2d_48.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.79199")
@@ -297,6 +324,7 @@ class Program_weight_tensor_parameter_26:
 
 class Program_weight_tensor_parameter_27:
     name = "parameter_27"
+    original_name = "batch_norm2d_48.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.739017")
@@ -308,6 +336,7 @@ class Program_weight_tensor_parameter_27:
 
 class Program_weight_tensor_parameter_28:
     name = "parameter_28"
+    original_name = "batch_norm2d_48.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("2.49668")
@@ -319,6 +348,7 @@ class Program_weight_tensor_parameter_28:
 
 class Program_weight_tensor_parameter_29:
     name = "parameter_29"
+    original_name = "batch_norm2d_48.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-2.47973")
@@ -330,6 +360,7 @@ class Program_weight_tensor_parameter_29:
 
 class Program_weight_tensor_parameter_30:
     name = "parameter_30"
+    original_name = "conv2d_113.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.0314374")
@@ -341,6 +372,7 @@ class Program_weight_tensor_parameter_30:
 
 class Program_weight_tensor_parameter_31:
     name = "parameter_31"
+    original_name = "conv2d_113.w_0"
     shape = [256, 1024, 1, 1]
     dtype = "float32"
     min_val = float("-0.404197")
@@ -352,6 +384,7 @@ class Program_weight_tensor_parameter_31:
 
 class Program_weight_tensor_parameter_32:
     name = "parameter_32"
+    original_name = "conv2d_112.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-4.52733")
@@ -363,6 +396,7 @@ class Program_weight_tensor_parameter_32:
 
 class Program_weight_tensor_parameter_33:
     name = "parameter_33"
+    original_name = "conv2d_112.w_0"
     shape = [1024, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.545753")
@@ -374,6 +408,7 @@ class Program_weight_tensor_parameter_33:
 
 class Program_weight_tensor_parameter_34:
     name = "parameter_34"
+    original_name = "conv2d_111.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-4.02668")
@@ -385,6 +420,7 @@ class Program_weight_tensor_parameter_34:
 
 class Program_weight_tensor_parameter_35:
     name = "parameter_35"
+    original_name = "conv2d_111.w_0"
     shape = [1024, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.663076")
@@ -396,6 +432,7 @@ class Program_weight_tensor_parameter_35:
 
 class Program_weight_tensor_parameter_36:
     name = "parameter_36"
+    original_name = "batch_norm2d_47.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.73481")
@@ -407,6 +444,7 @@ class Program_weight_tensor_parameter_36:
 
 class Program_weight_tensor_parameter_37:
     name = "parameter_37"
+    original_name = "batch_norm2d_47.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.0360077")
@@ -418,6 +456,7 @@ class Program_weight_tensor_parameter_37:
 
 class Program_weight_tensor_parameter_38:
     name = "parameter_38"
+    original_name = "batch_norm2d_47.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.209583")
@@ -429,6 +468,7 @@ class Program_weight_tensor_parameter_38:
 
 class Program_weight_tensor_parameter_39:
     name = "parameter_39"
+    original_name = "batch_norm2d_47.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-2.16308")
@@ -440,6 +480,7 @@ class Program_weight_tensor_parameter_39:
 
 class Program_weight_tensor_parameter_40:
     name = "parameter_40"
+    original_name = "conv2d_110.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.142789")
@@ -451,6 +492,7 @@ class Program_weight_tensor_parameter_40:
 
 class Program_weight_tensor_parameter_41:
     name = "parameter_41"
+    original_name = "conv2d_110.w_0"
     shape = [256, 1, 7, 7]
     dtype = "float32"
     min_val = float("-1.12913")
@@ -462,6 +504,7 @@ class Program_weight_tensor_parameter_41:
 
 class Program_weight_tensor_parameter_42:
     name = "parameter_42"
+    original_name = "conv2d_109.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-2.83035")
@@ -473,6 +516,7 @@ class Program_weight_tensor_parameter_42:
 
 class Program_weight_tensor_parameter_43:
     name = "parameter_43"
+    original_name = "conv2d_109.w_0"
     shape = [256, 1, 7, 7]
     dtype = "float32"
     min_val = float("-0.444536")
@@ -484,6 +528,7 @@ class Program_weight_tensor_parameter_43:
 
 class Program_weight_tensor_parameter_44:
     name = "parameter_44"
+    original_name = "batch_norm2d_46.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.32623")
@@ -495,6 +540,7 @@ class Program_weight_tensor_parameter_44:
 
 class Program_weight_tensor_parameter_45:
     name = "parameter_45"
+    original_name = "batch_norm2d_46.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.573188")
@@ -506,6 +552,7 @@ class Program_weight_tensor_parameter_45:
 
 class Program_weight_tensor_parameter_46:
     name = "parameter_46"
+    original_name = "batch_norm2d_46.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.122334")
@@ -517,6 +564,7 @@ class Program_weight_tensor_parameter_46:
 
 class Program_weight_tensor_parameter_47:
     name = "parameter_47"
+    original_name = "batch_norm2d_46.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.204797")
@@ -528,6 +576,7 @@ class Program_weight_tensor_parameter_47:
 
 class Program_weight_tensor_parameter_48:
     name = "parameter_48"
+    original_name = "conv2d_108.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.0402677")
@@ -539,6 +588,7 @@ class Program_weight_tensor_parameter_48:
 
 class Program_weight_tensor_parameter_49:
     name = "parameter_49"
+    original_name = "conv2d_108.w_0"
     shape = [256, 1024, 1, 1]
     dtype = "float32"
     min_val = float("-0.317078")
@@ -550,6 +600,7 @@ class Program_weight_tensor_parameter_49:
 
 class Program_weight_tensor_parameter_50:
     name = "parameter_50"
+    original_name = "conv2d_107.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-1.94129")
@@ -561,6 +612,7 @@ class Program_weight_tensor_parameter_50:
 
 class Program_weight_tensor_parameter_51:
     name = "parameter_51"
+    original_name = "conv2d_107.w_0"
     shape = [1024, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.421505")
@@ -572,6 +624,7 @@ class Program_weight_tensor_parameter_51:
 
 class Program_weight_tensor_parameter_52:
     name = "parameter_52"
+    original_name = "conv2d_106.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-3.01847")
@@ -583,6 +636,7 @@ class Program_weight_tensor_parameter_52:
 
 class Program_weight_tensor_parameter_53:
     name = "parameter_53"
+    original_name = "conv2d_106.w_0"
     shape = [1024, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.340588")
@@ -594,6 +648,7 @@ class Program_weight_tensor_parameter_53:
 
 class Program_weight_tensor_parameter_54:
     name = "parameter_54"
+    original_name = "batch_norm2d_45.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.686937")
@@ -605,6 +660,7 @@ class Program_weight_tensor_parameter_54:
 
 class Program_weight_tensor_parameter_55:
     name = "parameter_55"
+    original_name = "batch_norm2d_45.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.277554")
@@ -616,6 +672,7 @@ class Program_weight_tensor_parameter_55:
 
 class Program_weight_tensor_parameter_56:
     name = "parameter_56"
+    original_name = "batch_norm2d_45.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.00638061")
@@ -627,6 +684,7 @@ class Program_weight_tensor_parameter_56:
 
 class Program_weight_tensor_parameter_57:
     name = "parameter_57"
+    original_name = "batch_norm2d_45.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-2.40107")
@@ -638,6 +696,7 @@ class Program_weight_tensor_parameter_57:
 
 class Program_weight_tensor_parameter_58:
     name = "parameter_58"
+    original_name = "conv2d_105.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.144772")
@@ -649,6 +708,7 @@ class Program_weight_tensor_parameter_58:
 
 class Program_weight_tensor_parameter_59:
     name = "parameter_59"
+    original_name = "conv2d_105.w_0"
     shape = [256, 1, 7, 7]
     dtype = "float32"
     min_val = float("-1.62806")
@@ -660,6 +720,7 @@ class Program_weight_tensor_parameter_59:
 
 class Program_weight_tensor_parameter_60:
     name = "parameter_60"
+    original_name = "conv2d_104.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.903194")
@@ -671,6 +732,7 @@ class Program_weight_tensor_parameter_60:
 
 class Program_weight_tensor_parameter_61:
     name = "parameter_61"
+    original_name = "conv2d_104.w_0"
     shape = [256, 1, 7, 7]
     dtype = "float32"
     min_val = float("-0.472713")
@@ -682,6 +744,7 @@ class Program_weight_tensor_parameter_61:
 
 class Program_weight_tensor_parameter_62:
     name = "parameter_62"
+    original_name = "batch_norm2d_44.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.552558")
@@ -693,6 +756,7 @@ class Program_weight_tensor_parameter_62:
 
 class Program_weight_tensor_parameter_63:
     name = "parameter_63"
+    original_name = "batch_norm2d_44.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.268836")
@@ -704,6 +768,7 @@ class Program_weight_tensor_parameter_63:
 
 class Program_weight_tensor_parameter_64:
     name = "parameter_64"
+    original_name = "batch_norm2d_44.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("1.99867")
@@ -715,6 +780,7 @@ class Program_weight_tensor_parameter_64:
 
 class Program_weight_tensor_parameter_65:
     name = "parameter_65"
+    original_name = "batch_norm2d_44.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.940692")
@@ -726,6 +792,7 @@ class Program_weight_tensor_parameter_65:
 
 class Program_weight_tensor_parameter_66:
     name = "parameter_66"
+    original_name = "conv2d_103.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.0351644")
@@ -737,6 +804,7 @@ class Program_weight_tensor_parameter_66:
 
 class Program_weight_tensor_parameter_67:
     name = "parameter_67"
+    original_name = "conv2d_103.w_0"
     shape = [256, 1024, 1, 1]
     dtype = "float32"
     min_val = float("-0.688841")
@@ -748,6 +816,7 @@ class Program_weight_tensor_parameter_67:
 
 class Program_weight_tensor_parameter_68:
     name = "parameter_68"
+    original_name = "conv2d_102.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-2.60141")
@@ -759,6 +828,7 @@ class Program_weight_tensor_parameter_68:
 
 class Program_weight_tensor_parameter_69:
     name = "parameter_69"
+    original_name = "conv2d_102.w_0"
     shape = [1024, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.779816")
@@ -770,6 +840,7 @@ class Program_weight_tensor_parameter_69:
 
 class Program_weight_tensor_parameter_70:
     name = "parameter_70"
+    original_name = "conv2d_101.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-3.42659")
@@ -781,6 +852,7 @@ class Program_weight_tensor_parameter_70:
 
 class Program_weight_tensor_parameter_71:
     name = "parameter_71"
+    original_name = "conv2d_101.w_0"
     shape = [1024, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.620109")
@@ -792,6 +864,7 @@ class Program_weight_tensor_parameter_71:
 
 class Program_weight_tensor_parameter_72:
     name = "parameter_72"
+    original_name = "batch_norm2d_43.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.30447")
@@ -803,6 +876,7 @@ class Program_weight_tensor_parameter_72:
 
 class Program_weight_tensor_parameter_73:
     name = "parameter_73"
+    original_name = "batch_norm2d_43.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.321669")
@@ -814,6 +888,7 @@ class Program_weight_tensor_parameter_73:
 
 class Program_weight_tensor_parameter_74:
     name = "parameter_74"
+    original_name = "batch_norm2d_43.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("0.00238325")
@@ -825,6 +900,7 @@ class Program_weight_tensor_parameter_74:
 
 class Program_weight_tensor_parameter_75:
     name = "parameter_75"
+    original_name = "batch_norm2d_43.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-2.12046")
@@ -836,6 +912,7 @@ class Program_weight_tensor_parameter_75:
 
 class Program_weight_tensor_parameter_76:
     name = "parameter_76"
+    original_name = "conv2d_100.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.154412")
@@ -847,6 +924,7 @@ class Program_weight_tensor_parameter_76:
 
 class Program_weight_tensor_parameter_77:
     name = "parameter_77"
+    original_name = "conv2d_100.w_0"
     shape = [256, 1, 7, 7]
     dtype = "float32"
     min_val = float("-1.38957")
@@ -858,6 +936,7 @@ class Program_weight_tensor_parameter_77:
 
 class Program_weight_tensor_parameter_78:
     name = "parameter_78"
+    original_name = "conv2d_99.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.988958")
@@ -869,6 +948,7 @@ class Program_weight_tensor_parameter_78:
 
 class Program_weight_tensor_parameter_79:
     name = "parameter_79"
+    original_name = "conv2d_99.w_0"
     shape = [256, 1, 7, 7]
     dtype = "float32"
     min_val = float("-0.493732")
@@ -880,6 +960,7 @@ class Program_weight_tensor_parameter_79:
 
 class Program_weight_tensor_parameter_80:
     name = "parameter_80"
+    original_name = "batch_norm2d_42.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.433841")
@@ -891,6 +972,7 @@ class Program_weight_tensor_parameter_80:
 
 class Program_weight_tensor_parameter_81:
     name = "parameter_81"
+    original_name = "batch_norm2d_42.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.10502")
@@ -902,6 +984,7 @@ class Program_weight_tensor_parameter_81:
 
 class Program_weight_tensor_parameter_82:
     name = "parameter_82"
+    original_name = "batch_norm2d_42.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("2.50348")
@@ -913,6 +996,7 @@ class Program_weight_tensor_parameter_82:
 
 class Program_weight_tensor_parameter_83:
     name = "parameter_83"
+    original_name = "batch_norm2d_42.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-1.67788")
@@ -924,6 +1008,7 @@ class Program_weight_tensor_parameter_83:
 
 class Program_weight_tensor_parameter_84:
     name = "parameter_84"
+    original_name = "conv2d_98.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.0314715")
@@ -935,6 +1020,7 @@ class Program_weight_tensor_parameter_84:
 
 class Program_weight_tensor_parameter_85:
     name = "parameter_85"
+    original_name = "conv2d_98.w_0"
     shape = [256, 1024, 1, 1]
     dtype = "float32"
     min_val = float("-1.01317")
@@ -946,6 +1032,7 @@ class Program_weight_tensor_parameter_85:
 
 class Program_weight_tensor_parameter_86:
     name = "parameter_86"
+    original_name = "conv2d_97.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-3.14175")
@@ -957,6 +1044,7 @@ class Program_weight_tensor_parameter_86:
 
 class Program_weight_tensor_parameter_87:
     name = "parameter_87"
+    original_name = "conv2d_97.w_0"
     shape = [1024, 256, 1, 1]
     dtype = "float32"
     min_val = float("-1.0105")
@@ -968,6 +1056,7 @@ class Program_weight_tensor_parameter_87:
 
 class Program_weight_tensor_parameter_88:
     name = "parameter_88"
+    original_name = "conv2d_96.b_0"
     shape = [1024]
     dtype = "float32"
     min_val = float("-3.72122")
@@ -979,6 +1068,7 @@ class Program_weight_tensor_parameter_88:
 
 class Program_weight_tensor_parameter_89:
     name = "parameter_89"
+    original_name = "conv2d_96.w_0"
     shape = [1024, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.819629")
@@ -990,6 +1080,7 @@ class Program_weight_tensor_parameter_89:
 
 class Program_weight_tensor_parameter_90:
     name = "parameter_90"
+    original_name = "batch_norm2d_41.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.413222")
@@ -1001,6 +1092,7 @@ class Program_weight_tensor_parameter_90:
 
 class Program_weight_tensor_parameter_91:
     name = "parameter_91"
+    original_name = "batch_norm2d_41.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.514091")
@@ -1012,6 +1104,7 @@ class Program_weight_tensor_parameter_91:
 
 class Program_weight_tensor_parameter_92:
     name = "parameter_92"
+    original_name = "batch_norm2d_41.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("6.67398e-05")
@@ -1023,6 +1116,7 @@ class Program_weight_tensor_parameter_92:
 
 class Program_weight_tensor_parameter_93:
     name = "parameter_93"
+    original_name = "batch_norm2d_41.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-2.20769")
@@ -1034,6 +1128,7 @@ class Program_weight_tensor_parameter_93:
 
 class Program_weight_tensor_parameter_94:
     name = "parameter_94"
+    original_name = "conv2d_95.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.161261")
@@ -1045,6 +1140,7 @@ class Program_weight_tensor_parameter_94:
 
 class Program_weight_tensor_parameter_95:
     name = "parameter_95"
+    original_name = "conv2d_95.w_0"
     shape = [256, 1, 7, 7]
     dtype = "float32"
     min_val = float("-1.18997")
@@ -1056,6 +1152,7 @@ class Program_weight_tensor_parameter_95:
 
 class Program_weight_tensor_parameter_96:
     name = "parameter_96"
+    original_name = "batch_norm2d_40.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-2.02571")
@@ -1067,6 +1164,7 @@ class Program_weight_tensor_parameter_96:
 
 class Program_weight_tensor_parameter_97:
     name = "parameter_97"
+    original_name = "batch_norm2d_40.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.0143092")
@@ -1078,6 +1176,7 @@ class Program_weight_tensor_parameter_97:
 
 class Program_weight_tensor_parameter_98:
     name = "parameter_98"
+    original_name = "batch_norm2d_40.w_2"
     shape = [256]
     dtype = "float32"
     min_val = float("192.295")
@@ -1089,6 +1188,7 @@ class Program_weight_tensor_parameter_98:
 
 class Program_weight_tensor_parameter_99:
     name = "parameter_99"
+    original_name = "batch_norm2d_40.w_1"
     shape = [256]
     dtype = "float32"
     min_val = float("-52.9636")
@@ -1100,6 +1200,7 @@ class Program_weight_tensor_parameter_99:
 
 class Program_weight_tensor_parameter_100:
     name = "parameter_100"
+    original_name = "conv2d_94.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.0307969")
@@ -1111,6 +1212,7 @@ class Program_weight_tensor_parameter_100:
 
 class Program_weight_tensor_parameter_101:
     name = "parameter_101"
+    original_name = "conv2d_94.w_0"
     shape = [256, 128, 3, 3]
     dtype = "float32"
     min_val = float("-1.44776")
@@ -1122,6 +1224,7 @@ class Program_weight_tensor_parameter_101:
 
 class Program_weight_tensor_parameter_102:
     name = "parameter_102"
+    original_name = "conv2d_93.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.852947")
@@ -1133,6 +1236,7 @@ class Program_weight_tensor_parameter_102:
 
 class Program_weight_tensor_parameter_103:
     name = "parameter_103"
+    original_name = "conv2d_93.w_0"
     shape = [128, 1, 7, 7]
     dtype = "float32"
     min_val = float("-0.441275")
@@ -1144,6 +1248,7 @@ class Program_weight_tensor_parameter_103:
 
 class Program_weight_tensor_parameter_104:
     name = "parameter_104"
+    original_name = "batch_norm2d_39.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.477835")
@@ -1155,6 +1260,7 @@ class Program_weight_tensor_parameter_104:
 
 class Program_weight_tensor_parameter_105:
     name = "parameter_105"
+    original_name = "batch_norm2d_39.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.42698")
@@ -1166,6 +1272,7 @@ class Program_weight_tensor_parameter_105:
 
 class Program_weight_tensor_parameter_106:
     name = "parameter_106"
+    original_name = "batch_norm2d_39.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("2.28089")
@@ -1177,6 +1284,7 @@ class Program_weight_tensor_parameter_106:
 
 class Program_weight_tensor_parameter_107:
     name = "parameter_107"
+    original_name = "batch_norm2d_39.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.574635")
@@ -1188,6 +1296,7 @@ class Program_weight_tensor_parameter_107:
 
 class Program_weight_tensor_parameter_108:
     name = "parameter_108"
+    original_name = "conv2d_92.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.0445944")
@@ -1199,6 +1308,7 @@ class Program_weight_tensor_parameter_108:
 
 class Program_weight_tensor_parameter_109:
     name = "parameter_109"
+    original_name = "conv2d_92.w_0"
     shape = [128, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.628284")
@@ -1210,6 +1320,7 @@ class Program_weight_tensor_parameter_109:
 
 class Program_weight_tensor_parameter_110:
     name = "parameter_110"
+    original_name = "conv2d_91.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-3.08006")
@@ -1221,6 +1332,7 @@ class Program_weight_tensor_parameter_110:
 
 class Program_weight_tensor_parameter_111:
     name = "parameter_111"
+    original_name = "conv2d_91.w_0"
     shape = [512, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.600485")
@@ -1232,6 +1344,7 @@ class Program_weight_tensor_parameter_111:
 
 class Program_weight_tensor_parameter_112:
     name = "parameter_112"
+    original_name = "conv2d_90.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-3.34777")
@@ -1243,6 +1356,7 @@ class Program_weight_tensor_parameter_112:
 
 class Program_weight_tensor_parameter_113:
     name = "parameter_113"
+    original_name = "conv2d_90.w_0"
     shape = [512, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.705387")
@@ -1254,6 +1368,7 @@ class Program_weight_tensor_parameter_113:
 
 class Program_weight_tensor_parameter_114:
     name = "parameter_114"
+    original_name = "batch_norm2d_38.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.31233")
@@ -1265,6 +1380,7 @@ class Program_weight_tensor_parameter_114:
 
 class Program_weight_tensor_parameter_115:
     name = "parameter_115"
+    original_name = "batch_norm2d_38.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.679802")
@@ -1276,6 +1392,7 @@ class Program_weight_tensor_parameter_115:
 
 class Program_weight_tensor_parameter_116:
     name = "parameter_116"
+    original_name = "batch_norm2d_38.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.104631")
@@ -1287,6 +1404,7 @@ class Program_weight_tensor_parameter_116:
 
 class Program_weight_tensor_parameter_117:
     name = "parameter_117"
+    original_name = "batch_norm2d_38.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-8.90043")
@@ -1298,6 +1416,7 @@ class Program_weight_tensor_parameter_117:
 
 class Program_weight_tensor_parameter_118:
     name = "parameter_118"
+    original_name = "conv2d_89.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.139214")
@@ -1309,6 +1428,7 @@ class Program_weight_tensor_parameter_118:
 
 class Program_weight_tensor_parameter_119:
     name = "parameter_119"
+    original_name = "conv2d_89.w_0"
     shape = [128, 1, 7, 7]
     dtype = "float32"
     min_val = float("-0.853487")
@@ -1320,6 +1440,7 @@ class Program_weight_tensor_parameter_119:
 
 class Program_weight_tensor_parameter_120:
     name = "parameter_120"
+    original_name = "conv2d_88.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-2.19792")
@@ -1331,6 +1452,7 @@ class Program_weight_tensor_parameter_120:
 
 class Program_weight_tensor_parameter_121:
     name = "parameter_121"
+    original_name = "conv2d_88.w_0"
     shape = [128, 1, 7, 7]
     dtype = "float32"
     min_val = float("-0.526694")
@@ -1342,6 +1464,7 @@ class Program_weight_tensor_parameter_121:
 
 class Program_weight_tensor_parameter_122:
     name = "parameter_122"
+    original_name = "batch_norm2d_37.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.631598")
@@ -1353,6 +1476,7 @@ class Program_weight_tensor_parameter_122:
 
 class Program_weight_tensor_parameter_123:
     name = "parameter_123"
+    original_name = "batch_norm2d_37.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.67992")
@@ -1364,6 +1488,7 @@ class Program_weight_tensor_parameter_123:
 
 class Program_weight_tensor_parameter_124:
     name = "parameter_124"
+    original_name = "batch_norm2d_37.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("1.52835")
@@ -1375,6 +1500,7 @@ class Program_weight_tensor_parameter_124:
 
 class Program_weight_tensor_parameter_125:
     name = "parameter_125"
+    original_name = "batch_norm2d_37.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.420316")
@@ -1386,6 +1512,7 @@ class Program_weight_tensor_parameter_125:
 
 class Program_weight_tensor_parameter_126:
     name = "parameter_126"
+    original_name = "conv2d_87.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.0464981")
@@ -1397,6 +1524,7 @@ class Program_weight_tensor_parameter_126:
 
 class Program_weight_tensor_parameter_127:
     name = "parameter_127"
+    original_name = "conv2d_87.w_0"
     shape = [128, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.895167")
@@ -1408,6 +1536,7 @@ class Program_weight_tensor_parameter_127:
 
 class Program_weight_tensor_parameter_128:
     name = "parameter_128"
+    original_name = "conv2d_86.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-2.18981")
@@ -1419,6 +1548,7 @@ class Program_weight_tensor_parameter_128:
 
 class Program_weight_tensor_parameter_129:
     name = "parameter_129"
+    original_name = "conv2d_86.w_0"
     shape = [512, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.772085")
@@ -1430,6 +1560,7 @@ class Program_weight_tensor_parameter_129:
 
 class Program_weight_tensor_parameter_130:
     name = "parameter_130"
+    original_name = "conv2d_85.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-3.0388")
@@ -1441,6 +1572,7 @@ class Program_weight_tensor_parameter_130:
 
 class Program_weight_tensor_parameter_131:
     name = "parameter_131"
+    original_name = "conv2d_85.w_0"
     shape = [512, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.591903")
@@ -1452,6 +1584,7 @@ class Program_weight_tensor_parameter_131:
 
 class Program_weight_tensor_parameter_132:
     name = "parameter_132"
+    original_name = "batch_norm2d_36.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.829408")
@@ -1463,6 +1596,7 @@ class Program_weight_tensor_parameter_132:
 
 class Program_weight_tensor_parameter_133:
     name = "parameter_133"
+    original_name = "batch_norm2d_36.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.512153")
@@ -1474,6 +1608,7 @@ class Program_weight_tensor_parameter_133:
 
 class Program_weight_tensor_parameter_134:
     name = "parameter_134"
+    original_name = "batch_norm2d_36.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.0546607")
@@ -1485,6 +1620,7 @@ class Program_weight_tensor_parameter_134:
 
 class Program_weight_tensor_parameter_135:
     name = "parameter_135"
+    original_name = "batch_norm2d_36.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-7.76527")
@@ -1496,6 +1632,7 @@ class Program_weight_tensor_parameter_135:
 
 class Program_weight_tensor_parameter_136:
     name = "parameter_136"
+    original_name = "conv2d_84.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.153262")
@@ -1507,6 +1644,7 @@ class Program_weight_tensor_parameter_136:
 
 class Program_weight_tensor_parameter_137:
     name = "parameter_137"
+    original_name = "conv2d_84.w_0"
     shape = [128, 1, 7, 7]
     dtype = "float32"
     min_val = float("-1.39548")
@@ -1518,6 +1656,7 @@ class Program_weight_tensor_parameter_137:
 
 class Program_weight_tensor_parameter_138:
     name = "parameter_138"
+    original_name = "conv2d_83.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.20731")
@@ -1529,6 +1668,7 @@ class Program_weight_tensor_parameter_138:
 
 class Program_weight_tensor_parameter_139:
     name = "parameter_139"
+    original_name = "conv2d_83.w_0"
     shape = [128, 1, 7, 7]
     dtype = "float32"
     min_val = float("-0.577266")
@@ -1540,6 +1680,7 @@ class Program_weight_tensor_parameter_139:
 
 class Program_weight_tensor_parameter_140:
     name = "parameter_140"
+    original_name = "batch_norm2d_35.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.88003")
@@ -1551,6 +1692,7 @@ class Program_weight_tensor_parameter_140:
 
 class Program_weight_tensor_parameter_141:
     name = "parameter_141"
+    original_name = "batch_norm2d_35.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-2.07312")
@@ -1562,6 +1704,7 @@ class Program_weight_tensor_parameter_141:
 
 class Program_weight_tensor_parameter_142:
     name = "parameter_142"
+    original_name = "batch_norm2d_35.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("2.28507")
@@ -1573,6 +1716,7 @@ class Program_weight_tensor_parameter_142:
 
 class Program_weight_tensor_parameter_143:
     name = "parameter_143"
+    original_name = "batch_norm2d_35.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-3.22538")
@@ -1584,6 +1728,7 @@ class Program_weight_tensor_parameter_143:
 
 class Program_weight_tensor_parameter_144:
     name = "parameter_144"
+    original_name = "conv2d_82.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.0447568")
@@ -1595,6 +1740,7 @@ class Program_weight_tensor_parameter_144:
 
 class Program_weight_tensor_parameter_145:
     name = "parameter_145"
+    original_name = "conv2d_82.w_0"
     shape = [128, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.584019")
@@ -1606,6 +1752,7 @@ class Program_weight_tensor_parameter_145:
 
 class Program_weight_tensor_parameter_146:
     name = "parameter_146"
+    original_name = "conv2d_81.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-4.01139")
@@ -1617,6 +1764,7 @@ class Program_weight_tensor_parameter_146:
 
 class Program_weight_tensor_parameter_147:
     name = "parameter_147"
+    original_name = "conv2d_81.w_0"
     shape = [512, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.646427")
@@ -1628,6 +1776,7 @@ class Program_weight_tensor_parameter_147:
 
 class Program_weight_tensor_parameter_148:
     name = "parameter_148"
+    original_name = "conv2d_80.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-3.53886")
@@ -1639,6 +1788,7 @@ class Program_weight_tensor_parameter_148:
 
 class Program_weight_tensor_parameter_149:
     name = "parameter_149"
+    original_name = "conv2d_80.w_0"
     shape = [512, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.797738")
@@ -1650,6 +1800,7 @@ class Program_weight_tensor_parameter_149:
 
 class Program_weight_tensor_parameter_150:
     name = "parameter_150"
+    original_name = "batch_norm2d_34.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.709732")
@@ -1661,6 +1812,7 @@ class Program_weight_tensor_parameter_150:
 
 class Program_weight_tensor_parameter_151:
     name = "parameter_151"
+    original_name = "batch_norm2d_34.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.541121")
@@ -1672,6 +1824,7 @@ class Program_weight_tensor_parameter_151:
 
 class Program_weight_tensor_parameter_152:
     name = "parameter_152"
+    original_name = "batch_norm2d_34.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.088578")
@@ -1683,6 +1836,7 @@ class Program_weight_tensor_parameter_152:
 
 class Program_weight_tensor_parameter_153:
     name = "parameter_153"
+    original_name = "batch_norm2d_34.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-8.39471")
@@ -1694,6 +1848,7 @@ class Program_weight_tensor_parameter_153:
 
 class Program_weight_tensor_parameter_154:
     name = "parameter_154"
+    original_name = "conv2d_79.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.138416")
@@ -1705,6 +1860,7 @@ class Program_weight_tensor_parameter_154:
 
 class Program_weight_tensor_parameter_155:
     name = "parameter_155"
+    original_name = "conv2d_79.w_0"
     shape = [128, 1, 7, 7]
     dtype = "float32"
     min_val = float("-1.31764")
@@ -1716,6 +1872,7 @@ class Program_weight_tensor_parameter_155:
 
 class Program_weight_tensor_parameter_156:
     name = "parameter_156"
+    original_name = "conv2d_78.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.588783")
@@ -1727,6 +1884,7 @@ class Program_weight_tensor_parameter_156:
 
 class Program_weight_tensor_parameter_157:
     name = "parameter_157"
+    original_name = "conv2d_78.w_0"
     shape = [128, 1, 7, 7]
     dtype = "float32"
     min_val = float("-0.506741")
@@ -1738,6 +1896,7 @@ class Program_weight_tensor_parameter_157:
 
 class Program_weight_tensor_parameter_158:
     name = "parameter_158"
+    original_name = "batch_norm2d_33.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.909684")
@@ -1749,6 +1908,7 @@ class Program_weight_tensor_parameter_158:
 
 class Program_weight_tensor_parameter_159:
     name = "parameter_159"
+    original_name = "batch_norm2d_33.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.15937")
@@ -1760,6 +1920,7 @@ class Program_weight_tensor_parameter_159:
 
 class Program_weight_tensor_parameter_160:
     name = "parameter_160"
+    original_name = "batch_norm2d_33.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("1.73524")
@@ -1771,6 +1932,7 @@ class Program_weight_tensor_parameter_160:
 
 class Program_weight_tensor_parameter_161:
     name = "parameter_161"
+    original_name = "batch_norm2d_33.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.38462")
@@ -1782,6 +1944,7 @@ class Program_weight_tensor_parameter_161:
 
 class Program_weight_tensor_parameter_162:
     name = "parameter_162"
+    original_name = "conv2d_77.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.0441143")
@@ -1793,6 +1956,7 @@ class Program_weight_tensor_parameter_162:
 
 class Program_weight_tensor_parameter_163:
     name = "parameter_163"
+    original_name = "conv2d_77.w_0"
     shape = [128, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.674942")
@@ -1804,6 +1968,7 @@ class Program_weight_tensor_parameter_163:
 
 class Program_weight_tensor_parameter_164:
     name = "parameter_164"
+    original_name = "conv2d_76.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-2.61396")
@@ -1815,6 +1980,7 @@ class Program_weight_tensor_parameter_164:
 
 class Program_weight_tensor_parameter_165:
     name = "parameter_165"
+    original_name = "conv2d_76.w_0"
     shape = [512, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.697565")
@@ -1826,6 +1992,7 @@ class Program_weight_tensor_parameter_165:
 
 class Program_weight_tensor_parameter_166:
     name = "parameter_166"
+    original_name = "conv2d_75.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-5.12998")
@@ -1837,6 +2004,7 @@ class Program_weight_tensor_parameter_166:
 
 class Program_weight_tensor_parameter_167:
     name = "parameter_167"
+    original_name = "conv2d_75.w_0"
     shape = [512, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.657221")
@@ -1848,6 +2016,7 @@ class Program_weight_tensor_parameter_167:
 
 class Program_weight_tensor_parameter_168:
     name = "parameter_168"
+    original_name = "batch_norm2d_32.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.08255")
@@ -1859,6 +2028,7 @@ class Program_weight_tensor_parameter_168:
 
 class Program_weight_tensor_parameter_169:
     name = "parameter_169"
+    original_name = "batch_norm2d_32.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.505736")
@@ -1870,6 +2040,7 @@ class Program_weight_tensor_parameter_169:
 
 class Program_weight_tensor_parameter_170:
     name = "parameter_170"
+    original_name = "batch_norm2d_32.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.164336")
@@ -1881,6 +2052,7 @@ class Program_weight_tensor_parameter_170:
 
 class Program_weight_tensor_parameter_171:
     name = "parameter_171"
+    original_name = "batch_norm2d_32.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-2.57843")
@@ -1892,6 +2064,7 @@ class Program_weight_tensor_parameter_171:
 
 class Program_weight_tensor_parameter_172:
     name = "parameter_172"
+    original_name = "conv2d_74.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.144461")
@@ -1903,6 +2076,7 @@ class Program_weight_tensor_parameter_172:
 
 class Program_weight_tensor_parameter_173:
     name = "parameter_173"
+    original_name = "conv2d_74.w_0"
     shape = [128, 1, 7, 7]
     dtype = "float32"
     min_val = float("-1.0385")
@@ -1914,6 +2088,7 @@ class Program_weight_tensor_parameter_173:
 
 class Program_weight_tensor_parameter_174:
     name = "parameter_174"
+    original_name = "conv2d_73.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.23389")
@@ -1925,6 +2100,7 @@ class Program_weight_tensor_parameter_174:
 
 class Program_weight_tensor_parameter_175:
     name = "parameter_175"
+    original_name = "conv2d_73.w_0"
     shape = [128, 1, 7, 7]
     dtype = "float32"
     min_val = float("-0.498669")
@@ -1936,6 +2112,7 @@ class Program_weight_tensor_parameter_175:
 
 class Program_weight_tensor_parameter_176:
     name = "parameter_176"
+    original_name = "batch_norm2d_31.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.765629")
@@ -1947,6 +2124,7 @@ class Program_weight_tensor_parameter_176:
 
 class Program_weight_tensor_parameter_177:
     name = "parameter_177"
+    original_name = "batch_norm2d_31.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.903917")
@@ -1958,6 +2136,7 @@ class Program_weight_tensor_parameter_177:
 
 class Program_weight_tensor_parameter_178:
     name = "parameter_178"
+    original_name = "batch_norm2d_31.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.426626")
@@ -1969,6 +2148,7 @@ class Program_weight_tensor_parameter_178:
 
 class Program_weight_tensor_parameter_179:
     name = "parameter_179"
+    original_name = "batch_norm2d_31.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.560968")
@@ -1980,6 +2160,7 @@ class Program_weight_tensor_parameter_179:
 
 class Program_weight_tensor_parameter_180:
     name = "parameter_180"
+    original_name = "conv2d_72.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.0469455")
@@ -1991,6 +2172,7 @@ class Program_weight_tensor_parameter_180:
 
 class Program_weight_tensor_parameter_181:
     name = "parameter_181"
+    original_name = "conv2d_72.w_0"
     shape = [128, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.804746")
@@ -2002,6 +2184,7 @@ class Program_weight_tensor_parameter_181:
 
 class Program_weight_tensor_parameter_182:
     name = "parameter_182"
+    original_name = "conv2d_71.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-2.45871")
@@ -2013,6 +2196,7 @@ class Program_weight_tensor_parameter_182:
 
 class Program_weight_tensor_parameter_183:
     name = "parameter_183"
+    original_name = "conv2d_71.w_0"
     shape = [512, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.564703")
@@ -2024,6 +2208,7 @@ class Program_weight_tensor_parameter_183:
 
 class Program_weight_tensor_parameter_184:
     name = "parameter_184"
+    original_name = "conv2d_70.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-3.70818")
@@ -2035,6 +2220,7 @@ class Program_weight_tensor_parameter_184:
 
 class Program_weight_tensor_parameter_185:
     name = "parameter_185"
+    original_name = "conv2d_70.w_0"
     shape = [512, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.729343")
@@ -2046,6 +2232,7 @@ class Program_weight_tensor_parameter_185:
 
 class Program_weight_tensor_parameter_186:
     name = "parameter_186"
+    original_name = "batch_norm2d_30.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.78249")
@@ -2057,6 +2244,7 @@ class Program_weight_tensor_parameter_186:
 
 class Program_weight_tensor_parameter_187:
     name = "parameter_187"
+    original_name = "batch_norm2d_30.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.644031")
@@ -2068,6 +2256,7 @@ class Program_weight_tensor_parameter_187:
 
 class Program_weight_tensor_parameter_188:
     name = "parameter_188"
+    original_name = "batch_norm2d_30.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.0435065")
@@ -2079,6 +2268,7 @@ class Program_weight_tensor_parameter_188:
 
 class Program_weight_tensor_parameter_189:
     name = "parameter_189"
+    original_name = "batch_norm2d_30.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-5.27051")
@@ -2090,6 +2280,7 @@ class Program_weight_tensor_parameter_189:
 
 class Program_weight_tensor_parameter_190:
     name = "parameter_190"
+    original_name = "conv2d_69.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.139056")
@@ -2101,6 +2292,7 @@ class Program_weight_tensor_parameter_190:
 
 class Program_weight_tensor_parameter_191:
     name = "parameter_191"
+    original_name = "conv2d_69.w_0"
     shape = [128, 1, 7, 7]
     dtype = "float32"
     min_val = float("-1.52711")
@@ -2112,6 +2304,7 @@ class Program_weight_tensor_parameter_191:
 
 class Program_weight_tensor_parameter_192:
     name = "parameter_192"
+    original_name = "conv2d_68.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.720742")
@@ -2123,6 +2316,7 @@ class Program_weight_tensor_parameter_192:
 
 class Program_weight_tensor_parameter_193:
     name = "parameter_193"
+    original_name = "conv2d_68.w_0"
     shape = [128, 1, 7, 7]
     dtype = "float32"
     min_val = float("-0.520031")
@@ -2134,6 +2328,7 @@ class Program_weight_tensor_parameter_193:
 
 class Program_weight_tensor_parameter_194:
     name = "parameter_194"
+    original_name = "batch_norm2d_29.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.676791")
@@ -2145,6 +2340,7 @@ class Program_weight_tensor_parameter_194:
 
 class Program_weight_tensor_parameter_195:
     name = "parameter_195"
+    original_name = "batch_norm2d_29.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.17447")
@@ -2156,6 +2352,7 @@ class Program_weight_tensor_parameter_195:
 
 class Program_weight_tensor_parameter_196:
     name = "parameter_196"
+    original_name = "batch_norm2d_29.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("1.843")
@@ -2167,6 +2364,7 @@ class Program_weight_tensor_parameter_196:
 
 class Program_weight_tensor_parameter_197:
     name = "parameter_197"
+    original_name = "batch_norm2d_29.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.72153")
@@ -2178,6 +2376,7 @@ class Program_weight_tensor_parameter_197:
 
 class Program_weight_tensor_parameter_198:
     name = "parameter_198"
+    original_name = "conv2d_67.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.0434215")
@@ -2189,6 +2388,7 @@ class Program_weight_tensor_parameter_198:
 
 class Program_weight_tensor_parameter_199:
     name = "parameter_199"
+    original_name = "conv2d_67.w_0"
     shape = [128, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.617624")
@@ -2200,6 +2400,7 @@ class Program_weight_tensor_parameter_199:
 
 class Program_weight_tensor_parameter_200:
     name = "parameter_200"
+    original_name = "conv2d_66.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-3.5835")
@@ -2211,6 +2412,7 @@ class Program_weight_tensor_parameter_200:
 
 class Program_weight_tensor_parameter_201:
     name = "parameter_201"
+    original_name = "conv2d_66.w_0"
     shape = [512, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.747026")
@@ -2222,6 +2424,7 @@ class Program_weight_tensor_parameter_201:
 
 class Program_weight_tensor_parameter_202:
     name = "parameter_202"
+    original_name = "conv2d_65.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-4.0722")
@@ -2233,6 +2436,7 @@ class Program_weight_tensor_parameter_202:
 
 class Program_weight_tensor_parameter_203:
     name = "parameter_203"
+    original_name = "conv2d_65.w_0"
     shape = [512, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.664354")
@@ -2244,6 +2448,7 @@ class Program_weight_tensor_parameter_203:
 
 class Program_weight_tensor_parameter_204:
     name = "parameter_204"
+    original_name = "batch_norm2d_28.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.604076")
@@ -2255,6 +2460,7 @@ class Program_weight_tensor_parameter_204:
 
 class Program_weight_tensor_parameter_205:
     name = "parameter_205"
+    original_name = "batch_norm2d_28.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.646245")
@@ -2266,6 +2472,7 @@ class Program_weight_tensor_parameter_205:
 
 class Program_weight_tensor_parameter_206:
     name = "parameter_206"
+    original_name = "batch_norm2d_28.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.0217316")
@@ -2277,6 +2484,7 @@ class Program_weight_tensor_parameter_206:
 
 class Program_weight_tensor_parameter_207:
     name = "parameter_207"
+    original_name = "batch_norm2d_28.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.94532")
@@ -2288,6 +2496,7 @@ class Program_weight_tensor_parameter_207:
 
 class Program_weight_tensor_parameter_208:
     name = "parameter_208"
+    original_name = "conv2d_64.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.145021")
@@ -2299,6 +2508,7 @@ class Program_weight_tensor_parameter_208:
 
 class Program_weight_tensor_parameter_209:
     name = "parameter_209"
+    original_name = "conv2d_64.w_0"
     shape = [128, 1, 7, 7]
     dtype = "float32"
     min_val = float("-0.906635")
@@ -2310,6 +2520,7 @@ class Program_weight_tensor_parameter_209:
 
 class Program_weight_tensor_parameter_210:
     name = "parameter_210"
+    original_name = "conv2d_63.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.07468")
@@ -2321,6 +2532,7 @@ class Program_weight_tensor_parameter_210:
 
 class Program_weight_tensor_parameter_211:
     name = "parameter_211"
+    original_name = "conv2d_63.w_0"
     shape = [128, 1, 7, 7]
     dtype = "float32"
     min_val = float("-0.495817")
@@ -2332,6 +2544,7 @@ class Program_weight_tensor_parameter_211:
 
 class Program_weight_tensor_parameter_212:
     name = "parameter_212"
+    original_name = "batch_norm2d_27.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.353858")
@@ -2343,6 +2556,7 @@ class Program_weight_tensor_parameter_212:
 
 class Program_weight_tensor_parameter_213:
     name = "parameter_213"
+    original_name = "batch_norm2d_27.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.756984")
@@ -2354,6 +2568,7 @@ class Program_weight_tensor_parameter_213:
 
 class Program_weight_tensor_parameter_214:
     name = "parameter_214"
+    original_name = "batch_norm2d_27.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.788884")
@@ -2365,6 +2580,7 @@ class Program_weight_tensor_parameter_214:
 
 class Program_weight_tensor_parameter_215:
     name = "parameter_215"
+    original_name = "batch_norm2d_27.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.709572")
@@ -2376,6 +2592,7 @@ class Program_weight_tensor_parameter_215:
 
 class Program_weight_tensor_parameter_216:
     name = "parameter_216"
+    original_name = "conv2d_62.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.0475848")
@@ -2387,6 +2604,7 @@ class Program_weight_tensor_parameter_216:
 
 class Program_weight_tensor_parameter_217:
     name = "parameter_217"
+    original_name = "conv2d_62.w_0"
     shape = [128, 512, 1, 1]
     dtype = "float32"
     min_val = float("-1.22397")
@@ -2398,6 +2616,7 @@ class Program_weight_tensor_parameter_217:
 
 class Program_weight_tensor_parameter_218:
     name = "parameter_218"
+    original_name = "conv2d_61.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-4.39947")
@@ -2409,6 +2628,7 @@ class Program_weight_tensor_parameter_218:
 
 class Program_weight_tensor_parameter_219:
     name = "parameter_219"
+    original_name = "conv2d_61.w_0"
     shape = [512, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.827994")
@@ -2420,6 +2640,7 @@ class Program_weight_tensor_parameter_219:
 
 class Program_weight_tensor_parameter_220:
     name = "parameter_220"
+    original_name = "conv2d_60.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-3.53049")
@@ -2431,6 +2652,7 @@ class Program_weight_tensor_parameter_220:
 
 class Program_weight_tensor_parameter_221:
     name = "parameter_221"
+    original_name = "conv2d_60.w_0"
     shape = [512, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.695935")
@@ -2442,6 +2664,7 @@ class Program_weight_tensor_parameter_221:
 
 class Program_weight_tensor_parameter_222:
     name = "parameter_222"
+    original_name = "batch_norm2d_26.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.298573")
@@ -2453,6 +2676,7 @@ class Program_weight_tensor_parameter_222:
 
 class Program_weight_tensor_parameter_223:
     name = "parameter_223"
+    original_name = "batch_norm2d_26.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.637879")
@@ -2464,6 +2688,7 @@ class Program_weight_tensor_parameter_223:
 
 class Program_weight_tensor_parameter_224:
     name = "parameter_224"
+    original_name = "batch_norm2d_26.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.0147042")
@@ -2475,6 +2700,7 @@ class Program_weight_tensor_parameter_224:
 
 class Program_weight_tensor_parameter_225:
     name = "parameter_225"
+    original_name = "batch_norm2d_26.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-3.63653")
@@ -2486,6 +2712,7 @@ class Program_weight_tensor_parameter_225:
 
 class Program_weight_tensor_parameter_226:
     name = "parameter_226"
+    original_name = "conv2d_59.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.150433")
@@ -2497,6 +2724,7 @@ class Program_weight_tensor_parameter_226:
 
 class Program_weight_tensor_parameter_227:
     name = "parameter_227"
+    original_name = "conv2d_59.w_0"
     shape = [128, 1, 7, 7]
     dtype = "float32"
     min_val = float("-1.29257")
@@ -2508,6 +2736,7 @@ class Program_weight_tensor_parameter_227:
 
 class Program_weight_tensor_parameter_228:
     name = "parameter_228"
+    original_name = "conv2d_58.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.355061")
@@ -2519,6 +2748,7 @@ class Program_weight_tensor_parameter_228:
 
 class Program_weight_tensor_parameter_229:
     name = "parameter_229"
+    original_name = "conv2d_58.w_0"
     shape = [128, 1, 7, 7]
     dtype = "float32"
     min_val = float("-0.597051")
@@ -2530,6 +2760,7 @@ class Program_weight_tensor_parameter_229:
 
 class Program_weight_tensor_parameter_230:
     name = "parameter_230"
+    original_name = "batch_norm2d_25.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.20745")
@@ -2541,6 +2772,7 @@ class Program_weight_tensor_parameter_230:
 
 class Program_weight_tensor_parameter_231:
     name = "parameter_231"
+    original_name = "batch_norm2d_25.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.945283")
@@ -2552,6 +2784,7 @@ class Program_weight_tensor_parameter_231:
 
 class Program_weight_tensor_parameter_232:
     name = "parameter_232"
+    original_name = "batch_norm2d_25.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("2.49121")
@@ -2563,6 +2796,7 @@ class Program_weight_tensor_parameter_232:
 
 class Program_weight_tensor_parameter_233:
     name = "parameter_233"
+    original_name = "batch_norm2d_25.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-4.11726")
@@ -2574,6 +2808,7 @@ class Program_weight_tensor_parameter_233:
 
 class Program_weight_tensor_parameter_234:
     name = "parameter_234"
+    original_name = "conv2d_57.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.0436538")
@@ -2585,6 +2820,7 @@ class Program_weight_tensor_parameter_234:
 
 class Program_weight_tensor_parameter_235:
     name = "parameter_235"
+    original_name = "conv2d_57.w_0"
     shape = [128, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.823406")
@@ -2596,6 +2832,7 @@ class Program_weight_tensor_parameter_235:
 
 class Program_weight_tensor_parameter_236:
     name = "parameter_236"
+    original_name = "conv2d_56.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-3.38335")
@@ -2607,6 +2844,7 @@ class Program_weight_tensor_parameter_236:
 
 class Program_weight_tensor_parameter_237:
     name = "parameter_237"
+    original_name = "conv2d_56.w_0"
     shape = [512, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.717584")
@@ -2618,6 +2856,7 @@ class Program_weight_tensor_parameter_237:
 
 class Program_weight_tensor_parameter_238:
     name = "parameter_238"
+    original_name = "conv2d_55.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-4.67608")
@@ -2629,6 +2868,7 @@ class Program_weight_tensor_parameter_238:
 
 class Program_weight_tensor_parameter_239:
     name = "parameter_239"
+    original_name = "conv2d_55.w_0"
     shape = [512, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.666404")
@@ -2640,6 +2880,7 @@ class Program_weight_tensor_parameter_239:
 
 class Program_weight_tensor_parameter_240:
     name = "parameter_240"
+    original_name = "batch_norm2d_24.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.377511")
@@ -2651,6 +2892,7 @@ class Program_weight_tensor_parameter_240:
 
 class Program_weight_tensor_parameter_241:
     name = "parameter_241"
+    original_name = "batch_norm2d_24.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.671257")
@@ -2662,6 +2904,7 @@ class Program_weight_tensor_parameter_241:
 
 class Program_weight_tensor_parameter_242:
     name = "parameter_242"
+    original_name = "batch_norm2d_24.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.00752779")
@@ -2673,6 +2916,7 @@ class Program_weight_tensor_parameter_242:
 
 class Program_weight_tensor_parameter_243:
     name = "parameter_243"
+    original_name = "batch_norm2d_24.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-2.68807")
@@ -2684,6 +2928,7 @@ class Program_weight_tensor_parameter_243:
 
 class Program_weight_tensor_parameter_244:
     name = "parameter_244"
+    original_name = "conv2d_54.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.136121")
@@ -2695,6 +2940,7 @@ class Program_weight_tensor_parameter_244:
 
 class Program_weight_tensor_parameter_245:
     name = "parameter_245"
+    original_name = "conv2d_54.w_0"
     shape = [128, 1, 7, 7]
     dtype = "float32"
     min_val = float("-1.38453")
@@ -2706,6 +2952,7 @@ class Program_weight_tensor_parameter_245:
 
 class Program_weight_tensor_parameter_246:
     name = "parameter_246"
+    original_name = "conv2d_53.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.290586")
@@ -2717,6 +2964,7 @@ class Program_weight_tensor_parameter_246:
 
 class Program_weight_tensor_parameter_247:
     name = "parameter_247"
+    original_name = "conv2d_53.w_0"
     shape = [128, 1, 7, 7]
     dtype = "float32"
     min_val = float("-0.569712")
@@ -2728,6 +2976,7 @@ class Program_weight_tensor_parameter_247:
 
 class Program_weight_tensor_parameter_248:
     name = "parameter_248"
+    original_name = "batch_norm2d_23.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.512494")
@@ -2739,6 +2988,7 @@ class Program_weight_tensor_parameter_248:
 
 class Program_weight_tensor_parameter_249:
     name = "parameter_249"
+    original_name = "batch_norm2d_23.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.93346")
@@ -2750,6 +3000,7 @@ class Program_weight_tensor_parameter_249:
 
 class Program_weight_tensor_parameter_250:
     name = "parameter_250"
+    original_name = "batch_norm2d_23.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("1.99282")
@@ -2761,6 +3012,7 @@ class Program_weight_tensor_parameter_250:
 
 class Program_weight_tensor_parameter_251:
     name = "parameter_251"
+    original_name = "batch_norm2d_23.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-2.05308")
@@ -2772,6 +3024,7 @@ class Program_weight_tensor_parameter_251:
 
 class Program_weight_tensor_parameter_252:
     name = "parameter_252"
+    original_name = "conv2d_52.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.0487046")
@@ -2783,6 +3036,7 @@ class Program_weight_tensor_parameter_252:
 
 class Program_weight_tensor_parameter_253:
     name = "parameter_253"
+    original_name = "conv2d_52.w_0"
     shape = [128, 512, 1, 1]
     dtype = "float32"
     min_val = float("-1.59466")
@@ -2794,6 +3048,7 @@ class Program_weight_tensor_parameter_253:
 
 class Program_weight_tensor_parameter_254:
     name = "parameter_254"
+    original_name = "conv2d_51.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-4.39223")
@@ -2805,6 +3060,7 @@ class Program_weight_tensor_parameter_254:
 
 class Program_weight_tensor_parameter_255:
     name = "parameter_255"
+    original_name = "conv2d_51.w_0"
     shape = [512, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.948685")
@@ -2816,6 +3072,7 @@ class Program_weight_tensor_parameter_255:
 
 class Program_weight_tensor_parameter_256:
     name = "parameter_256"
+    original_name = "conv2d_50.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-4.04187")
@@ -2827,6 +3084,7 @@ class Program_weight_tensor_parameter_256:
 
 class Program_weight_tensor_parameter_257:
     name = "parameter_257"
+    original_name = "conv2d_50.w_0"
     shape = [512, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.709004")
@@ -2838,6 +3096,7 @@ class Program_weight_tensor_parameter_257:
 
 class Program_weight_tensor_parameter_258:
     name = "parameter_258"
+    original_name = "batch_norm2d_22.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.631024")
@@ -2849,6 +3108,7 @@ class Program_weight_tensor_parameter_258:
 
 class Program_weight_tensor_parameter_259:
     name = "parameter_259"
+    original_name = "batch_norm2d_22.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.325362")
@@ -2860,6 +3120,7 @@ class Program_weight_tensor_parameter_259:
 
 class Program_weight_tensor_parameter_260:
     name = "parameter_260"
+    original_name = "batch_norm2d_22.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.000788164")
@@ -2871,6 +3132,7 @@ class Program_weight_tensor_parameter_260:
 
 class Program_weight_tensor_parameter_261:
     name = "parameter_261"
+    original_name = "batch_norm2d_22.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-2.23649")
@@ -2882,6 +3144,7 @@ class Program_weight_tensor_parameter_261:
 
 class Program_weight_tensor_parameter_262:
     name = "parameter_262"
+    original_name = "conv2d_49.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.160991")
@@ -2893,6 +3156,7 @@ class Program_weight_tensor_parameter_262:
 
 class Program_weight_tensor_parameter_263:
     name = "parameter_263"
+    original_name = "conv2d_49.w_0"
     shape = [128, 1, 7, 7]
     dtype = "float32"
     min_val = float("-1.1908")
@@ -2904,6 +3168,7 @@ class Program_weight_tensor_parameter_263:
 
 class Program_weight_tensor_parameter_264:
     name = "parameter_264"
+    original_name = "conv2d_48.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.391315")
@@ -2915,6 +3180,7 @@ class Program_weight_tensor_parameter_264:
 
 class Program_weight_tensor_parameter_265:
     name = "parameter_265"
+    original_name = "conv2d_48.w_0"
     shape = [128, 1, 7, 7]
     dtype = "float32"
     min_val = float("-0.489312")
@@ -2926,6 +3192,7 @@ class Program_weight_tensor_parameter_265:
 
 class Program_weight_tensor_parameter_266:
     name = "parameter_266"
+    original_name = "batch_norm2d_21.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.340196")
@@ -2937,6 +3204,7 @@ class Program_weight_tensor_parameter_266:
 
 class Program_weight_tensor_parameter_267:
     name = "parameter_267"
+    original_name = "batch_norm2d_21.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.404431")
@@ -2948,6 +3216,7 @@ class Program_weight_tensor_parameter_267:
 
 class Program_weight_tensor_parameter_268:
     name = "parameter_268"
+    original_name = "batch_norm2d_21.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("1.26191")
@@ -2959,6 +3228,7 @@ class Program_weight_tensor_parameter_268:
 
 class Program_weight_tensor_parameter_269:
     name = "parameter_269"
+    original_name = "batch_norm2d_21.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.20994")
@@ -2970,6 +3240,7 @@ class Program_weight_tensor_parameter_269:
 
 class Program_weight_tensor_parameter_270:
     name = "parameter_270"
+    original_name = "conv2d_47.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.0461756")
@@ -2981,6 +3252,7 @@ class Program_weight_tensor_parameter_270:
 
 class Program_weight_tensor_parameter_271:
     name = "parameter_271"
+    original_name = "conv2d_47.w_0"
     shape = [128, 512, 1, 1]
     dtype = "float32"
     min_val = float("-1.48134")
@@ -2992,6 +3264,7 @@ class Program_weight_tensor_parameter_271:
 
 class Program_weight_tensor_parameter_272:
     name = "parameter_272"
+    original_name = "conv2d_46.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-2.32612")
@@ -3003,6 +3276,7 @@ class Program_weight_tensor_parameter_272:
 
 class Program_weight_tensor_parameter_273:
     name = "parameter_273"
+    original_name = "conv2d_46.w_0"
     shape = [512, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.711491")
@@ -3014,6 +3288,7 @@ class Program_weight_tensor_parameter_273:
 
 class Program_weight_tensor_parameter_274:
     name = "parameter_274"
+    original_name = "conv2d_45.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-3.72484")
@@ -3025,6 +3300,7 @@ class Program_weight_tensor_parameter_274:
 
 class Program_weight_tensor_parameter_275:
     name = "parameter_275"
+    original_name = "conv2d_45.w_0"
     shape = [512, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.609138")
@@ -3036,6 +3312,7 @@ class Program_weight_tensor_parameter_275:
 
 class Program_weight_tensor_parameter_276:
     name = "parameter_276"
+    original_name = "batch_norm2d_20.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.801689")
@@ -3047,6 +3324,7 @@ class Program_weight_tensor_parameter_276:
 
 class Program_weight_tensor_parameter_277:
     name = "parameter_277"
+    original_name = "batch_norm2d_20.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.495276")
@@ -3058,6 +3336,7 @@ class Program_weight_tensor_parameter_277:
 
 class Program_weight_tensor_parameter_278:
     name = "parameter_278"
+    original_name = "batch_norm2d_20.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("0.000176376")
@@ -3069,6 +3348,7 @@ class Program_weight_tensor_parameter_278:
 
 class Program_weight_tensor_parameter_279:
     name = "parameter_279"
+    original_name = "batch_norm2d_20.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-2.53384")
@@ -3080,6 +3360,7 @@ class Program_weight_tensor_parameter_279:
 
 class Program_weight_tensor_parameter_280:
     name = "parameter_280"
+    original_name = "conv2d_44.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.158631")
@@ -3091,6 +3372,7 @@ class Program_weight_tensor_parameter_280:
 
 class Program_weight_tensor_parameter_281:
     name = "parameter_281"
+    original_name = "conv2d_44.w_0"
     shape = [128, 1, 7, 7]
     dtype = "float32"
     min_val = float("-1.14238")
@@ -3102,6 +3384,7 @@ class Program_weight_tensor_parameter_281:
 
 class Program_weight_tensor_parameter_282:
     name = "parameter_282"
+    original_name = "conv2d_43.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.9907")
@@ -3113,6 +3396,7 @@ class Program_weight_tensor_parameter_282:
 
 class Program_weight_tensor_parameter_283:
     name = "parameter_283"
+    original_name = "conv2d_43.w_0"
     shape = [128, 1, 7, 7]
     dtype = "float32"
     min_val = float("-0.561595")
@@ -3124,6 +3408,7 @@ class Program_weight_tensor_parameter_283:
 
 class Program_weight_tensor_parameter_284:
     name = "parameter_284"
+    original_name = "batch_norm2d_19.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.253088")
@@ -3135,6 +3420,7 @@ class Program_weight_tensor_parameter_284:
 
 class Program_weight_tensor_parameter_285:
     name = "parameter_285"
+    original_name = "batch_norm2d_19.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.0191531")
@@ -3146,6 +3432,7 @@ class Program_weight_tensor_parameter_285:
 
 class Program_weight_tensor_parameter_286:
     name = "parameter_286"
+    original_name = "batch_norm2d_19.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("3.17114")
@@ -3157,6 +3444,7 @@ class Program_weight_tensor_parameter_286:
 
 class Program_weight_tensor_parameter_287:
     name = "parameter_287"
+    original_name = "batch_norm2d_19.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-6.33778")
@@ -3168,6 +3456,7 @@ class Program_weight_tensor_parameter_287:
 
 class Program_weight_tensor_parameter_288:
     name = "parameter_288"
+    original_name = "conv2d_42.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.0456159")
@@ -3179,6 +3468,7 @@ class Program_weight_tensor_parameter_288:
 
 class Program_weight_tensor_parameter_289:
     name = "parameter_289"
+    original_name = "conv2d_42.w_0"
     shape = [128, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.723161")
@@ -3190,6 +3480,7 @@ class Program_weight_tensor_parameter_289:
 
 class Program_weight_tensor_parameter_290:
     name = "parameter_290"
+    original_name = "conv2d_41.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-5.24605")
@@ -3201,6 +3492,7 @@ class Program_weight_tensor_parameter_290:
 
 class Program_weight_tensor_parameter_291:
     name = "parameter_291"
+    original_name = "conv2d_41.w_0"
     shape = [512, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.646012")
@@ -3212,6 +3504,7 @@ class Program_weight_tensor_parameter_291:
 
 class Program_weight_tensor_parameter_292:
     name = "parameter_292"
+    original_name = "conv2d_40.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-2.88247")
@@ -3223,6 +3516,7 @@ class Program_weight_tensor_parameter_292:
 
 class Program_weight_tensor_parameter_293:
     name = "parameter_293"
+    original_name = "conv2d_40.w_0"
     shape = [512, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.709569")
@@ -3234,6 +3528,7 @@ class Program_weight_tensor_parameter_293:
 
 class Program_weight_tensor_parameter_294:
     name = "parameter_294"
+    original_name = "batch_norm2d_18.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.875663")
@@ -3245,6 +3540,7 @@ class Program_weight_tensor_parameter_294:
 
 class Program_weight_tensor_parameter_295:
     name = "parameter_295"
+    original_name = "batch_norm2d_18.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.440169")
@@ -3256,6 +3552,7 @@ class Program_weight_tensor_parameter_295:
 
 class Program_weight_tensor_parameter_296:
     name = "parameter_296"
+    original_name = "batch_norm2d_18.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("1.98121e-05")
@@ -3267,6 +3564,7 @@ class Program_weight_tensor_parameter_296:
 
 class Program_weight_tensor_parameter_297:
     name = "parameter_297"
+    original_name = "batch_norm2d_18.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.920499")
@@ -3278,6 +3576,7 @@ class Program_weight_tensor_parameter_297:
 
 class Program_weight_tensor_parameter_298:
     name = "parameter_298"
+    original_name = "conv2d_39.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.188368")
@@ -3289,6 +3588,7 @@ class Program_weight_tensor_parameter_298:
 
 class Program_weight_tensor_parameter_299:
     name = "parameter_299"
+    original_name = "conv2d_39.w_0"
     shape = [128, 1, 7, 7]
     dtype = "float32"
     min_val = float("-0.941805")
@@ -3300,6 +3600,7 @@ class Program_weight_tensor_parameter_299:
 
 class Program_weight_tensor_parameter_300:
     name = "parameter_300"
+    original_name = "conv2d_38.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.674694")
@@ -3311,6 +3612,7 @@ class Program_weight_tensor_parameter_300:
 
 class Program_weight_tensor_parameter_301:
     name = "parameter_301"
+    original_name = "conv2d_38.w_0"
     shape = [128, 1, 7, 7]
     dtype = "float32"
     min_val = float("-0.50717")
@@ -3322,6 +3624,7 @@ class Program_weight_tensor_parameter_301:
 
 class Program_weight_tensor_parameter_302:
     name = "parameter_302"
+    original_name = "batch_norm2d_17.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.276117")
@@ -3333,6 +3636,7 @@ class Program_weight_tensor_parameter_302:
 
 class Program_weight_tensor_parameter_303:
     name = "parameter_303"
+    original_name = "batch_norm2d_17.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.0125068")
@@ -3344,6 +3648,7 @@ class Program_weight_tensor_parameter_303:
 
 class Program_weight_tensor_parameter_304:
     name = "parameter_304"
+    original_name = "batch_norm2d_17.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("1.94781")
@@ -3355,6 +3660,7 @@ class Program_weight_tensor_parameter_304:
 
 class Program_weight_tensor_parameter_305:
     name = "parameter_305"
+    original_name = "batch_norm2d_17.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-2.53967")
@@ -3366,6 +3672,7 @@ class Program_weight_tensor_parameter_305:
 
 class Program_weight_tensor_parameter_306:
     name = "parameter_306"
+    original_name = "conv2d_37.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.0449748")
@@ -3377,6 +3684,7 @@ class Program_weight_tensor_parameter_306:
 
 class Program_weight_tensor_parameter_307:
     name = "parameter_307"
+    original_name = "conv2d_37.w_0"
     shape = [128, 512, 1, 1]
     dtype = "float32"
     min_val = float("-0.688971")
@@ -3388,6 +3696,7 @@ class Program_weight_tensor_parameter_307:
 
 class Program_weight_tensor_parameter_308:
     name = "parameter_308"
+    original_name = "conv2d_36.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-3.68555")
@@ -3399,6 +3708,7 @@ class Program_weight_tensor_parameter_308:
 
 class Program_weight_tensor_parameter_309:
     name = "parameter_309"
+    original_name = "conv2d_36.w_0"
     shape = [512, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.678808")
@@ -3410,6 +3720,7 @@ class Program_weight_tensor_parameter_309:
 
 class Program_weight_tensor_parameter_310:
     name = "parameter_310"
+    original_name = "conv2d_35.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-4.12256")
@@ -3421,6 +3732,7 @@ class Program_weight_tensor_parameter_310:
 
 class Program_weight_tensor_parameter_311:
     name = "parameter_311"
+    original_name = "conv2d_35.w_0"
     shape = [512, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.794867")
@@ -3432,6 +3744,7 @@ class Program_weight_tensor_parameter_311:
 
 class Program_weight_tensor_parameter_312:
     name = "parameter_312"
+    original_name = "batch_norm2d_16.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.21297")
@@ -3443,6 +3756,7 @@ class Program_weight_tensor_parameter_312:
 
 class Program_weight_tensor_parameter_313:
     name = "parameter_313"
+    original_name = "batch_norm2d_16.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.74261")
@@ -3454,6 +3768,7 @@ class Program_weight_tensor_parameter_313:
 
 class Program_weight_tensor_parameter_314:
     name = "parameter_314"
+    original_name = "batch_norm2d_16.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("1.95141e-05")
@@ -3465,6 +3780,7 @@ class Program_weight_tensor_parameter_314:
 
 class Program_weight_tensor_parameter_315:
     name = "parameter_315"
+    original_name = "batch_norm2d_16.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.90997")
@@ -3476,6 +3792,7 @@ class Program_weight_tensor_parameter_315:
 
 class Program_weight_tensor_parameter_316:
     name = "parameter_316"
+    original_name = "conv2d_34.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.213434")
@@ -3487,6 +3804,7 @@ class Program_weight_tensor_parameter_316:
 
 class Program_weight_tensor_parameter_317:
     name = "parameter_317"
+    original_name = "conv2d_34.w_0"
     shape = [128, 1, 7, 7]
     dtype = "float32"
     min_val = float("-1.00105")
@@ -3498,6 +3816,7 @@ class Program_weight_tensor_parameter_317:
 
 class Program_weight_tensor_parameter_318:
     name = "parameter_318"
+    original_name = "batch_norm2d_15.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.77275")
@@ -3509,6 +3828,7 @@ class Program_weight_tensor_parameter_318:
 
 class Program_weight_tensor_parameter_319:
     name = "parameter_319"
+    original_name = "batch_norm2d_15.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.00469534")
@@ -3520,6 +3840,7 @@ class Program_weight_tensor_parameter_319:
 
 class Program_weight_tensor_parameter_320:
     name = "parameter_320"
+    original_name = "batch_norm2d_15.w_2"
     shape = [128]
     dtype = "float32"
     min_val = float("17.0344")
@@ -3531,6 +3852,7 @@ class Program_weight_tensor_parameter_320:
 
 class Program_weight_tensor_parameter_321:
     name = "parameter_321"
+    original_name = "batch_norm2d_15.w_1"
     shape = [128]
     dtype = "float32"
     min_val = float("-5.54424")
@@ -3542,6 +3864,7 @@ class Program_weight_tensor_parameter_321:
 
 class Program_weight_tensor_parameter_322:
     name = "parameter_322"
+    original_name = "conv2d_33.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.0397483")
@@ -3553,6 +3876,7 @@ class Program_weight_tensor_parameter_322:
 
 class Program_weight_tensor_parameter_323:
     name = "parameter_323"
+    original_name = "conv2d_33.w_0"
     shape = [128, 64, 3, 3]
     dtype = "float32"
     min_val = float("-1.39468")
@@ -3564,6 +3888,7 @@ class Program_weight_tensor_parameter_323:
 
 class Program_weight_tensor_parameter_324:
     name = "parameter_324"
+    original_name = "conv2d_32.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -3573,6 +3898,7 @@ class Program_weight_tensor_parameter_324:
 
 class Program_weight_tensor_parameter_325:
     name = "parameter_325"
+    original_name = "conv2d_32.w_0"
     shape = [64, 1, 7, 7]
     dtype = "float32"
     min_val = float("-0.409961")
@@ -3584,6 +3910,7 @@ class Program_weight_tensor_parameter_325:
 
 class Program_weight_tensor_parameter_326:
     name = "parameter_326"
+    original_name = "batch_norm2d_14.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -3593,6 +3920,7 @@ class Program_weight_tensor_parameter_326:
 
 class Program_weight_tensor_parameter_327:
     name = "parameter_327"
+    original_name = "batch_norm2d_14.w_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -3602,6 +3930,7 @@ class Program_weight_tensor_parameter_327:
 
 class Program_weight_tensor_parameter_328:
     name = "parameter_328"
+    original_name = "batch_norm2d_14.w_2"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -3611,6 +3940,7 @@ class Program_weight_tensor_parameter_328:
 
 class Program_weight_tensor_parameter_329:
     name = "parameter_329"
+    original_name = "batch_norm2d_14.w_1"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -3620,6 +3950,7 @@ class Program_weight_tensor_parameter_329:
 
 class Program_weight_tensor_parameter_330:
     name = "parameter_330"
+    original_name = "conv2d_31.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -3629,6 +3960,7 @@ class Program_weight_tensor_parameter_330:
 
 class Program_weight_tensor_parameter_331:
     name = "parameter_331"
+    original_name = "conv2d_31.w_0"
     shape = [64, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.781185")
@@ -3640,6 +3972,7 @@ class Program_weight_tensor_parameter_331:
 
 class Program_weight_tensor_parameter_332:
     name = "parameter_332"
+    original_name = "conv2d_30.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-2.86243")
@@ -3651,6 +3984,7 @@ class Program_weight_tensor_parameter_332:
 
 class Program_weight_tensor_parameter_333:
     name = "parameter_333"
+    original_name = "conv2d_30.w_0"
     shape = [256, 64, 1, 1]
     dtype = "float32"
     min_val = float("-0.757058")
@@ -3662,6 +3996,7 @@ class Program_weight_tensor_parameter_333:
 
 class Program_weight_tensor_parameter_334:
     name = "parameter_334"
+    original_name = "conv2d_29.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-2.31713")
@@ -3673,6 +4008,7 @@ class Program_weight_tensor_parameter_334:
 
 class Program_weight_tensor_parameter_335:
     name = "parameter_335"
+    original_name = "conv2d_29.w_0"
     shape = [256, 64, 1, 1]
     dtype = "float32"
     min_val = float("-0.505031")
@@ -3684,6 +4020,7 @@ class Program_weight_tensor_parameter_335:
 
 class Program_weight_tensor_parameter_336:
     name = "parameter_336"
+    original_name = "batch_norm2d_13.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -3693,6 +4030,7 @@ class Program_weight_tensor_parameter_336:
 
 class Program_weight_tensor_parameter_337:
     name = "parameter_337"
+    original_name = "batch_norm2d_13.w_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -3702,6 +4040,7 @@ class Program_weight_tensor_parameter_337:
 
 class Program_weight_tensor_parameter_338:
     name = "parameter_338"
+    original_name = "batch_norm2d_13.w_2"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -3711,6 +4050,7 @@ class Program_weight_tensor_parameter_338:
 
 class Program_weight_tensor_parameter_339:
     name = "parameter_339"
+    original_name = "batch_norm2d_13.w_1"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -3720,6 +4060,7 @@ class Program_weight_tensor_parameter_339:
 
 class Program_weight_tensor_parameter_340:
     name = "parameter_340"
+    original_name = "conv2d_28.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -3729,6 +4070,7 @@ class Program_weight_tensor_parameter_340:
 
 class Program_weight_tensor_parameter_341:
     name = "parameter_341"
+    original_name = "conv2d_28.w_0"
     shape = [64, 1, 7, 7]
     dtype = "float32"
     min_val = float("-0.96996")
@@ -3740,6 +4082,7 @@ class Program_weight_tensor_parameter_341:
 
 class Program_weight_tensor_parameter_342:
     name = "parameter_342"
+    original_name = "conv2d_27.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -3749,6 +4092,7 @@ class Program_weight_tensor_parameter_342:
 
 class Program_weight_tensor_parameter_343:
     name = "parameter_343"
+    original_name = "conv2d_27.w_0"
     shape = [64, 1, 7, 7]
     dtype = "float32"
     min_val = float("-0.546841")
@@ -3760,6 +4104,7 @@ class Program_weight_tensor_parameter_343:
 
 class Program_weight_tensor_parameter_344:
     name = "parameter_344"
+    original_name = "batch_norm2d_12.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -3769,6 +4114,7 @@ class Program_weight_tensor_parameter_344:
 
 class Program_weight_tensor_parameter_345:
     name = "parameter_345"
+    original_name = "batch_norm2d_12.w_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -3778,6 +4124,7 @@ class Program_weight_tensor_parameter_345:
 
 class Program_weight_tensor_parameter_346:
     name = "parameter_346"
+    original_name = "batch_norm2d_12.w_2"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -3787,6 +4134,7 @@ class Program_weight_tensor_parameter_346:
 
 class Program_weight_tensor_parameter_347:
     name = "parameter_347"
+    original_name = "batch_norm2d_12.w_1"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -3796,6 +4144,7 @@ class Program_weight_tensor_parameter_347:
 
 class Program_weight_tensor_parameter_348:
     name = "parameter_348"
+    original_name = "conv2d_26.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -3805,6 +4154,7 @@ class Program_weight_tensor_parameter_348:
 
 class Program_weight_tensor_parameter_349:
     name = "parameter_349"
+    original_name = "conv2d_26.w_0"
     shape = [64, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.729303")
@@ -3816,6 +4166,7 @@ class Program_weight_tensor_parameter_349:
 
 class Program_weight_tensor_parameter_350:
     name = "parameter_350"
+    original_name = "conv2d_25.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-4.63379")
@@ -3827,6 +4178,7 @@ class Program_weight_tensor_parameter_350:
 
 class Program_weight_tensor_parameter_351:
     name = "parameter_351"
+    original_name = "conv2d_25.w_0"
     shape = [256, 64, 1, 1]
     dtype = "float32"
     min_val = float("-0.731877")
@@ -3838,6 +4190,7 @@ class Program_weight_tensor_parameter_351:
 
 class Program_weight_tensor_parameter_352:
     name = "parameter_352"
+    original_name = "conv2d_24.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-2.28813")
@@ -3849,6 +4202,7 @@ class Program_weight_tensor_parameter_352:
 
 class Program_weight_tensor_parameter_353:
     name = "parameter_353"
+    original_name = "conv2d_24.w_0"
     shape = [256, 64, 1, 1]
     dtype = "float32"
     min_val = float("-0.910923")
@@ -3860,6 +4214,7 @@ class Program_weight_tensor_parameter_353:
 
 class Program_weight_tensor_parameter_354:
     name = "parameter_354"
+    original_name = "batch_norm2d_11.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -3869,6 +4224,7 @@ class Program_weight_tensor_parameter_354:
 
 class Program_weight_tensor_parameter_355:
     name = "parameter_355"
+    original_name = "batch_norm2d_11.w_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -3878,6 +4234,7 @@ class Program_weight_tensor_parameter_355:
 
 class Program_weight_tensor_parameter_356:
     name = "parameter_356"
+    original_name = "batch_norm2d_11.w_2"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -3887,6 +4244,7 @@ class Program_weight_tensor_parameter_356:
 
 class Program_weight_tensor_parameter_357:
     name = "parameter_357"
+    original_name = "batch_norm2d_11.w_1"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -3896,6 +4254,7 @@ class Program_weight_tensor_parameter_357:
 
 class Program_weight_tensor_parameter_358:
     name = "parameter_358"
+    original_name = "conv2d_23.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -3905,6 +4264,7 @@ class Program_weight_tensor_parameter_358:
 
 class Program_weight_tensor_parameter_359:
     name = "parameter_359"
+    original_name = "conv2d_23.w_0"
     shape = [64, 1, 7, 7]
     dtype = "float32"
     min_val = float("-0.734399")
@@ -3916,6 +4276,7 @@ class Program_weight_tensor_parameter_359:
 
 class Program_weight_tensor_parameter_360:
     name = "parameter_360"
+    original_name = "conv2d_22.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -3925,6 +4286,7 @@ class Program_weight_tensor_parameter_360:
 
 class Program_weight_tensor_parameter_361:
     name = "parameter_361"
+    original_name = "conv2d_22.w_0"
     shape = [64, 1, 7, 7]
     dtype = "float32"
     min_val = float("-0.555204")
@@ -3936,6 +4298,7 @@ class Program_weight_tensor_parameter_361:
 
 class Program_weight_tensor_parameter_362:
     name = "parameter_362"
+    original_name = "batch_norm2d_10.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -3945,6 +4308,7 @@ class Program_weight_tensor_parameter_362:
 
 class Program_weight_tensor_parameter_363:
     name = "parameter_363"
+    original_name = "batch_norm2d_10.w_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -3954,6 +4318,7 @@ class Program_weight_tensor_parameter_363:
 
 class Program_weight_tensor_parameter_364:
     name = "parameter_364"
+    original_name = "batch_norm2d_10.w_2"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -3963,6 +4328,7 @@ class Program_weight_tensor_parameter_364:
 
 class Program_weight_tensor_parameter_365:
     name = "parameter_365"
+    original_name = "batch_norm2d_10.w_1"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -3972,6 +4338,7 @@ class Program_weight_tensor_parameter_365:
 
 class Program_weight_tensor_parameter_366:
     name = "parameter_366"
+    original_name = "conv2d_21.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -3981,6 +4348,7 @@ class Program_weight_tensor_parameter_366:
 
 class Program_weight_tensor_parameter_367:
     name = "parameter_367"
+    original_name = "conv2d_21.w_0"
     shape = [64, 256, 1, 1]
     dtype = "float32"
     min_val = float("-0.511328")
@@ -3992,6 +4360,7 @@ class Program_weight_tensor_parameter_367:
 
 class Program_weight_tensor_parameter_368:
     name = "parameter_368"
+    original_name = "conv2d_20.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-4.08617")
@@ -4003,6 +4372,7 @@ class Program_weight_tensor_parameter_368:
 
 class Program_weight_tensor_parameter_369:
     name = "parameter_369"
+    original_name = "conv2d_20.w_0"
     shape = [256, 64, 1, 1]
     dtype = "float32"
     min_val = float("-0.62145")
@@ -4014,6 +4384,7 @@ class Program_weight_tensor_parameter_369:
 
 class Program_weight_tensor_parameter_370:
     name = "parameter_370"
+    original_name = "conv2d_19.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-4.46826")
@@ -4025,6 +4396,7 @@ class Program_weight_tensor_parameter_370:
 
 class Program_weight_tensor_parameter_371:
     name = "parameter_371"
+    original_name = "conv2d_19.w_0"
     shape = [256, 64, 1, 1]
     dtype = "float32"
     min_val = float("-1.07402")
@@ -4036,6 +4408,7 @@ class Program_weight_tensor_parameter_371:
 
 class Program_weight_tensor_parameter_372:
     name = "parameter_372"
+    original_name = "batch_norm2d_9.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -4045,6 +4418,7 @@ class Program_weight_tensor_parameter_372:
 
 class Program_weight_tensor_parameter_373:
     name = "parameter_373"
+    original_name = "batch_norm2d_9.w_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -4054,6 +4428,7 @@ class Program_weight_tensor_parameter_373:
 
 class Program_weight_tensor_parameter_374:
     name = "parameter_374"
+    original_name = "batch_norm2d_9.w_2"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -4063,6 +4438,7 @@ class Program_weight_tensor_parameter_374:
 
 class Program_weight_tensor_parameter_375:
     name = "parameter_375"
+    original_name = "batch_norm2d_9.w_1"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -4072,6 +4448,7 @@ class Program_weight_tensor_parameter_375:
 
 class Program_weight_tensor_parameter_376:
     name = "parameter_376"
+    original_name = "conv2d_18.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -4081,6 +4458,7 @@ class Program_weight_tensor_parameter_376:
 
 class Program_weight_tensor_parameter_377:
     name = "parameter_377"
+    original_name = "conv2d_18.w_0"
     shape = [64, 1, 7, 7]
     dtype = "float32"
     min_val = float("-1.31751")
@@ -4092,6 +4470,7 @@ class Program_weight_tensor_parameter_377:
 
 class Program_weight_tensor_parameter_378:
     name = "parameter_378"
+    original_name = "batch_norm2d_8.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -4101,6 +4480,7 @@ class Program_weight_tensor_parameter_378:
 
 class Program_weight_tensor_parameter_379:
     name = "parameter_379"
+    original_name = "batch_norm2d_8.w_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -4110,6 +4490,7 @@ class Program_weight_tensor_parameter_379:
 
 class Program_weight_tensor_parameter_380:
     name = "parameter_380"
+    original_name = "batch_norm2d_8.w_2"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -4119,6 +4500,7 @@ class Program_weight_tensor_parameter_380:
 
 class Program_weight_tensor_parameter_381:
     name = "parameter_381"
+    original_name = "batch_norm2d_8.w_1"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -4128,6 +4510,7 @@ class Program_weight_tensor_parameter_381:
 
 class Program_weight_tensor_parameter_382:
     name = "parameter_382"
+    original_name = "conv2d_17.b_0"
     shape = [64]
     dtype = "float32"
     min_val = float("0")
@@ -4137,6 +4520,7 @@ class Program_weight_tensor_parameter_382:
 
 class Program_weight_tensor_parameter_383:
     name = "parameter_383"
+    original_name = "conv2d_17.w_0"
     shape = [64, 32, 3, 3]
     dtype = "float32"
     min_val = float("-1.12519")
@@ -4148,6 +4532,7 @@ class Program_weight_tensor_parameter_383:
 
 class Program_weight_tensor_parameter_384:
     name = "parameter_384"
+    original_name = "conv2d_16.b_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -4157,6 +4542,7 @@ class Program_weight_tensor_parameter_384:
 
 class Program_weight_tensor_parameter_385:
     name = "parameter_385"
+    original_name = "conv2d_16.w_0"
     shape = [32, 1, 7, 7]
     dtype = "float32"
     min_val = float("-0.372446")
@@ -4168,6 +4554,7 @@ class Program_weight_tensor_parameter_385:
 
 class Program_weight_tensor_parameter_386:
     name = "parameter_386"
+    original_name = "batch_norm2d_7.b_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -4177,6 +4564,7 @@ class Program_weight_tensor_parameter_386:
 
 class Program_weight_tensor_parameter_387:
     name = "parameter_387"
+    original_name = "batch_norm2d_7.w_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -4186,6 +4574,7 @@ class Program_weight_tensor_parameter_387:
 
 class Program_weight_tensor_parameter_388:
     name = "parameter_388"
+    original_name = "batch_norm2d_7.w_2"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -4195,6 +4584,7 @@ class Program_weight_tensor_parameter_388:
 
 class Program_weight_tensor_parameter_389:
     name = "parameter_389"
+    original_name = "batch_norm2d_7.w_1"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -4204,6 +4594,7 @@ class Program_weight_tensor_parameter_389:
 
 class Program_weight_tensor_parameter_390:
     name = "parameter_390"
+    original_name = "conv2d_15.b_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -4213,6 +4604,7 @@ class Program_weight_tensor_parameter_390:
 
 class Program_weight_tensor_parameter_391:
     name = "parameter_391"
+    original_name = "conv2d_15.w_0"
     shape = [32, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.541365")
@@ -4224,6 +4616,7 @@ class Program_weight_tensor_parameter_391:
 
 class Program_weight_tensor_parameter_392:
     name = "parameter_392"
+    original_name = "conv2d_14.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-2.82501")
@@ -4235,6 +4628,7 @@ class Program_weight_tensor_parameter_392:
 
 class Program_weight_tensor_parameter_393:
     name = "parameter_393"
+    original_name = "conv2d_14.w_0"
     shape = [128, 32, 1, 1]
     dtype = "float32"
     min_val = float("-0.729872")
@@ -4246,6 +4640,7 @@ class Program_weight_tensor_parameter_393:
 
 class Program_weight_tensor_parameter_394:
     name = "parameter_394"
+    original_name = "conv2d_13.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.07606")
@@ -4257,6 +4652,7 @@ class Program_weight_tensor_parameter_394:
 
 class Program_weight_tensor_parameter_395:
     name = "parameter_395"
+    original_name = "conv2d_13.w_0"
     shape = [128, 32, 1, 1]
     dtype = "float32"
     min_val = float("-0.408246")
@@ -4268,6 +4664,7 @@ class Program_weight_tensor_parameter_395:
 
 class Program_weight_tensor_parameter_396:
     name = "parameter_396"
+    original_name = "batch_norm2d_6.b_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -4277,6 +4674,7 @@ class Program_weight_tensor_parameter_396:
 
 class Program_weight_tensor_parameter_397:
     name = "parameter_397"
+    original_name = "batch_norm2d_6.w_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -4286,6 +4684,7 @@ class Program_weight_tensor_parameter_397:
 
 class Program_weight_tensor_parameter_398:
     name = "parameter_398"
+    original_name = "batch_norm2d_6.w_2"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -4295,6 +4694,7 @@ class Program_weight_tensor_parameter_398:
 
 class Program_weight_tensor_parameter_399:
     name = "parameter_399"
+    original_name = "batch_norm2d_6.w_1"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -4304,6 +4704,7 @@ class Program_weight_tensor_parameter_399:
 
 class Program_weight_tensor_parameter_400:
     name = "parameter_400"
+    original_name = "conv2d_12.b_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -4313,6 +4714,7 @@ class Program_weight_tensor_parameter_400:
 
 class Program_weight_tensor_parameter_401:
     name = "parameter_401"
+    original_name = "conv2d_12.w_0"
     shape = [32, 1, 7, 7]
     dtype = "float32"
     min_val = float("-0.644885")
@@ -4324,6 +4726,7 @@ class Program_weight_tensor_parameter_401:
 
 class Program_weight_tensor_parameter_402:
     name = "parameter_402"
+    original_name = "conv2d_11.b_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -4333,6 +4736,7 @@ class Program_weight_tensor_parameter_402:
 
 class Program_weight_tensor_parameter_403:
     name = "parameter_403"
+    original_name = "conv2d_11.w_0"
     shape = [32, 1, 7, 7]
     dtype = "float32"
     min_val = float("-0.518232")
@@ -4344,6 +4748,7 @@ class Program_weight_tensor_parameter_403:
 
 class Program_weight_tensor_parameter_404:
     name = "parameter_404"
+    original_name = "batch_norm2d_5.b_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -4353,6 +4758,7 @@ class Program_weight_tensor_parameter_404:
 
 class Program_weight_tensor_parameter_405:
     name = "parameter_405"
+    original_name = "batch_norm2d_5.w_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -4362,6 +4768,7 @@ class Program_weight_tensor_parameter_405:
 
 class Program_weight_tensor_parameter_406:
     name = "parameter_406"
+    original_name = "batch_norm2d_5.w_2"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -4371,6 +4778,7 @@ class Program_weight_tensor_parameter_406:
 
 class Program_weight_tensor_parameter_407:
     name = "parameter_407"
+    original_name = "batch_norm2d_5.w_1"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -4380,6 +4788,7 @@ class Program_weight_tensor_parameter_407:
 
 class Program_weight_tensor_parameter_408:
     name = "parameter_408"
+    original_name = "conv2d_10.b_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -4389,6 +4798,7 @@ class Program_weight_tensor_parameter_408:
 
 class Program_weight_tensor_parameter_409:
     name = "parameter_409"
+    original_name = "conv2d_10.w_0"
     shape = [32, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.879897")
@@ -4400,6 +4810,7 @@ class Program_weight_tensor_parameter_409:
 
 class Program_weight_tensor_parameter_410:
     name = "parameter_410"
+    original_name = "conv2d_9.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-3.30911")
@@ -4411,6 +4822,7 @@ class Program_weight_tensor_parameter_410:
 
 class Program_weight_tensor_parameter_411:
     name = "parameter_411"
+    original_name = "conv2d_9.w_0"
     shape = [128, 32, 1, 1]
     dtype = "float32"
     min_val = float("-0.406711")
@@ -4422,6 +4834,7 @@ class Program_weight_tensor_parameter_411:
 
 class Program_weight_tensor_parameter_412:
     name = "parameter_412"
+    original_name = "conv2d_8.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.37156")
@@ -4433,6 +4846,7 @@ class Program_weight_tensor_parameter_412:
 
 class Program_weight_tensor_parameter_413:
     name = "parameter_413"
+    original_name = "conv2d_8.w_0"
     shape = [128, 32, 1, 1]
     dtype = "float32"
     min_val = float("-0.894553")
@@ -4444,6 +4858,7 @@ class Program_weight_tensor_parameter_413:
 
 class Program_weight_tensor_parameter_414:
     name = "parameter_414"
+    original_name = "batch_norm2d_4.b_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -4453,6 +4868,7 @@ class Program_weight_tensor_parameter_414:
 
 class Program_weight_tensor_parameter_415:
     name = "parameter_415"
+    original_name = "batch_norm2d_4.w_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -4462,6 +4878,7 @@ class Program_weight_tensor_parameter_415:
 
 class Program_weight_tensor_parameter_416:
     name = "parameter_416"
+    original_name = "batch_norm2d_4.w_2"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -4471,6 +4888,7 @@ class Program_weight_tensor_parameter_416:
 
 class Program_weight_tensor_parameter_417:
     name = "parameter_417"
+    original_name = "batch_norm2d_4.w_1"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -4480,6 +4898,7 @@ class Program_weight_tensor_parameter_417:
 
 class Program_weight_tensor_parameter_418:
     name = "parameter_418"
+    original_name = "conv2d_7.b_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -4489,6 +4908,7 @@ class Program_weight_tensor_parameter_418:
 
 class Program_weight_tensor_parameter_419:
     name = "parameter_419"
+    original_name = "conv2d_7.w_0"
     shape = [32, 1, 7, 7]
     dtype = "float32"
     min_val = float("-0.946039")
@@ -4500,6 +4920,7 @@ class Program_weight_tensor_parameter_419:
 
 class Program_weight_tensor_parameter_420:
     name = "parameter_420"
+    original_name = "conv2d_6.b_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -4509,6 +4930,7 @@ class Program_weight_tensor_parameter_420:
 
 class Program_weight_tensor_parameter_421:
     name = "parameter_421"
+    original_name = "conv2d_6.w_0"
     shape = [32, 1, 7, 7]
     dtype = "float32"
     min_val = float("-0.487273")
@@ -4520,6 +4942,7 @@ class Program_weight_tensor_parameter_421:
 
 class Program_weight_tensor_parameter_422:
     name = "parameter_422"
+    original_name = "batch_norm2d_3.b_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -4529,6 +4952,7 @@ class Program_weight_tensor_parameter_422:
 
 class Program_weight_tensor_parameter_423:
     name = "parameter_423"
+    original_name = "batch_norm2d_3.w_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -4538,6 +4962,7 @@ class Program_weight_tensor_parameter_423:
 
 class Program_weight_tensor_parameter_424:
     name = "parameter_424"
+    original_name = "batch_norm2d_3.w_2"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -4547,6 +4972,7 @@ class Program_weight_tensor_parameter_424:
 
 class Program_weight_tensor_parameter_425:
     name = "parameter_425"
+    original_name = "batch_norm2d_3.w_1"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -4556,6 +4982,7 @@ class Program_weight_tensor_parameter_425:
 
 class Program_weight_tensor_parameter_426:
     name = "parameter_426"
+    original_name = "conv2d_5.b_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -4565,6 +4992,7 @@ class Program_weight_tensor_parameter_426:
 
 class Program_weight_tensor_parameter_427:
     name = "parameter_427"
+    original_name = "conv2d_5.w_0"
     shape = [32, 128, 1, 1]
     dtype = "float32"
     min_val = float("-0.47752")
@@ -4576,6 +5004,7 @@ class Program_weight_tensor_parameter_427:
 
 class Program_weight_tensor_parameter_428:
     name = "parameter_428"
+    original_name = "conv2d_4.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-2.4435")
@@ -4587,6 +5016,7 @@ class Program_weight_tensor_parameter_428:
 
 class Program_weight_tensor_parameter_429:
     name = "parameter_429"
+    original_name = "conv2d_4.w_0"
     shape = [128, 32, 1, 1]
     dtype = "float32"
     min_val = float("-0.422683")
@@ -4598,6 +5028,7 @@ class Program_weight_tensor_parameter_429:
 
 class Program_weight_tensor_parameter_430:
     name = "parameter_430"
+    original_name = "conv2d_3.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.938533")
@@ -4609,6 +5040,7 @@ class Program_weight_tensor_parameter_430:
 
 class Program_weight_tensor_parameter_431:
     name = "parameter_431"
+    original_name = "conv2d_3.w_0"
     shape = [128, 32, 1, 1]
     dtype = "float32"
     min_val = float("-0.588492")
@@ -4620,6 +5052,7 @@ class Program_weight_tensor_parameter_431:
 
 class Program_weight_tensor_parameter_432:
     name = "parameter_432"
+    original_name = "batch_norm2d_2.b_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -4629,6 +5062,7 @@ class Program_weight_tensor_parameter_432:
 
 class Program_weight_tensor_parameter_433:
     name = "parameter_433"
+    original_name = "batch_norm2d_2.w_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -4638,6 +5072,7 @@ class Program_weight_tensor_parameter_433:
 
 class Program_weight_tensor_parameter_434:
     name = "parameter_434"
+    original_name = "batch_norm2d_2.w_2"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -4647,6 +5082,7 @@ class Program_weight_tensor_parameter_434:
 
 class Program_weight_tensor_parameter_435:
     name = "parameter_435"
+    original_name = "batch_norm2d_2.w_1"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -4656,6 +5092,7 @@ class Program_weight_tensor_parameter_435:
 
 class Program_weight_tensor_parameter_436:
     name = "parameter_436"
+    original_name = "conv2d_2.b_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -4665,6 +5102,7 @@ class Program_weight_tensor_parameter_436:
 
 class Program_weight_tensor_parameter_437:
     name = "parameter_437"
+    original_name = "conv2d_2.w_0"
     shape = [32, 1, 7, 7]
     dtype = "float32"
     min_val = float("-2.11644")
@@ -4676,6 +5114,7 @@ class Program_weight_tensor_parameter_437:
 
 class Program_weight_tensor_parameter_438:
     name = "parameter_438"
+    original_name = "batch_norm2d_1.b_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -4685,6 +5124,7 @@ class Program_weight_tensor_parameter_438:
 
 class Program_weight_tensor_parameter_439:
     name = "parameter_439"
+    original_name = "batch_norm2d_1.w_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -4694,6 +5134,7 @@ class Program_weight_tensor_parameter_439:
 
 class Program_weight_tensor_parameter_440:
     name = "parameter_440"
+    original_name = "batch_norm2d_1.w_2"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -4703,6 +5144,7 @@ class Program_weight_tensor_parameter_440:
 
 class Program_weight_tensor_parameter_441:
     name = "parameter_441"
+    original_name = "batch_norm2d_1.w_1"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -4712,6 +5154,7 @@ class Program_weight_tensor_parameter_441:
 
 class Program_weight_tensor_parameter_442:
     name = "parameter_442"
+    original_name = "conv2d_1.b_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -4721,6 +5164,7 @@ class Program_weight_tensor_parameter_442:
 
 class Program_weight_tensor_parameter_443:
     name = "parameter_443"
+    original_name = "conv2d_1.w_0"
     shape = [32, 32, 3, 3]
     dtype = "float32"
     min_val = float("-0.652491")
@@ -4732,6 +5176,7 @@ class Program_weight_tensor_parameter_443:
 
 class Program_weight_tensor_parameter_444:
     name = "parameter_444"
+    original_name = "batch_norm2d_0.b_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -4741,6 +5186,7 @@ class Program_weight_tensor_parameter_444:
 
 class Program_weight_tensor_parameter_445:
     name = "parameter_445"
+    original_name = "batch_norm2d_0.w_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -4750,6 +5196,7 @@ class Program_weight_tensor_parameter_445:
 
 class Program_weight_tensor_parameter_446:
     name = "parameter_446"
+    original_name = "batch_norm2d_0.w_2"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -4759,6 +5206,7 @@ class Program_weight_tensor_parameter_446:
 
 class Program_weight_tensor_parameter_447:
     name = "parameter_447"
+    original_name = "batch_norm2d_0.w_1"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -4768,6 +5216,7 @@ class Program_weight_tensor_parameter_447:
 
 class Program_weight_tensor_parameter_448:
     name = "parameter_448"
+    original_name = "conv2d_0.b_0"
     shape = [32]
     dtype = "float32"
     min_val = float("0")
@@ -4777,6 +5226,7 @@ class Program_weight_tensor_parameter_448:
 
 class Program_weight_tensor_parameter_449:
     name = "parameter_449"
+    original_name = "conv2d_0.w_0"
     shape = [32, 3, 3, 3]
     dtype = "float32"
     min_val = float("-0.313016")

--- a/paddle_samples/PaddleX/ch_SVTRv2_rec/subgraph_12/input_meta.py
+++ b/paddle_samples/PaddleX/ch_SVTRv2_rec/subgraph_12/input_meta.py
@@ -1,5 +1,6 @@
 class Program_weight_tensor_data_0:
     name = "data_0"
+    original_name = "var_3345"
     shape = [8, 128, 8, 80]
     dtype = "float32"
     min_val = float("-0.169971")

--- a/paddle_samples/PaddleX/ch_SVTRv2_rec/subgraph_12/weight_meta.py
+++ b/paddle_samples/PaddleX/ch_SVTRv2_rec/subgraph_12/weight_meta.py
@@ -1,5 +1,6 @@
 class Program_weight_tensor_parameter_0:
     name = "parameter_0"
+    original_name = "layer_norm_12.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-0.668521")
@@ -11,6 +12,7 @@ class Program_weight_tensor_parameter_0:
 
 class Program_weight_tensor_parameter_1:
     name = "parameter_1"
+    original_name = "layer_norm_12.w_0"
     shape = [256]
     dtype = "float32"
     min_val = float("0.187715")
@@ -22,6 +24,7 @@ class Program_weight_tensor_parameter_1:
 
 class Program_weight_tensor_parameter_2:
     name = "parameter_2"
+    original_name = "conv2d_8.b_0"
     shape = [256]
     dtype = "float32"
     min_val = float("-8.25526")
@@ -33,6 +36,7 @@ class Program_weight_tensor_parameter_2:
 
 class Program_weight_tensor_parameter_3:
     name = "parameter_3"
+    original_name = "conv2d_8.w_0"
     shape = [256, 128, 3, 3]
     dtype = "float32"
     min_val = float("-6.30351")
@@ -44,6 +48,7 @@ class Program_weight_tensor_parameter_3:
 
 class Program_weight_tensor_parameter_4:
     name = "parameter_4"
+    original_name = "layer_norm_11.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.716209")
@@ -55,6 +60,7 @@ class Program_weight_tensor_parameter_4:
 
 class Program_weight_tensor_parameter_5:
     name = "parameter_5"
+    original_name = "layer_norm_11.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.40875")
@@ -66,6 +72,7 @@ class Program_weight_tensor_parameter_5:
 
 class Program_weight_tensor_parameter_6:
     name = "parameter_6"
+    original_name = "linear_11.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-4.08424")
@@ -77,6 +84,7 @@ class Program_weight_tensor_parameter_6:
 
 class Program_weight_tensor_parameter_7:
     name = "parameter_7"
+    original_name = "linear_11.w_0"
     shape = [512, 128]
     dtype = "float32"
     min_val = float("-0.471752")
@@ -88,6 +96,7 @@ class Program_weight_tensor_parameter_7:
 
 class Program_weight_tensor_parameter_8:
     name = "parameter_8"
+    original_name = "linear_10.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-1.89779")
@@ -99,6 +108,7 @@ class Program_weight_tensor_parameter_8:
 
 class Program_weight_tensor_parameter_9:
     name = "parameter_9"
+    original_name = "linear_10.w_0"
     shape = [128, 512]
     dtype = "float32"
     min_val = float("-0.322236")
@@ -110,6 +120,7 @@ class Program_weight_tensor_parameter_9:
 
 class Program_weight_tensor_parameter_10:
     name = "parameter_10"
+    original_name = "layer_norm_10.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.681698")
@@ -121,6 +132,7 @@ class Program_weight_tensor_parameter_10:
 
 class Program_weight_tensor_parameter_11:
     name = "parameter_11"
+    original_name = "layer_norm_10.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.572885")
@@ -132,6 +144,7 @@ class Program_weight_tensor_parameter_11:
 
 class Program_weight_tensor_parameter_12:
     name = "parameter_12"
+    original_name = "conv2d_7.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.7091")
@@ -143,6 +156,7 @@ class Program_weight_tensor_parameter_12:
 
 class Program_weight_tensor_parameter_13:
     name = "parameter_13"
+    original_name = "conv2d_7.w_0"
     shape = [128, 32, 5, 5]
     dtype = "float32"
     min_val = float("-0.399123")
@@ -154,6 +168,7 @@ class Program_weight_tensor_parameter_13:
 
 class Program_weight_tensor_parameter_14:
     name = "parameter_14"
+    original_name = "layer_norm_9.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.594308")
@@ -165,6 +180,7 @@ class Program_weight_tensor_parameter_14:
 
 class Program_weight_tensor_parameter_15:
     name = "parameter_15"
+    original_name = "layer_norm_9.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.274019")
@@ -176,6 +192,7 @@ class Program_weight_tensor_parameter_15:
 
 class Program_weight_tensor_parameter_16:
     name = "parameter_16"
+    original_name = "linear_9.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-5.1138")
@@ -187,6 +204,7 @@ class Program_weight_tensor_parameter_16:
 
 class Program_weight_tensor_parameter_17:
     name = "parameter_17"
+    original_name = "linear_9.w_0"
     shape = [512, 128]
     dtype = "float32"
     min_val = float("-0.818937")
@@ -198,6 +216,7 @@ class Program_weight_tensor_parameter_17:
 
 class Program_weight_tensor_parameter_18:
     name = "parameter_18"
+    original_name = "linear_8.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-1.37765")
@@ -209,6 +228,7 @@ class Program_weight_tensor_parameter_18:
 
 class Program_weight_tensor_parameter_19:
     name = "parameter_19"
+    original_name = "linear_8.w_0"
     shape = [128, 512]
     dtype = "float32"
     min_val = float("-0.405105")
@@ -220,6 +240,7 @@ class Program_weight_tensor_parameter_19:
 
 class Program_weight_tensor_parameter_20:
     name = "parameter_20"
+    original_name = "layer_norm_8.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.815685")
@@ -231,6 +252,7 @@ class Program_weight_tensor_parameter_20:
 
 class Program_weight_tensor_parameter_21:
     name = "parameter_21"
+    original_name = "layer_norm_8.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.685492")
@@ -242,6 +264,7 @@ class Program_weight_tensor_parameter_21:
 
 class Program_weight_tensor_parameter_22:
     name = "parameter_22"
+    original_name = "conv2d_6.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.885409")
@@ -253,6 +276,7 @@ class Program_weight_tensor_parameter_22:
 
 class Program_weight_tensor_parameter_23:
     name = "parameter_23"
+    original_name = "conv2d_6.w_0"
     shape = [128, 32, 5, 5]
     dtype = "float32"
     min_val = float("-0.317961")
@@ -264,6 +288,7 @@ class Program_weight_tensor_parameter_23:
 
 class Program_weight_tensor_parameter_24:
     name = "parameter_24"
+    original_name = "layer_norm_7.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.55219")
@@ -275,6 +300,7 @@ class Program_weight_tensor_parameter_24:
 
 class Program_weight_tensor_parameter_25:
     name = "parameter_25"
+    original_name = "layer_norm_7.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.0629769")
@@ -286,6 +312,7 @@ class Program_weight_tensor_parameter_25:
 
 class Program_weight_tensor_parameter_26:
     name = "parameter_26"
+    original_name = "linear_7.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.830581")
@@ -297,6 +324,7 @@ class Program_weight_tensor_parameter_26:
 
 class Program_weight_tensor_parameter_27:
     name = "parameter_27"
+    original_name = "linear_7.w_0"
     shape = [512, 128]
     dtype = "float32"
     min_val = float("-0.988648")
@@ -308,6 +336,7 @@ class Program_weight_tensor_parameter_27:
 
 class Program_weight_tensor_parameter_28:
     name = "parameter_28"
+    original_name = "linear_6.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-1.56353")
@@ -319,6 +348,7 @@ class Program_weight_tensor_parameter_28:
 
 class Program_weight_tensor_parameter_29:
     name = "parameter_29"
+    original_name = "linear_6.w_0"
     shape = [128, 512]
     dtype = "float32"
     min_val = float("-0.414822")
@@ -330,6 +360,7 @@ class Program_weight_tensor_parameter_29:
 
 class Program_weight_tensor_parameter_30:
     name = "parameter_30"
+    original_name = "layer_norm_6.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.706417")
@@ -341,6 +372,7 @@ class Program_weight_tensor_parameter_30:
 
 class Program_weight_tensor_parameter_31:
     name = "parameter_31"
+    original_name = "layer_norm_6.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.782251")
@@ -352,6 +384,7 @@ class Program_weight_tensor_parameter_31:
 
 class Program_weight_tensor_parameter_32:
     name = "parameter_32"
+    original_name = "conv2d_5.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.829148")
@@ -363,6 +396,7 @@ class Program_weight_tensor_parameter_32:
 
 class Program_weight_tensor_parameter_33:
     name = "parameter_33"
+    original_name = "conv2d_5.w_0"
     shape = [128, 32, 5, 5]
     dtype = "float32"
     min_val = float("-0.276089")
@@ -374,6 +408,7 @@ class Program_weight_tensor_parameter_33:
 
 class Program_weight_tensor_parameter_34:
     name = "parameter_34"
+    original_name = "layer_norm_5.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.43839")
@@ -385,6 +420,7 @@ class Program_weight_tensor_parameter_34:
 
 class Program_weight_tensor_parameter_35:
     name = "parameter_35"
+    original_name = "layer_norm_5.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.2699")
@@ -396,6 +432,7 @@ class Program_weight_tensor_parameter_35:
 
 class Program_weight_tensor_parameter_36:
     name = "parameter_36"
+    original_name = "linear_5.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-4.80893")
@@ -407,6 +444,7 @@ class Program_weight_tensor_parameter_36:
 
 class Program_weight_tensor_parameter_37:
     name = "parameter_37"
+    original_name = "linear_5.w_0"
     shape = [512, 128]
     dtype = "float32"
     min_val = float("-0.66374")
@@ -418,6 +456,7 @@ class Program_weight_tensor_parameter_37:
 
 class Program_weight_tensor_parameter_38:
     name = "parameter_38"
+    original_name = "linear_4.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-1.38975")
@@ -429,6 +468,7 @@ class Program_weight_tensor_parameter_38:
 
 class Program_weight_tensor_parameter_39:
     name = "parameter_39"
+    original_name = "linear_4.w_0"
     shape = [128, 512]
     dtype = "float32"
     min_val = float("-0.337775")
@@ -440,6 +480,7 @@ class Program_weight_tensor_parameter_39:
 
 class Program_weight_tensor_parameter_40:
     name = "parameter_40"
+    original_name = "layer_norm_4.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.21058")
@@ -451,6 +492,7 @@ class Program_weight_tensor_parameter_40:
 
 class Program_weight_tensor_parameter_41:
     name = "parameter_41"
+    original_name = "layer_norm_4.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.698989")
@@ -462,6 +504,7 @@ class Program_weight_tensor_parameter_41:
 
 class Program_weight_tensor_parameter_42:
     name = "parameter_42"
+    original_name = "conv2d_4.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.06")
@@ -473,6 +516,7 @@ class Program_weight_tensor_parameter_42:
 
 class Program_weight_tensor_parameter_43:
     name = "parameter_43"
+    original_name = "conv2d_4.w_0"
     shape = [128, 32, 5, 5]
     dtype = "float32"
     min_val = float("-0.351555")
@@ -484,6 +528,7 @@ class Program_weight_tensor_parameter_43:
 
 class Program_weight_tensor_parameter_44:
     name = "parameter_44"
+    original_name = "layer_norm_3.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.978141")
@@ -495,6 +540,7 @@ class Program_weight_tensor_parameter_44:
 
 class Program_weight_tensor_parameter_45:
     name = "parameter_45"
+    original_name = "layer_norm_3.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.301306")
@@ -506,6 +552,7 @@ class Program_weight_tensor_parameter_45:
 
 class Program_weight_tensor_parameter_46:
     name = "parameter_46"
+    original_name = "linear_3.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-4.93517")
@@ -517,6 +564,7 @@ class Program_weight_tensor_parameter_46:
 
 class Program_weight_tensor_parameter_47:
     name = "parameter_47"
+    original_name = "linear_3.w_0"
     shape = [512, 128]
     dtype = "float32"
     min_val = float("-0.634287")
@@ -528,6 +576,7 @@ class Program_weight_tensor_parameter_47:
 
 class Program_weight_tensor_parameter_48:
     name = "parameter_48"
+    original_name = "linear_2.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-1.76981")
@@ -539,6 +588,7 @@ class Program_weight_tensor_parameter_48:
 
 class Program_weight_tensor_parameter_49:
     name = "parameter_49"
+    original_name = "linear_2.w_0"
     shape = [128, 512]
     dtype = "float32"
     min_val = float("-0.369617")
@@ -550,6 +600,7 @@ class Program_weight_tensor_parameter_49:
 
 class Program_weight_tensor_parameter_50:
     name = "parameter_50"
+    original_name = "layer_norm_2.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.941485")
@@ -561,6 +612,7 @@ class Program_weight_tensor_parameter_50:
 
 class Program_weight_tensor_parameter_51:
     name = "parameter_51"
+    original_name = "layer_norm_2.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.631475")
@@ -572,6 +624,7 @@ class Program_weight_tensor_parameter_51:
 
 class Program_weight_tensor_parameter_52:
     name = "parameter_52"
+    original_name = "conv2d_3.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.6476")
@@ -583,6 +636,7 @@ class Program_weight_tensor_parameter_52:
 
 class Program_weight_tensor_parameter_53:
     name = "parameter_53"
+    original_name = "conv2d_3.w_0"
     shape = [128, 32, 5, 5]
     dtype = "float32"
     min_val = float("-0.423287")
@@ -594,6 +648,7 @@ class Program_weight_tensor_parameter_53:
 
 class Program_weight_tensor_parameter_54:
     name = "parameter_54"
+    original_name = "layer_norm_1.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-1.06966")
@@ -605,6 +660,7 @@ class Program_weight_tensor_parameter_54:
 
 class Program_weight_tensor_parameter_55:
     name = "parameter_55"
+    original_name = "layer_norm_1.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.476229")
@@ -616,6 +672,7 @@ class Program_weight_tensor_parameter_55:
 
 class Program_weight_tensor_parameter_56:
     name = "parameter_56"
+    original_name = "linear_1.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.885903")
@@ -627,6 +684,7 @@ class Program_weight_tensor_parameter_56:
 
 class Program_weight_tensor_parameter_57:
     name = "parameter_57"
+    original_name = "linear_1.w_0"
     shape = [512, 128]
     dtype = "float32"
     min_val = float("-0.397077")
@@ -638,6 +696,7 @@ class Program_weight_tensor_parameter_57:
 
 class Program_weight_tensor_parameter_58:
     name = "parameter_58"
+    original_name = "linear_0.b_0"
     shape = [512]
     dtype = "float32"
     min_val = float("-1.34719")
@@ -649,6 +708,7 @@ class Program_weight_tensor_parameter_58:
 
 class Program_weight_tensor_parameter_59:
     name = "parameter_59"
+    original_name = "linear_0.w_0"
     shape = [128, 512]
     dtype = "float32"
     min_val = float("-0.549137")
@@ -660,6 +720,7 @@ class Program_weight_tensor_parameter_59:
 
 class Program_weight_tensor_parameter_60:
     name = "parameter_60"
+    original_name = "layer_norm_0.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.778871")
@@ -671,6 +732,7 @@ class Program_weight_tensor_parameter_60:
 
 class Program_weight_tensor_parameter_61:
     name = "parameter_61"
+    original_name = "layer_norm_0.w_0"
     shape = [128]
     dtype = "float32"
     min_val = float("0.533039")
@@ -682,6 +744,7 @@ class Program_weight_tensor_parameter_61:
 
 class Program_weight_tensor_parameter_62:
     name = "parameter_62"
+    original_name = "conv2d_2.b_0"
     shape = [128]
     dtype = "float32"
     min_val = float("-0.822867")
@@ -693,6 +756,7 @@ class Program_weight_tensor_parameter_62:
 
 class Program_weight_tensor_parameter_63:
     name = "parameter_63"
+    original_name = "conv2d_2.w_0"
     shape = [128, 32, 5, 5]
     dtype = "float32"
     min_val = float("-0.486222")

--- a/paddle_samples/PaddleX/ch_SVTRv2_rec/subgraph_14/input_meta.py
+++ b/paddle_samples/PaddleX/ch_SVTRv2_rec/subgraph_14/input_meta.py
@@ -1,5 +1,6 @@
 class Program_weight_tensor_data_0:
     name = "data_0"
+    original_name = "var_817"
     shape = [4, 384, 1, 40]
     dtype = "float32"
     min_val = float("-6.75135")
@@ -11,6 +12,7 @@ class Program_weight_tensor_data_0:
 
 class Program_weight_tensor_data_1:
     name = "data_1"
+    original_name = "var_819"
     shape = [4, 25]
     dtype = "int64"
     min_val = 0
@@ -20,6 +22,7 @@ class Program_weight_tensor_data_1:
 
 class Program_weight_tensor_data_2:
     name = "data_2"
+    original_name = "var_820"
     shape = [4]
     dtype = "int64"
     data = [3, 4, 3, 3]
@@ -27,6 +30,7 @@ class Program_weight_tensor_data_2:
 
 class Program_weight_tensor_data_3:
     name = "data_3"
+    original_name = "var_832"
     shape = [5000, 1, 384]
     dtype = "float32"
     min_val = float("-1.0")

--- a/paddle_samples/PaddleX/ch_SVTRv2_rec/subgraph_14/weight_meta.py
+++ b/paddle_samples/PaddleX/ch_SVTRv2_rec/subgraph_14/weight_meta.py
@@ -1,5 +1,6 @@
 class Program_weight_tensor_parameter_0:
     name = "parameter_0"
+    original_name = "linear_80.w_0"
     shape = [384, 6629]
     dtype = "float32"
     min_val = float("-0.342261")
@@ -11,6 +12,7 @@ class Program_weight_tensor_parameter_0:
 
 class Program_weight_tensor_parameter_1:
     name = "parameter_1"
+    original_name = "layer_norm_48.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-2.01452")
@@ -22,6 +24,7 @@ class Program_weight_tensor_parameter_1:
 
 class Program_weight_tensor_parameter_2:
     name = "parameter_2"
+    original_name = "layer_norm_48.w_0"
     shape = [384]
     dtype = "float32"
     min_val = float("0.163422")
@@ -33,6 +36,7 @@ class Program_weight_tensor_parameter_2:
 
 class Program_weight_tensor_parameter_3:
     name = "parameter_3"
+    original_name = "linear_79.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-0.646689")
@@ -44,6 +48,7 @@ class Program_weight_tensor_parameter_3:
 
 class Program_weight_tensor_parameter_4:
     name = "parameter_4"
+    original_name = "linear_79.w_0"
     shape = [1536, 384]
     dtype = "float32"
     min_val = float("-1.60316")
@@ -55,6 +60,7 @@ class Program_weight_tensor_parameter_4:
 
 class Program_weight_tensor_parameter_5:
     name = "parameter_5"
+    original_name = "linear_78.b_0"
     shape = [1536]
     dtype = "float32"
     min_val = float("-2.77784")
@@ -66,6 +72,7 @@ class Program_weight_tensor_parameter_5:
 
 class Program_weight_tensor_parameter_6:
     name = "parameter_6"
+    original_name = "linear_78.w_0"
     shape = [384, 1536]
     dtype = "float32"
     min_val = float("-0.471037")
@@ -77,6 +84,7 @@ class Program_weight_tensor_parameter_6:
 
 class Program_weight_tensor_parameter_7:
     name = "parameter_7"
+    original_name = "layer_norm_47.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-2.65602")
@@ -88,6 +96,7 @@ class Program_weight_tensor_parameter_7:
 
 class Program_weight_tensor_parameter_8:
     name = "parameter_8"
+    original_name = "layer_norm_47.w_0"
     shape = [384]
     dtype = "float32"
     min_val = float("0.0759988")
@@ -99,6 +108,7 @@ class Program_weight_tensor_parameter_8:
 
 class Program_weight_tensor_parameter_9:
     name = "parameter_9"
+    original_name = "linear_77.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-0.648992")
@@ -110,6 +120,7 @@ class Program_weight_tensor_parameter_9:
 
 class Program_weight_tensor_parameter_10:
     name = "parameter_10"
+    original_name = "linear_77.w_0"
     shape = [384, 384]
     dtype = "float32"
     min_val = float("-0.506227")
@@ -121,6 +132,7 @@ class Program_weight_tensor_parameter_10:
 
 class Program_weight_tensor_parameter_11:
     name = "parameter_11"
+    original_name = "linear_76.b_0"
     shape = [768]
     dtype = "float32"
     min_val = float("-0.815102")
@@ -132,6 +144,7 @@ class Program_weight_tensor_parameter_11:
 
 class Program_weight_tensor_parameter_12:
     name = "parameter_12"
+    original_name = "linear_76.w_0"
     shape = [384, 768]
     dtype = "float32"
     min_val = float("-0.540834")
@@ -143,6 +156,7 @@ class Program_weight_tensor_parameter_12:
 
 class Program_weight_tensor_parameter_13:
     name = "parameter_13"
+    original_name = "linear_75.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-3.03302")
@@ -154,6 +168,7 @@ class Program_weight_tensor_parameter_13:
 
 class Program_weight_tensor_parameter_14:
     name = "parameter_14"
+    original_name = "linear_75.w_0"
     shape = [384, 384]
     dtype = "float32"
     min_val = float("-0.385865")
@@ -165,6 +180,7 @@ class Program_weight_tensor_parameter_14:
 
 class Program_weight_tensor_parameter_15:
     name = "parameter_15"
+    original_name = "layer_norm_46.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-2.49454")
@@ -176,6 +192,7 @@ class Program_weight_tensor_parameter_15:
 
 class Program_weight_tensor_parameter_16:
     name = "parameter_16"
+    original_name = "layer_norm_46.w_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-0.106595")
@@ -187,6 +204,7 @@ class Program_weight_tensor_parameter_16:
 
 class Program_weight_tensor_parameter_17:
     name = "parameter_17"
+    original_name = "linear_74.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-7.57866")
@@ -198,6 +216,7 @@ class Program_weight_tensor_parameter_17:
 
 class Program_weight_tensor_parameter_18:
     name = "parameter_18"
+    original_name = "linear_74.w_0"
     shape = [384, 384]
     dtype = "float32"
     min_val = float("-1.09284")
@@ -209,6 +228,7 @@ class Program_weight_tensor_parameter_18:
 
 class Program_weight_tensor_parameter_19:
     name = "parameter_19"
+    original_name = "linear_73.b_0"
     shape = [1152]
     dtype = "float32"
     min_val = float("-2.83286")
@@ -220,6 +240,7 @@ class Program_weight_tensor_parameter_19:
 
 class Program_weight_tensor_parameter_20:
     name = "parameter_20"
+    original_name = "linear_73.w_0"
     shape = [384, 1152]
     dtype = "float32"
     min_val = float("-0.339692")
@@ -231,6 +252,7 @@ class Program_weight_tensor_parameter_20:
 
 class Program_weight_tensor_parameter_21:
     name = "parameter_21"
+    original_name = "layer_norm_45.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-0.485227")
@@ -242,6 +264,7 @@ class Program_weight_tensor_parameter_21:
 
 class Program_weight_tensor_parameter_22:
     name = "parameter_22"
+    original_name = "layer_norm_45.w_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-0.00470934")
@@ -253,6 +276,7 @@ class Program_weight_tensor_parameter_22:
 
 class Program_weight_tensor_parameter_23:
     name = "parameter_23"
+    original_name = "linear_72.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-0.324262")
@@ -264,6 +288,7 @@ class Program_weight_tensor_parameter_23:
 
 class Program_weight_tensor_parameter_24:
     name = "parameter_24"
+    original_name = "linear_72.w_0"
     shape = [1536, 384]
     dtype = "float32"
     min_val = float("-1.52937")
@@ -275,6 +300,7 @@ class Program_weight_tensor_parameter_24:
 
 class Program_weight_tensor_parameter_25:
     name = "parameter_25"
+    original_name = "linear_71.b_0"
     shape = [1536]
     dtype = "float32"
     min_val = float("-2.05469")
@@ -286,6 +312,7 @@ class Program_weight_tensor_parameter_25:
 
 class Program_weight_tensor_parameter_26:
     name = "parameter_26"
+    original_name = "linear_71.w_0"
     shape = [384, 1536]
     dtype = "float32"
     min_val = float("-0.378399")
@@ -297,6 +324,7 @@ class Program_weight_tensor_parameter_26:
 
 class Program_weight_tensor_parameter_27:
     name = "parameter_27"
+    original_name = "layer_norm_44.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-4.4161")
@@ -308,6 +336,7 @@ class Program_weight_tensor_parameter_27:
 
 class Program_weight_tensor_parameter_28:
     name = "parameter_28"
+    original_name = "layer_norm_44.w_0"
     shape = [384]
     dtype = "float32"
     min_val = float("0.596234")
@@ -319,6 +348,7 @@ class Program_weight_tensor_parameter_28:
 
 class Program_weight_tensor_parameter_29:
     name = "parameter_29"
+    original_name = "linear_70.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-0.398408")
@@ -330,6 +360,7 @@ class Program_weight_tensor_parameter_29:
 
 class Program_weight_tensor_parameter_30:
     name = "parameter_30"
+    original_name = "linear_70.w_0"
     shape = [384, 384]
     dtype = "float32"
     min_val = float("-0.70338")
@@ -341,6 +372,7 @@ class Program_weight_tensor_parameter_30:
 
 class Program_weight_tensor_parameter_31:
     name = "parameter_31"
+    original_name = "linear_69.b_0"
     shape = [768]
     dtype = "float32"
     min_val = float("-0.907861")
@@ -352,6 +384,7 @@ class Program_weight_tensor_parameter_31:
 
 class Program_weight_tensor_parameter_32:
     name = "parameter_32"
+    original_name = "linear_69.w_0"
     shape = [384, 768]
     dtype = "float32"
     min_val = float("-0.337297")
@@ -363,6 +396,7 @@ class Program_weight_tensor_parameter_32:
 
 class Program_weight_tensor_parameter_33:
     name = "parameter_33"
+    original_name = "linear_68.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-3.12403")
@@ -374,6 +408,7 @@ class Program_weight_tensor_parameter_33:
 
 class Program_weight_tensor_parameter_34:
     name = "parameter_34"
+    original_name = "linear_68.w_0"
     shape = [384, 384]
     dtype = "float32"
     min_val = float("-0.222749")
@@ -385,6 +420,7 @@ class Program_weight_tensor_parameter_34:
 
 class Program_weight_tensor_parameter_35:
     name = "parameter_35"
+    original_name = "layer_norm_43.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-1.38136")
@@ -396,6 +432,7 @@ class Program_weight_tensor_parameter_35:
 
 class Program_weight_tensor_parameter_36:
     name = "parameter_36"
+    original_name = "layer_norm_43.w_0"
     shape = [384]
     dtype = "float32"
     min_val = float("0.114127")
@@ -407,6 +444,7 @@ class Program_weight_tensor_parameter_36:
 
 class Program_weight_tensor_parameter_37:
     name = "parameter_37"
+    original_name = "linear_67.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-0.927027")
@@ -418,6 +456,7 @@ class Program_weight_tensor_parameter_37:
 
 class Program_weight_tensor_parameter_38:
     name = "parameter_38"
+    original_name = "linear_67.w_0"
     shape = [384, 384]
     dtype = "float32"
     min_val = float("-0.301063")
@@ -429,6 +468,7 @@ class Program_weight_tensor_parameter_38:
 
 class Program_weight_tensor_parameter_39:
     name = "parameter_39"
+    original_name = "linear_66.b_0"
     shape = [1152]
     dtype = "float32"
     min_val = float("-3.37262")
@@ -440,6 +480,7 @@ class Program_weight_tensor_parameter_39:
 
 class Program_weight_tensor_parameter_40:
     name = "parameter_40"
+    original_name = "linear_66.w_0"
     shape = [384, 1152]
     dtype = "float32"
     min_val = float("-0.742585")
@@ -451,6 +492,7 @@ class Program_weight_tensor_parameter_40:
 
 class Program_weight_tensor_parameter_41:
     name = "parameter_41"
+    original_name = "embedding_0.w_0"
     shape = [6629, 384]
     dtype = "float32"
     min_val = float("-0.386902")
@@ -462,6 +504,7 @@ class Program_weight_tensor_parameter_41:
 
 class Program_weight_tensor_parameter_42:
     name = "parameter_42"
+    original_name = "linear_65.w_0"
     shape = [384, 384]
     dtype = "float32"
     min_val = float("-0.465531")

--- a/paddle_samples/PaddleX/ch_SVTRv2_rec/subgraph_8/input_meta.py
+++ b/paddle_samples/PaddleX/ch_SVTRv2_rec/subgraph_8/input_meta.py
@@ -1,5 +1,6 @@
 class Program_weight_tensor_data_0:
     name = "data_0"
+    original_name = "var_2488"
     shape = [5, 384, 1, 40]
     dtype = "float32"
     min_val = float("-8.03003")
@@ -11,6 +12,7 @@ class Program_weight_tensor_data_0:
 
 class Program_weight_tensor_data_1:
     name = "data_1"
+    original_name = "var_2490"
     shape = [5, 25]
     dtype = "int64"
     min_val = 0
@@ -20,6 +22,7 @@ class Program_weight_tensor_data_1:
 
 class Program_weight_tensor_data_2:
     name = "data_2"
+    original_name = "var_2491"
     shape = [5]
     dtype = "int64"
     data = [5, 4, 5, 10, 3]
@@ -27,6 +30,7 @@ class Program_weight_tensor_data_2:
 
 class Program_weight_tensor_data_3:
     name = "data_3"
+    original_name = "var_2503"
     shape = [5000, 1, 384]
     dtype = "float32"
     min_val = float("-1.0")

--- a/paddle_samples/PaddleX/ch_SVTRv2_rec/subgraph_8/weight_meta.py
+++ b/paddle_samples/PaddleX/ch_SVTRv2_rec/subgraph_8/weight_meta.py
@@ -1,5 +1,6 @@
 class Program_weight_tensor_parameter_0:
     name = "parameter_0"
+    original_name = "linear_80.w_0"
     shape = [384, 6629]
     dtype = "float32"
     min_val = float("-0.342261")
@@ -11,6 +12,7 @@ class Program_weight_tensor_parameter_0:
 
 class Program_weight_tensor_parameter_1:
     name = "parameter_1"
+    original_name = "layer_norm_48.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-2.01452")
@@ -22,6 +24,7 @@ class Program_weight_tensor_parameter_1:
 
 class Program_weight_tensor_parameter_2:
     name = "parameter_2"
+    original_name = "layer_norm_48.w_0"
     shape = [384]
     dtype = "float32"
     min_val = float("0.163422")
@@ -33,6 +36,7 @@ class Program_weight_tensor_parameter_2:
 
 class Program_weight_tensor_parameter_3:
     name = "parameter_3"
+    original_name = "linear_79.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-0.646689")
@@ -44,6 +48,7 @@ class Program_weight_tensor_parameter_3:
 
 class Program_weight_tensor_parameter_4:
     name = "parameter_4"
+    original_name = "linear_79.w_0"
     shape = [1536, 384]
     dtype = "float32"
     min_val = float("-1.60316")
@@ -55,6 +60,7 @@ class Program_weight_tensor_parameter_4:
 
 class Program_weight_tensor_parameter_5:
     name = "parameter_5"
+    original_name = "linear_78.b_0"
     shape = [1536]
     dtype = "float32"
     min_val = float("-2.77784")
@@ -66,6 +72,7 @@ class Program_weight_tensor_parameter_5:
 
 class Program_weight_tensor_parameter_6:
     name = "parameter_6"
+    original_name = "linear_78.w_0"
     shape = [384, 1536]
     dtype = "float32"
     min_val = float("-0.471037")
@@ -77,6 +84,7 @@ class Program_weight_tensor_parameter_6:
 
 class Program_weight_tensor_parameter_7:
     name = "parameter_7"
+    original_name = "layer_norm_47.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-2.65602")
@@ -88,6 +96,7 @@ class Program_weight_tensor_parameter_7:
 
 class Program_weight_tensor_parameter_8:
     name = "parameter_8"
+    original_name = "layer_norm_47.w_0"
     shape = [384]
     dtype = "float32"
     min_val = float("0.0759988")
@@ -99,6 +108,7 @@ class Program_weight_tensor_parameter_8:
 
 class Program_weight_tensor_parameter_9:
     name = "parameter_9"
+    original_name = "linear_77.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-0.648992")
@@ -110,6 +120,7 @@ class Program_weight_tensor_parameter_9:
 
 class Program_weight_tensor_parameter_10:
     name = "parameter_10"
+    original_name = "linear_77.w_0"
     shape = [384, 384]
     dtype = "float32"
     min_val = float("-0.506227")
@@ -121,6 +132,7 @@ class Program_weight_tensor_parameter_10:
 
 class Program_weight_tensor_parameter_11:
     name = "parameter_11"
+    original_name = "linear_76.b_0"
     shape = [768]
     dtype = "float32"
     min_val = float("-0.815102")
@@ -132,6 +144,7 @@ class Program_weight_tensor_parameter_11:
 
 class Program_weight_tensor_parameter_12:
     name = "parameter_12"
+    original_name = "linear_76.w_0"
     shape = [384, 768]
     dtype = "float32"
     min_val = float("-0.540834")
@@ -143,6 +156,7 @@ class Program_weight_tensor_parameter_12:
 
 class Program_weight_tensor_parameter_13:
     name = "parameter_13"
+    original_name = "linear_75.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-3.03302")
@@ -154,6 +168,7 @@ class Program_weight_tensor_parameter_13:
 
 class Program_weight_tensor_parameter_14:
     name = "parameter_14"
+    original_name = "linear_75.w_0"
     shape = [384, 384]
     dtype = "float32"
     min_val = float("-0.385865")
@@ -165,6 +180,7 @@ class Program_weight_tensor_parameter_14:
 
 class Program_weight_tensor_parameter_15:
     name = "parameter_15"
+    original_name = "layer_norm_46.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-2.49454")
@@ -176,6 +192,7 @@ class Program_weight_tensor_parameter_15:
 
 class Program_weight_tensor_parameter_16:
     name = "parameter_16"
+    original_name = "layer_norm_46.w_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-0.106595")
@@ -187,6 +204,7 @@ class Program_weight_tensor_parameter_16:
 
 class Program_weight_tensor_parameter_17:
     name = "parameter_17"
+    original_name = "linear_74.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-7.57866")
@@ -198,6 +216,7 @@ class Program_weight_tensor_parameter_17:
 
 class Program_weight_tensor_parameter_18:
     name = "parameter_18"
+    original_name = "linear_74.w_0"
     shape = [384, 384]
     dtype = "float32"
     min_val = float("-1.09284")
@@ -209,6 +228,7 @@ class Program_weight_tensor_parameter_18:
 
 class Program_weight_tensor_parameter_19:
     name = "parameter_19"
+    original_name = "linear_73.b_0"
     shape = [1152]
     dtype = "float32"
     min_val = float("-2.83286")
@@ -220,6 +240,7 @@ class Program_weight_tensor_parameter_19:
 
 class Program_weight_tensor_parameter_20:
     name = "parameter_20"
+    original_name = "linear_73.w_0"
     shape = [384, 1152]
     dtype = "float32"
     min_val = float("-0.339692")
@@ -231,6 +252,7 @@ class Program_weight_tensor_parameter_20:
 
 class Program_weight_tensor_parameter_21:
     name = "parameter_21"
+    original_name = "layer_norm_45.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-0.485227")
@@ -242,6 +264,7 @@ class Program_weight_tensor_parameter_21:
 
 class Program_weight_tensor_parameter_22:
     name = "parameter_22"
+    original_name = "layer_norm_45.w_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-0.00470934")
@@ -253,6 +276,7 @@ class Program_weight_tensor_parameter_22:
 
 class Program_weight_tensor_parameter_23:
     name = "parameter_23"
+    original_name = "linear_72.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-0.324262")
@@ -264,6 +288,7 @@ class Program_weight_tensor_parameter_23:
 
 class Program_weight_tensor_parameter_24:
     name = "parameter_24"
+    original_name = "linear_72.w_0"
     shape = [1536, 384]
     dtype = "float32"
     min_val = float("-1.52937")
@@ -275,6 +300,7 @@ class Program_weight_tensor_parameter_24:
 
 class Program_weight_tensor_parameter_25:
     name = "parameter_25"
+    original_name = "linear_71.b_0"
     shape = [1536]
     dtype = "float32"
     min_val = float("-2.05469")
@@ -286,6 +312,7 @@ class Program_weight_tensor_parameter_25:
 
 class Program_weight_tensor_parameter_26:
     name = "parameter_26"
+    original_name = "linear_71.w_0"
     shape = [384, 1536]
     dtype = "float32"
     min_val = float("-0.378399")
@@ -297,6 +324,7 @@ class Program_weight_tensor_parameter_26:
 
 class Program_weight_tensor_parameter_27:
     name = "parameter_27"
+    original_name = "layer_norm_44.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-4.4161")
@@ -308,6 +336,7 @@ class Program_weight_tensor_parameter_27:
 
 class Program_weight_tensor_parameter_28:
     name = "parameter_28"
+    original_name = "layer_norm_44.w_0"
     shape = [384]
     dtype = "float32"
     min_val = float("0.596234")
@@ -319,6 +348,7 @@ class Program_weight_tensor_parameter_28:
 
 class Program_weight_tensor_parameter_29:
     name = "parameter_29"
+    original_name = "linear_70.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-0.398408")
@@ -330,6 +360,7 @@ class Program_weight_tensor_parameter_29:
 
 class Program_weight_tensor_parameter_30:
     name = "parameter_30"
+    original_name = "linear_70.w_0"
     shape = [384, 384]
     dtype = "float32"
     min_val = float("-0.70338")
@@ -341,6 +372,7 @@ class Program_weight_tensor_parameter_30:
 
 class Program_weight_tensor_parameter_31:
     name = "parameter_31"
+    original_name = "linear_69.b_0"
     shape = [768]
     dtype = "float32"
     min_val = float("-0.907861")
@@ -352,6 +384,7 @@ class Program_weight_tensor_parameter_31:
 
 class Program_weight_tensor_parameter_32:
     name = "parameter_32"
+    original_name = "linear_69.w_0"
     shape = [384, 768]
     dtype = "float32"
     min_val = float("-0.337297")
@@ -363,6 +396,7 @@ class Program_weight_tensor_parameter_32:
 
 class Program_weight_tensor_parameter_33:
     name = "parameter_33"
+    original_name = "linear_68.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-3.12403")
@@ -374,6 +408,7 @@ class Program_weight_tensor_parameter_33:
 
 class Program_weight_tensor_parameter_34:
     name = "parameter_34"
+    original_name = "linear_68.w_0"
     shape = [384, 384]
     dtype = "float32"
     min_val = float("-0.222749")
@@ -385,6 +420,7 @@ class Program_weight_tensor_parameter_34:
 
 class Program_weight_tensor_parameter_35:
     name = "parameter_35"
+    original_name = "layer_norm_43.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-1.38136")
@@ -396,6 +432,7 @@ class Program_weight_tensor_parameter_35:
 
 class Program_weight_tensor_parameter_36:
     name = "parameter_36"
+    original_name = "layer_norm_43.w_0"
     shape = [384]
     dtype = "float32"
     min_val = float("0.114127")
@@ -407,6 +444,7 @@ class Program_weight_tensor_parameter_36:
 
 class Program_weight_tensor_parameter_37:
     name = "parameter_37"
+    original_name = "linear_67.b_0"
     shape = [384]
     dtype = "float32"
     min_val = float("-0.927027")
@@ -418,6 +456,7 @@ class Program_weight_tensor_parameter_37:
 
 class Program_weight_tensor_parameter_38:
     name = "parameter_38"
+    original_name = "linear_67.w_0"
     shape = [384, 384]
     dtype = "float32"
     min_val = float("-0.301063")
@@ -429,6 +468,7 @@ class Program_weight_tensor_parameter_38:
 
 class Program_weight_tensor_parameter_39:
     name = "parameter_39"
+    original_name = "linear_66.b_0"
     shape = [1152]
     dtype = "float32"
     min_val = float("-3.37262")
@@ -440,6 +480,7 @@ class Program_weight_tensor_parameter_39:
 
 class Program_weight_tensor_parameter_40:
     name = "parameter_40"
+    original_name = "linear_66.w_0"
     shape = [384, 1152]
     dtype = "float32"
     min_val = float("-0.742585")
@@ -451,6 +492,7 @@ class Program_weight_tensor_parameter_40:
 
 class Program_weight_tensor_parameter_41:
     name = "parameter_41"
+    original_name = "embedding_0.w_0"
     shape = [6629, 384]
     dtype = "float32"
     min_val = float("-0.386902")
@@ -462,6 +504,7 @@ class Program_weight_tensor_parameter_41:
 
 class Program_weight_tensor_parameter_42:
     name = "parameter_42"
+    original_name = "linear_65.w_0"
     shape = [384, 384]
     dtype = "float32"
     min_val = float("-0.465531")


### PR DESCRIPTION
### PR Category
<!-- One of [ New Sample | Feature Enhancement | Bug Fix | Other ] -->
Feature Enhancement

### Description
<!-- Describe what you’ve done -->
在某国产新硬件上，t>=0时有31个样本精度不正确，为了更准确地使用二分分解法逐步定位问题算子，需要为paddle样本添加original_name字段，便于分解后恢复样本meta数据。
本PR更新了31个+ResNet18示例样本，其中有3个样本因早期抽取代码实现存在bug（meta不会写入0值），样本入库后应避免修改，故需手动处理一下。这3个样本分别是：
- `paddle_samples/PaddleX/Mask-RT-DETR-S/subgraph_14`
- `paddle_samples/PaddleX/MobileNetV4_hybrid_large/subgraph_2`
- `paddle_samples/PaddleX/Nonstationary/subgraph_8`