### PR TITLE
[Feature] Copy forward graph to original name in backward graph extra…

### DIFF
--- a/graph_net/torch/sample_pass/backward_graph_extractor.py
+++ b/graph_net/torch/sample_pass/backward_graph_extractor.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 import inspect
 from pathlib import Path
 
@@ -33,6 +34,11 @@ class BackwardGraphExtractor:
         gm_holder, backward_inputs = self.capture_graph(module, forward_inputs)
         self.get_extractor("forward")(gm_holder["forward_gm"], forward_inputs)
         self.get_extractor("backward")(gm_holder["backward_gm"], backward_inputs)
+
+        forward_dir = os.path.join(self.output_dir, f"{self.model_name}_forward")
+        original_name_dir = os.path.join(self.output_dir, self.model_name)
+        if os.path.exists(forward_dir) and not os.path.exists(original_name_dir):
+            shutil.copytree(forward_dir, original_name_dir)
 
     def get_extractor(self, suffix):
         return BuiltinGraphExtractor(

--- a/graph_net/torch/sample_pass/backward_graph_extractor.py
+++ b/graph_net/torch/sample_pass/backward_graph_extractor.py
@@ -28,17 +28,16 @@ class BackwardGraphExtractor:
         )
         module.train()
 
+        original_name_dir = os.path.join(self.output_dir, self.model_name)
+        if not os.path.exists(original_name_dir):
+            shutil.copytree(self.model_path, original_name_dir)
+
         forward_inputs = self.set_requires_grad_for_forward_inputs(
             self.model_path, module, forward_inputs
         )
         gm_holder, backward_inputs = self.capture_graph(module, forward_inputs)
         self.get_extractor("forward")(gm_holder["forward_gm"], forward_inputs)
         self.get_extractor("backward")(gm_holder["backward_gm"], backward_inputs)
-
-        forward_dir = os.path.join(self.output_dir, f"{self.model_name}_forward")
-        original_name_dir = os.path.join(self.output_dir, self.model_name)
-        if os.path.exists(forward_dir) and not os.path.exists(original_name_dir):
-            shutil.copytree(forward_dir, original_name_dir)
 
     def get_extractor(self, suffix):
         return BuiltinGraphExtractor(


### PR DESCRIPTION
### PR Category
<!-- One of [ New Sample | Feature Enhancement | Bug Fix | Other ] -->
Feature Enhancement

### Description
<!-- Describe what you’ve done -->
在反向图提取后，复制原始模型名称目录，使输出包含：
- `model_name/` - 推理前向图副本
- `model_name_forward/` - 训练前向图
- `model_name_backward/` - 训练反向图