### PR TITLE
[Bug Fix]Fix BackwardGraphExtractor

### DIFF
--- a/graph_net/test/backward_graph_extractor.sh
+++ b/graph_net/test/backward_graph_extractor.sh
@@ -3,6 +3,30 @@
 GRAPH_NET_ROOT=$(python3 -c "import graph_net; import os; print(
 os.path.dirname(graph_net.__file__))")
 GRAPHNET_ROOT="$GRAPH_NET_ROOT/../"
+
+# Device rewrite pass
+DEVICE_REWRITE_OUTPUT_DIR="/tmp/device_rewrited_samples"
+mkdir -p "$DEVICE_REWRITE_OUTPUT_DIR"
+
+python3 -m graph_net.model_path_handler \
+    --model-path-list "graph_net/config/small100_torch_samples_list.txt" \
+    --handler-config $(base64 -w 0 <<EOF
+{
+    "handler_path": "$GRAPHNET_ROOT/graph_net/torch/sample_pass/device_rewrite_sample_pass.py",
+    "handler_class_name": "DeviceRewriteSamplePass",
+    "handler_config": {
+        "device": "cuda",
+        "resume": false,
+        "model_path_prefix": "$GRAPHNET_ROOT",
+        "output_dir": "$DEVICE_REWRITE_OUTPUT_DIR"
+    }
+}
+EOF
+)
+
+echo "Device rewrite pass completed!"
+
+# Backward graph extraction
 OUTPUT_DIR="/tmp/backward_graph_samples"
 mkdir -p "$OUTPUT_DIR"
 
@@ -12,7 +36,7 @@ python3 -m graph_net.apply_sample_pass \
     --sample-pass-class-name "BackwardGraphExtractorPass" \
     --sample-pass-config $(base64 -w 0 <<EOF
 {
-    "model_path_prefix": "$GRAPHNET_ROOT",
+    "model_path_prefix": "$DEVICE_REWRITE_OUTPUT_DIR",
     "output_dir": "$OUTPUT_DIR",
     "device": "cuda"
 }


### PR DESCRIPTION
### PR Category
<!-- One of [ New Sample | Feature Enhancement | Bug Fix | Other ] -->
Bug Fix

### Description
<!-- Describe what you’ve done -->
新增前向图捕捉部分，保存训练时前反向图
在sh脚本中新增device rewrite pass 来避免运行出错
参考https://github.com/PaddlePaddle/GraphNet/discussions/610#discussioncomment-15636620的设计

现有问题
1. 在使用aot的时候，模型中的item会触发faketensor的同步，但是faketensor没有实际数据无法同步
2. 提取出来的反向图，_scaled_dot_product_efficient_attention_backward会发生报错，无法运行