### PR TITLE
Add torch.cuda.empty_cache() in decompose process

### DIFF
--- a/graph_net/torch/decompose_util.py
+++ b/graph_net/torch/decompose_util.py
@@ -1,20 +1,8 @@
 import torch
 import copy
 import operator
-import gc
-from contextlib import contextmanager
 from collections import defaultdict
 from dataclasses import dataclass
-
-
-@contextmanager
-def cuda_gc(enabled: bool = True):
-    try:
-        yield
-    finally:
-        if enabled:
-            gc.collect()
-            torch.cuda.empty_cache()
 
 
 def convert_to_submodules_graph(

--- a/graph_net/torch/decompose_util.py
+++ b/graph_net/torch/decompose_util.py
@@ -1,8 +1,20 @@
 import torch
 import copy
 import operator
+import gc
+from contextlib import contextmanager
 from collections import defaultdict
 from dataclasses import dataclass
+
+
+@contextmanager
+def cuda_gc(enabled: bool = True):
+    try:
+        yield
+    finally:
+        if enabled:
+            gc.collect()
+            torch.cuda.empty_cache()
 
 
 def convert_to_submodules_graph(

--- a/graph_net/torch/graph_decomposer.py
+++ b/graph_net/torch/graph_decomposer.py
@@ -5,7 +5,7 @@ import torch
 import json
 import sys
 
-from graph_net.torch.decompose_util import convert_to_submodules_graph, cuda_gc
+from graph_net.torch.decompose_util import convert_to_submodules_graph
 from graph_net.torch.extractor import GraphExtractor as BuiltinGraphExtractor
 import graph_net.imp_util as imp_util
 from graph_net.torch.fx_graph_module_util import get_torch_module_and_inputs
@@ -244,27 +244,20 @@ class RangeDecomposerExtractor:
         ):
             return
 
-        with cuda_gc():
-            module, inputs = get_torch_module_and_inputs(
-                model_path, use_dummy_inputs=False
-            )
+        torch.cuda.empty_cache()
+        module, inputs = get_torch_module_and_inputs(model_path, use_dummy_inputs=False)
         gm = parse_sole_graph_module(module, inputs)
-        del module
 
-        with cuda_gc():
-            rewrited_gm: torch.fx.GraphModule = convert_to_submodules_graph(
-                gm,
-                submodule_hook=self.get_naive_decomposer_extractor(rel_model_path),
-                split_positions=split_positions,
-                subgraph_ranges=subgraph_ranges,
-                group_head_and_tail=self.config.get("group_head_and_tail", False),
-                chain_style=self.config.get("chain_style", False),
-            )
-            rewrited_gm(*inputs)
-        del inputs, rewrited_gm
-
-        with cuda_gc():
-            pass
+        torch.cuda.empty_cache()
+        rewrited_gm: torch.fx.GraphModule = convert_to_submodules_graph(
+            gm,
+            submodule_hook=self.get_naive_decomposer_extractor(rel_model_path),
+            split_positions=split_positions,
+            subgraph_ranges=subgraph_ranges,
+            group_head_and_tail=self.config.get("group_head_and_tail", False),
+            chain_style=self.config.get("chain_style", False),
+        )
+        rewrited_gm(*inputs)
 
     def get_naive_decomposer_extractor(self, rel_model_path):
         def fn(submodule, seq_no):

--- a/graph_net/torch/graph_decomposer.py
+++ b/graph_net/torch/graph_decomposer.py
@@ -4,7 +4,8 @@ from pathlib import Path
 import torch
 import json
 import sys
-from graph_net.torch.decompose_util import convert_to_submodules_graph
+
+from graph_net.torch.decompose_util import convert_to_submodules_graph, cuda_gc
 from graph_net.torch.extractor import GraphExtractor as BuiltinGraphExtractor
 import graph_net.imp_util as imp_util
 from graph_net.torch.fx_graph_module_util import get_torch_module_and_inputs
@@ -12,15 +13,15 @@ from graph_net.torch.fx_graph_cache_util import (
     parse_immutable_model_path_into_sole_graph_module,
 )
 from graph_net.torch.fx_graph_parse_util import parse_sole_graph_module
+
 import logging
 
 logger = logging.getLogger(__name__)
 
 
 def load_json(file_path):
-    with open(file_path, "r", encoding="utf-8") as file:
-        data_dict = json.load(file)
-    return data_dict
+    with open(file_path, "r", encoding="utf-8") as f:
+        return json.load(f)
 
 
 class GraphExtractor:
@@ -221,20 +222,27 @@ class RangeDecomposerExtractor:
             rel_model_path, split_positions
         ):
             return
-        torch.cuda.empty_cache()
-        config = {
-            "split_positions": split_positions,
-            "group_head_and_tail": self.config.get("group_head_and_tail", False),
-            "chain_style": self.config.get("chain_style", False),
-        }
-        module, inputs = get_torch_module_and_inputs(model_path, use_dummy_inputs=False)
+
+        with cuda_gc():
+            module, inputs = get_torch_module_and_inputs(
+                model_path, use_dummy_inputs=False
+            )
         gm = parse_sole_graph_module(module, inputs)
-        rewrited_gm: torch.fx.GraphModule = convert_to_submodules_graph(
-            gm,
-            submodule_hook=self.get_naive_decomposer_extractor(rel_model_path),
-            **config,
-        )
-        rewrited_gm(*inputs)
+        del module
+
+        with cuda_gc():
+            rewrited_gm: torch.fx.GraphModule = convert_to_submodules_graph(
+                gm,
+                submodule_hook=self.get_naive_decomposer_extractor(rel_model_path),
+                split_positions=split_positions,
+                group_head_and_tail=self.config.get("group_head_and_tail", False),
+                chain_style=self.config.get("chain_style", False),
+            )
+            rewrited_gm(*inputs)
+        del inputs, rewrited_gm
+
+        with cuda_gc():
+            pass
 
     def get_naive_decomposer_extractor(self, rel_model_path):
         def fn(submodule, seq_no):

--- a/graph_net/torch/graph_variable_renamer.py
+++ b/graph_net/torch/graph_variable_renamer.py
@@ -88,7 +88,7 @@ class GraphVariableRenamer:
             return
 
         src_model_path = os.path.join(self.config["model_path_prefix"], rel_model_path)
-        with cuda_gc(enabled=self.config["release_gpu_memory"]):
+        with cuda_gc():
             module, inputs = get_torch_module_and_inputs(src_model_path)
             gm = parse_sole_graph_module(module, inputs)
             gm, rename_map = self.rename_graph_variables(gm, inputs, src_model_path)

--- a/graph_net/torch/graph_variable_renamer.py
+++ b/graph_net/torch/graph_variable_renamer.py
@@ -10,7 +10,6 @@ from pathlib import Path
 from graph_net.torch.utils import apply_templates
 from graph_net.imp_util import load_module
 from graph_net.hash_util import get_sha256_hash
-from graph_net.torch.decompose_util import cuda_gc
 
 
 class GraphVariableRenamer:
@@ -79,6 +78,8 @@ class GraphVariableRenamer:
         }
 
     def __call__(self, rel_model_path):
+        torch.cuda.empty_cache()
+
         dst_model_path = os.path.realpath(
             os.path.join(self.config["output_dir"], rel_model_path)
         )
@@ -88,11 +89,9 @@ class GraphVariableRenamer:
             return
 
         src_model_path = os.path.join(self.config["model_path_prefix"], rel_model_path)
-        with cuda_gc():
-            module, inputs = get_torch_module_and_inputs(src_model_path)
-            gm = parse_sole_graph_module(module, inputs)
-            gm, rename_map = self.rename_graph_variables(gm, inputs, src_model_path)
-            del module, inputs
+        module, inputs = get_torch_module_and_inputs(src_model_path)
+        gm = parse_sole_graph_module(module, inputs)
+        gm, rename_map = self.rename_graph_variables(gm, inputs, src_model_path)
 
         Path(dst_model_path).parent.mkdir(parents=True, exist_ok=True)
         with tempfile.TemporaryDirectory(prefix="graph_variable_renamer_") as temp_dir:
@@ -103,8 +102,8 @@ class GraphVariableRenamer:
                 src_model_path, temp_model_path, rename_map
             )
             self._update_input_meta_py_file(src_model_path, temp_model_path, rename_map)
-            print("Try to run renamed model...")
-            self._try_run(temp_model_path)
+            # print("Try to run renamed model...")
+            # self._try_run(temp_model_path)
             shutil.copytree(temp_model_path, dst_model_path)
 
     def _try_run(self, model_path):

--- a/graph_net/torch/graph_variable_renamer.py
+++ b/graph_net/torch/graph_variable_renamer.py
@@ -80,12 +80,6 @@ class GraphVariableRenamer:
         }
 
     def __call__(self, rel_model_path):
-        src_model_path = os.path.join(self.config["model_path_prefix"], rel_model_path)
-        with cuda_gc(enabled=self.config["release_gpu_memory"]):
-            module, inputs = get_torch_module_and_inputs(src_model_path)
-            gm = parse_sole_graph_module(module, inputs)
-            gm = self.rename_graph_variables(gm, inputs, src_model_path)
-            del module, inputs
         dst_model_path = os.path.realpath(
             os.path.join(self.config["output_dir"], rel_model_path)
         )
@@ -93,6 +87,14 @@ class GraphVariableRenamer:
             os.path.join(dst_model_path, "model.py")
         ):
             return
+
+        src_model_path = os.path.join(self.config["model_path_prefix"], rel_model_path)
+        with cuda_gc(enabled=self.config["release_gpu_memory"]):
+            module, inputs = get_torch_module_and_inputs(src_model_path)
+            gm = parse_sole_graph_module(module, inputs)
+            gm = self.rename_graph_variables(gm, inputs, src_model_path)
+            del module, inputs
+
         Path(dst_model_path).parent.mkdir(parents=True, exist_ok=True)
         with tempfile.TemporaryDirectory(prefix="graph_variable_renamer_") as temp_dir:
             temp_model_path = os.path.join(temp_dir, os.path.basename(dst_model_path))

--- a/graph_net/torch/graph_variable_renamer.py
+++ b/graph_net/torch/graph_variable_renamer.py
@@ -3,6 +3,7 @@ import torch
 import shutil
 import inspect
 import tempfile
+
 from graph_net.torch.fx_graph_module_util import get_torch_module_and_inputs
 from graph_net.torch.fx_graph_parse_util import parse_sole_graph_module
 from graph_net.tensor_meta import TensorMeta
@@ -10,6 +11,7 @@ from pathlib import Path
 from graph_net.torch.utils import apply_templates
 from graph_net.imp_util import load_module
 from graph_net.hash_util import get_sha256_hash
+from graph_net.torch.decompose_util import cuda_gc
 
 
 class GraphVariableRenamer:
@@ -79,9 +81,11 @@ class GraphVariableRenamer:
 
     def __call__(self, rel_model_path):
         src_model_path = os.path.join(self.config["model_path_prefix"], rel_model_path)
-        module, inputs = get_torch_module_and_inputs(src_model_path)
-        gm = parse_sole_graph_module(module, inputs)
-        gm = self.rename_graph_variables(gm, inputs, src_model_path)
+        with cuda_gc(enabled=self.config["release_gpu_memory"]):
+            module, inputs = get_torch_module_and_inputs(src_model_path)
+            gm = parse_sole_graph_module(module, inputs)
+            gm = self.rename_graph_variables(gm, inputs, src_model_path)
+            del module, inputs
         dst_model_path = os.path.realpath(
             os.path.join(self.config["output_dir"], rel_model_path)
         )

--- a/graph_net/torch/typical_sequence_split_points.py
+++ b/graph_net/torch/typical_sequence_split_points.py
@@ -12,7 +12,6 @@ from graph_net.torch.rp_expr.rp_expr_util import (
 )
 from graph_net.torch.fx_graph_module_util import get_torch_module_and_inputs
 from graph_net.torch.fx_graph_parse_util import parse_sole_graph_module_without_varify
-from graph_net.torch.decompose_util import cuda_gc
 
 
 class TypicalSequenceExtractor:
@@ -71,6 +70,7 @@ class OpNamesExtractor:
         }
 
     def __call__(self, rel_model_path: str):
+        torch.cuda.empty_cache()
         model_path = os.path.join(self.config["model_path_prefix"], rel_model_path)
         output_path = self._get_output_path(rel_model_path)
         if self.config["resume"] and output_path.exists():
@@ -87,12 +87,10 @@ class OpNamesExtractor:
 
     def _extract_ops(self, model_path: str) -> List[str]:
         extractor = TypicalSequenceExtractor()
-        with cuda_gc():
-            model, inputs = get_torch_module_and_inputs(model_path)
-            compiled_model, _ = parse_sole_graph_module_without_varify(model, inputs)
-            extractor.extract_compiler(compiled_model, inputs)
-            ops_info = extractor.extract_node
-            del model, inputs, compiled_model
+        model, inputs = get_torch_module_and_inputs(model_path)
+        compiled_model, _ = parse_sole_graph_module_without_varify(model, inputs)
+        extractor.extract_compiler(compiled_model, inputs)
+        ops_info = extractor.extract_node
 
         return [op["target_name"] for op in ops_info]
 

--- a/graph_net/torch/typical_sequence_split_points.py
+++ b/graph_net/torch/typical_sequence_split_points.py
@@ -5,12 +5,14 @@ from pathlib import Path
 from typing import Any, Dict, List
 import torch
 import torch.nn as nn
+
 from graph_net.torch.rp_expr.rp_expr_parser import RpExprParser
 from graph_net.torch.rp_expr.rp_expr_util import (
     MakeNestedIndexRangeFromLetsListTokenRpExpr,
 )
 from graph_net.torch.fx_graph_module_util import get_torch_module_and_inputs
 from graph_net.torch.fx_graph_parse_util import parse_sole_graph_module_without_varify
+from graph_net.torch.decompose_util import cuda_gc
 
 
 class TypicalSequenceExtractor:
@@ -85,10 +87,12 @@ class OpNamesExtractor:
 
     def _extract_ops(self, model_path: str) -> List[str]:
         extractor = TypicalSequenceExtractor()
-        model, inputs = get_torch_module_and_inputs(model_path)
-        compiled_model, _ = parse_sole_graph_module_without_varify(model, inputs)
-        extractor.extract_compiler(compiled_model, inputs)
-        ops_info = extractor.extract_node
+        with cuda_gc():
+            model, inputs = get_torch_module_and_inputs(model_path)
+            compiled_model, _ = parse_sole_graph_module_without_varify(model, inputs)
+            extractor.extract_compiler(compiled_model, inputs)
+            ops_info = extractor.extract_node
+            del model, inputs, compiled_model
 
         return [op["target_name"] for op in ops_info]
 


### PR DESCRIPTION
### PR Category
Feature Enhancement


### Description
- Add torch.cuda.empty_cache() in torch.graph_decomposer, torch.graph_variable_renamer and torch.typical_sequence_split_points.
- Fix resume in torch.graph_variable_renamer to early exit
