### PR TITLE
[Bug Fix] Add the default device when loading the model

### DIFF
--- a/graph_net/torch/test_reference_device.py
+++ b/graph_net/torch/test_reference_device.py
@@ -2,6 +2,7 @@ import argparse
 import os
 import sys
 import types
+import torch
 from pathlib import Path
 
 from graph_net_bench import path_utils
@@ -78,6 +79,7 @@ def main(args):
     assert args.device in ["cuda", "cpu"]
 
     eval_backend_perf.set_seed(args.seed)
+    torch.set_default_device(args.device)
 
     ref_dump_dir = Path(args.reference_dir)
     ref_dump_dir.mkdir(parents=True, exist_ok=True)

--- a/graph_net_bench/torch/eval_backend_perf.py
+++ b/graph_net_bench/torch/eval_backend_perf.py
@@ -195,6 +195,7 @@ def measure_performance(model_call, args, compiler):
 def eval_single_model_with_single_backend(args):
     check_and_complete_args(args)
     set_seed(args.seed)
+    torch.set_default_device(args.device)
     os.makedirs(args.output_path, exist_ok=True)
     log_path = utils.get_log_path(args.output_path, args.model_path)
     output_dump_path = utils.get_output_path(args.output_path, args.model_path)

--- a/graph_net_bench/torch/test_compiler.py
+++ b/graph_net_bench/torch/test_compiler.py
@@ -487,6 +487,7 @@ def main(args):
 
     initalize_seed = 123
     set_seed(random_seed=initalize_seed)
+    torch.set_default_device(args.device)
 
     if path_utils.is_single_model_dir(args.model_path):
         test_single_model(args)


### PR DESCRIPTION
### PR Category
<!-- One of [ New Sample | Feature Enhancement | Bug Fix | Other ] -->
Bug Fix

### Description
<!-- Describe what you’ve done -->
加载模型时添加默认设备
例如torch.tensor([1, 2, 3])、torch.zeros(5)、torch.ones(5)、torch.randn(5)、torch.arange(10)、torch.linspace(0, 1, 5)等操作未指定设备，需要指定全局设备