### PR TITLE
[Feature Enhancement] Support use_all_inputs for graph decomposing.

### DIFF
--- a/graph_net/paddle/extractor.py
+++ b/graph_net/paddle/extractor.py
@@ -204,6 +204,7 @@ class GraphExtractor:
         model_dump_path,
         split_positions=None,
         group_head_and_tail=True,
+        use_all_inputs=False,
     ):
         ir_programs_path = self.get_ir_programs_path(model_dump_path)
         example_inputs_path = self.get_example_inputs_path(model_dump_path)
@@ -218,6 +219,7 @@ class GraphExtractor:
             op_example_inputs=op_example_inputs_path,
             split_positions=split_positions,
             group_head_and_tail=group_head_and_tail,
+            use_all_inputs=use_all_inputs,
             eval_mode=True,
             tmp_dir=model_dump_path,
         )

--- a/graph_net/paddle/graph_decomposer.py
+++ b/graph_net/paddle/graph_decomposer.py
@@ -105,18 +105,18 @@ class NaiveDecomposerExtractor:
         )
 
         # 3. Save to model_path
-        self.subgraph_path_list = []
+        self.subgraph_path2subgraph_range = {}
         model_path = os.path.join(
             self.builtin_extractor.workspace_path, self.builtin_extractor.name
         )
         assert len(self.builtin_extractor.subgraph_idx2samples) == 1
 
         samples = self.builtin_extractor.subgraph_idx2samples[0]
-        for seq_idx in range(len(samples)):
+        for seq_idx, sample in enumerate(samples):
             subgraph_path = f"{model_path}_{seq_idx}"
-            self.subgraph_path_list.append(subgraph_path)
-            self.builtin_extractor.write_sample_to_file(subgraph_path, samples[seq_idx])
-            print(f"Save to {subgraph_path}")
+            self.subgraph_path2subgraph_range[subgraph_path] = sample.subgraph_range
+            self.builtin_extractor.write_sample_to_file(subgraph_path, sample)
+            print(f"[NaiveDecomposerExtractor] Save to {subgraph_path}")
         return static_model
 
     def __call__(self, **input_dict):
@@ -125,12 +125,11 @@ class NaiveDecomposerExtractor:
             extracted_model = self.do_extract(**input_dict)
             self.extracted = True
 
-        for subgraph_path in self.subgraph_path_list:
-            self._post_extract_process(subgraph_path)
+        for subgraph_path, subgraph_range in self.subgraph_path2subgraph_range.items():
+            return self.post_extract_process(
+                subgraph_path, subgraph_range, self.use_all_inputs
+            )
         return extracted_model
-
-    def _post_extract_process(self, subgraph_path):
-        return self.post_extract_process(subgraph_path)
 
     def make_post_extract_process(self, config):
         if config.get("post_extract_process_path") is None:

--- a/graph_net/paddle/graph_decomposer.py
+++ b/graph_net/paddle/graph_decomposer.py
@@ -24,6 +24,7 @@ class GraphExtractor:
         self,
         split_positions=None,
         group_head_and_tail=False,
+        use_all_inputs=False,
         chain_style=False,
         output_dir="./tmp/naive_decomposer_dir",
         post_extract_process_path=None,
@@ -42,6 +43,7 @@ class GraphExtractor:
         return {
             "split_positions": split_positions,
             "group_head_and_tail": group_head_and_tail,
+            "use_all_inputs": use_all_inputs,
             "chain_style": chain_style,
             "output_dir": output_dir,
             "post_extract_process_path": post_extract_process_path,
@@ -82,6 +84,7 @@ class NaiveDecomposerExtractor:
         )
         self.split_positions = self.config["split_positions"]
         self.group_head_and_tail = self.config["group_head_and_tail"]
+        self.use_all_inputs = self.config["use_all_inputs"]
         self.post_extract_process = self.make_post_extract_process(self.config)
 
     def do_extract(self, **input_dict):
@@ -98,6 +101,7 @@ class NaiveDecomposerExtractor:
             model_dump_path,
             split_positions=self.split_positions,
             group_head_and_tail=self.group_head_and_tail,
+            use_all_inputs=self.use_all_inputs,
         )
 
         # 3. Save to model_path

--- a/graph_net/paddle/graph_meta_restorer.py
+++ b/graph_net/paddle/graph_meta_restorer.py
@@ -23,16 +23,23 @@ class GraphMetaRestorer:
             parent_input_meta_classes
         )
 
-    def __call__(self, model_path):
+    def __call__(self, model_path, subgraph_range=None, use_all_inputs=False):
         assert path_utils.is_single_model_dir(
             model_path
         ), f"{model_path=} is not a graphnet sample."
+        if isinstance(subgraph_range, (tuple, list)) and len(subgraph_range) == 2:
+            use_all_inputs = subgraph_range[0] == 0 and use_all_inputs
+        else:
+            use_all_inputs = False
+
         (
             weight_meta_classes,
             input_meta_classes,
         ) = self._load_weight_and_input_meta_classes(model_path)
 
         assert self.config["update_inplace"]
+
+        # Restore weight_meta according to original_name.
         (
             is_weight_meta_fully_updated,
             weight_meta_classes,
@@ -42,11 +49,19 @@ class GraphMetaRestorer:
         assert is_weight_meta_fully_updated
         self._rewrite_meta_codes(model_path, weight_meta_classes, "weight_meta.py")
 
-        is_input_meta_fully_updated = self._update_by_tensor_spec(
-            input_meta_classes, self.original_name2parent_input_meta_class
-        )
+        # Restore input_meta according to name order or tensor spec (dtype and shape),
+        # because ordinary paddle.Tensor does not support user-defined names.
+        is_input_meta_fully_updated = False
+        if use_all_inputs:
+            is_input_meta_fully_updated = self._update_by_name_order(
+                input_meta_classes, self.original_name2parent_input_meta_class
+            )
+        if not is_input_meta_fully_updated:
+            is_input_meta_fully_updated = self._update_by_tensor_spec(
+                input_meta_classes, self.original_name2parent_input_meta_class
+            )
         if (
-            not self.config["input_meta_allow_partial_update"]
+            self.config["input_meta_allow_partial_update"]
             or is_input_meta_fully_updated
         ):
             self._rewrite_meta_codes(model_path, input_meta_classes, "input_meta.py")
@@ -73,12 +88,16 @@ class GraphMetaRestorer:
             original_name2meta_class[meta_class.original_name] = meta_class
         return original_name2meta_class
 
+    def _has_same_tensor_spec(self, meta_class, parent_meta_class):
+        if meta_class is None or parent_meta_class is None:
+            return False
+        return (
+            meta_class.dtype == parent_meta_class.dtype
+            and meta_class.shape == parent_meta_class.shape
+        )
+
     def _update_tensor_meta(self, meta_class, parent_meta_class):
-        if (
-            not parent_meta_class
-            or meta_class.dtype != parent_meta_class.dtype
-            or meta_class.shape != parent_meta_class.shape
-        ):
+        if not self._has_same_tensor_spec(meta_class, parent_meta_class):
             return False
 
         for attr_name in ["max_val", "min_val", "mean", "std", "data"]:
@@ -117,14 +136,38 @@ class GraphMetaRestorer:
         )
         return sorted_meta_classess
 
+    def _update_by_name_order(self, meta_classes, original_name2parent_meta_class):
+        parent_meta_classes = list(original_name2parent_meta_class.values())
+        if len(meta_classes) != len(parent_meta_classes):
+            return False
+
+        updated_meta_classes = []
+        name2meta_class = {meta_class.name: meta_class for meta_class in meta_classes}
+        same_in_order = all(
+            self._has_same_tensor_spec(
+                name2meta_class.get(parent_meta_class.name, None), parent_meta_class
+            )
+            for parent_meta_class in parent_meta_classes
+        )
+        if same_in_order:
+            for parent_meta_class in parent_meta_classes:
+                meta_class = name2meta_class[parent_meta_class.name]
+                if self._update_tensor_meta(meta_class, parent_meta_class):
+                    updated_meta_classes.append(meta_class)
+            meta_classes[:] = updated_meta_classes
+
+        print(
+            f"[GraphMetaRestorer] {len(updated_meta_classes)}/{len(meta_classes)} classes can be restored."
+        )
+        return len(meta_classes) == len(updated_meta_classes)
+
     def _update_by_tensor_spec(self, meta_classes, original_name2parent_meta_class):
         updated_class_names = set()
         for meta_class in meta_classes:
             matched_parent_meta_class = [
                 parent_meta_class
                 for parent_meta_class in original_name2parent_meta_class.values()
-                if meta_class.dtype == parent_meta_class.dtype
-                and meta_class.shape == parent_meta_class.shape
+                if self._has_same_tensor_spec(meta_class, parent_meta_class)
             ]
             if len(matched_parent_meta_class) == 1:
                 self._update_tensor_meta(meta_class, matched_parent_meta_class[0])

--- a/graph_net/paddle/graph_meta_restorer.py
+++ b/graph_net/paddle/graph_meta_restorer.py
@@ -75,18 +75,19 @@ class GraphMetaRestorer:
 
     def _update_tensor_meta(self, meta_class, parent_meta_class):
         if (
-            parent_meta_class
-            and meta_class.dtype == parent_meta_class.dtype
-            and meta_class.shape == parent_meta_class.shape
+            not parent_meta_class
+            or meta_class.dtype != parent_meta_class.dtype
+            or meta_class.shape != parent_meta_class.shape
         ):
-            for attr_name in ["max_val", "min_val", "mean", "std", "data"]:
-                if hasattr(meta_class, attr_name) or hasattr(
-                    parent_meta_class, attr_name
-                ):
-                    attr_value = getattr(parent_meta_class, attr_name, None)
-                    setattr(meta_class, attr_name, attr_value)
-            return True
-        return False
+            return False
+
+        for attr_name in ["max_val", "min_val", "mean", "std", "data"]:
+            if hasattr(parent_meta_class, attr_name):
+                attr_value = getattr(parent_meta_class, attr_name)
+                setattr(meta_class, attr_name, attr_value)
+            elif hasattr(meta_class, attr_name):
+                delattr(meta_class, attr_name)
+        return True
 
     def _update_by_original_name(self, meta_classes, original_name2parent_meta_class):
         updated_class_names = set()

--- a/graph_net/paddle/prologue_subgraph_unittest_generator.py
+++ b/graph_net/paddle/prologue_subgraph_unittest_generator.py
@@ -69,6 +69,16 @@ class GraphExtractor:
 
 
 PADDLE_UNITTEST_TEMPLATE = r"""
+# Usage:
+# 1. Run following command on reference hardware.
+#    python {{graph_module_desc.model_name}}_test.py --is-reference --device "cuda" --reference-dir "test_reference_outputs"
+#
+# 2. Copy all of the unittest and outputs of reference to target hardware.
+#
+# 3. Run following command on target hardware (xpu as example).
+#    python {{graph_module_desc.model_name}}_test.py --device "xpu" --reference-dir "test_reference_outputs"
+#
+
 import os
 import sys
 import argparse
@@ -157,7 +167,7 @@ def tolerance_generator(tolerance, dtype):
     elif dtype == paddle.float64:
         return 10 ** (tolerance * 7 / 5), 10 ** (tolerance * 7 / 5)
     else:
-        assert False, f"Unsupported {dtype=}."
+        return 0, 0
 
 
 class {{graph_module_desc.test_name}}Test(unittest.TestCase):
@@ -231,7 +241,7 @@ class {{graph_module_desc.test_name}}Test(unittest.TestCase):
         dtype_match = all(
             reference == target for reference, target in zip(reference_dtypes, target_dtypes)
         )
-        self.assertTrue(dtype_match, f"Data type of outputs are not matched ({reference_dtypes=} vs {target_dtypes}).")
+        self.assertTrue(dtype_match, f"Data type of outputs are not matched ({reference_dtypes=} vs {target_dtypes=}).")
 
     def check_shapes(self, reference_outputs, target_outputs):
         def _get_output_shapes(outs):
@@ -246,11 +256,11 @@ class {{graph_module_desc.test_name}}Test(unittest.TestCase):
         shape_match = all(
             reference == target for reference, target in zip(reference_shapes, target_shapes)
         )
-        self.assertTrue(shape_match, f"Shape of outputs are not matched ({reference_shapes=} vs {target_shapes}).")
+        self.assertTrue(shape_match, f"Shape of outputs are not matched ({reference_shapes=} vs {target_shapes=}).")
 
     def check_results(self, reference_outputs, target_outputs):
         def _convert_to_numpy(out):
-            if out.dtype in [paddle.float16, paddle.bfloat16]:
+            if out.dtype not in [paddle.float32, paddle.float64]:
                 return out.cast("float32").numpy()
             else:
                 return out.numpy()
@@ -521,6 +531,11 @@ class PrologueSubgraphUnittestGenerator:
                 Path(model_path) / "input_meta.py"
             )
         )
+        for meta in tensor_metas:
+            if meta.min_val is None:
+                meta.min_val = 0
+            if meta.max_val is None:
+                meta.max_val = 2
         return tensor_metas
 
     def _get_forward_arg_names(self, graph_module):

--- a/graph_net/paddle/prologue_subgraph_unittest_generator.py
+++ b/graph_net/paddle/prologue_subgraph_unittest_generator.py
@@ -71,6 +71,9 @@ class GraphExtractor:
 
 
 PADDLE_UNITTEST_TEMPLATE = r"""
+# This unittest is auto-generated from https://github.com/PaddlePaddle/GraphNet/tree/develop/{{graph_module_desc.rel_model_path_to_graphnet}}
+# with subgraph_range={{graph_module_desc.subgraph_range}}.
+#
 # Usage:
 # 1. Run following command on reference hardware.
 #    python {{graph_module_desc.model_name}}_test.py --is-reference --device "cuda" --reference-dir "test_reference_outputs"
@@ -173,18 +176,25 @@ def tolerance_generator(tolerance, dtype):
 
 
 class {{graph_module_desc.test_name}}Test(unittest.TestCase):
-    def setUp(self):
+    @classmethod
+    def setUpClass(self):
         self.device = TEST_ARGS.device
         self.is_reference = TEST_ARGS.is_reference
         self.reference_dir = TEST_ARGS.reference_dir
-        self.tolerance = {{graph_module_desc.tolerance}}
+        self.tolerance = TEST_ARGS.tolerance
+        self.random_seed = TEST_ARGS.random_seed
+        self.runtime_seed = TEST_ARGS.runtime_seed
 
-        paddle.seed(123)
-        random.seed(123)
-        np.random.seed(123)
+        paddle.seed(self.random_seed)
+        random.seed(self.random_seed)
+        np.random.seed(self.random_seed)
 
         self.input_dict = get_input_dict(self.device)
         self.test_model = TestModel()
+        self.test_model.eval()
+
+        if any(k in self.device for k in ["cuda", "gpu"]):
+            paddle.set_flags({"FLAGS_cudnn_exhaustive_search": 1})
 
     def _flatten_outputs_to_list(self, outs):
         flattened_outs = outs
@@ -273,9 +283,15 @@ class {{graph_module_desc.test_name}}Test(unittest.TestCase):
 
         for reference, target in zip(reference_outputs, target_outputs):
             atol, rtol = tolerance_generator(self.tolerance, reference.dtype)
-            np.testing.assert_allclose(_convert_to_numpy(reference), _convert_to_numpy(target), atol, rtol)
+            np.testing.assert_allclose(
+                actual=_convert_to_numpy(target),
+                desired=_convert_to_numpy(reference),
+                atol=atol,
+                rtol=rtol,
+            )
 
     def test_separated(self):
+        paddle.seed(self.runtime_seed)
         prologue_output_path = os.path.join(self.reference_dir, "{{graph_module_desc.model_name}}_prologue_reference.pdout")
         prologue_outputs = self.run_prologue_layer()
         if self.is_reference:
@@ -285,9 +301,10 @@ class {{graph_module_desc.test_name}}Test(unittest.TestCase):
         else:
             print(f"Load prologue output tensors from {prologue_output_path}")
             prologue_reference_outputs = paddle.load(prologue_output_path)
-            self.check_results(prologue_reference_outputs, prologue_outputs)
+            with self.subTest(name="check_prologue_outputs"):
+                self.check_results(prologue_reference_outputs, prologue_outputs)
 
-        test_output_path = os.path.join(self.reference_dir, "{{graph_module_desc.model_name}}_separate_reference.pdout")
+        test_output_path = os.path.join(self.reference_dir, "{{graph_module_desc.model_name}}_separated_reference.pdout")
         test_outputs = self.run_suspect_layer(prologue_reference_outputs)
         if self.is_reference:
             print(f"Save test output tensors to {test_output_path}.")
@@ -295,9 +312,11 @@ class {{graph_module_desc.test_name}}Test(unittest.TestCase):
         else:
             print(f"Load test output tensors on reference device from {test_output_path}.")
             test_reference_outputs = paddle.load(test_output_path)
-            self.check_results(test_reference_outputs, test_outputs)
+            with self.subTest(name="check_suspect_outputs"):
+                self.check_results(test_reference_outputs, test_outputs)
 
     def test_combined(self):
+        paddle.seed(self.runtime_seed)
         test_output_path = os.path.join(self.reference_dir, "{{graph_module_desc.model_name}}_combined_reference.pdout")
         test_outputs = self.run_test_model()
         if self.is_reference:
@@ -306,19 +325,25 @@ class {{graph_module_desc.test_name}}Test(unittest.TestCase):
         else:
             print(f"Load test output tensors on reference device from {test_output_path}.")
             test_reference_outputs = paddle.load(test_output_path)
-            self.check_results(test_reference_outputs, test_outputs)
+            with self.subTest(name="check_combined_outputs"):
+                self.check_results(test_reference_outputs, test_outputs)
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument("--is-reference", action="store_true", default=False)
-    parser.add_argument("--device", type=str, required=True)
-    parser.add_argument("--reference-dir", type=str, required=True)
+    parser.add_argument("--is-reference", action="store_true", default=False, help="Whether it runs on the reference hardware.")
+    parser.add_argument("--device", type=str, required=True, help="Device to run on.")
+    parser.add_argument("--reference-dir", type=str, required=True, help="Directory to save the results on reference hardware.")
+    parser.add_argument("--tolerance", type=int, default={{graph_module_desc.tolerance}}, help="Tolerance level used in allclose check.")
+    parser.add_argument("--random-seed", type=int, default=123, help="Random seed to initialize the input tensors.")
+    parser.add_argument("--runtime-seed", type=int, default=1024, help="Random seed for runtime.")
     args, remaining = parser.parse_known_args()
 
     global TEST_ARGS
     TEST_ARGS = args
 
+    print(f"PaddlePaddle version: {paddle.__version__}")
+    print(f"PaddlePaddle commit: {paddle.version.commit}")
     unittest.main(argv=[sys.argv[0]] + remaining)
 """
 
@@ -337,6 +362,8 @@ GraphModuleDescriptor = namedtuple(
         "suspect_arg_names",
         "suspect_returns",
         "suspect_forward_func",
+        "rel_model_path_to_graphnet",
+        "subgraph_range",
     ],
 )
 
@@ -475,6 +502,10 @@ class PrologueSubgraphUnittestGenerator:
                 suspect_arg_names=suspect_arg_names,
                 suspect_returns=suspect_returns,
                 suspect_forward_func=suspect_forward_func,
+                rel_model_path_to_graphnet=self.parent_model_path.split("GraphNet/")[
+                    -1
+                ],
+                subgraph_range=self.subgraph_range,
             )
             return self._render_template(graph_module_desc)
 

--- a/graph_net/paddle/prologue_subgraph_unittest_generator.py
+++ b/graph_net/paddle/prologue_subgraph_unittest_generator.py
@@ -37,6 +37,7 @@ class GraphExtractor:
     def make_config(
         self,
         subgraph_range: list,
+        use_all_inputs: bool,
         device: Literal["auto", "cpu", "cuda", "xpu"] = "auto",
         tolerance: int = 0,
         try_run: bool = False,
@@ -49,6 +50,7 @@ class GraphExtractor:
             ), f"subgraph_range should be list of int, {subgraph_range=}"
         return {
             "subgraph_range": subgraph_range,
+            "use_all_inputs": use_all_inputs,
             "device": device,
             "tolerance": tolerance,
             "try_run": try_run,
@@ -366,6 +368,7 @@ class PrologueSubgraphUnittestGenerator:
             workspace_path=self.config["output_dir"],
         )
         self.subgraph_range = self.config["subgraph_range"]
+        self.use_all_inputs = self.config["use_all_inputs"]
         self.device = self._choose_device(self.config["device"])
         self.tolerance = self.config["tolerance"]
         self.try_run = self.config["try_run"]
@@ -433,10 +436,10 @@ class PrologueSubgraphUnittestGenerator:
         )
 
         graph_module, output_path = self._save_and_get_graph_module(
-            subgraph_generator, self.subgraph_range, True, tmp_dir
+            subgraph_generator, self.subgraph_range, self.use_all_inputs, tmp_dir
         )
         arg_names = self._get_forward_arg_names(graph_module)
-        self.graph_meta_restorer(output_path)
+        self.graph_meta_restorer(output_path, self.subgraph_range, self.use_all_inputs)
         tensor_metas = self._get_tensor_metas(output_path)
 
         # prologue model information

--- a/graph_net/paddle/prologue_subgraph_unittest_generator.py
+++ b/graph_net/paddle/prologue_subgraph_unittest_generator.py
@@ -402,8 +402,10 @@ class PrologueSubgraphUnittestGenerator:
             self.generate(subgraph_generator, tmp_dir)
         return static_model
 
-    def _save_and_get_graph_module(self, subgraph_generator, subgraph_range, tmp_dir):
-        results = subgraph_generator(subgraph_range, False)
+    def _save_and_get_graph_module(
+        self, subgraph_generator, subgraph_range, use_all_inputs, tmp_dir
+    ):
+        results = subgraph_generator(subgraph_range, False, use_all_inputs)
         assert len(results) == 1
         output_name = f"{subgraph_range[0]}_{subgraph_range[1]}"
         output_path = os.path.join(tmp_dir, f"{self.model_name}-{output_name}")
@@ -419,7 +421,7 @@ class PrologueSubgraphUnittestGenerator:
         )
 
         graph_module, output_path = self._save_and_get_graph_module(
-            subgraph_generator, self.subgraph_range, tmp_dir
+            subgraph_generator, self.subgraph_range, True, tmp_dir
         )
         arg_names = self._get_forward_arg_names(graph_module)
         self.graph_meta_restorer(output_path)
@@ -428,7 +430,7 @@ class PrologueSubgraphUnittestGenerator:
         # prologue model information
         prologue_subgraph_range = [self.subgraph_range[0], self.subgraph_range[1] - 1]
         prologue_graph_module, _ = self._save_and_get_graph_module(
-            subgraph_generator, prologue_subgraph_range, tmp_dir
+            subgraph_generator, prologue_subgraph_range, False, tmp_dir
         )
         prologue_forward_func, prologue_returns = self._get_forward_func_and_returns(
             prologue_graph_module
@@ -438,7 +440,7 @@ class PrologueSubgraphUnittestGenerator:
         # suspect model information
         suspect_subgraph_range = [self.subgraph_range[1] - 1, self.subgraph_range[1]]
         suspect_graph_module, _ = self._save_and_get_graph_module(
-            subgraph_generator, suspect_subgraph_range, tmp_dir
+            subgraph_generator, suspect_subgraph_range, False, tmp_dir
         )
         suspect_forward_func, suspect_returns = self._get_forward_func_and_returns(
             suspect_graph_module

--- a/graph_net/paddle/prologue_subgraph_unittest_generator.py
+++ b/graph_net/paddle/prologue_subgraph_unittest_generator.py
@@ -264,17 +264,19 @@ class {{graph_module_desc.test_name}}Test(unittest.TestCase):
             np.testing.assert_allclose(_convert_to_numpy(reference), _convert_to_numpy(target), atol, rtol)
 
     def test_separated(self):
-        prologue_output_path = os.path.join(self.reference_dir, "{{graph_module_desc.model_name}}_separate_prologue.pdout")
+        prologue_output_path = os.path.join(self.reference_dir, "{{graph_module_desc.model_name}}_prologue_reference.pdout")
+        prologue_outputs = self.run_prologue_layer()
         if self.is_reference:
-            prologue_outputs = self.run_prologue_layer()
             print(f"Save prologue output tensors to {prologue_output_path}.")
             paddle.save(prologue_outputs, prologue_output_path)
+            prologue_reference_outputs = prologue_outputs
         else:
             print(f"Load prologue output tensors from {prologue_output_path}")
-            prologue_outputs = paddle.load(prologue_output_path)
-        
+            prologue_reference_outputs = paddle.load(prologue_output_path)
+            self.check_results(prologue_reference_outputs, prologue_outputs)
+
         test_output_path = os.path.join(self.reference_dir, "{{graph_module_desc.model_name}}_separate_reference.pdout")
-        test_outputs = self.run_suspect_layer(prologue_outputs)
+        test_outputs = self.run_suspect_layer(prologue_reference_outputs)
         if self.is_reference:
             print(f"Save test output tensors to {test_output_path}.")
             paddle.save(test_outputs, test_output_path)

--- a/graph_net/subgraph_decompose_and_evaluation_step.py
+++ b/graph_net/subgraph_decompose_and_evaluation_step.py
@@ -325,6 +325,7 @@ def run_decomposer_for_single_model(
                 "output_dir": output_dir,
                 "split_positions": split_positions,
                 "group_head_and_tail": False,
+                "use_all_inputs": True,
                 "chain_style": False,
             },
         },
@@ -472,10 +473,10 @@ def generate_unittest(decompose_config, pass_id, output_dir):
         if decompose_config.decompose_method == "fixed-start":
             subgraph_range = [0, model_record.uniform_split_positions[subgraph_idx + 1]]
         else:
-            subgraph_range = [
-                model_record.uniform_split_positions[subgraph_idx],
-                model_record.uniform_split_positions[subgraph_idx + 1],
+            subgraph_range = model_record.uniform_split_positions[
+                subgraph_idx : subgraph_idx + 2
             ]
+            assert False, "Not supported!"
 
         rectified_model_path = get_rectfied_model_path(original_path)
         assert os.path.exists(

--- a/graph_net/subgraph_decompose_and_evaluation_step.py
+++ b/graph_net/subgraph_decompose_and_evaluation_step.py
@@ -698,6 +698,8 @@ def execute_decomposition_phase(decompose_config, pass_id, workspace):
             f"[WARN] {len(failed_decomposition_models)} models failed to decompose.",
             flush=True,
         )
+        for idx, model_path in enumerate(failed_decomposition_models):
+            print(f"- [{idx}] {model_path=}", flush=True)
 
     running_state.collect_decomposed_subgraphs(decomposed_samples_dir)
     decompose_config.max_subgraph_size = max_subgraph_size

--- a/graph_net/subgraph_decompose_and_evaluation_step.py
+++ b/graph_net/subgraph_decompose_and_evaluation_step.py
@@ -740,7 +740,7 @@ def print_summary_and_suggestion(decompose_config, pass_id):
         )
     elif decompose_config.max_subgraph_size <= 1:
         print(
-            f">>> [Conclusion] Decomposition has reached the minimal granularity (max_subgraph_size = 1) after {pass_id - 1} steps.",
+            f">>> [Conclusion] Decomposition has reached the minimal granularity (max_subgraph_size = 1) after {pass_id} steps.",
             flush=True,
         )
     print("=" * 80, flush=True)

--- a/graph_net/subgraph_decompose_and_evaluation_step.py
+++ b/graph_net/subgraph_decompose_and_evaluation_step.py
@@ -431,6 +431,7 @@ def generate_unittest_for_single_model(
             "custom_extractor_config": {
                 "output_dir": output_dir,
                 "subgraph_range": subgraph_range,
+                "use_all_inputs": True,
                 "device": "auto",
                 "tolerance": tolerance,
                 "try_run": True,
@@ -529,7 +530,7 @@ def generate_initial_tasks(args):
     initial_incorrect_models = get_ranged_incorrect_models(
         args.tolerance, args.log_file
     )
-    for model_path in initial_incorrect_models:
+    for model_path in sorted(initial_incorrect_models):
         model_name = get_model_name_with_subgraph_tag(model_path)
         model_name2record[model_name] = ModelRecord(
             original_path=model_path,
@@ -721,7 +722,7 @@ def print_incorrect_models(decompose_config, pass_id, log_prompt):
         f"{log_prompt} number of incorrect subgraphs: {len(incorrect_models)}; number of incorrect original models: {len(original_model_paths)}",
         flush=True,
     )
-    for idx, model_path in enumerate(incorrect_models):
+    for idx, model_path in enumerate(sorted(incorrect_models)):
         print(f"- [{idx}] {model_path}", flush=True)
 
 
@@ -739,7 +740,7 @@ def print_summary_and_suggestion(decompose_config, pass_id):
         )
     elif decompose_config.max_subgraph_size <= 1:
         print(
-            ">>> [Conclusion] Decomposition has reached the minimal granularity (max_subgraph_size = 1) after {pass_id - 1} steps.",
+            f">>> [Conclusion] Decomposition has reached the minimal granularity (max_subgraph_size = 1) after {pass_id - 1} steps.",
             flush=True,
         )
     print("=" * 80, flush=True)

--- a/graph_net/test/paddle_nlp_model_getter.py
+++ b/graph_net/test/paddle_nlp_model_getter.py
@@ -116,7 +116,6 @@ def get_bart_model_and_inputs(model_name, text, dtype):
     model.eval()
 
     tokenizer = BartTokenizer.from_pretrained(model_name)
-
     inputs = tokenizer(
         text,
         return_tensors="pd",
@@ -125,7 +124,6 @@ def get_bart_model_and_inputs(model_name, text, dtype):
         max_length=512,
     )
     inputs.pop("token_type_ids", None)
-
     return model, inputs
 
 
@@ -152,5 +150,16 @@ def get_xlnet_model_and_inputs(model_name, text, dtype):
         input_ids = enc["input_ids"]
         pad_id = tokenizer.pad_token_id
         enc["attention_mask"] = (input_ids != pad_id).astype("int64")
-
     return model, enc
+
+
+def get_fnet_model_and_inputs(model_name, text, dtype):
+    from paddlenlp.transformers.fnet.modeling import FNetModel, FNetConfig
+    from paddlenlp.transformers.fnet.tokenizer import FNetTokenizer
+
+    config = FNetConfig.from_pretrained(model_name)
+    model = FNetModel(config)
+
+    tokenizer = FNetTokenizer.from_pretrained(model_name)
+    inputs = tokenizer(text, return_tensors="pd")
+    return model, inputs

--- a/graph_net/test/paddle_nlp_test.py
+++ b/graph_net/test/paddle_nlp_test.py
@@ -1,10 +1,5 @@
 import os
-import sys
-import subprocess
 import shutil
-import traceback
-import time
-import glob
 import logging
 
 from graph_net.paddle.extractor import extract
@@ -274,13 +269,19 @@ def extract_skep_models(text_en, text_cn):
         process_model(model_name, nlp_model_getter.get_skep_model_and_inputs, text)
 
 
+def extract_fnet_models(text_en, text_cn):
+    # fnet-base models
+    model_name = "fnet-base"
+    process_model(model_name, nlp_model_getter.get_fnet_model_and_inputs, text_en)
+
+
 def main():
     current_dir = os.path.dirname(os.path.abspath(__file__))
     dump_dir = os.path.join(current_dir, "dump")
     os.environ["GRAPH_NET_PIR_DUMP_WORKSPACE"] = dump_dir
 
     text_en = "Hello, my name is Bob. I am learning about large language models and their architectures. "
-    text_cn = "欢迎使用百度飞桨!"
+    text_cn = "欢迎使用百度飞桨!"  # noqa
 
     # auto models
     model_name = "facebook/llama-7b"

--- a/paddle_samples/PaddleNLP/fnet-base/input_meta.py
+++ b/paddle_samples/PaddleNLP/fnet-base/input_meta.py
@@ -1,5 +1,6 @@
 class Program_weight_tensor_data_0:
     name = "data_0"
+    original_name = "input_ids"
     shape = [1, 21]
     dtype = "int64"
     data = [
@@ -29,6 +30,7 @@ class Program_weight_tensor_data_0:
 
 class Program_weight_tensor_data_1:
     name = "data_1"
+    original_name = "token_type_ids"
     shape = [1, 21]
     dtype = "int64"
     data = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]

--- a/paddle_samples/PaddleNLP/fnet-base/weight_meta.py
+++ b/paddle_samples/PaddleNLP/fnet-base/weight_meta.py
@@ -1,5 +1,6 @@
 class Program_weight_tensor_parameter_0:
     name = "parameter_0"
+    original_name = "eager_tmp_0"
     shape = [1, 512]
     dtype = "int64"
     min_val = 0
@@ -9,6 +10,7 @@ class Program_weight_tensor_parameter_0:
 
 class Program_weight_tensor_parameter_1:
     name = "parameter_1"
+    original_name = "linear_25.b_0"
     shape = [768]
     dtype = "float32"
     data = None
@@ -16,6 +18,7 @@ class Program_weight_tensor_parameter_1:
 
 class Program_weight_tensor_parameter_2:
     name = "parameter_2"
+    original_name = "linear_25.w_0"
     shape = [768, 768]
     dtype = "float32"
     min_val = float("-0.0931399")
@@ -27,6 +30,7 @@ class Program_weight_tensor_parameter_2:
 
 class Program_weight_tensor_parameter_3:
     name = "parameter_3"
+    original_name = "layer_norm_24.b_0"
     shape = [768]
     dtype = "float32"
     data = None
@@ -34,6 +38,7 @@ class Program_weight_tensor_parameter_3:
 
 class Program_weight_tensor_parameter_4:
     name = "parameter_4"
+    original_name = "layer_norm_24.w_0"
     shape = [768]
     dtype = "float32"
     min_val = float("1.0")
@@ -44,6 +49,7 @@ class Program_weight_tensor_parameter_4:
 
 class Program_weight_tensor_parameter_5:
     name = "parameter_5"
+    original_name = "linear_24.b_0"
     shape = [768]
     dtype = "float32"
     data = None
@@ -51,6 +57,7 @@ class Program_weight_tensor_parameter_5:
 
 class Program_weight_tensor_parameter_6:
     name = "parameter_6"
+    original_name = "linear_24.w_0"
     shape = [3072, 768]
     dtype = "float32"
     min_val = float("-0.0995459")
@@ -62,6 +69,7 @@ class Program_weight_tensor_parameter_6:
 
 class Program_weight_tensor_parameter_7:
     name = "parameter_7"
+    original_name = "linear_23.b_0"
     shape = [3072]
     dtype = "float32"
     data = None
@@ -69,6 +77,7 @@ class Program_weight_tensor_parameter_7:
 
 class Program_weight_tensor_parameter_8:
     name = "parameter_8"
+    original_name = "linear_23.w_0"
     shape = [768, 3072]
     dtype = "float32"
     min_val = float("-0.112446")
@@ -80,6 +89,7 @@ class Program_weight_tensor_parameter_8:
 
 class Program_weight_tensor_parameter_9:
     name = "parameter_9"
+    original_name = "layer_norm_23.b_0"
     shape = [768]
     dtype = "float32"
     data = None
@@ -87,6 +97,7 @@ class Program_weight_tensor_parameter_9:
 
 class Program_weight_tensor_parameter_10:
     name = "parameter_10"
+    original_name = "layer_norm_23.w_0"
     shape = [768]
     dtype = "float32"
     min_val = float("1.0")
@@ -97,6 +108,7 @@ class Program_weight_tensor_parameter_10:
 
 class Program_weight_tensor_parameter_11:
     name = "parameter_11"
+    original_name = "layer_norm_22.b_0"
     shape = [768]
     dtype = "float32"
     data = None
@@ -104,6 +116,7 @@ class Program_weight_tensor_parameter_11:
 
 class Program_weight_tensor_parameter_12:
     name = "parameter_12"
+    original_name = "layer_norm_22.w_0"
     shape = [768]
     dtype = "float32"
     min_val = float("1.0")
@@ -114,6 +127,7 @@ class Program_weight_tensor_parameter_12:
 
 class Program_weight_tensor_parameter_13:
     name = "parameter_13"
+    original_name = "linear_22.b_0"
     shape = [768]
     dtype = "float32"
     data = None
@@ -121,6 +135,7 @@ class Program_weight_tensor_parameter_13:
 
 class Program_weight_tensor_parameter_14:
     name = "parameter_14"
+    original_name = "linear_22.w_0"
     shape = [3072, 768]
     dtype = "float32"
     min_val = float("-0.0955202")
@@ -132,6 +147,7 @@ class Program_weight_tensor_parameter_14:
 
 class Program_weight_tensor_parameter_15:
     name = "parameter_15"
+    original_name = "linear_21.b_0"
     shape = [3072]
     dtype = "float32"
     data = None
@@ -139,6 +155,7 @@ class Program_weight_tensor_parameter_15:
 
 class Program_weight_tensor_parameter_16:
     name = "parameter_16"
+    original_name = "linear_21.w_0"
     shape = [768, 3072]
     dtype = "float32"
     min_val = float("-0.0972084")
@@ -150,6 +167,7 @@ class Program_weight_tensor_parameter_16:
 
 class Program_weight_tensor_parameter_17:
     name = "parameter_17"
+    original_name = "layer_norm_21.b_0"
     shape = [768]
     dtype = "float32"
     data = None
@@ -157,6 +175,7 @@ class Program_weight_tensor_parameter_17:
 
 class Program_weight_tensor_parameter_18:
     name = "parameter_18"
+    original_name = "layer_norm_21.w_0"
     shape = [768]
     dtype = "float32"
     min_val = float("1.0")
@@ -167,6 +186,7 @@ class Program_weight_tensor_parameter_18:
 
 class Program_weight_tensor_parameter_19:
     name = "parameter_19"
+    original_name = "layer_norm_20.b_0"
     shape = [768]
     dtype = "float32"
     data = None
@@ -174,6 +194,7 @@ class Program_weight_tensor_parameter_19:
 
 class Program_weight_tensor_parameter_20:
     name = "parameter_20"
+    original_name = "layer_norm_20.w_0"
     shape = [768]
     dtype = "float32"
     min_val = float("1.0")
@@ -184,6 +205,7 @@ class Program_weight_tensor_parameter_20:
 
 class Program_weight_tensor_parameter_21:
     name = "parameter_21"
+    original_name = "linear_20.b_0"
     shape = [768]
     dtype = "float32"
     data = None
@@ -191,6 +213,7 @@ class Program_weight_tensor_parameter_21:
 
 class Program_weight_tensor_parameter_22:
     name = "parameter_22"
+    original_name = "linear_20.w_0"
     shape = [3072, 768]
     dtype = "float32"
     min_val = float("-0.100785")
@@ -202,6 +225,7 @@ class Program_weight_tensor_parameter_22:
 
 class Program_weight_tensor_parameter_23:
     name = "parameter_23"
+    original_name = "linear_19.b_0"
     shape = [3072]
     dtype = "float32"
     data = None
@@ -209,6 +233,7 @@ class Program_weight_tensor_parameter_23:
 
 class Program_weight_tensor_parameter_24:
     name = "parameter_24"
+    original_name = "linear_19.w_0"
     shape = [768, 3072]
     dtype = "float32"
     min_val = float("-0.0993488")
@@ -220,6 +245,7 @@ class Program_weight_tensor_parameter_24:
 
 class Program_weight_tensor_parameter_25:
     name = "parameter_25"
+    original_name = "layer_norm_19.b_0"
     shape = [768]
     dtype = "float32"
     data = None
@@ -227,6 +253,7 @@ class Program_weight_tensor_parameter_25:
 
 class Program_weight_tensor_parameter_26:
     name = "parameter_26"
+    original_name = "layer_norm_19.w_0"
     shape = [768]
     dtype = "float32"
     min_val = float("1.0")
@@ -237,6 +264,7 @@ class Program_weight_tensor_parameter_26:
 
 class Program_weight_tensor_parameter_27:
     name = "parameter_27"
+    original_name = "layer_norm_18.b_0"
     shape = [768]
     dtype = "float32"
     data = None
@@ -244,6 +272,7 @@ class Program_weight_tensor_parameter_27:
 
 class Program_weight_tensor_parameter_28:
     name = "parameter_28"
+    original_name = "layer_norm_18.w_0"
     shape = [768]
     dtype = "float32"
     min_val = float("1.0")
@@ -254,6 +283,7 @@ class Program_weight_tensor_parameter_28:
 
 class Program_weight_tensor_parameter_29:
     name = "parameter_29"
+    original_name = "linear_18.b_0"
     shape = [768]
     dtype = "float32"
     data = None
@@ -261,6 +291,7 @@ class Program_weight_tensor_parameter_29:
 
 class Program_weight_tensor_parameter_30:
     name = "parameter_30"
+    original_name = "linear_18.w_0"
     shape = [3072, 768]
     dtype = "float32"
     min_val = float("-0.0949435")
@@ -272,6 +303,7 @@ class Program_weight_tensor_parameter_30:
 
 class Program_weight_tensor_parameter_31:
     name = "parameter_31"
+    original_name = "linear_17.b_0"
     shape = [3072]
     dtype = "float32"
     data = None
@@ -279,6 +311,7 @@ class Program_weight_tensor_parameter_31:
 
 class Program_weight_tensor_parameter_32:
     name = "parameter_32"
+    original_name = "linear_17.w_0"
     shape = [768, 3072]
     dtype = "float32"
     min_val = float("-0.0979802")
@@ -290,6 +323,7 @@ class Program_weight_tensor_parameter_32:
 
 class Program_weight_tensor_parameter_33:
     name = "parameter_33"
+    original_name = "layer_norm_17.b_0"
     shape = [768]
     dtype = "float32"
     data = None
@@ -297,6 +331,7 @@ class Program_weight_tensor_parameter_33:
 
 class Program_weight_tensor_parameter_34:
     name = "parameter_34"
+    original_name = "layer_norm_17.w_0"
     shape = [768]
     dtype = "float32"
     min_val = float("1.0")
@@ -307,6 +342,7 @@ class Program_weight_tensor_parameter_34:
 
 class Program_weight_tensor_parameter_35:
     name = "parameter_35"
+    original_name = "layer_norm_16.b_0"
     shape = [768]
     dtype = "float32"
     data = None
@@ -314,6 +350,7 @@ class Program_weight_tensor_parameter_35:
 
 class Program_weight_tensor_parameter_36:
     name = "parameter_36"
+    original_name = "layer_norm_16.w_0"
     shape = [768]
     dtype = "float32"
     min_val = float("1.0")
@@ -324,6 +361,7 @@ class Program_weight_tensor_parameter_36:
 
 class Program_weight_tensor_parameter_37:
     name = "parameter_37"
+    original_name = "linear_16.b_0"
     shape = [768]
     dtype = "float32"
     data = None
@@ -331,6 +369,7 @@ class Program_weight_tensor_parameter_37:
 
 class Program_weight_tensor_parameter_38:
     name = "parameter_38"
+    original_name = "linear_16.w_0"
     shape = [3072, 768]
     dtype = "float32"
     min_val = float("-0.100097")
@@ -342,6 +381,7 @@ class Program_weight_tensor_parameter_38:
 
 class Program_weight_tensor_parameter_39:
     name = "parameter_39"
+    original_name = "linear_15.b_0"
     shape = [3072]
     dtype = "float32"
     data = None
@@ -349,6 +389,7 @@ class Program_weight_tensor_parameter_39:
 
 class Program_weight_tensor_parameter_40:
     name = "parameter_40"
+    original_name = "linear_15.w_0"
     shape = [768, 3072]
     dtype = "float32"
     min_val = float("-0.105403")
@@ -360,6 +401,7 @@ class Program_weight_tensor_parameter_40:
 
 class Program_weight_tensor_parameter_41:
     name = "parameter_41"
+    original_name = "layer_norm_15.b_0"
     shape = [768]
     dtype = "float32"
     data = None
@@ -367,6 +409,7 @@ class Program_weight_tensor_parameter_41:
 
 class Program_weight_tensor_parameter_42:
     name = "parameter_42"
+    original_name = "layer_norm_15.w_0"
     shape = [768]
     dtype = "float32"
     min_val = float("1.0")
@@ -377,6 +420,7 @@ class Program_weight_tensor_parameter_42:
 
 class Program_weight_tensor_parameter_43:
     name = "parameter_43"
+    original_name = "layer_norm_14.b_0"
     shape = [768]
     dtype = "float32"
     data = None
@@ -384,6 +428,7 @@ class Program_weight_tensor_parameter_43:
 
 class Program_weight_tensor_parameter_44:
     name = "parameter_44"
+    original_name = "layer_norm_14.w_0"
     shape = [768]
     dtype = "float32"
     min_val = float("1.0")
@@ -394,6 +439,7 @@ class Program_weight_tensor_parameter_44:
 
 class Program_weight_tensor_parameter_45:
     name = "parameter_45"
+    original_name = "linear_14.b_0"
     shape = [768]
     dtype = "float32"
     data = None
@@ -401,6 +447,7 @@ class Program_weight_tensor_parameter_45:
 
 class Program_weight_tensor_parameter_46:
     name = "parameter_46"
+    original_name = "linear_14.w_0"
     shape = [3072, 768]
     dtype = "float32"
     min_val = float("-0.0976846")
@@ -412,6 +459,7 @@ class Program_weight_tensor_parameter_46:
 
 class Program_weight_tensor_parameter_47:
     name = "parameter_47"
+    original_name = "linear_13.b_0"
     shape = [3072]
     dtype = "float32"
     data = None
@@ -419,6 +467,7 @@ class Program_weight_tensor_parameter_47:
 
 class Program_weight_tensor_parameter_48:
     name = "parameter_48"
+    original_name = "linear_13.w_0"
     shape = [768, 3072]
     dtype = "float32"
     min_val = float("-0.0990286")
@@ -430,6 +479,7 @@ class Program_weight_tensor_parameter_48:
 
 class Program_weight_tensor_parameter_49:
     name = "parameter_49"
+    original_name = "layer_norm_13.b_0"
     shape = [768]
     dtype = "float32"
     data = None
@@ -437,6 +487,7 @@ class Program_weight_tensor_parameter_49:
 
 class Program_weight_tensor_parameter_50:
     name = "parameter_50"
+    original_name = "layer_norm_13.w_0"
     shape = [768]
     dtype = "float32"
     min_val = float("1.0")
@@ -447,6 +498,7 @@ class Program_weight_tensor_parameter_50:
 
 class Program_weight_tensor_parameter_51:
     name = "parameter_51"
+    original_name = "layer_norm_12.b_0"
     shape = [768]
     dtype = "float32"
     data = None
@@ -454,6 +506,7 @@ class Program_weight_tensor_parameter_51:
 
 class Program_weight_tensor_parameter_52:
     name = "parameter_52"
+    original_name = "layer_norm_12.w_0"
     shape = [768]
     dtype = "float32"
     min_val = float("1.0")
@@ -464,6 +517,7 @@ class Program_weight_tensor_parameter_52:
 
 class Program_weight_tensor_parameter_53:
     name = "parameter_53"
+    original_name = "linear_12.b_0"
     shape = [768]
     dtype = "float32"
     data = None
@@ -471,6 +525,7 @@ class Program_weight_tensor_parameter_53:
 
 class Program_weight_tensor_parameter_54:
     name = "parameter_54"
+    original_name = "linear_12.w_0"
     shape = [3072, 768]
     dtype = "float32"
     min_val = float("-0.0983106")
@@ -482,6 +537,7 @@ class Program_weight_tensor_parameter_54:
 
 class Program_weight_tensor_parameter_55:
     name = "parameter_55"
+    original_name = "linear_11.b_0"
     shape = [3072]
     dtype = "float32"
     data = None
@@ -489,6 +545,7 @@ class Program_weight_tensor_parameter_55:
 
 class Program_weight_tensor_parameter_56:
     name = "parameter_56"
+    original_name = "linear_11.w_0"
     shape = [768, 3072]
     dtype = "float32"
     min_val = float("-0.0996774")
@@ -500,6 +557,7 @@ class Program_weight_tensor_parameter_56:
 
 class Program_weight_tensor_parameter_57:
     name = "parameter_57"
+    original_name = "layer_norm_11.b_0"
     shape = [768]
     dtype = "float32"
     data = None
@@ -507,6 +565,7 @@ class Program_weight_tensor_parameter_57:
 
 class Program_weight_tensor_parameter_58:
     name = "parameter_58"
+    original_name = "layer_norm_11.w_0"
     shape = [768]
     dtype = "float32"
     min_val = float("1.0")
@@ -517,6 +576,7 @@ class Program_weight_tensor_parameter_58:
 
 class Program_weight_tensor_parameter_59:
     name = "parameter_59"
+    original_name = "layer_norm_10.b_0"
     shape = [768]
     dtype = "float32"
     data = None
@@ -524,6 +584,7 @@ class Program_weight_tensor_parameter_59:
 
 class Program_weight_tensor_parameter_60:
     name = "parameter_60"
+    original_name = "layer_norm_10.w_0"
     shape = [768]
     dtype = "float32"
     min_val = float("1.0")
@@ -534,6 +595,7 @@ class Program_weight_tensor_parameter_60:
 
 class Program_weight_tensor_parameter_61:
     name = "parameter_61"
+    original_name = "linear_10.b_0"
     shape = [768]
     dtype = "float32"
     data = None
@@ -541,6 +603,7 @@ class Program_weight_tensor_parameter_61:
 
 class Program_weight_tensor_parameter_62:
     name = "parameter_62"
+    original_name = "linear_10.w_0"
     shape = [3072, 768]
     dtype = "float32"
     min_val = float("-0.0949245")
@@ -552,6 +615,7 @@ class Program_weight_tensor_parameter_62:
 
 class Program_weight_tensor_parameter_63:
     name = "parameter_63"
+    original_name = "linear_9.b_0"
     shape = [3072]
     dtype = "float32"
     data = None
@@ -559,6 +623,7 @@ class Program_weight_tensor_parameter_63:
 
 class Program_weight_tensor_parameter_64:
     name = "parameter_64"
+    original_name = "linear_9.w_0"
     shape = [768, 3072]
     dtype = "float32"
     min_val = float("-0.0997805")
@@ -570,6 +635,7 @@ class Program_weight_tensor_parameter_64:
 
 class Program_weight_tensor_parameter_65:
     name = "parameter_65"
+    original_name = "layer_norm_9.b_0"
     shape = [768]
     dtype = "float32"
     data = None
@@ -577,6 +643,7 @@ class Program_weight_tensor_parameter_65:
 
 class Program_weight_tensor_parameter_66:
     name = "parameter_66"
+    original_name = "layer_norm_9.w_0"
     shape = [768]
     dtype = "float32"
     min_val = float("1.0")
@@ -587,6 +654,7 @@ class Program_weight_tensor_parameter_66:
 
 class Program_weight_tensor_parameter_67:
     name = "parameter_67"
+    original_name = "layer_norm_8.b_0"
     shape = [768]
     dtype = "float32"
     data = None
@@ -594,6 +662,7 @@ class Program_weight_tensor_parameter_67:
 
 class Program_weight_tensor_parameter_68:
     name = "parameter_68"
+    original_name = "layer_norm_8.w_0"
     shape = [768]
     dtype = "float32"
     min_val = float("1.0")
@@ -604,6 +673,7 @@ class Program_weight_tensor_parameter_68:
 
 class Program_weight_tensor_parameter_69:
     name = "parameter_69"
+    original_name = "linear_8.b_0"
     shape = [768]
     dtype = "float32"
     data = None
@@ -611,6 +681,7 @@ class Program_weight_tensor_parameter_69:
 
 class Program_weight_tensor_parameter_70:
     name = "parameter_70"
+    original_name = "linear_8.w_0"
     shape = [3072, 768]
     dtype = "float32"
     min_val = float("-0.100831")
@@ -622,6 +693,7 @@ class Program_weight_tensor_parameter_70:
 
 class Program_weight_tensor_parameter_71:
     name = "parameter_71"
+    original_name = "linear_7.b_0"
     shape = [3072]
     dtype = "float32"
     data = None
@@ -629,6 +701,7 @@ class Program_weight_tensor_parameter_71:
 
 class Program_weight_tensor_parameter_72:
     name = "parameter_72"
+    original_name = "linear_7.w_0"
     shape = [768, 3072]
     dtype = "float32"
     min_val = float("-0.0946749")
@@ -640,6 +713,7 @@ class Program_weight_tensor_parameter_72:
 
 class Program_weight_tensor_parameter_73:
     name = "parameter_73"
+    original_name = "layer_norm_7.b_0"
     shape = [768]
     dtype = "float32"
     data = None
@@ -647,6 +721,7 @@ class Program_weight_tensor_parameter_73:
 
 class Program_weight_tensor_parameter_74:
     name = "parameter_74"
+    original_name = "layer_norm_7.w_0"
     shape = [768]
     dtype = "float32"
     min_val = float("1.0")
@@ -657,6 +732,7 @@ class Program_weight_tensor_parameter_74:
 
 class Program_weight_tensor_parameter_75:
     name = "parameter_75"
+    original_name = "layer_norm_6.b_0"
     shape = [768]
     dtype = "float32"
     data = None
@@ -664,6 +740,7 @@ class Program_weight_tensor_parameter_75:
 
 class Program_weight_tensor_parameter_76:
     name = "parameter_76"
+    original_name = "layer_norm_6.w_0"
     shape = [768]
     dtype = "float32"
     min_val = float("1.0")
@@ -674,6 +751,7 @@ class Program_weight_tensor_parameter_76:
 
 class Program_weight_tensor_parameter_77:
     name = "parameter_77"
+    original_name = "linear_6.b_0"
     shape = [768]
     dtype = "float32"
     data = None
@@ -681,6 +759,7 @@ class Program_weight_tensor_parameter_77:
 
 class Program_weight_tensor_parameter_78:
     name = "parameter_78"
+    original_name = "linear_6.w_0"
     shape = [3072, 768]
     dtype = "float32"
     min_val = float("-0.112368")
@@ -692,6 +771,7 @@ class Program_weight_tensor_parameter_78:
 
 class Program_weight_tensor_parameter_79:
     name = "parameter_79"
+    original_name = "linear_5.b_0"
     shape = [3072]
     dtype = "float32"
     data = None
@@ -699,6 +779,7 @@ class Program_weight_tensor_parameter_79:
 
 class Program_weight_tensor_parameter_80:
     name = "parameter_80"
+    original_name = "linear_5.w_0"
     shape = [768, 3072]
     dtype = "float32"
     min_val = float("-0.101019")
@@ -710,6 +791,7 @@ class Program_weight_tensor_parameter_80:
 
 class Program_weight_tensor_parameter_81:
     name = "parameter_81"
+    original_name = "layer_norm_5.b_0"
     shape = [768]
     dtype = "float32"
     data = None
@@ -717,6 +799,7 @@ class Program_weight_tensor_parameter_81:
 
 class Program_weight_tensor_parameter_82:
     name = "parameter_82"
+    original_name = "layer_norm_5.w_0"
     shape = [768]
     dtype = "float32"
     min_val = float("1.0")
@@ -727,6 +810,7 @@ class Program_weight_tensor_parameter_82:
 
 class Program_weight_tensor_parameter_83:
     name = "parameter_83"
+    original_name = "layer_norm_4.b_0"
     shape = [768]
     dtype = "float32"
     data = None
@@ -734,6 +818,7 @@ class Program_weight_tensor_parameter_83:
 
 class Program_weight_tensor_parameter_84:
     name = "parameter_84"
+    original_name = "layer_norm_4.w_0"
     shape = [768]
     dtype = "float32"
     min_val = float("1.0")
@@ -744,6 +829,7 @@ class Program_weight_tensor_parameter_84:
 
 class Program_weight_tensor_parameter_85:
     name = "parameter_85"
+    original_name = "linear_4.b_0"
     shape = [768]
     dtype = "float32"
     data = None
@@ -751,6 +837,7 @@ class Program_weight_tensor_parameter_85:
 
 class Program_weight_tensor_parameter_86:
     name = "parameter_86"
+    original_name = "linear_4.w_0"
     shape = [3072, 768]
     dtype = "float32"
     min_val = float("-0.103274")
@@ -762,6 +849,7 @@ class Program_weight_tensor_parameter_86:
 
 class Program_weight_tensor_parameter_87:
     name = "parameter_87"
+    original_name = "linear_3.b_0"
     shape = [3072]
     dtype = "float32"
     data = None
@@ -769,6 +857,7 @@ class Program_weight_tensor_parameter_87:
 
 class Program_weight_tensor_parameter_88:
     name = "parameter_88"
+    original_name = "linear_3.w_0"
     shape = [768, 3072]
     dtype = "float32"
     min_val = float("-0.0972919")
@@ -780,6 +869,7 @@ class Program_weight_tensor_parameter_88:
 
 class Program_weight_tensor_parameter_89:
     name = "parameter_89"
+    original_name = "layer_norm_3.b_0"
     shape = [768]
     dtype = "float32"
     data = None
@@ -787,6 +877,7 @@ class Program_weight_tensor_parameter_89:
 
 class Program_weight_tensor_parameter_90:
     name = "parameter_90"
+    original_name = "layer_norm_3.w_0"
     shape = [768]
     dtype = "float32"
     min_val = float("1.0")
@@ -797,6 +888,7 @@ class Program_weight_tensor_parameter_90:
 
 class Program_weight_tensor_parameter_91:
     name = "parameter_91"
+    original_name = "layer_norm_2.b_0"
     shape = [768]
     dtype = "float32"
     data = None
@@ -804,6 +896,7 @@ class Program_weight_tensor_parameter_91:
 
 class Program_weight_tensor_parameter_92:
     name = "parameter_92"
+    original_name = "layer_norm_2.w_0"
     shape = [768]
     dtype = "float32"
     min_val = float("1.0")
@@ -814,6 +907,7 @@ class Program_weight_tensor_parameter_92:
 
 class Program_weight_tensor_parameter_93:
     name = "parameter_93"
+    original_name = "linear_2.b_0"
     shape = [768]
     dtype = "float32"
     data = None
@@ -821,6 +915,7 @@ class Program_weight_tensor_parameter_93:
 
 class Program_weight_tensor_parameter_94:
     name = "parameter_94"
+    original_name = "linear_2.w_0"
     shape = [3072, 768]
     dtype = "float32"
     min_val = float("-0.102109")
@@ -832,6 +927,7 @@ class Program_weight_tensor_parameter_94:
 
 class Program_weight_tensor_parameter_95:
     name = "parameter_95"
+    original_name = "linear_1.b_0"
     shape = [3072]
     dtype = "float32"
     data = None
@@ -839,6 +935,7 @@ class Program_weight_tensor_parameter_95:
 
 class Program_weight_tensor_parameter_96:
     name = "parameter_96"
+    original_name = "linear_1.w_0"
     shape = [768, 3072]
     dtype = "float32"
     min_val = float("-0.10697")
@@ -850,6 +947,7 @@ class Program_weight_tensor_parameter_96:
 
 class Program_weight_tensor_parameter_97:
     name = "parameter_97"
+    original_name = "layer_norm_1.b_0"
     shape = [768]
     dtype = "float32"
     data = None
@@ -857,6 +955,7 @@ class Program_weight_tensor_parameter_97:
 
 class Program_weight_tensor_parameter_98:
     name = "parameter_98"
+    original_name = "layer_norm_1.w_0"
     shape = [768]
     dtype = "float32"
     min_val = float("1.0")
@@ -867,6 +966,7 @@ class Program_weight_tensor_parameter_98:
 
 class Program_weight_tensor_parameter_99:
     name = "parameter_99"
+    original_name = "linear_0.b_0"
     shape = [768]
     dtype = "float32"
     data = None
@@ -874,6 +974,7 @@ class Program_weight_tensor_parameter_99:
 
 class Program_weight_tensor_parameter_100:
     name = "parameter_100"
+    original_name = "linear_0.w_0"
     shape = [768, 768]
     dtype = "float32"
     min_val = float("-0.0907303")
@@ -885,6 +986,7 @@ class Program_weight_tensor_parameter_100:
 
 class Program_weight_tensor_parameter_101:
     name = "parameter_101"
+    original_name = "layer_norm_0.b_0"
     shape = [768]
     dtype = "float32"
     data = None
@@ -892,6 +994,7 @@ class Program_weight_tensor_parameter_101:
 
 class Program_weight_tensor_parameter_102:
     name = "parameter_102"
+    original_name = "layer_norm_0.w_0"
     shape = [768]
     dtype = "float32"
     min_val = float("1.0")
@@ -902,6 +1005,7 @@ class Program_weight_tensor_parameter_102:
 
 class Program_weight_tensor_parameter_103:
     name = "parameter_103"
+    original_name = "embedding_2.w_0"
     shape = [4, 768]
     dtype = "float32"
     min_val = float("-0.0778939")
@@ -913,6 +1017,7 @@ class Program_weight_tensor_parameter_103:
 
 class Program_weight_tensor_parameter_104:
     name = "parameter_104"
+    original_name = "embedding_1.w_0"
     shape = [512, 768]
     dtype = "float32"
     min_val = float("-0.108045")
@@ -924,6 +1029,7 @@ class Program_weight_tensor_parameter_104:
 
 class Program_weight_tensor_parameter_105:
     name = "parameter_105"
+    original_name = "embedding_0.w_0"
     shape = [32000, 768]
     dtype = "float32"
     min_val = float("-0.103792")


### PR DESCRIPTION
### PR Category
<!-- One of [ New Sample | Feature Enhancement | Bug Fix | Other ] -->
Feature Enhancement

### Description
<!-- Describe what you’ve done -->
1. 当子图范围是从0开始时，支持配置use_all_inputs，即子图使用原图的全部输入信息。依赖：https://github.com/PaddlePaddle/Athena/pull/21
2. 完善`use_all_inputs=True`时`GraphMetaRestorer`的功能，假设这种情况下子图中输入Tensor定义的顺序和原图一样，从而可以依据`name`完全恢复子图输入Tensor的meta信息。
3. 修复单测生成若干问题，并支持在单测反馈详细的测试信息。
4. 为fnet-base样本添加`original_name`信息。