### PR TITLE
fix: apply pre-commit lint fixes (ruff + black)

### DIFF
--- a/graph_net/paddle/backend/cinn_backend.py
+++ b/graph_net/paddle/backend/cinn_backend.py
@@ -12,7 +12,6 @@ class CinnBackend(GraphCompilerBackend):
             full_graph=True,
         )
         compiled_model.eval()
-        program = compiled_model.forward.concrete_program.main_program
         return compiled_model
 
     def synchronize(self):

--- a/graph_net/paddle/check_redundant_incrementally.py
+++ b/graph_net/paddle/check_redundant_incrementally.py
@@ -1,16 +1,6 @@
-from . import utils
 import argparse
-import importlib.util
-import inspect
-from pathlib import Path
-from typing import Type, Any
-import sys
 import os
 import os.path
-from dataclasses import dataclass
-from contextlib import contextmanager
-import time
-import glob
 
 
 def get_recursively_model_pathes(root_dir):

--- a/graph_net/paddle/remove_redundant_incrementally.py
+++ b/graph_net/paddle/remove_redundant_incrementally.py
@@ -1,16 +1,6 @@
-from . import utils
 import argparse
-import importlib.util
-import inspect
-from pathlib import Path
-from typing import Type, Any
-import sys
 import os
 import os.path
-from dataclasses import dataclass
-from contextlib import contextmanager
-import time
-import glob
 import shutil
 
 

--- a/graph_net/paddle/validate.py
+++ b/graph_net/paddle/validate.py
@@ -1,14 +1,8 @@
 from . import utils
 import argparse
 import importlib.util
-import inspect
-from pathlib import Path
-from typing import Type, Any
 import sys
 import hashlib
-from contextlib import contextmanager
-from collections import ChainMap
-import numpy as np
 import graph_net
 import os
 import ast
@@ -36,7 +30,6 @@ def _extract_forward_source(model_path, class_name):
         source = f.read()
 
     tree = ast.parse(source)
-    forward_code = None
 
     for node in tree.body:
         if isinstance(node, ast.ClassDef) and node.name == class_name:

--- a/graph_net/test/bert_model_test.py
+++ b/graph_net/test/bert_model_test.py
@@ -1,7 +1,6 @@
 import torch
 from transformers import AutoModel, AutoTokenizer
 import graph_net.torch
-import os
 
 
 def get_model_name():

--- a/graph_net/torch/check_redundant_incrementally.py
+++ b/graph_net/torch/check_redundant_incrementally.py
@@ -1,17 +1,6 @@
-from . import utils
 import argparse
-import importlib.util
-import inspect
-import torch
-from pathlib import Path
-from typing import Type, Any
-import sys
 import os
 import os.path
-from dataclasses import dataclass
-from contextlib import contextmanager
-import time
-import glob
 
 
 def get_recursively_model_pathes(root_dir):

--- a/graph_net/torch/dim_gen_passes/__init__.py
+++ b/graph_net/torch/dim_gen_passes/__init__.py
@@ -1,1 +1,3 @@
-from graph_net.torch.dim_gen_passes.pass_base import DimensionGeneralizationPass
+from graph_net.torch.dim_gen_passes.pass_base import (
+    DimensionGeneralizationPass as DimensionGeneralizationPass,
+)

--- a/graph_net/torch/dim_gen_passes/naive_call_method_reshape_pass.py
+++ b/graph_net/torch/dim_gen_passes/naive_call_method_reshape_pass.py
@@ -1,4 +1,3 @@
-import torch
 import torch.fx as fx
 from graph_net.torch.dim_gen_passes import DimensionGeneralizationPass
 import os

--- a/graph_net/torch/dim_gen_passes/non_batch_call_function_getitem_slice_pass.py
+++ b/graph_net/torch/dim_gen_passes/non_batch_call_function_getitem_slice_pass.py
@@ -1,4 +1,3 @@
-import torch
 import torch.fx as fx
 from graph_net.torch.dim_gen_passes import DimensionGeneralizationPass
 from collections import namedtuple

--- a/graph_net/torch/dim_gen_passes/pass_base.py
+++ b/graph_net/torch/dim_gen_passes/pass_base.py
@@ -1,7 +1,4 @@
-import torch
 import torch.fx as fx
-import inspect
-import os
 
 
 class DimensionGeneralizationPass:

--- a/graph_net/torch/dim_gen_passes/pass_mgr.py
+++ b/graph_net/torch/dim_gen_passes/pass_mgr.py
@@ -2,7 +2,7 @@ from graph_net.imp_util import load_module
 import os
 
 
-def get_dim_gen_pass(pass_name) -> "DimensionGeneralizationPass":
+def get_dim_gen_pass(pass_name) -> "DimensionGeneralizationPass":  # noqa: F821
     import graph_net.torch.dim_gen_passes as dgpass
 
     py_module = load_module(f"{os.path.dirname(dgpass.__file__)}/{pass_name}.py")

--- a/graph_net/torch/dump_graph_hash.py
+++ b/graph_net/torch/dump_graph_hash.py
@@ -3,7 +3,6 @@ import os
 import tempfile
 import sys
 import contextlib
-import graph_net
 
 
 @contextlib.contextmanager
@@ -17,7 +16,7 @@ def temp_workspace():
 
 def main(args):
     model_path = args.model_path
-    with temp_workspace() as tmp_dir_name:
+    with temp_workspace():
         print("dump-graph-hash ...")
         extract_name = "temp"
         cmd = f"{sys.executable} -m graph_net.torch.single_device_runner --model-path {model_path} --enable-extract True --extract-name {extract_name} --dump-graph-hash-key"

--- a/graph_net/torch/remove_redundant_incrementally.py
+++ b/graph_net/torch/remove_redundant_incrementally.py
@@ -1,17 +1,6 @@
-from . import utils
 import argparse
-import importlib.util
-import inspect
-import torch
-from pathlib import Path
-from typing import Type, Any
-import sys
 import os
 import os.path
-from dataclasses import dataclass
-from contextlib import contextmanager
-import time
-import glob
 import shutil
 
 

--- a/graph_net/torch/rp_expr/longest_rp_expr_parser.py
+++ b/graph_net/torch/rp_expr/longest_rp_expr_parser.py
@@ -2,7 +2,6 @@ import typing as t
 from graph_net.torch.rp_expr.rp_expr_parser import RpExprParser
 from graph_net.torch.rp_expr.rp_expr import PrimitiveId, LetsListTokenRpExpr
 import numpy as np
-import sys
 
 
 class LongestRpExprParser:

--- a/graph_net/torch/rp_expr/rp_expr.py
+++ b/graph_net/torch/rp_expr/rp_expr.py
@@ -3,7 +3,6 @@ import typing as t
 import numpy as np
 import torch
 from collections import defaultdict
-import functools
 
 PrimitiveId = t.TypeVar("PrimitiveId")
 
@@ -428,7 +427,7 @@ class LetsListTokenRpExpr(TokenRpExpr):
             ]
         )
         yield from [
-            f"def main():",
+            "def main():",
             *[
                 f"  {SymbolToString(int(t[0]))}(){end_of_line}"
                 for t in self.body_rp_expr

--- a/graph_net/torch/rp_expr/rp_expr_parser.py
+++ b/graph_net/torch/rp_expr/rp_expr_parser.py
@@ -3,9 +3,7 @@ import numpy as np
 from graph_net.torch.rp_expr.rp_expr import Tokenize, PrimitiveId, LetsListTokenRpExpr
 from graph_net.torch.rp_expr.rp_expr_passes import (
     FlattenTokenListPass,
-    FoldTokensPass,
     RecursiveFoldTokensPass,
-    FoldIfTokenIdGreatEqualPass,
     UnflattenAndSubThresholdPass,
 )
 

--- a/graph_net/torch/rp_expr/rp_expr_passes.py
+++ b/graph_net/torch/rp_expr/rp_expr_passes.py
@@ -1,11 +1,8 @@
-from dataclasses import dataclass
 import typing as t
 import numpy as np
-import re
 import itertools
 import torch
 import torch.nn.functional as F
-import math
 from graph_net.torch.rp_expr.rp_expr import (
     TokenIdAllocator,
     NaiveTokenListRpExpr,
@@ -14,7 +11,6 @@ from graph_net.torch.rp_expr.rp_expr import (
     LetsTokenRpExpr,
     LetsListTokenRpExpr,
 )
-import itertools
 import sys
 
 
@@ -167,7 +163,7 @@ class FoldTokensPass(Pass):
         conv_weight = torch.cat(
             [GetWeight() for _ in range(self.random_feature_size)], dim=1
         )
-        conv = lambda input: F.conv1d(input, conv_weight, padding=0)
+        conv = lambda input: F.conv1d(input, conv_weight, padding=0)  # noqa: E731
         return conv, windows_size
 
     def GetDisjoint(self, gap, indexes):

--- a/graph_net/torch/rp_expr/rp_expr_util.py
+++ b/graph_net/torch/rp_expr/rp_expr_util.py
@@ -2,7 +2,6 @@ import typing as t
 from graph_net.torch.rp_expr.rp_expr import LetsListTokenRpExpr
 from graph_net.torch.rp_expr.nested_range import Range, Tree
 from collections import defaultdict
-from dataclasses import dataclass
 
 
 def MakeNestedIndexRangeFromLetsListTokenRpExpr(

--- a/graph_net/torch/shape_prop.py
+++ b/graph_net/torch/shape_prop.py
@@ -1,5 +1,4 @@
 import torch
-from typing import Union, Callable
 from torch.fx.passes.shape_prop import ShapeProp
 import inspect
 import os
@@ -33,4 +32,4 @@ class ShapePropModule(torch.nn.Module):
         inputs = [
             kwargs[name] for name in inspect.signature(self.module.forward).parameters
         ]
-        propagated_model = ShapeProp(traced_model).propagate(*inputs)
+        ShapeProp(traced_model).propagate(*inputs)

--- a/graph_net/torch/single_device_runner.py
+++ b/graph_net/torch/single_device_runner.py
@@ -1,12 +1,9 @@
 from . import utils
 import argparse
 import importlib.util
-import inspect
 import torch
 import logging
-from pathlib import Path
-from typing import Type, Any
-import sys
+from typing import Type
 from graph_net.torch.extractor import extract
 import hashlib
 import json

--- a/graph_net/torch/typical_sequence_split_points.py
+++ b/graph_net/torch/typical_sequence_split_points.py
@@ -1,17 +1,12 @@
 import argparse
 import json
-import os
 from pathlib import Path
-from typing import Any, Dict, List
-import torch
-import torch.nn as nn
+from typing import Dict, List
 
 from graph_net.torch.rp_expr.rp_expr_parser import RpExprParser
 from graph_net.torch.rp_expr.rp_expr_util import (
     MakeNestedIndexRangeFromLetsListTokenRpExpr,
 )
-from graph_net.torch.fx_graph_module_util import get_torch_module_and_inputs
-from graph_net.torch.fx_graph_parse_util import parse_sole_graph_module_without_varify
 
 
 class SplitAnalyzer:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,4 +34,7 @@ include = [
   "LICENSE",
 ]
 
-
+[tool.ruff.lint.per-file-ignores]
+# F821: numpy string annotations like np.ndarray["N", np.int64] trigger false positives
+"graph_net/torch/rp_expr/rp_expr.py" = ["F821"]
+"graph_net/torch/rp_expr/rp_expr_passes.py" = ["F821"]


### PR DESCRIPTION
### PR Category
<!-- One of [ New Sample | Feature Enhancement | Bug Fix | Other ] -->
Bug Fix

### Description
<!-- Describe what you’ve done -->
- Remove unused imports across paddle and torch modules
- Remove unused local variable assignments (F841)
- Fix explicit re-export in dim_gen_passes/__init__.py (F401)
- Add noqa comments for false-positive F821 in numpy string annotations
- Add noqa comment for E731 lambda assignment in rp_expr_passes.py
- Add ruff per-file-ignores in pyproject.toml for numpy type annotation F821

All pre-commit hooks (black, ruff-check, remove-crlf, remove-tabs) pass.