### PR TITLE
Enable dimension and type generalization for typical subgraphs.

### DIFF
--- a/graph_net/tools/generate_subgraph_dataset.sh
+++ b/graph_net/tools/generate_subgraph_dataset.sh
@@ -3,7 +3,7 @@ set -x
 
 MIN_SEQ_OPS=${1:-4}
 MAX_SEQ_OPS=${2:-64}
-GPU_ID=${3:-0}
+GPU_ID=${3:-5}
 
 OP_RANGE=$MIN_SEQ_OPS-$MAX_SEQ_OPS
 
@@ -12,7 +12,7 @@ export CUDA_VISIBLE_DEVICES="${GPU_ID}"
 GRAPH_NET_ROOT=$(python3 -c "import graph_net; import os; print(os.path.dirname(os.path.dirname(graph_net.__file__)))")
 RESUME="true"
 
-DECOMPOSE_WORKSPACE=/tmp/subgraph_dataset_workspace
+DECOMPOSE_WORKSPACE=/work/graphnet_test_workspace/subgraph_dataset_20260203
 DEVICE_REWRITED_OUTPUT_DIR=$DECOMPOSE_WORKSPACE/01_device_rewrited_samples
 DIMENSION_GENERALIZED_OUTPUT_DIR=$DECOMPOSE_WORKSPACE/02_dimension_generalized_samples
 OP_NAMES_OUTPUT_DIR=$DECOMPOSE_WORKSPACE/03_sample_op_names
@@ -20,6 +20,8 @@ SUBGRAPH_RANGES_JSON_ROOT=$DECOMPOSE_WORKSPACE/04_subgraph_ranges
 RANGE_DECOMPOSE_OUTPUT_DIR=$DECOMPOSE_WORKSPACE/05_range_decompose_subgraphs
 GRAPH_VAR_RENAME_OUTPUT_DIR=$DECOMPOSE_WORKSPACE/06_renamed_subgraphs
 DEDUPLICATED_OUTPUT_DIR=$DECOMPOSE_WORKSPACE/07_deduplicated_subgraphs
+
+# fusible_subgraphs
 CUMSUM_NUM_KERNELS_DIR=$DECOMPOSE_WORKSPACE/08_cumsum_num_kernels
 FUSIBLE_SUBGRAPH_RANGES_DIR=$DECOMPOSE_WORKSPACE/09_fusible_subgraph_ranges
 GROUPED_FUSIBLE_SUBGRAPH_RANGES_DIR=$DECOMPOSE_WORKSPACE/10_grouped_fusible_subgraph_ranges
@@ -29,17 +31,32 @@ DEDUPLICATED_DIMENSION_GENERALIZED_FUSIBLE_SUBGRAPH_DIR=$DECOMPOSE_WORKSPACE/13_
 DTYPE_GENERALIZED_OUTPUT_DIR=$DECOMPOSE_WORKSPACE/14_dtype_generalized_fusible_subgraphs
 UNITTESTS_OUTPUT_DIR=$DECOMPOSE_WORKSPACE/15_kernelbench_unittests
 
+# typical_subgraphs
+DIMENSION_GENERALIZED_TIPICAL_SUBGRAPH_DIR=$DECOMPOSE_WORKSPACE/2-08_dimension_generalized_typical_subgraphs
+RENAMED_DIMENSION_GENERALIZED_TYPICAL_SUBGRAPH_DIR=$DECOMPOSE_WORKSPACE/2-09_renamed_dimension_generalized_typical_subgraphs
+DEDUPLICATED_DIMENSION_GENERALIZED_TYPICAL_SUBGRAPH_DIR=$DECOMPOSE_WORKSPACE/2-10_deduplicated_dimension_generalized_typical_subgraphs
+DTYPE_GENERALIZED_TYPICAL_SUBGRAPH_DIR=$DECOMPOSE_WORKSPACE/2-11_dtype_generalized_typical_subgraphs
+TYPICAL_SUBGRAPH_UNITTESTS_DIR=$DECOMPOSE_WORKSPACE/2-12_typical_kernelbench_unittests
+
 mkdir -p "$DECOMPOSE_WORKSPACE"
 
-model_list="$GRAPH_NET_ROOT/graph_net/config/small100_torch_samples_list.txt"
+model_list="$GRAPH_NET_ROOT/graph_net/config/torch_samples_list.txt"
 DB_PATH=$DECOMPOSE_WORKSPACE/small100_torch_samples.db
 
 device_rewrited_sample_list=${DECOMPOSE_WORKSPACE}/device_rewrited_sample_list.txt
 range_decomposed_subgraph_list=${DECOMPOSE_WORKSPACE}/range_decomposed_subgraph_sample_list.txt
 deduplicated_subgraph_list=${DECOMPOSE_WORKSPACE}/deduplicated_subgraph_sample_list.txt
+
+# fusible_subgraphs
 dimension_generalized_subgraph_list=${DECOMPOSE_WORKSPACE}/dimension_generalized_subgraph_sample_list.txt
 deduplicated_fusible_subgraphs_list=${DECOMPOSE_WORKSPACE}/deduplicated_dimension_generalized_subgraph_sample_list.txt
 dtype_generalized_subgraphs_list=${DECOMPOSE_WORKSPACE}/dtype_generalized_subgraphs_sample_list.txt
+
+# typical_subgraphs
+dimension_generalized_typical_subgraph_list=${DECOMPOSE_WORKSPACE}/dimension_generalized_typical_subgraph_list.txt
+deduplicated_typical_subgraph_list=${DECOMPOSE_WORKSPACE}/deduplicated_dimension_generalized_typical_subgraph_list.txt
+dtype_generalized_typical_subgraph_list=${DECOMPOSE_WORKSPACE}/dtype_generalized_typical_subgraph_list.txt
+
 
 if [[ "$model_list" == *"/torch_samples_list.txt" ]]; then
     USE_SUBPROCESS_ARGS="--use-subprocess"
@@ -99,6 +116,7 @@ function insert_graph_sample(){
 
     done < "$sample_list"
 }
+
 
 function rewrite_device() {
     echo ">>> [1] Rewrite devices for subgraph samples under ${GRAPH_NET_ROOT}."
@@ -242,6 +260,10 @@ function remove_duplicate_renamed_graphs() {
         --samples-dir ${GRAPH_VAR_RENAME_OUTPUT_DIR} \
         --target-dir ${DEDUPLICATED_OUTPUT_DIR}
 }
+
+###############################################################################
+# fusible subgraphs generating pipeline
+###############################################################################
 
 function gen_fusible_subgraph_ranges() {
     echo ">>> [8] Generate fusible subgraphs for subgraph samples under ${DEDUPLICATED_OUTPUT_DIR}."
@@ -404,13 +426,123 @@ EOF
 )
 }
 
-main() {
+###############################################################################
+# typical subgraphs generating pipeline
+###############################################################################
+
+function dimension_generalizer_for_typical_subgraphs() {
+    echo ">>> [2-9] Generate dimension generalized subgraph samples under ${DIMENSION_GENERALIZED_OUTPUT_DIR}."
+    for index in {0..8}; do
+        echo ">>> Generating dimension generalized subgraph variant index: ${index}"
+        dimension_generalized_sample_list="${DIMENSION_GENERALIZED_OUTPUT_DIR}/${index}/dimension_generalized_sample_list.txt"
+        dimension_generalized_subgraph_list="${DIMENSION_GENERALIZED_OUTPUT_DIR}/${index}/dimension_generalized_subgraph_list.txt"
+        generate_subgraph_list ${DIMENSION_GENERALIZED_OUTPUT_DIR}/${index} ${dimension_generalized_sample_list}
+        sed 's|/_decomposed/.*||' ${deduplicated_subgraph_list} | uniq | grep -Fxf "$dimension_generalized_sample_list" > ${dimension_generalized_subgraph_list}
+
+        python3 -m graph_net.model_path_handler ${USE_SUBPROCESS_ARGS} \
+            --model-path-list "${dimension_generalized_subgraph_list}" \
+            --handler-config $(base64 -w 0 <<EOF
+{
+    "handler_path": "$GRAPH_NET_ROOT/graph_net/torch/sample_pass/subgraph_generator.py",
+    "handler_class_name": "SubgraphGenerator",
+    "handler_config": {
+        "model_path_prefix": "${DIMENSION_GENERALIZED_OUTPUT_DIR}/${index}",
+        "output_dir": "${DIMENSION_GENERALIZED_TIPICAL_SUBGRAPH_DIR}/${index}",
+        "subgraph_ranges_json_root": "$SUBGRAPH_RANGES_JSON_ROOT",
+        "subgraph_ranges_json_file_name": "typical_subgraph_ranges.json",
+        "device": "cuda",
+        "resume": ${RESUME}
+    }
+}
+EOF
+)
+    done
+}
+
+function rename_dimension_generalized_typical_subgraphs() {
+    echo ">>> [2-10] Rename subgraph samples under ${DIMENSION_GENERALIZED_TIPICAL_SUBGRAPH_DIR}."
+    echo ">>>"
+    python3 -m graph_net.model_path_handler \
+        --model-path-list ${dimension_generalized_typical_subgraph_list} \
+        --handler-config=$(base64 -w 0 <<EOF
+{
+    "handler_path": "$GRAPH_NET_ROOT/graph_net/sample_pass/ast_graph_variable_renamer.py",
+    "handler_class_name": "AstGraphVariableRenamer",
+    "handler_config": {
+        "device": "cuda",
+        "try_run": false,
+        "resume": ${RESUME},
+        "model_path_prefix": "${DIMENSION_GENERALIZED_TIPICAL_SUBGRAPH_DIR}",
+        "data_input_predicator_filepath": "$GRAPH_NET_ROOT/graph_net/torch/constraint_util.py",
+        "data_input_predicator_class_name": "RenamedDataInputPredicator",
+        "model_runnable_predicator_filepath": "$GRAPH_NET_ROOT/graph_net/torch/constraint_util.py",
+        "model_runnable_predicator_class_name": "ModelRunnablePredicator",
+        "output_dir": "${RENAMED_DIMENSION_GENERALIZED_TYPICAL_SUBGRAPH_DIR}"
+    }
+}
+EOF
+)
+}
+
+function remove_duplicate_dimension_generalized_typical_subgraphs() {
+    echo ">>> [2-11] Remove duplicated subgraph samples under ${RENAMED_DIMENSION_GENERALIZED_TYPICAL_SUBGRAPH_DIR}."
+    echo ">>>"
+    for index in {0..8}; do
+        python3 -m graph_net.tools.deduplicated \
+            --samples-dir ${RENAMED_DIMENSION_GENERALIZED_TYPICAL_SUBGRAPH_DIR}/${index} \
+            --target-dir ${DEDUPLICATED_DIMENSION_GENERALIZED_TYPICAL_SUBGRAPH_DIR}/${index}
+    done
+}
+
+function dtype_generalizer_for_typical_subgraphs() {
+    echo ">>> [2-12] Data type generalizer for samples under ${DEDUPLICATED_DIMENSION_GENERALIZED_TYPICAL_SUBGRAPH_DIR}."
+    echo ">>>"
+    python3 -m graph_net.apply_sample_pass \
+        --use-subprocess \
+        --model-path-list $deduplicated_typical_subgraph_list \
+        --sample-pass-file-path "$GRAPH_NET_ROOT/graph_net/torch/sample_pass/dtype_generalizer.py" \
+        --sample-pass-class-name ApplyDataTypeGeneralizationPasses \
+        --sample-pass-config $(base64 -w 0 <<EOF
+{
+    "output_dir": "$DTYPE_GENERALIZED_TYPICAL_SUBGRAPH_DIR",
+    "model_path_prefix": "$DEDUPLICATED_DIMENSION_GENERALIZED_TYPICAL_SUBGRAPH_DIR",
+    "model_runnable_predicator_filepath": "$GRAPH_NET_ROOT/graph_net/torch/constraint_util.py",
+    "try_run": false,
+    "device": "cuda",
+    "resume": ${RESUME}
+}
+EOF
+)
+}
+
+function generate_unittest_for_typical_subgraphs() {
+    echo ">>> [2-13] Generate unittests for subgraph samples under ${DTYPE_GENERALIZED_TYPICAL_SUBGRAPH_DIR}. "
+    echo ">>>"
+    python3 -m graph_net.model_path_handler \
+        --model-path-list ${dtype_generalized_typical_subgraph_list} \
+        --handler-config=$(base64 -w 0 <<EOF
+{
+    "handler_path": "${GRAPH_NET_ROOT}/graph_net/sample_pass/agent_unittest_generator.py",
+    "handler_class_name": "AgentUnittestGeneratorPass",
+    "handler_config": {
+        "framework": "torch",
+        "model_path_prefix": "${DTYPE_GENERALIZED_TYPICAL_SUBGRAPH_DIR}",
+        "output_dir": "${TYPICAL_SUBGRAPH_UNITTESTS_DIR}",
+        "device": "cuda",
+        "generate_main": false,
+        "try_run": true,
+        "resume": ${RESUME},
+        "data_input_predicator_filepath": "${GRAPH_NET_ROOT}/graph_net/torch/constraint_util.py",                                                                   
+        "data_input_predicator_class_name": "RenamedDataInputPredicator"
+    }
+}
+EOF
+)
+}
+
+function do_common_generalzation_and_decompose() {
     timestamp=`date +%Y%m%d_%H%M`
     suffix="${OP_RANGE}ops_${timestamp}"
-
-    # init database
-    python ${GRAPH_NET_ROOT}/sqlite/init_db.py --db_path ${DB_PATH} 2>&1 | tee sqlite/logs/init_db_${timestamp}.log
-    insert_graph_sample ${GRAPH_NET_ROOT} "github_torch_samples" "full_graph" ${model_list}
 
     # rewrite the device in model to cuda
     rewrite_device 2>&1 | tee ${DECOMPOSE_WORKSPACE}/log_rewrite_device_${suffix}.txt
@@ -428,7 +560,11 @@ main() {
     rename_decomposed_subgraph 2>&1 | tee ${DECOMPOSE_WORKSPACE}/log_rename_decomposed_subgraph_${suffix}.txt
     remove_duplicate_renamed_graphs 2>&1 | tee ${DECOMPOSE_WORKSPACE}/log_remove_duplicate_renamed_graphs_${suffix}.txt
     generate_subgraph_list ${DEDUPLICATED_OUTPUT_DIR} ${deduplicated_subgraph_list}
-    insert_graph_sample ${DEDUPLICATED_OUTPUT_DIR} "github_torch_samples" "typical_graph" ${deduplicated_subgraph_list}
+}
+
+function generate_fusible_subgraphs() {
+    timestamp=`date +%Y%m%d_%H%M`
+    suffix="${OP_RANGE}ops_${timestamp}"
 
     # generate fusible subgraph ranges
     gen_fusible_subgraph_ranges 2>&1 | tee ${DECOMPOSE_WORKSPACE}/log_fusible_subgraphs_${suffix}.txt
@@ -444,10 +580,43 @@ main() {
     # dtype generalization
     dtype_generalizer 2>&1 | tee ${DECOMPOSE_WORKSPACE}/log_dtype_generalizer_${suffix}.txt
     generate_generalized_subgraph_list ${DTYPE_GENERALIZED_OUTPUT_DIR} ${dtype_generalized_subgraphs_list}
-    insert_graph_sample ${DEDUPLICATED_DIMENSION_GENERALIZED_FUSIBLE_SUBGRAPH_DIR} "github_torch_samples" "fusible_graph" ${dtype_generalized_subgraphs_list}
 
     # generate kernelbench format unittest
     generate_unittests 2>&1 | tee ${DECOMPOSE_WORKSPACE}/log_unittests_${suffix}.txt
+}
+
+function generate_typical_subgraphs() {
+    timestamp=`date +%Y%m%d_%H%M`
+    suffix="${OP_RANGE}ops_${timestamp}"
+
+    # subgraph dimension generalization
+    dimension_generalizer_for_typical_subgraphs 2>&1 | tee ${DECOMPOSE_WORKSPACE}/log_dimension_generalizer_typical_subgraphs_${suffix}.txt
+    generate_generalized_subgraph_list ${DIMENSION_GENERALIZED_TIPICAL_SUBGRAPH_DIR} ${dimension_generalized_typical_subgraph_list}
+
+    rename_dimension_generalized_typical_subgraphs 2>&1 | tee ${DECOMPOSE_WORKSPACE}/log_rename_dimension_generalized_typical_subgraph_${suffix}.txt
+    remove_duplicate_dimension_generalized_typical_subgraphs 2>&1 | tee ${DECOMPOSE_WORKSPACE}/log_remove_duplicate_dimension_generalized_subgraphs_${suffix}.txt
+    generate_generalized_subgraph_list ${DEDUPLICATED_DIMENSION_GENERALIZED_TYPICAL_SUBGRAPH_DIR} ${deduplicated_typical_subgraph_list}
+
+    # dtype generalization
+    dtype_generalizer_for_typical_subgraphs 2>&1 | tee ${DECOMPOSE_WORKSPACE}/log_dtype_generalizer_typical_subgraphs_${suffix}.txt
+    generate_generalized_subgraph_list ${DTYPE_GENERALIZED_TYPICAL_SUBGRAPH_DIR} ${dtype_generalized_typical_subgraph_list}
+
+    # generate kernelbench format unittest
+    generate_unittest_for_typical_subgraphs 2>&1 | tee ${DECOMPOSE_WORKSPACE}/log_unittests_typical_subgraphs_${suffix}.txt
+}
+
+function main() {
+    timestamp=`date +%Y%m%d_%H%M`
+
+    # init database
+    #python ${GRAPH_NET_ROOT}/sqlite/init_db.py --db_path ${DB_PATH} 2>&1 | tee sqlite/logs/init_db_${timestamp}.log
+    #insert_graph_sample ${GRAPH_NET_ROOT} "github_torch_samples" "full_graph" ${model_list}
+
+    #generate_fusible_subgraphs
+    #insert_graph_sample ${DEDUPLICATED_DIMENSION_GENERALIZED_FUSIBLE_SUBGRAPH_DIR} "github_torch_samples" "fusible_graph" ${dtype_generalized_subgraphs_list}
+
+    generate_typical_subgraphs
+    #insert_graph_sample ${DEDUPLICATED_OUTPUT_DIR} "github_torch_samples" "typical_graph" ${deduplicated_subgraph_list}    
 }
 
 summary() {
@@ -541,4 +710,4 @@ summary() {
 main
 
 set +x
-summary 2>&1 | tee ${DECOMPOSE_WORKSPACE}/summary.txt
+#summary 2>&1 | tee ${DECOMPOSE_WORKSPACE}/summary.txt

--- a/graph_net/tools/generate_subgraph_dataset.sh
+++ b/graph_net/tools/generate_subgraph_dataset.sh
@@ -3,7 +3,7 @@ set -x
 
 MIN_SEQ_OPS=${1:-4}
 MAX_SEQ_OPS=${2:-64}
-GPU_ID=${3:-5}
+GPU_ID=${3:-0}
 
 OP_RANGE=$MIN_SEQ_OPS-$MAX_SEQ_OPS
 
@@ -12,31 +12,31 @@ export CUDA_VISIBLE_DEVICES="${GPU_ID}"
 GRAPH_NET_ROOT=$(python3 -c "import graph_net; import os; print(os.path.dirname(os.path.dirname(graph_net.__file__)))")
 RESUME="true"
 
-DECOMPOSE_WORKSPACE=/work/graphnet_test_workspace/subgraph_dataset_20260203
-DEVICE_REWRITED_OUTPUT_DIR=$DECOMPOSE_WORKSPACE/01_device_rewrited_samples
-DIMENSION_GENERALIZED_OUTPUT_DIR=$DECOMPOSE_WORKSPACE/02_dimension_generalized_samples
-OP_NAMES_OUTPUT_DIR=$DECOMPOSE_WORKSPACE/03_sample_op_names
-SUBGRAPH_RANGES_JSON_ROOT=$DECOMPOSE_WORKSPACE/04_subgraph_ranges
-RANGE_DECOMPOSE_OUTPUT_DIR=$DECOMPOSE_WORKSPACE/05_range_decompose_subgraphs
-GRAPH_VAR_RENAME_OUTPUT_DIR=$DECOMPOSE_WORKSPACE/06_renamed_subgraphs
-DEDUPLICATED_OUTPUT_DIR=$DECOMPOSE_WORKSPACE/07_deduplicated_subgraphs
+DECOMPOSE_WORKSPACE=/tmp/subgraph_dataset_workspace
+DEVICE_REWRITED_SAMPLE_DIR=$DECOMPOSE_WORKSPACE/01_device_rewrited_samples
+DIM_GENERALIZED_SAMPLE_DIR=$DECOMPOSE_WORKSPACE/02_dimension_generalized_samples
+SAMPLE_OP_NAMES_DIR=$DECOMPOSE_WORKSPACE/03_sample_op_names
+TYPICAL_SUBGRAPH_RANGE_DIR=$DECOMPOSE_WORKSPACE/04_typical_subgraph_ranges
+TYPICAL_SUBGRAPH_DIR=$DECOMPOSE_WORKSPACE/05_typical_subgraphs
+RENAMED_TYPICAL_SUBGRAPH_DIR=$DECOMPOSE_WORKSPACE/06_renamed_typical_subgraphs
+DEDUP_TYPICAL_SUBGRAPH_DIR=$DECOMPOSE_WORKSPACE/07_deduplicated_typical_subgraphs
 
 # fusible_subgraphs
 CUMSUM_NUM_KERNELS_DIR=$DECOMPOSE_WORKSPACE/08_cumsum_num_kernels
-FUSIBLE_SUBGRAPH_RANGES_DIR=$DECOMPOSE_WORKSPACE/09_fusible_subgraph_ranges
-GROUPED_FUSIBLE_SUBGRAPH_RANGES_DIR=$DECOMPOSE_WORKSPACE/10_grouped_fusible_subgraph_ranges
-SUBGRAPH_DIMENSION_GENERALIZED_OUTPUT_DIR=$DECOMPOSE_WORKSPACE/11_dimension_generalized_fusible_subgraphs
-RENAMED_DIMENSION_GENERALIZED_FUSIBLE_SUBGRAPH_DIR=$DECOMPOSE_WORKSPACE/12_renamed_dimension_generalized_fusible_subgraphs
-DEDUPLICATED_DIMENSION_GENERALIZED_FUSIBLE_SUBGRAPH_DIR=$DECOMPOSE_WORKSPACE/13_deduplicated_dimension_generalized_fusible_subgraphs
-DTYPE_GENERALIZED_OUTPUT_DIR=$DECOMPOSE_WORKSPACE/14_dtype_generalized_fusible_subgraphs
-UNITTESTS_OUTPUT_DIR=$DECOMPOSE_WORKSPACE/15_kernelbench_unittests
+FUSIBLE_SUBGRAPH_RANGE_DIR=$DECOMPOSE_WORKSPACE/09_fusible_subgraph_ranges
+GROUPED_FUSIBLE_SUBGRAPH_RANGE_DIR=$DECOMPOSE_WORKSPACE/10_grouped_fusible_subgraph_ranges
+DIM_GENERALIZED_FUSIBLE_SUBGRAPH_DIR=$DECOMPOSE_WORKSPACE/11_dimension_generalized_fusible_subgraphs
+RENAMED_DIM_GENERALIZED_FUSIBLE_SUBGRAPH_DIR=$DECOMPOSE_WORKSPACE/12_renamed_dimension_generalized_fusible_subgraphs
+DEDUP_DIM_GENERALIZED_FUSIBLE_SUBGRAPH_DIR=$DECOMPOSE_WORKSPACE/13_deduplicated_dimension_generalized_fusible_subgraphs
+DTYPE_GENERALIZED_FUSIBLE_SUBGRAPH_DIR=$DECOMPOSE_WORKSPACE/14_dtype_generalized_fusible_subgraphs
+FUSIBLE_SUBGRAPH_UNITTEST_DIR=$DECOMPOSE_WORKSPACE/15_fusible_subgraphs_unittests
 
 # typical_subgraphs
-DIMENSION_GENERALIZED_TIPICAL_SUBGRAPH_DIR=$DECOMPOSE_WORKSPACE/2-08_dimension_generalized_typical_subgraphs
-RENAMED_DIMENSION_GENERALIZED_TYPICAL_SUBGRAPH_DIR=$DECOMPOSE_WORKSPACE/2-09_renamed_dimension_generalized_typical_subgraphs
-DEDUPLICATED_DIMENSION_GENERALIZED_TYPICAL_SUBGRAPH_DIR=$DECOMPOSE_WORKSPACE/2-10_deduplicated_dimension_generalized_typical_subgraphs
+DIM_GENERALIZED_TYPICAL_SUBGRAPH_DIR=$DECOMPOSE_WORKSPACE/2-08_dimension_generalized_typical_subgraphs
+RENAMED_DIM_GENERALIZED_TYPICAL_SUBGRAPH_DIR=$DECOMPOSE_WORKSPACE/2-09_renamed_dimension_generalized_typical_subgraphs
+DEDUP_DIM_GENERALIZED_TYPICAL_SUBGRAPH_DIR=$DECOMPOSE_WORKSPACE/2-10_deduplicated_dimension_generalized_typical_subgraphs
 DTYPE_GENERALIZED_TYPICAL_SUBGRAPH_DIR=$DECOMPOSE_WORKSPACE/2-11_dtype_generalized_typical_subgraphs
-TYPICAL_SUBGRAPH_UNITTESTS_DIR=$DECOMPOSE_WORKSPACE/2-12_typical_kernelbench_unittests
+TYPICAL_SUBGRAPH_UNITTEST_DIR=$DECOMPOSE_WORKSPACE/2-12_typical_kernelbench_unittests
 
 mkdir -p "$DECOMPOSE_WORKSPACE"
 
@@ -131,7 +131,7 @@ function rewrite_device() {
         "device": "cuda",
         "resume": ${RESUME},
         "model_path_prefix": "${GRAPH_NET_ROOT}",
-        "output_dir": "${DEVICE_REWRITED_OUTPUT_DIR}"
+        "output_dir": "${DEVICE_REWRITED_SAMPLE_DIR}"
     }
 }
 EOF
@@ -147,8 +147,8 @@ function dimension_generalizer(){
         --sample-pass-class-name "ApplyDimGenPasses" \
         --sample-pass-config $(base64 -w 0 <<EOF
 {
-    "output_dir": "${DIMENSION_GENERALIZED_OUTPUT_DIR}",
-    "model_path_prefix": "$DEVICE_REWRITED_OUTPUT_DIR",
+    "output_dir": "${DIM_GENERALIZED_SAMPLE_DIR}",
+    "model_path_prefix": "$DEVICE_REWRITED_SAMPLE_DIR",
     "dimension_generalizer_filepath": "$GRAPH_NET_ROOT/graph_net/torch/static_to_dynamic.py",
     "dimension_generalizer_class_name": "StaticToDynamic",
     "resume": ${RESUME},
@@ -170,7 +170,7 @@ function generate_op_names() {
     "handler_config": {
         "resume": ${RESUME},
         "model_path_prefix": "$GRAPH_NET_ROOT",
-        "output_dir": "${OP_NAMES_OUTPUT_DIR}"
+        "output_dir": "${SAMPLE_OP_NAMES_DIR}"
     }
 }
 EOF
@@ -188,8 +188,8 @@ function generate_split_point() {
         --sample-pass-config=$(base64 -w 0 <<EOF
 {
         "model_path_prefix": "$GRAPH_NET_ROOT",
-        "output_dir": "$SUBGRAPH_RANGES_JSON_ROOT", 
-        "op_names_path_prefix": "${OP_NAMES_OUTPUT_DIR}",
+        "output_dir": "$TYPICAL_SUBGRAPH_RANGE_DIR", 
+        "op_names_path_prefix": "${SAMPLE_OP_NAMES_DIR}",
         "device": "cuda",
         "window_size": 64,
         "fold_policy": "default",
@@ -215,9 +215,9 @@ function range_decompose() {
     "handler_class_name": "SubgraphGenerator",
     "handler_config": {
         "resume": ${RESUME},
-        "model_path_prefix": "$DEVICE_REWRITED_OUTPUT_DIR",
-        "output_dir": "${RANGE_DECOMPOSE_OUTPUT_DIR}",
-        "subgraph_ranges_json_root": "${SUBGRAPH_RANGES_JSON_ROOT}",
+        "model_path_prefix": "$DEVICE_REWRITED_SAMPLE_DIR",
+        "output_dir": "${TYPICAL_SUBGRAPH_DIR}",
+        "subgraph_ranges_json_root": "${TYPICAL_SUBGRAPH_RANGE_DIR}",
         "subgraph_ranges_json_file_name": "typical_subgraph_ranges.json",
         "group_head_and_tail": false,
         "chain_style": false,
@@ -229,7 +229,7 @@ EOF
 }
 
 function rename_decomposed_subgraph() {
-    echo ">>> [6] Rename subgraph samples under ${RANGE_DECOMPOSE_OUTPUT_DIR}."
+    echo ">>> [6] Rename subgraph samples under ${TYPICAL_SUBGRAPH_DIR}."
     echo ">>>"
     python3 -m graph_net.model_path_handler \
         --model-path-list ${range_decomposed_subgraph_list} \
@@ -241,12 +241,12 @@ function rename_decomposed_subgraph() {
         "device": "cuda",
         "try_run": false,
         "resume": ${RESUME},
-        "model_path_prefix": "${RANGE_DECOMPOSE_OUTPUT_DIR}",
+        "model_path_prefix": "${TYPICAL_SUBGRAPH_DIR}",
         "data_input_predicator_filepath": "$GRAPH_NET_ROOT/graph_net/torch/constraint_util.py",
         "data_input_predicator_class_name": "NaiveDataInputPredicator",
         "model_runnable_predicator_filepath": "$GRAPH_NET_ROOT/graph_net/torch/constraint_util.py",
         "model_runnable_predicator_class_name": "ModelRunnablePredicator",
-        "output_dir": "$GRAPH_VAR_RENAME_OUTPUT_DIR"
+        "output_dir": "$RENAMED_TYPICAL_SUBGRAPH_DIR"
     }
 }
 EOF
@@ -254,11 +254,11 @@ EOF
 }
 
 function remove_duplicate_renamed_graphs() {
-    echo ">>> [7] Remove duplicated subgraph samples under ${GRAPH_VAR_RENAME_OUTPUT_DIR}."
+    echo ">>> [7] Remove duplicated subgraph samples under ${RENAMED_TYPICAL_SUBGRAPH_DIR}."
     echo ">>>"
     python3 -m graph_net.tools.deduplicated \
-        --samples-dir ${GRAPH_VAR_RENAME_OUTPUT_DIR} \
-        --target-dir ${DEDUPLICATED_OUTPUT_DIR}
+        --samples-dir ${RENAMED_TYPICAL_SUBGRAPH_DIR} \
+        --target-dir ${DEDUP_TYPICAL_SUBGRAPH_DIR}
 }
 
 ###############################################################################
@@ -266,7 +266,7 @@ function remove_duplicate_renamed_graphs() {
 ###############################################################################
 
 function gen_fusible_subgraph_ranges() {
-    echo ">>> [8] Generate fusible subgraphs for subgraph samples under ${DEDUPLICATED_OUTPUT_DIR}."
+    echo ">>> [8] Generate fusible subgraphs for subgraph samples under ${DEDUP_TYPICAL_SUBGRAPH_DIR}."
     echo ">>>"
     python3 -m graph_net.model_path_handler \
         --use-subprocess    \
@@ -277,7 +277,7 @@ function gen_fusible_subgraph_ranges() {
     "handler_class_name": "CumSumNumKernelsGenerator",
     "handler_config": {
         "output_json_file_name": "cumsum_num_kernels.json",
-        "model_path_prefix": "${DEDUPLICATED_OUTPUT_DIR}",
+        "model_path_prefix": "${DEDUP_TYPICAL_SUBGRAPH_DIR}",
         "output_dir": "$CUMSUM_NUM_KERNELS_DIR",
         "device": "cuda",
         "resume": ${RESUME}
@@ -296,7 +296,7 @@ EOF
         "model_path_prefix": "$CUMSUM_NUM_KERNELS_DIR",
         "input_json_file_name": "cumsum_num_kernels.json",
         "output_json_file_name": "fusible_subgraph_ranges.json",
-        "output_dir": "$FUSIBLE_SUBGRAPH_RANGES_DIR",
+        "output_dir": "$FUSIBLE_SUBGRAPH_RANGE_DIR",
         "resume": ${RESUME}
     }
 }
@@ -309,8 +309,8 @@ EOF
         --sample-pass-class-name "GroupFusibleSubgraphRanges" \
         --sample-pass-config $(base64 -w 0 <<EOF
 {
-    "subgraph_model_path_prefix": "$FUSIBLE_SUBGRAPH_RANGES_DIR",
-    "output_dir": "$GROUPED_FUSIBLE_SUBGRAPH_RANGES_DIR",
+    "subgraph_model_path_prefix": "$FUSIBLE_SUBGRAPH_RANGE_DIR",
+    "output_dir": "$GROUPED_FUSIBLE_SUBGRAPH_RANGE_DIR",
     "input_json_file_name": "fusible_subgraph_ranges.json",
     "output_json_file_name": "grouped_fusible_subgraph_ranges.json",
     "output_json_key": "subgraph_ranges"
@@ -320,11 +320,11 @@ EOF
 }
 
 function subgraph_dimension_generalizer(){
-    echo ">>> [9] Generate dimension generalized subgraph samples under ${DIMENSION_GENERALIZED_OUTPUT_DIR}."
+    echo ">>> [9] Generate dimension generalized subgraph samples under ${DIM_GENERALIZED_SAMPLE_DIR}."
     for index in {0..8}; do
         echo ">>> Generating dimension generalized subgraph variant index: ${index}"
-        dimension_generalized_sample_list="${DIMENSION_GENERALIZED_OUTPUT_DIR}/${index}/dimension_generalized_sample_list.txt"
-        generate_subgraph_list ${DIMENSION_GENERALIZED_OUTPUT_DIR}/${index} ${dimension_generalized_sample_list}
+        dimension_generalized_sample_list="${DIM_GENERALIZED_SAMPLE_DIR}/${index}/dimension_generalized_sample_list.txt"
+        generate_subgraph_list ${DIM_GENERALIZED_SAMPLE_DIR}/${index} ${dimension_generalized_sample_list}
         python3 -m graph_net.model_path_handler ${USE_SUBPROCESS_ARGS} \
             --model-path-list "${dimension_generalized_sample_list}" \
             --handler-config $(base64 -w 0 <<EOF
@@ -332,9 +332,9 @@ function subgraph_dimension_generalizer(){
     "handler_path": "$GRAPH_NET_ROOT/graph_net/torch/sample_pass/subgraph_generator.py",
     "handler_class_name": "SubgraphGenerator",
     "handler_config": {
-        "model_path_prefix": "${DIMENSION_GENERALIZED_OUTPUT_DIR}/${index}",
-        "output_dir": "${SUBGRAPH_DIMENSION_GENERALIZED_OUTPUT_DIR}/${index}",
-        "subgraph_ranges_json_root": "$GROUPED_FUSIBLE_SUBGRAPH_RANGES_DIR",
+        "model_path_prefix": "${DIM_GENERALIZED_SAMPLE_DIR}/${index}",
+        "output_dir": "${DIM_GENERALIZED_FUSIBLE_SUBGRAPH_DIR}/${index}",
+        "subgraph_ranges_json_root": "$GROUPED_FUSIBLE_SUBGRAPH_RANGE_DIR",
         "subgraph_ranges_json_file_name": "grouped_fusible_subgraph_ranges.json",
         "device": "cuda",
         "resume": ${RESUME}
@@ -346,7 +346,7 @@ EOF
 }
 
 function rename_dimension_generalized_fusible_subgraph() {
-    echo ">>> [10] Rename subgraph samples under ${SUBGRAPH_DIMENSION_GENERALIZED_OUTPUT_DIR}."
+    echo ">>> [10] Rename subgraph samples under ${DIM_GENERALIZED_FUSIBLE_SUBGRAPH_DIR}."
     echo ">>>"
     python3 -m graph_net.model_path_handler \
         --model-path-list ${dimension_generalized_subgraph_list} \
@@ -358,12 +358,12 @@ function rename_dimension_generalized_fusible_subgraph() {
         "device": "cuda",
         "try_run": false,
         "resume": ${RESUME},
-        "model_path_prefix": "${SUBGRAPH_DIMENSION_GENERALIZED_OUTPUT_DIR}",
+        "model_path_prefix": "${DIM_GENERALIZED_FUSIBLE_SUBGRAPH_DIR}",
         "data_input_predicator_filepath": "$GRAPH_NET_ROOT/graph_net/torch/constraint_util.py",
         "data_input_predicator_class_name": "RenamedDataInputPredicator",
         "model_runnable_predicator_filepath": "$GRAPH_NET_ROOT/graph_net/torch/constraint_util.py",
         "model_runnable_predicator_class_name": "ModelRunnablePredicator",
-        "output_dir": "${RENAMED_DIMENSION_GENERALIZED_FUSIBLE_SUBGRAPH_DIR}"
+        "output_dir": "${RENAMED_DIM_GENERALIZED_FUSIBLE_SUBGRAPH_DIR}"
     }
 }
 EOF
@@ -371,17 +371,17 @@ EOF
 }
 
 function remove_duplicate_dimension_generalized_fusible_graphs() {
-    echo ">>> [11] Remove duplicated subgraph samples under ${RENAMED_DIMENSION_GENERALIZED_FUSIBLE_SUBGRAPH_DIR}."
+    echo ">>> [11] Remove duplicated subgraph samples under ${RENAMED_DIM_GENERALIZED_FUSIBLE_SUBGRAPH_DIR}."
     echo ">>>"
     for index in {0..8}; do
         python3 -m graph_net.tools.deduplicated \
-            --samples-dir ${RENAMED_DIMENSION_GENERALIZED_FUSIBLE_SUBGRAPH_DIR}/${index} \
-            --target-dir ${DEDUPLICATED_DIMENSION_GENERALIZED_FUSIBLE_SUBGRAPH_DIR}/${index}
+            --samples-dir ${RENAMED_DIM_GENERALIZED_FUSIBLE_SUBGRAPH_DIR}/${index} \
+            --target-dir ${DEDUP_DIM_GENERALIZED_FUSIBLE_SUBGRAPH_DIR}/${index}
     done
 }
 
 function dtype_generalizer() {
-    echo ">>> [12] Data type generalizer for samples under ${DEDUPLICATED_DIMENSION_GENERALIZED_FUSIBLE_SUBGRAPH_DIR}."
+    echo ">>> [12] Data type generalizer for samples under ${DEDUP_DIM_GENERALIZED_FUSIBLE_SUBGRAPH_DIR}."
     echo ">>>"
     python3 -m graph_net.apply_sample_pass \
         --use-subprocess \
@@ -390,8 +390,8 @@ function dtype_generalizer() {
         --sample-pass-class-name ApplyDataTypeGeneralizationPasses \
         --sample-pass-config $(base64 -w 0 <<EOF
 {
-    "output_dir": "$DTYPE_GENERALIZED_OUTPUT_DIR",
-    "model_path_prefix": "$DEDUPLICATED_DIMENSION_GENERALIZED_FUSIBLE_SUBGRAPH_DIR",
+    "output_dir": "$DTYPE_GENERALIZED_FUSIBLE_SUBGRAPH_DIR",
+    "model_path_prefix": "$DEDUP_DIM_GENERALIZED_FUSIBLE_SUBGRAPH_DIR",
     "model_runnable_predicator_filepath": "$GRAPH_NET_ROOT/graph_net/torch/constraint_util.py",
     "try_run": false,
     "device": "cuda",
@@ -402,7 +402,7 @@ EOF
 }
 
 function generate_unittests() {
-    echo ">>> [13] Generate unittests for subgraph samples under ${DTYPE_GENERALIZED_OUTPUT_DIR}. "
+    echo ">>> [13] Generate unittests for subgraph samples under ${DTYPE_GENERALIZED_FUSIBLE_SUBGRAPH_DIR}. "
     echo ">>>"
     python3 -m graph_net.model_path_handler \
         --model-path-list ${dtype_generalized_subgraphs_list} \
@@ -412,8 +412,8 @@ function generate_unittests() {
     "handler_class_name": "AgentUnittestGeneratorPass",
     "handler_config": {
         "framework": "torch",
-        "model_path_prefix": "${DTYPE_GENERALIZED_OUTPUT_DIR}",
-        "output_dir": "${UNITTESTS_OUTPUT_DIR}",
+        "model_path_prefix": "${DTYPE_GENERALIZED_FUSIBLE_SUBGRAPH_DIR}",
+        "output_dir": "${FUSIBLE_SUBGRAPH_UNITTEST_DIR}",
         "device": "cuda",
         "generate_main": false,
         "try_run": true,
@@ -431,24 +431,24 @@ EOF
 ###############################################################################
 
 function dimension_generalizer_for_typical_subgraphs() {
-    echo ">>> [2-9] Generate dimension generalized subgraph samples under ${DIMENSION_GENERALIZED_OUTPUT_DIR}."
+    echo ">>> [2-9] Generate dimension generalized subgraph samples under ${DIM_GENERALIZED_SAMPLE_DIR}."
     for index in {0..8}; do
         echo ">>> Generating dimension generalized subgraph variant index: ${index}"
-        dimension_generalized_sample_list="${DIMENSION_GENERALIZED_OUTPUT_DIR}/${index}/dimension_generalized_sample_list.txt"
-        dimension_generalized_subgraph_list="${DIMENSION_GENERALIZED_OUTPUT_DIR}/${index}/dimension_generalized_subgraph_list.txt"
-        generate_subgraph_list ${DIMENSION_GENERALIZED_OUTPUT_DIR}/${index} ${dimension_generalized_sample_list}
-        sed 's|/_decomposed/.*||' ${deduplicated_subgraph_list} | uniq | grep -Fxf "$dimension_generalized_sample_list" > ${dimension_generalized_subgraph_list}
-
+        dimension_generalized_sample_list="${DIM_GENERALIZED_SAMPLE_DIR}/${index}/dimension_generalized_sample_list.txt"
+        # An optimized method for backup
+        # dimension_generalized_subgraph_list="${DIM_GENERALIZED_SAMPLE_DIR}/${index}/dimension_generalized_subgraph_list.txt"
+        # generate_subgraph_list ${DIM_GENERALIZED_SAMPLE_DIR}/${index} ${dimension_generalized_sample_list}
+        # sed 's|/_decomposed/.*||' ${deduplicated_subgraph_list} | uniq | grep -Fxf "$dimension_generalized_sample_list" > ${dimension_generalized_subgraph_list}
         python3 -m graph_net.model_path_handler ${USE_SUBPROCESS_ARGS} \
-            --model-path-list "${dimension_generalized_subgraph_list}" \
+            --model-path-list "${dimension_generalized_sample_list}" \
             --handler-config $(base64 -w 0 <<EOF
 {
     "handler_path": "$GRAPH_NET_ROOT/graph_net/torch/sample_pass/subgraph_generator.py",
     "handler_class_name": "SubgraphGenerator",
     "handler_config": {
-        "model_path_prefix": "${DIMENSION_GENERALIZED_OUTPUT_DIR}/${index}",
-        "output_dir": "${DIMENSION_GENERALIZED_TIPICAL_SUBGRAPH_DIR}/${index}",
-        "subgraph_ranges_json_root": "$SUBGRAPH_RANGES_JSON_ROOT",
+        "model_path_prefix": "${DIM_GENERALIZED_SAMPLE_DIR}/${index}",
+        "output_dir": "${DIM_GENERALIZED_TYPICAL_SUBGRAPH_DIR}/${index}",
+        "subgraph_ranges_json_root": "$TYPICAL_SUBGRAPH_RANGE_DIR",
         "subgraph_ranges_json_file_name": "typical_subgraph_ranges.json",
         "device": "cuda",
         "resume": ${RESUME}
@@ -460,7 +460,7 @@ EOF
 }
 
 function rename_dimension_generalized_typical_subgraphs() {
-    echo ">>> [2-10] Rename subgraph samples under ${DIMENSION_GENERALIZED_TIPICAL_SUBGRAPH_DIR}."
+    echo ">>> [2-10] Rename subgraph samples under ${DIM_GENERALIZED_TYPICAL_SUBGRAPH_DIR}."
     echo ">>>"
     python3 -m graph_net.model_path_handler \
         --model-path-list ${dimension_generalized_typical_subgraph_list} \
@@ -472,12 +472,12 @@ function rename_dimension_generalized_typical_subgraphs() {
         "device": "cuda",
         "try_run": false,
         "resume": ${RESUME},
-        "model_path_prefix": "${DIMENSION_GENERALIZED_TIPICAL_SUBGRAPH_DIR}",
+        "model_path_prefix": "${DIM_GENERALIZED_TYPICAL_SUBGRAPH_DIR}",
         "data_input_predicator_filepath": "$GRAPH_NET_ROOT/graph_net/torch/constraint_util.py",
         "data_input_predicator_class_name": "RenamedDataInputPredicator",
         "model_runnable_predicator_filepath": "$GRAPH_NET_ROOT/graph_net/torch/constraint_util.py",
         "model_runnable_predicator_class_name": "ModelRunnablePredicator",
-        "output_dir": "${RENAMED_DIMENSION_GENERALIZED_TYPICAL_SUBGRAPH_DIR}"
+        "output_dir": "${RENAMED_DIM_GENERALIZED_TYPICAL_SUBGRAPH_DIR}"
     }
 }
 EOF
@@ -485,17 +485,18 @@ EOF
 }
 
 function remove_duplicate_dimension_generalized_typical_subgraphs() {
-    echo ">>> [2-11] Remove duplicated subgraph samples under ${RENAMED_DIMENSION_GENERALIZED_TYPICAL_SUBGRAPH_DIR}."
+    echo ">>> [2-11] Remove duplicated subgraph samples under ${RENAMED_DIM_GENERALIZED_TYPICAL_SUBGRAPH_DIR}."
     echo ">>>"
     for index in {0..8}; do
         python3 -m graph_net.tools.deduplicated \
-            --samples-dir ${RENAMED_DIMENSION_GENERALIZED_TYPICAL_SUBGRAPH_DIR}/${index} \
-            --target-dir ${DEDUPLICATED_DIMENSION_GENERALIZED_TYPICAL_SUBGRAPH_DIR}/${index}
+            --samples-dir ${RENAMED_DIM_GENERALIZED_TYPICAL_SUBGRAPH_DIR}/${index} \
+            --target-dir ${DEDUP_DIM_GENERALIZED_TYPICAL_SUBGRAPH_DIR}/${index}
     done
+    cp -rf ${DEDUP_TYPICAL_SUBGRAPH_DIR} ${DEDUP_DIM_GENERALIZED_TYPICAL_SUBGRAPH_DIR}/9
 }
 
 function dtype_generalizer_for_typical_subgraphs() {
-    echo ">>> [2-12] Data type generalizer for samples under ${DEDUPLICATED_DIMENSION_GENERALIZED_TYPICAL_SUBGRAPH_DIR}."
+    echo ">>> [2-12] Data type generalizer for samples under ${DEDUP_DIM_GENERALIZED_TYPICAL_SUBGRAPH_DIR}."
     echo ">>>"
     python3 -m graph_net.apply_sample_pass \
         --use-subprocess \
@@ -505,7 +506,7 @@ function dtype_generalizer_for_typical_subgraphs() {
         --sample-pass-config $(base64 -w 0 <<EOF
 {
     "output_dir": "$DTYPE_GENERALIZED_TYPICAL_SUBGRAPH_DIR",
-    "model_path_prefix": "$DEDUPLICATED_DIMENSION_GENERALIZED_TYPICAL_SUBGRAPH_DIR",
+    "model_path_prefix": "$DEDUP_DIM_GENERALIZED_TYPICAL_SUBGRAPH_DIR",
     "model_runnable_predicator_filepath": "$GRAPH_NET_ROOT/graph_net/torch/constraint_util.py",
     "try_run": false,
     "device": "cuda",
@@ -527,7 +528,7 @@ function generate_unittest_for_typical_subgraphs() {
     "handler_config": {
         "framework": "torch",
         "model_path_prefix": "${DTYPE_GENERALIZED_TYPICAL_SUBGRAPH_DIR}",
-        "output_dir": "${TYPICAL_SUBGRAPH_UNITTESTS_DIR}",
+        "output_dir": "${TYPICAL_SUBGRAPH_UNITTEST_DIR}",
         "device": "cuda",
         "generate_main": false,
         "try_run": true,
@@ -546,7 +547,7 @@ function do_common_generalzation_and_decompose() {
 
     # rewrite the device in model to cuda
     rewrite_device 2>&1 | tee ${DECOMPOSE_WORKSPACE}/log_rewrite_device_${suffix}.txt
-    generate_subgraph_list ${DEVICE_REWRITED_OUTPUT_DIR} ${device_rewrited_sample_list}
+    generate_subgraph_list ${DEVICE_REWRITED_SAMPLE_DIR} ${device_rewrited_sample_list}
 
     # whole-graph dimension generalization
     dimension_generalizer 2>&1 | tee ${DECOMPOSE_WORKSPACE}/log_dimension_generalizer_${suffix}.txt
@@ -555,11 +556,11 @@ function do_common_generalzation_and_decompose() {
     generate_op_names 2>&1 | tee ${DECOMPOSE_WORKSPACE}/log_op_names_${suffix}.txt
     generate_split_point 2>&1 | tee ${DECOMPOSE_WORKSPACE}/log_split_point_${suffix}.txt
     range_decompose 2>&1 | tee ${DECOMPOSE_WORKSPACE}/log_range_decompose_${suffix}.txt
-    generate_subgraph_list ${RANGE_DECOMPOSE_OUTPUT_DIR} ${range_decomposed_subgraph_list}
+    generate_subgraph_list ${TYPICAL_SUBGRAPH_DIR} ${range_decomposed_subgraph_list}
     
     rename_decomposed_subgraph 2>&1 | tee ${DECOMPOSE_WORKSPACE}/log_rename_decomposed_subgraph_${suffix}.txt
     remove_duplicate_renamed_graphs 2>&1 | tee ${DECOMPOSE_WORKSPACE}/log_remove_duplicate_renamed_graphs_${suffix}.txt
-    generate_subgraph_list ${DEDUPLICATED_OUTPUT_DIR} ${deduplicated_subgraph_list}
+    generate_subgraph_list ${DEDUP_TYPICAL_SUBGRAPH_DIR} ${deduplicated_subgraph_list}
 }
 
 function generate_fusible_subgraphs() {
@@ -571,15 +572,15 @@ function generate_fusible_subgraphs() {
 
     # subgraph dimension generalization
     subgraph_dimension_generalizer 2>&1 | tee ${DECOMPOSE_WORKSPACE}/log_subgraph_dimension_generalizer_${suffix}.txt
-    generate_generalized_subgraph_list ${SUBGRAPH_DIMENSION_GENERALIZED_OUTPUT_DIR} ${dimension_generalized_subgraph_list}
+    generate_generalized_subgraph_list ${DIM_GENERALIZED_FUSIBLE_SUBGRAPH_DIR} ${dimension_generalized_subgraph_list}
     
     rename_dimension_generalized_fusible_subgraph 2>&1 | tee ${DECOMPOSE_WORKSPACE}/log_rename_dimension_generalized_subgraph_${suffix}.txt
     remove_duplicate_dimension_generalized_fusible_graphs 2>&1 | tee ${DECOMPOSE_WORKSPACE}/log_remove_duplicate_dimension_generalized_subgraphs_${suffix}.txt
-    generate_generalized_subgraph_list ${DEDUPLICATED_DIMENSION_GENERALIZED_FUSIBLE_SUBGRAPH_DIR} ${deduplicated_fusible_subgraphs_list}
+    generate_generalized_subgraph_list ${DEDUP_DIM_GENERALIZED_FUSIBLE_SUBGRAPH_DIR} ${deduplicated_fusible_subgraphs_list}
 
     # dtype generalization
     dtype_generalizer 2>&1 | tee ${DECOMPOSE_WORKSPACE}/log_dtype_generalizer_${suffix}.txt
-    generate_generalized_subgraph_list ${DTYPE_GENERALIZED_OUTPUT_DIR} ${dtype_generalized_subgraphs_list}
+    generate_generalized_subgraph_list ${DTYPE_GENERALIZED_FUSIBLE_SUBGRAPH_DIR} ${dtype_generalized_subgraphs_list}
 
     # generate kernelbench format unittest
     generate_unittests 2>&1 | tee ${DECOMPOSE_WORKSPACE}/log_unittests_${suffix}.txt
@@ -591,11 +592,11 @@ function generate_typical_subgraphs() {
 
     # subgraph dimension generalization
     dimension_generalizer_for_typical_subgraphs 2>&1 | tee ${DECOMPOSE_WORKSPACE}/log_dimension_generalizer_typical_subgraphs_${suffix}.txt
-    generate_generalized_subgraph_list ${DIMENSION_GENERALIZED_TIPICAL_SUBGRAPH_DIR} ${dimension_generalized_typical_subgraph_list}
+    generate_generalized_subgraph_list ${DIM_GENERALIZED_TYPICAL_SUBGRAPH_DIR} ${dimension_generalized_typical_subgraph_list}
 
     rename_dimension_generalized_typical_subgraphs 2>&1 | tee ${DECOMPOSE_WORKSPACE}/log_rename_dimension_generalized_typical_subgraph_${suffix}.txt
     remove_duplicate_dimension_generalized_typical_subgraphs 2>&1 | tee ${DECOMPOSE_WORKSPACE}/log_remove_duplicate_dimension_generalized_subgraphs_${suffix}.txt
-    generate_generalized_subgraph_list ${DEDUPLICATED_DIMENSION_GENERALIZED_TYPICAL_SUBGRAPH_DIR} ${deduplicated_typical_subgraph_list}
+    generate_generalized_subgraph_list ${DEDUP_DIM_GENERALIZED_TYPICAL_SUBGRAPH_DIR} ${deduplicated_typical_subgraph_list}
 
     # dtype generalization
     dtype_generalizer_for_typical_subgraphs 2>&1 | tee ${DECOMPOSE_WORKSPACE}/log_dtype_generalizer_typical_subgraphs_${suffix}.txt
@@ -609,105 +610,133 @@ function main() {
     timestamp=`date +%Y%m%d_%H%M`
 
     # init database
-    #python ${GRAPH_NET_ROOT}/sqlite/init_db.py --db_path ${DB_PATH} 2>&1 | tee sqlite/logs/init_db_${timestamp}.log
-    #insert_graph_sample ${GRAPH_NET_ROOT} "github_torch_samples" "full_graph" ${model_list}
+    python ${GRAPH_NET_ROOT}/sqlite/init_db.py --db_path ${DB_PATH} 2>&1 | tee sqlite/logs/init_db_${timestamp}.log
+    insert_graph_sample ${GRAPH_NET_ROOT} "github_torch_samples" "full_graph" ${model_list}
 
-    #generate_fusible_subgraphs
-    #insert_graph_sample ${DEDUPLICATED_DIMENSION_GENERALIZED_FUSIBLE_SUBGRAPH_DIR} "github_torch_samples" "fusible_graph" ${dtype_generalized_subgraphs_list}
+    generate_fusible_subgraphs
+    insert_graph_sample ${DEDUP_DIM_GENERALIZED_FUSIBLE_SUBGRAPH_DIR} "github_torch_samples" "fusible_graph" ${deduplicated_fusible_subgraphs_list}
 
     generate_typical_subgraphs
-    #insert_graph_sample ${DEDUPLICATED_OUTPUT_DIR} "github_torch_samples" "typical_graph" ${deduplicated_subgraph_list}    
+    insert_graph_sample ${DEDUP_TYPICAL_SUBGRAPH_DIR} "github_torch_samples" "typical_graph" ${deduplicated_typical_subgraph_list}    
 }
 
 summary() {
     num_original_samples=`cat $model_list | grep "^samples/" | wc -l`
     echo "Number of original graphnet samples: $num_original_samples"
 
-    num_device_rewrited_samples=`find ${DEVICE_REWRITED_OUTPUT_DIR} -name "model.py" | wc -l`
+    num_device_rewrited_samples=`find ${DEVICE_REWRITED_SAMPLE_DIR} -name "model.py" | wc -l`
     device_rewrited_successed_precent=$(( num_device_rewrited_samples * 100 / num_original_samples ))
-    echo "- [Step  1] device rewrite: successed=${num_device_rewrited_samples}, percent=$device_rewrited_successed_precent%"
+    echo "- [Common - 1] device rewrite: successed=${num_device_rewrited_samples}, percent=$device_rewrited_successed_precent%"
 
-    num_successed_dimension_generalized_samples=`find ${DIMENSION_GENERALIZED_OUTPUT_DIR} -name "model.py" | wc -l`
+    num_successed_dimension_generalized_samples=`find ${DIM_GENERALIZED_SAMPLE_DIR} -name "model.py" | wc -l`
     dimension_generalized_samples_successed_percent=$((num_successed_dimension_generalized_samples * 100 / (num_original_samples * 9)))
-    echo "- [Step  2] dimension generalization: successed=${num_successed_dimension_generalized_samples}, percent=${dimension_generalized_samples_successed_percent}%"
+    echo "- [Common - 2] dimension generalization: successed=${num_successed_dimension_generalized_samples}, percent=${dimension_generalized_samples_successed_percent}%"
     for index in {0..8}; do
-        num_successed_dimension_generalized_samples=`find ${DIMENSION_GENERALIZED_OUTPUT_DIR}/${index} -name "model.py" | wc -l`
+        num_successed_dimension_generalized_samples=`find ${DIM_GENERALIZED_SAMPLE_DIR}/${index} -name "model.py" | wc -l`
         dimension_generalized_samples_successed_percent=$(( num_successed_dimension_generalized_samples * 100 / num_original_samples ))
         echo "    ${index}, successed=${num_successed_dimension_generalized_samples}, percent=${dimension_generalized_samples_successed_percent}%"
     done
     echo ""
 
-    num_successed_op_names=`find ${OP_NAMES_OUTPUT_DIR} -name op_names.txt | wc -l`
+    num_successed_op_names=`find ${SAMPLE_OP_NAMES_DIR} -name op_names.txt | wc -l`
     op_names_successed_percent=$(( num_successed_op_names * 100 / num_original_samples ))
-    echo "- [Step  3] generate op names: successed=${num_successed_op_names}, percent=${op_names_successed_percent}%"
+    echo "- [Common - 3] generate op names: successed=${num_successed_op_names}, percent=${op_names_successed_percent}%"
 
-    num_typical_subgraph_ranges=`find ${SUBGRAPH_RANGES_JSON_ROOT} -name typical_subgraph_ranges.json | wc -l`
+    num_typical_subgraph_ranges=`find ${TYPICAL_SUBGRAPH_RANGE_DIR} -name typical_subgraph_ranges.json | wc -l`
     typical_subgraph_ranges_successed_percent=$(( num_typical_subgraph_ranges * 100 / num_original_samples ))
-    echo "- [Step  4] generate typical subgraph ranges: successed=${num_typical_subgraph_ranges}, percent=${typical_subgraph_ranges_successed_percent}%"
+    echo "- [Common - 4] generate typical subgraph ranges: successed=${num_typical_subgraph_ranges}, percent=${typical_subgraph_ranges_successed_percent}%"
 
-    num_successed_range_decomposed_subgraphs=`find ${RANGE_DECOMPOSE_OUTPUT_DIR} -name "model.py" | wc -l`
-    echo "- [Step  5] range decompose: successed=${num_successed_range_decomposed_subgraphs}"
+    num_successed_range_decomposed_subgraphs=`find ${TYPICAL_SUBGRAPH_DIR} -name "model.py" | wc -l`
+    echo "- [Common - 5] range decompose: successed=${num_successed_range_decomposed_subgraphs}"
     
-    num_renamed_subgraphs=`find ${GRAPH_VAR_RENAME_OUTPUT_DIR} -name "model.py" | wc -l`
-    echo "- [Step  6] rename: successed=${num_renamed_subgraphs}"
+    num_renamed_subgraphs=`find ${RENAMED_TYPICAL_SUBGRAPH_DIR} -name "model.py" | wc -l`
+    echo "- [Common - 6] rename: successed=${num_renamed_subgraphs}"
     
-    num_deduplicated_subgraphs=`find ${DEDUPLICATED_OUTPUT_DIR} -name "model.py" | wc -l`
-    echo "- [Step  7] remove duplicated: successed=${num_deduplicated_subgraphs}"
+    num_deduplicated_typical_subgraphs=`find ${DEDUP_TYPICAL_SUBGRAPH_DIR} -name "model.py" | wc -l`
+    echo "- [Common - 7] remove duplicated: successed=${num_deduplicated_typical_subgraphs}"
+    echo ""
 
+    # fusible subgraphs
     num_successed_cumsum_kernels_subgraphs=`find ${CUMSUM_NUM_KERNELS_DIR} -name "cumsum_num_kernels.json" | wc -l`
-    cumsum_kernels_successed_percent=$((num_successed_cumsum_kernels_subgraphs * 100 / num_deduplicated_subgraphs))
-    echo "- [Step  8] cumsum kernels: successed=${num_successed_cumsum_kernels_subgraphs}, percent=${cumsum_kernels_successed_percent}%"
+    cumsum_kernels_successed_percent=$((num_successed_cumsum_kernels_subgraphs * 100 / num_deduplicated_typical_subgraphs))
+    echo "- [Fusible - 1] cumsum kernels: successed=${num_successed_cumsum_kernels_subgraphs}, percent=${cumsum_kernels_successed_percent}%"
 
-    num_fusible_subgraph_ranges=`find ${FUSIBLE_SUBGRAPH_RANGES_DIR} -name "fusible_subgraph_ranges.json" | wc -l`
-    num_grouped_fusible_subgraph_ranges=`find ${GROUPED_FUSIBLE_SUBGRAPH_RANGES_DIR} -name "grouped_fusible_subgraph_ranges.json" | wc -l`
+    num_fusible_subgraph_ranges=`find ${FUSIBLE_SUBGRAPH_RANGE_DIR} -name "fusible_subgraph_ranges.json" | wc -l`
+    num_grouped_fusible_subgraph_ranges=`find ${GROUPED_FUSIBLE_SUBGRAPH_RANGE_DIR} -name "grouped_fusible_subgraph_ranges.json" | wc -l`
     echo "    fusible subgraph ranges: successed=${num_fusible_subgraph_ranges}"
     echo "    grouped fusible subgraph ranges: successed=${num_grouped_fusible_subgraph_ranges}"
     echo ""
 
-    num_successed_dimension_generalized_subgraphs=`find ${SUBGRAPH_DIMENSION_GENERALIZED_OUTPUT_DIR} -name "model.py" | wc -l`
-    echo "- [Step  9] subgraph dimension generalization: successed=${num_successed_dimension_generalized_subgraphs}"
+    num_successed_dimension_generalized_subgraphs=`find ${DIM_GENERALIZED_FUSIBLE_SUBGRAPH_DIR} -name "model.py" | wc -l`
+    echo "- [Fusible - 2] subgraph dimension generalization: successed=${num_successed_dimension_generalized_subgraphs}"
     for index in {0..8}; do
-        num_successed_dimension_generalized_subgraphs=`find ${SUBGRAPH_DIMENSION_GENERALIZED_OUTPUT_DIR}/${index} -name "model.py" | wc -l`
+        num_successed_dimension_generalized_subgraphs=`find ${DIM_GENERALIZED_FUSIBLE_SUBGRAPH_DIR}/${index} -name "model.py" | wc -l`
         echo "    ${index}, successed=${num_successed_dimension_generalized_subgraphs}"
     done
     echo ""
 
-    num_renamed_fusible_subgraphs=`find ${RENAMED_DIMENSION_GENERALIZED_FUSIBLE_SUBGRAPH_DIR} -name "model.py" | wc -l`
-    echo "- [Step 10] rename: successed=${num_renamed_fusible_subgraphs}"
+    num_renamed_fusible_subgraphs=`find ${RENAMED_DIM_GENERALIZED_FUSIBLE_SUBGRAPH_DIR} -name "model.py" | wc -l`
+    echo "- [Fusible - 3] rename: successed=${num_renamed_fusible_subgraphs}"
     for index in {0..8}; do
-        num_renamed_fusible_subgraphs_index=`find ${RENAMED_DIMENSION_GENERALIZED_FUSIBLE_SUBGRAPH_DIR}/${index} -name "model.py" | wc -l`
+        num_renamed_fusible_subgraphs_index=`find ${RENAMED_DIM_GENERALIZED_FUSIBLE_SUBGRAPH_DIR}/${index} -name "model.py" | wc -l`
         echo "    ${index}, successed=${num_renamed_fusible_subgraphs_index}"
     done
     echo ""
 
-    num_deduplicated_fusible_subgraphs=`find ${DEDUPLICATED_DIMENSION_GENERALIZED_FUSIBLE_SUBGRAPH_DIR} -name "model.py" | wc -l`
-    echo "- [Step 11] remove duplicated: successed=${num_deduplicated_fusible_subgraphs}"
+    num_deduplicated_fusible_subgraphs=`find ${DEDUP_DIM_GENERALIZED_FUSIBLE_SUBGRAPH_DIR} -name "model.py" | wc -l`
+    echo "- [Fusible - 4] remove duplicated: successed=${num_deduplicated_fusible_subgraphs}"
     for index in {0..8}; do
-        num_deduplicated_fusible_subgraphs_index=`find ${DEDUPLICATED_DIMENSION_GENERALIZED_FUSIBLE_SUBGRAPH_DIR}/${index} -name "model.py" | wc -l`
+        num_deduplicated_fusible_subgraphs_index=`find ${DEDUP_DIM_GENERALIZED_FUSIBLE_SUBGRAPH_DIR}/${index} -name "model.py" | wc -l`
         echo "    ${index}, successed=${num_deduplicated_fusible_subgraphs_index}"
     done
     echo ""
 
-    num_dtype_generalized_subgraphs=`find ${DTYPE_GENERALIZED_OUTPUT_DIR} -name "model.py" | wc -l`
-    echo "- [Step 12] dtype generalization: successed=${num_dtype_generalized_subgraphs}"
+    num_dtype_generalized_subgraphs=`find ${DTYPE_GENERALIZED_FUSIBLE_SUBGRAPH_DIR} -name "model.py" | wc -l`
+    echo "- [Fusible - 5] dtype generalization: successed=${num_dtype_generalized_subgraphs}"
     for dtype in float32 float16 bfloat16
     do
-        num_dtype_generalized_subgraphs_index=`find ${DTYPE_GENERALIZED_OUTPUT_DIR}/${dtype} -name "model.py" | wc -l`
+        num_dtype_generalized_subgraphs_index=`find ${DTYPE_GENERALIZED_FUSIBLE_SUBGRAPH_DIR}/${dtype} -name "model.py" | wc -l`
         echo "    ${dtype}, successed=${num_dtype_generalized_subgraphs_index}"
     done
     echo ""
 
-    num_successed_unittests=`find ${UNITTESTS_OUTPUT_DIR} -name "*_test.py" | wc -l`
+    num_successed_unittests=`find ${FUSIBLE_SUBGRAPH_UNITTEST_DIR} -name "*_test.py" | wc -l`
     unittest_successed_percent=$((num_successed_unittests * 100 / num_dtype_generalized_subgraphs))
-    echo "- [Step 13] generate unittest: successed=${num_successed_unittests}, percent=${unittest_successed_percent}%"
+    echo "- [Fusible - 6] generate unittest: successed=${num_successed_unittests}, percent=${unittest_successed_percent}%"
     for dtype in float32 float16 bfloat16
     do
-        num_successed_unittests=`find ${UNITTESTS_OUTPUT_DIR}/${dtype} -name "*_test.py" | wc -l`
+        num_successed_unittests=`find ${FUSIBLE_SUBGRAPH_UNITTEST_DIR}/${dtype} -name "*_test.py" | wc -l`
         echo "    ${dtype}, successed=${num_successed_unittests}"
     done
+    echo ""
+
+    # typical subgraphs
+    num_successed_dim_generalized_typical_subgraphs=`find ${DIM_GENERALIZED_TYPICAL_SUBGRAPH_DIR} -name "model.py" | wc -l`
+    echo "- [Typical - 1] subgraph dimension generalization: successed=${num_successed_dim_generalized_typical_subgraphs}"
+    for index in {0..8}; do
+        num_successed_dim_generalized_typical_index=`find ${DIM_GENERALIZED_TYPICAL_SUBGRAPH_DIR}/${index} -name "model.py" | wc -l`
+        echo "    ${index}, successed=${num_successed_dim_generalized_typical_index}"
+    done
+    echo ""
+
+    num_renamed_typical_subgraphs=`find ${RENAMED_DIM_GENERALIZED_TYPICAL_SUBGRAPH_DIR} -name "model.py" | wc -l`
+    echo "- [Typical - 2] rename: successed=${num_renamed_typical_subgraphs}"
+    for index in {0..8}; do
+        num_renamed_typical_subgraphs_index=`find ${RENAMED_DIM_GENERALIZED_TYPICAL_SUBGRAPH_DIR}/${index} -name "model.py" | wc -l`
+        echo "    ${index}, successed=${num_renamed_typical_subgraphs_index}"
+    done
+    echo ""
+
+    num_deduplicated_typical_subgraphs=`find ${DEDUP_DIM_GENERALIZED_TYPICAL_SUBGRAPH_DIR} -name "model.py" | wc -l`
+    echo "- [Typical - 3] remove duplicated: successed=${num_deduplicated_typical_subgraphs}"
+    for index in {0..9}; do
+        num_deduplicated_typical_subgraphs_index=`find ${DEDUP_DIM_GENERALIZED_TYPICAL_SUBGRAPH_DIR}/${index} -name "model.py" | wc -l`
+        echo "    ${index}, successed=${num_deduplicated_typical_subgraphs_index}"
+    done
+    echo ""
 }
 
 main
 
 set +x
-#summary 2>&1 | tee ${DECOMPOSE_WORKSPACE}/summary.txt
+summary 2>&1 | tee ${DECOMPOSE_WORKSPACE}/summary.txt


### PR DESCRIPTION
### PR Category
<!-- One of [ New Sample | Feature Enhancement | Bug Fix | Other ] -->
Other

### Description
<!-- Describe what you’ve done -->
经典子图数据集生成集成维度泛化、数据类型泛化功能。
维度泛化会生成9组维度，分别保存在0 - 8目录，将原始样本拷贝到第9个目录。维度泛化后经典子图样本如下：
```
- [Typical - 3] remove duplicated: successed=22115
    0, successed=1909
    1, successed=1870
    2, successed=2334
    3, successed=1911
    4, successed=1900
    5, successed=2026
    6, successed=1691
    7, successed=1999
    8, successed=1894
    9, successed=4581
```