### PR TITLE
feat: Add Inductor backend configs

### DIFF
--- a/graph_net_bench/torch/backend/inductor_backend.py
+++ b/graph_net_bench/torch/backend/inductor_backend.py
@@ -3,13 +3,8 @@ import torch
 from .graph_compiler_backend import GraphCompilerBackend
 
 
-# Predefined Inductor config templates.
-# Each template maps to a set of torch._inductor.config overrides.
-# Reference: https://github.com/pytorch/pytorch/blob/main/torch/_inductor/config.py
-#
-# Note: These are extension to PyTorch's official "mode" concept.
-# PyTorch modes: "default", "reduce-overhead", "max-autotune", "max-autotune-no-cudagraphs"
-# These templates provide additional config combinations for specific use cases.
+# Predefined Inductor config templates for GraphNet.
+# Each template maps to a set of torch._inductor.config options.
 _INDUCTOR_CONFIG_TEMPLATES = {
     "triton": {
         # Default Triton code generation (Inductor's default behavior).
@@ -21,31 +16,16 @@ _INDUCTOR_CONFIG_TEMPLATES = {
         # Reference: torch._inductor.config.cpp_wrapper
         "cpp_wrapper": True,
     },
-    "cutlass": {
-        # Enable max-autotune to potentially use CUTLASS-based GEMM kernels.
-        # CUTLASS backend requires separate installation.
-        # Reference: torch._inductor.config.max_autotune_gemm_backends
-        "max_autotune": True,
-        "max_autotune_gemm": True,
-        "epilogue_fusion": True,
-        "coordinate_descent_tuning": True,
-    },
-    "aten": {
-        # Enable autotune fallback to ATen kernels for debugging.
-        # This causes Inductor to fall back to ATen (eager) kernels
-        # when autotuning finds them faster. Useful for debugging.
-        # Reference: torch._inductor.config.autotune_fallback_to_aten
-        "autotune_fallback_to_aten": True,
-    },
     "cudagraphs": {
         # Enable CUDA Graphs to reduce kernel launch overhead.
         # Reference: torch._inductor.config.triton.cudagraphs
-        # Note: Prefer using mode="reduce-overhead" for official support.
+        # NOTE: CUDA Graphs does not support dynamic shapes or graph breaks, so it is
+        # highly recommended to use only for inference with fixed input shapes.
+        # Prefer using mode="reduce-overhead" for official support.
         "triton.cudagraphs": True,
     },
     "max_autotune": {
         # Enable comprehensive autotuning across all backends.
-        # Equivalent to torch.compile(mode="max-autotune") with extra options.
         "max_autotune": True,
         "max_autotune_gemm": True,
         "coordinate_descent_tuning": True,
@@ -59,111 +39,88 @@ _INDUCTOR_CONFIG_TEMPLATES = {
     },
     "tma": {
         # Enable persistent matmul kernels with TMA (Tensor Memory Accelerator).
+        # Reference: torch._inductor.config.triton.enable_persistent_tma_matmul
         # NOTE: This config has graceful fallback behavior:
         #   - On NVIDIA H100+ (Hopper, CC >= 9.0): Enables TMA persistent kernels
         #   - On other GPUs (A100, AMD, etc.): Enables non-TMA persistent kernels as fallback
-        # Reference: torch._inductor.config.triton.enable_persistent_tma_matmul
         "triton.enable_persistent_tma_matmul": True,
     },
 }
-
-# Map template names to torch.compile mode strings where applicable.
-# Reference: https://pytorch.org/docs/stable/generated/torch.compile.html
-_TEMPLATE_TO_COMPILE_MODE = {
-    "cudagraphs": "reduce-overhead",
-    "max_autotune": "max-autotune",
-}
-
-
-def _set_nested_attr(config_module, key, value):
-    """Set a possibly nested attribute on a config module.
-
-    For example, key="triton.cudagraphs" sets config_module.triton.cudagraphs = value.
-    """
-    parts = key.split(".")
-    obj = config_module
-    for part in parts[:-1]:
-        obj = getattr(obj, part)
-    setattr(obj, parts[-1], value)
 
 
 class InductorBackend(GraphCompilerBackend):
     """Inductor backend with configurable config template selection.
 
     Supported config keys:
-        template (str): One of "triton", "cpp_wrapper", "cutlass", "aten",
+        fullgraph (bool): Whether to compile the entire model into a single graph.
+            Defaults to False. Passed to torch.compile.
+        dynamic (bool | None): Whether to enable dynamic shape support.
+            Defaults to None. Passed to torch.compile.
+        graph_net_inductor_config_template (str): One of "triton", "cpp_wrapper",
             "cudagraphs", "max_autotune", "freezing", "tma".
-            Applies a predefined set of Inductor config overrides.
-            Note: These are extensions to PyTorch's official "mode" concept.
+            GraphNet predefined Inductor config templates.
         mode (str): torch.compile mode. One of "default", "reduce-overhead",
-            "max-autotune", "max-autotune-no-cudagraphs".
-            If a template implies a mode, that is used unless explicitly overridden.
-        freezing (bool): Enable/disable model freezing before compilation.
-        inductor_config (dict): Arbitrary torch._inductor.config overrides.
-            Keys can be dotted paths (e.g. "triton.cudagraphs").
-            These are applied last and override everything else.
+            "max-autotune". Passed directly to torch.compile.
+        options (dict): Direct torch.compile options dict.
+
+        NOTE: `torch.compile` does not allow `mode` and `options` to be specified together.
+        Therefore `graph_net_inductor_config_template` (which provides `options`),
+        `mode` and `options` are mutually exclusive with each other.
 
     Reference:
-        - PyTorch modes: https://pytorch.org/docs/stable/generated/torch.compile.html
+        - PyTorch compile: https://pytorch.org/docs/stable/generated/torch.compile.html
         - Inductor configs: https://github.com/pytorch/pytorch/blob/main/torch/_inductor/config.py
     """
 
     def __init__(self, config):
         super().__init__(config)
-        self._template = config.get("template", None)
-        self._mode = config.get("mode", None)
-        self._freezing = config.get("freezing", None)
-        self._inductor_config = config.get("inductor_config", {})
+        self._config_template = config.get("graph_net_inductor_config_template")
+        self._mode = config.get("mode")
+        self._fullgraph = config.get("fullgraph", False)
+        self._dynamic = config.get("dynamic")
+        self._options = config.get("options")
 
-    def _build_inductor_overrides(self):
-        """Collect all Inductor config overrides from template + explicit config."""
-        overrides = {}
+        # Mutually exclusive: exactly one of template / mode / options can be specified
+        provided = [self._config_template, self._mode, self._options]
+        if sum(1 for x in provided if x is not None) > 1:
+            raise ValueError(
+                "Specify exactly one of 'graph_net_inductor_config_template', "
+                "'mode', or 'options', not multiple."
+            )
 
-        # 1. Apply template defaults
-        if self._template is not None:
-            if self._template not in _INDUCTOR_CONFIG_TEMPLATES:
+    def _build_options(self):
+        if self._options:
+            return self._options
+
+        if self._config_template:
+            if self._config_template not in _INDUCTOR_CONFIG_TEMPLATES:
                 raise ValueError(
-                    f"Unknown Inductor config template: {self._template!r}. "
-                    f"Available templates: {sorted(_INDUCTOR_CONFIG_TEMPLATES.keys())}"
+                    f"Unknown config template: {self._config_template!r}. "
+                    f"Available: {sorted(_INDUCTOR_CONFIG_TEMPLATES.keys())}"
                 )
-            overrides.update(_INDUCTOR_CONFIG_TEMPLATES[self._template])
+            return _INDUCTOR_CONFIG_TEMPLATES[self._config_template]
 
-        # 2. Apply top-level convenience flags
-        if self._freezing is not None:
-            overrides["freezing"] = self._freezing
-
-        # 3. Apply explicit inductor_config overrides (highest priority)
-        overrides.update(self._inductor_config)
-
-        return overrides
-
-    def _resolve_compile_mode(self):
-        """Determine the torch.compile mode string."""
-        if self._mode is not None:
-            return self._mode
-        if self._template in _TEMPLATE_TO_COMPILE_MODE:
-            return _TEMPLATE_TO_COMPILE_MODE[self._template]
-        return "default"
+        return {}
 
     def __call__(self, model):
-        import torch._inductor.config as inductor_config
+        final_options = self._build_options()
 
-        overrides = self._build_inductor_overrides()
-        compile_mode = self._resolve_compile_mode()
-
-        if self._template or self._inductor_config:
+        if self._config_template is not None or self._options is not None:
             print(
-                f"[InductorBackend] template={self._template!r}, mode={compile_mode!r}, "
-                f"overrides={overrides}",
+                f"[InductorBackend] graph_net_inductor_config_template={self._config_template!r}, "
+                f"mode={self._mode!r}, options={final_options}",
                 file=sys.stderr,
                 flush=True,
             )
 
-        # Apply Inductor config overrides
-        for key, value in overrides.items():
-            _set_nested_attr(inductor_config, key, value)
-
-        return torch.compile(model, backend="inductor", mode=compile_mode)
+        return torch.compile(
+            model,
+            backend="inductor",
+            fullgraph=self._fullgraph,
+            dynamic=self._dynamic,
+            **({"mode": self._mode} if self._mode is not None else {}),
+            **({"options": final_options} if final_options else {}),
+        )
 
     def synchronize(self):
         if torch.cuda.is_available():

--- a/graph_net_bench/torch/backend/inductor_backend.py
+++ b/graph_net_bench/torch/backend/inductor_backend.py
@@ -1,13 +1,169 @@
+import sys
 import torch
 from .graph_compiler_backend import GraphCompilerBackend
 
 
+# Predefined Inductor config templates.
+# Each template maps to a set of torch._inductor.config overrides.
+# Reference: https://github.com/pytorch/pytorch/blob/main/torch/_inductor/config.py
+#
+# Note: These are extension to PyTorch's official "mode" concept.
+# PyTorch modes: "default", "reduce-overhead", "max-autotune", "max-autotune-no-cudagraphs"
+# These templates provide additional config combinations for specific use cases.
+_INDUCTOR_CONFIG_TEMPLATES = {
+    "triton": {
+        # Default Triton code generation (Inductor's default behavior).
+        # Explicitly disable cpp_wrapper to ensure Triton backend.
+        "cpp_wrapper": False,
+    },
+    "cpp_wrapper": {
+        # Use C++ wrapper for generated kernels instead of Python wrapper.
+        # Reference: torch._inductor.config.cpp_wrapper
+        "cpp_wrapper": True,
+    },
+    "cutlass": {
+        # Enable max-autotune to potentially use CUTLASS-based GEMM kernels.
+        # CUTLASS backend requires separate installation.
+        # Reference: torch._inductor.config.max_autotune_gemm_backends
+        "max_autotune": True,
+        "max_autotune_gemm": True,
+        "epilogue_fusion": True,
+        "coordinate_descent_tuning": True,
+    },
+    "aten": {
+        # Enable autotune fallback to ATen kernels for debugging.
+        # This causes Inductor to fall back to ATen (eager) kernels
+        # when autotuning finds them faster. Useful for debugging.
+        # Reference: torch._inductor.config.autotune_fallback_to_aten
+        "autotune_fallback_to_aten": True,
+    },
+    "cudagraphs": {
+        # Enable CUDA Graphs to reduce kernel launch overhead.
+        # Reference: torch._inductor.config.triton.cudagraphs
+        # Note: Prefer using mode="reduce-overhead" for official support.
+        "triton.cudagraphs": True,
+    },
+    "max_autotune": {
+        # Enable comprehensive autotuning across all backends.
+        # Equivalent to torch.compile(mode="max-autotune") with extra options.
+        "max_autotune": True,
+        "max_autotune_gemm": True,
+        "coordinate_descent_tuning": True,
+        "epilogue_fusion": True,
+    },
+    "freezing": {
+        # Enable model freezing to inline weights as constants.
+        # After freezing, weights can no longer be updated.
+        # Reference: torch._inductor.config.freezing
+        "freezing": True,
+    },
+    "tma": {
+        # Enable persistent matmul kernels with TMA (Tensor Memory Accelerator).
+        # NOTE: This config has graceful fallback behavior:
+        #   - On NVIDIA H100+ (Hopper, CC >= 9.0): Enables TMA persistent kernels
+        #   - On other GPUs (A100, AMD, etc.): Enables non-TMA persistent kernels as fallback
+        # Reference: torch._inductor.config.triton.enable_persistent_tma_matmul
+        "triton.enable_persistent_tma_matmul": True,
+    },
+}
+
+# Map template names to torch.compile mode strings where applicable.
+# Reference: https://pytorch.org/docs/stable/generated/torch.compile.html
+_TEMPLATE_TO_COMPILE_MODE = {
+    "cudagraphs": "reduce-overhead",
+    "max_autotune": "max-autotune",
+}
+
+
+def _set_nested_attr(config_module, key, value):
+    """Set a possibly nested attribute on a config module.
+
+    For example, key="triton.cudagraphs" sets config_module.triton.cudagraphs = value.
+    """
+    parts = key.split(".")
+    obj = config_module
+    for part in parts[:-1]:
+        obj = getattr(obj, part)
+    setattr(obj, parts[-1], value)
+
+
 class InductorBackend(GraphCompilerBackend):
+    """Inductor backend with configurable config template selection.
+
+    Supported config keys:
+        template (str): One of "triton", "cpp_wrapper", "cutlass", "aten",
+            "cudagraphs", "max_autotune", "freezing", "tma".
+            Applies a predefined set of Inductor config overrides.
+            Note: These are extensions to PyTorch's official "mode" concept.
+        mode (str): torch.compile mode. One of "default", "reduce-overhead",
+            "max-autotune", "max-autotune-no-cudagraphs".
+            If a template implies a mode, that is used unless explicitly overridden.
+        freezing (bool): Enable/disable model freezing before compilation.
+        inductor_config (dict): Arbitrary torch._inductor.config overrides.
+            Keys can be dotted paths (e.g. "triton.cudagraphs").
+            These are applied last and override everything else.
+
+    Reference:
+        - PyTorch modes: https://pytorch.org/docs/stable/generated/torch.compile.html
+        - Inductor configs: https://github.com/pytorch/pytorch/blob/main/torch/_inductor/config.py
+    """
+
     def __init__(self, config):
         super().__init__(config)
+        self._template = config.get("template", None)
+        self._mode = config.get("mode", None)
+        self._freezing = config.get("freezing", None)
+        self._inductor_config = config.get("inductor_config", {})
+
+    def _build_inductor_overrides(self):
+        """Collect all Inductor config overrides from template + explicit config."""
+        overrides = {}
+
+        # 1. Apply template defaults
+        if self._template is not None:
+            if self._template not in _INDUCTOR_CONFIG_TEMPLATES:
+                raise ValueError(
+                    f"Unknown Inductor config template: {self._template!r}. "
+                    f"Available templates: {sorted(_INDUCTOR_CONFIG_TEMPLATES.keys())}"
+                )
+            overrides.update(_INDUCTOR_CONFIG_TEMPLATES[self._template])
+
+        # 2. Apply top-level convenience flags
+        if self._freezing is not None:
+            overrides["freezing"] = self._freezing
+
+        # 3. Apply explicit inductor_config overrides (highest priority)
+        overrides.update(self._inductor_config)
+
+        return overrides
+
+    def _resolve_compile_mode(self):
+        """Determine the torch.compile mode string."""
+        if self._mode is not None:
+            return self._mode
+        if self._template in _TEMPLATE_TO_COMPILE_MODE:
+            return _TEMPLATE_TO_COMPILE_MODE[self._template]
+        return "default"
 
     def __call__(self, model):
-        return torch.compile(model, backend="inductor")
+        import torch._inductor.config as inductor_config
+
+        overrides = self._build_inductor_overrides()
+        compile_mode = self._resolve_compile_mode()
+
+        if self._template or self._inductor_config:
+            print(
+                f"[InductorBackend] template={self._template!r}, mode={compile_mode!r}, "
+                f"overrides={overrides}",
+                file=sys.stderr,
+                flush=True,
+            )
+
+        # Apply Inductor config overrides
+        for key, value in overrides.items():
+            _set_nested_attr(inductor_config, key, value)
+
+        return torch.compile(model, backend="inductor", mode=compile_mode)
 
     def synchronize(self):
         if torch.cuda.is_available():

--- a/graph_net_bench/torch/test_compiler.py
+++ b/graph_net_bench/torch/test_compiler.py
@@ -145,6 +145,12 @@ def measure_performance(model_call, args, compiler):
     stats = {}
     outs = model_call()
 
+    # Clone outputs to prevent CUDA Graphs buffer overwrite issues.
+    if isinstance(outs, torch.Tensor):
+        outs = outs.clone()
+    elif isinstance(outs, tuple):
+        outs = tuple(t.clone() if isinstance(t, torch.Tensor) else t for t in outs)
+
     # Warmup runs
     for _ in range(args.warmup):
         model_call()

--- a/test/inductor_backend_test.py
+++ b/test/inductor_backend_test.py
@@ -1,9 +1,10 @@
 """
 Unit tests for InductorBackend config templates.
 
-Tests verify that all config templates are valid and produce expected overrides.
+Tests verify that all config templates are valid and produce expected options.
 Uses relative paths to access the backend module.
 """
+
 import sys
 import unittest
 from pathlib import Path
@@ -23,7 +24,6 @@ except ImportError:
 
 from graph_net_bench.torch.backend.inductor_backend import (  # noqa: E402 - Import after try/except is intentional
     _INDUCTOR_CONFIG_TEMPLATES,
-    _TEMPLATE_TO_COMPILE_MODE,
     InductorBackend,
 )
 
@@ -36,8 +36,6 @@ class TestInductorBackendTemplates(unittest.TestCase):
         expected_templates = {
             "triton",
             "cpp_wrapper",
-            "cutlass",
-            "aten",
             "cudagraphs",
             "max_autotune",
             "freezing",
@@ -52,65 +50,34 @@ class TestInductorBackendTemplates(unittest.TestCase):
 
     def test_triton_template(self):
         """Test triton template configuration."""
-        backend = InductorBackend({"template": "triton"})
-        overrides = backend._build_inductor_overrides()
-        mode = backend._resolve_compile_mode()
+        backend = InductorBackend({"graph_net_inductor_config_template": "triton"})
+        options = backend._build_options()
 
-        self.assertEqual(overrides, {"cpp_wrapper": False})
-        self.assertEqual(mode, "default")
+        self.assertEqual(options, {"cpp_wrapper": False})
 
     def test_cpp_wrapper_template(self):
         """Test cpp_wrapper template configuration."""
-        backend = InductorBackend({"template": "cpp_wrapper"})
-        overrides = backend._build_inductor_overrides()
-        mode = backend._resolve_compile_mode()
+        backend = InductorBackend({"graph_net_inductor_config_template": "cpp_wrapper"})
+        options = backend._build_options()
 
-        self.assertEqual(overrides, {"cpp_wrapper": True})
-        self.assertEqual(mode, "default")
-
-    def test_cutlass_template(self):
-        """Test cutlass template configuration."""
-        backend = InductorBackend({"template": "cutlass"})
-        overrides = backend._build_inductor_overrides()
-        mode = backend._resolve_compile_mode()
-
-        self.assertEqual(
-            overrides,
-            {
-                "max_autotune": True,
-                "max_autotune_gemm": True,
-                "epilogue_fusion": True,
-                "coordinate_descent_tuning": True,
-            },
-        )
-        self.assertEqual(mode, "default")
-
-    def test_aten_template(self):
-        """Test aten template configuration."""
-        backend = InductorBackend({"template": "aten"})
-        overrides = backend._build_inductor_overrides()
-        mode = backend._resolve_compile_mode()
-
-        self.assertEqual(overrides, {"autotune_fallback_to_aten": True})
-        self.assertEqual(mode, "default")
+        self.assertEqual(options, {"cpp_wrapper": True})
 
     def test_cudagraphs_template(self):
         """Test cudagraphs template configuration."""
-        backend = InductorBackend({"template": "cudagraphs"})
-        overrides = backend._build_inductor_overrides()
-        mode = backend._resolve_compile_mode()
+        backend = InductorBackend({"graph_net_inductor_config_template": "cudagraphs"})
+        options = backend._build_options()
 
-        self.assertEqual(overrides, {"triton.cudagraphs": True})
-        self.assertEqual(mode, "reduce-overhead")
+        self.assertEqual(options, {"triton.cudagraphs": True})
 
     def test_max_autotune_template(self):
         """Test max_autotune template configuration."""
-        backend = InductorBackend({"template": "max_autotune"})
-        overrides = backend._build_inductor_overrides()
-        mode = backend._resolve_compile_mode()
+        backend = InductorBackend(
+            {"graph_net_inductor_config_template": "max_autotune"}
+        )
+        options = backend._build_options()
 
         self.assertEqual(
-            overrides,
+            options,
             {
                 "max_autotune": True,
                 "max_autotune_gemm": True,
@@ -118,96 +85,135 @@ class TestInductorBackendTemplates(unittest.TestCase):
                 "epilogue_fusion": True,
             },
         )
-        self.assertEqual(mode, "max-autotune")
 
     def test_freezing_template(self):
         """Test freezing template configuration."""
-        backend = InductorBackend({"template": "freezing"})
-        overrides = backend._build_inductor_overrides()
-        mode = backend._resolve_compile_mode()
+        backend = InductorBackend({"graph_net_inductor_config_template": "freezing"})
+        options = backend._build_options()
 
-        self.assertEqual(overrides, {"freezing": True})
-        self.assertEqual(mode, "default")
+        self.assertEqual(options, {"freezing": True})
 
     def test_tma_template(self):
         """Test TMA template configuration.
 
-        Note: This test verifies the config is accepted. On GPUs without
+        Note: This test verifies that config is accepted. On GPUs without
         TMA support (e.g., A100), Inductor will gracefully fall back
         to non-TMA persistent kernels. The config itself is valid regardless
-        of the underlying hardware.
+        of underlying hardware.
         """
-        backend = InductorBackend({"template": "tma"})
-        overrides = backend._build_inductor_overrides()
-        mode = backend._resolve_compile_mode()
+        backend = InductorBackend({"graph_net_inductor_config_template": "tma"})
+        options = backend._build_options()
 
-        self.assertEqual(overrides, {"triton.enable_persistent_tma_matmul": True})
-        self.assertEqual(mode, "default")
+        self.assertEqual(options, {"triton.enable_persistent_tma_matmul": True})
 
-    def test_mode_override(self):
-        """Test explicit mode override."""
-        backend = InductorBackend({"template": "cudagraphs", "mode": "max-autotune"})
-        mode = backend._resolve_compile_mode()
+    def test_options_only(self):
+        """Test options alone."""
+        backend = InductorBackend({"options": {"triton.cudagraphs": True}})
+        options = backend._build_options()
 
-        # Explicit mode should take precedence
-        self.assertEqual(mode, "max-autotune")
-
-    def test_freezing_override(self):
-        """Test explicit freezing override."""
-        backend = InductorBackend({"template": "max_autotune", "freezing": False})
-        overrides = backend._build_inductor_overrides()
-
-        # Freezing should override template defaults
-        self.assertIn("freezing", overrides)
-        self.assertEqual(overrides["freezing"], False)
-        self.assertIn("max_autotune", overrides)
-
-    def test_inductor_config_override(self):
-        """Test inductor_config overrides take highest priority."""
-        backend = InductorBackend(
-            {
-                "template": "triton",
-                "inductor_config": {"cpp_wrapper": True, "triton.cudagraphs": True},
-            }
-        )
-        overrides = backend._build_inductor_overrides()
-
-        # inductor_config overrides should be applied
-        self.assertIn("cpp_wrapper", overrides)
-        self.assertIn("triton.cudagraphs", overrides)
+        self.assertEqual(options, {"triton.cudagraphs": True})
 
     def test_invalid_template_raises_error(self):
         """Test invalid template raises ValueError."""
         with self.assertRaises(ValueError) as context:
-            backend = InductorBackend({"template": "invalid_template"})
-            backend._build_inductor_overrides()
+            backend = InductorBackend(
+                {"graph_net_inductor_config_template": "invalid_template"}
+            )
+            backend._build_options()
 
-        self.assertIn("Unknown Inductor config template", str(context.exception))
+        self.assertIn("Unknown config template", str(context.exception))
         self.assertIn("invalid_template", str(context.exception))
 
-    def test_empty_config(self):
-        """Test empty config produces no overrides."""
-        backend = InductorBackend({})
-        overrides = backend._build_inductor_overrides()
-        mode = backend._resolve_compile_mode()
-
-        self.assertEqual(overrides, {})
-        self.assertEqual(mode, "default")
-
-    def test_template_to_mode_mapping(self):
-        """Test template to mode mapping."""
-        self.assertEqual(
-            _TEMPLATE_TO_COMPILE_MODE,
+    def test_mutually_exclusive_params(self):
+        """Test that template/mode/options are mutually exclusive."""
+        configs = [
             {
-                "cudagraphs": "reduce-overhead",
-                "max_autotune": "max-autotune",
+                "graph_net_inductor_config_template": "triton",
+                "mode": "reduce-overhead",
             },
-        )
+            {
+                "graph_net_inductor_config_template": "triton",
+                "options": {"triton.cudagraphs": True},
+            },
+            {
+                "mode": "reduce-overhead",
+                "options": {"triton.cudagraphs": True},
+            },
+            {
+                "graph_net_inductor_config_template": "triton",
+                "mode": "reduce-overhead",
+                "options": {"triton.cudagraphs": True},
+            },
+        ]
+
+        for config in configs:
+            with self.assertRaises(ValueError) as context:
+                InductorBackend(config)
+
+            self.assertIn("exactly one", str(context.exception))
+
+    def test_empty_config(self):
+        """Test empty config produces no options."""
+        backend = InductorBackend({})
+        options = backend._build_options()
+
+        self.assertEqual(options, {})
+
+
+class TestInductorBackendParameters(unittest.TestCase):
+    """Test InductorBackend torch.compile parameters."""
+
+    def test_fullgraph_parameter(self):
+        """Test fullgraph parameter is stored."""
+        backend = InductorBackend({"fullgraph": True})
+        self.assertTrue(backend._fullgraph)
+
+        backend = InductorBackend({})
+        self.assertFalse(backend._fullgraph)
+
+    def test_dynamic_parameter(self):
+        """Test dynamic parameter is stored."""
+        backend = InductorBackend({"dynamic": True})
+        self.assertTrue(backend._dynamic)
+
+        backend = InductorBackend({"dynamic": False})
+        self.assertFalse(backend._dynamic)
+
+        backend = InductorBackend({})
+        self.assertIsNone(backend._dynamic)
+
+    def test_mode_parameter(self):
+        """Test mode parameter is stored."""
+        backend = InductorBackend({"mode": "max-autotune"})
+        self.assertEqual(backend._mode, "max-autotune")
+
+        backend = InductorBackend({})
+        self.assertIsNone(backend._mode)
+
+    def test_options_parameter(self):
+        """Test options parameter is stored."""
+        options = {"triton.cudagraphs": True, "max_autotune": True}
+        backend = InductorBackend({"options": options})
+        self.assertEqual(backend._options, options)
+
+    def test_all_compatible_parameters_combined(self):
+        """Test all torch.compile parameters can be combined when compatible."""
+        config = {
+            "graph_net_inductor_config_template": "max_autotune",
+            "fullgraph": True,
+            "dynamic": True,
+        }
+        backend = InductorBackend(config)
+
+        self.assertEqual(backend._config_template, "max_autotune")
+        self.assertIsNone(backend._mode)
+        self.assertTrue(backend._fullgraph)
+        self.assertTrue(backend._dynamic)
 
 
 @unittest.skipIf(not TORCH_AVAILABLE, "PyTorch not available")
 class TestInductorConfigValidation(unittest.TestCase):
-    """Test that all config overrides reference valid torch._inductor.config attributes."""
+    """Test that all config options reference valid torch._inductor.config attributes."""
 
     def _check_config_key_exists(self, key):
         """Check if a config key (possibly nested) exists in torch._inductor.config."""
@@ -250,10 +256,6 @@ class TestInductorConfigValidation(unittest.TestCase):
             self._check_config_key_exists("triton.enable_persistent_tma_matmul")
         )
 
-    def test_autotune_fallback_to_aten_config_exists(self):
-        """Test autotune_fallback_to_aten config exists."""
-        self.assertTrue(self._check_config_key_exists("autotune_fallback_to_aten"))
-
     def test_triton_cudagraphs_config_exists(self):
         """Test triton.cudagraphs config exists."""
         self.assertTrue(self._check_config_key_exists("triton.cudagraphs"))
@@ -269,33 +271,6 @@ class TestInductorConfigValidation(unittest.TestCase):
         if missing_configs:
             self.fail(f"Missing config keys: {missing_configs}")
 
-    @unittest.skipIf(not TORCH_AVAILABLE, "PyTorch not available")
-    def test_tma_fallback_on_non_tma_gpu(self):
-        """Test TMA config gracefully falls back on non-TMA GPUs.
-
-        This verifies that even on GPUs without TMA support (like A100),
-        the TMA config doesn't cause errors - it just falls back to
-        non-TMA persistent kernels.
-        """
-        backend = InductorBackend({"template": "tma"})
-
-        # On non-TMA GPUs, this should not raise an error
-        # (Inductor handles the fallback internally)
-        try:
-            import torch._inductor.config as cfg
-            from graph_net_bench.torch.backend.inductor_backend import _set_nested_attr
-
-            # This is what __call__ does - should not fail
-            for key, value in backend._build_inductor_overrides().items():
-                _set_nested_attr(cfg, key, value)
-
-            # If we get here, config was accepted successfully
-            # (regardless of actual TMA support on the GPU)
-            self.assertTrue(True)
-        except Exception as e:
-            # Should not fail even on non-TMA GPU
-            self.fail(f"TMA config should be accepted on non-TMA GPU: {e}")
-
 
 class TestInductorBackendIntegration(unittest.TestCase):
     """Integration tests for InductorBackend."""
@@ -304,32 +279,15 @@ class TestInductorBackendIntegration(unittest.TestCase):
         """Test backend can be initialized with various configs."""
         configs = [
             {},
-            {"template": "triton"},
-            {"template": "max_autotune", "mode": "default"},
-            {"template": "cudagraphs", "freezing": True},
+            {"graph_net_inductor_config_template": "triton"},
+            {"mode": "max-autotune"},
+            {"options": {"max_autotune": True}, "fullgraph": True},
+            {"fullgraph": True, "dynamic": True},
         ]
 
         for config in configs:
             backend = InductorBackend(config)
             self.assertIsNotNone(backend)
-
-    def test_build_overrides_priority(self):
-        """Test override priority: template < freezing < inductor_config."""
-        backend = InductorBackend(
-            {
-                "template": "freezing",
-                "freezing": False,
-                "inductor_config": {
-                    "freezing": True,
-                    "max_autotune": True,
-                },
-            }
-        )
-        overrides = backend._build_inductor_overrides()
-
-        # inductor_config has highest priority
-        self.assertTrue(overrides["freezing"])
-        self.assertTrue(overrides["max_autotune"])
 
 
 if __name__ == "__main__":

--- a/test/inductor_backend_test.py
+++ b/test/inductor_backend_test.py
@@ -1,0 +1,336 @@
+"""
+Unit tests for InductorBackend config templates.
+
+Tests verify that all config templates are valid and produce expected overrides.
+Uses relative paths to access the backend module.
+"""
+import sys
+import unittest
+from pathlib import Path
+
+# Add parent directory to path for imports
+test_dir = Path(__file__).parent
+project_root = test_dir.parent
+sys.path.insert(0, str(project_root))
+
+try:
+    import torch  # noqa: F401 - Used in @unittest.skipIf decorator
+    import torch._inductor.config as inductor_config
+
+    TORCH_AVAILABLE = True
+except ImportError:
+    TORCH_AVAILABLE = False
+
+from graph_net_bench.torch.backend.inductor_backend import (  # noqa: E402 - Import after try/except is intentional
+    _INDUCTOR_CONFIG_TEMPLATES,
+    _TEMPLATE_TO_COMPILE_MODE,
+    InductorBackend,
+)
+
+
+class TestInductorBackendTemplates(unittest.TestCase):
+    """Test InductorBackend config templates."""
+
+    def test_all_templates_exist(self):
+        """Verify all expected templates are defined."""
+        expected_templates = {
+            "triton",
+            "cpp_wrapper",
+            "cutlass",
+            "aten",
+            "cudagraphs",
+            "max_autotune",
+            "freezing",
+            "tma",
+        }
+        actual_templates = set(_INDUCTOR_CONFIG_TEMPLATES.keys())
+        self.assertEqual(
+            expected_templates,
+            actual_templates,
+            f"Expected templates {expected_templates}, got {actual_templates}",
+        )
+
+    def test_triton_template(self):
+        """Test triton template configuration."""
+        backend = InductorBackend({"template": "triton"})
+        overrides = backend._build_inductor_overrides()
+        mode = backend._resolve_compile_mode()
+
+        self.assertEqual(overrides, {"cpp_wrapper": False})
+        self.assertEqual(mode, "default")
+
+    def test_cpp_wrapper_template(self):
+        """Test cpp_wrapper template configuration."""
+        backend = InductorBackend({"template": "cpp_wrapper"})
+        overrides = backend._build_inductor_overrides()
+        mode = backend._resolve_compile_mode()
+
+        self.assertEqual(overrides, {"cpp_wrapper": True})
+        self.assertEqual(mode, "default")
+
+    def test_cutlass_template(self):
+        """Test cutlass template configuration."""
+        backend = InductorBackend({"template": "cutlass"})
+        overrides = backend._build_inductor_overrides()
+        mode = backend._resolve_compile_mode()
+
+        self.assertEqual(
+            overrides,
+            {
+                "max_autotune": True,
+                "max_autotune_gemm": True,
+                "epilogue_fusion": True,
+                "coordinate_descent_tuning": True,
+            },
+        )
+        self.assertEqual(mode, "default")
+
+    def test_aten_template(self):
+        """Test aten template configuration."""
+        backend = InductorBackend({"template": "aten"})
+        overrides = backend._build_inductor_overrides()
+        mode = backend._resolve_compile_mode()
+
+        self.assertEqual(overrides, {"autotune_fallback_to_aten": True})
+        self.assertEqual(mode, "default")
+
+    def test_cudagraphs_template(self):
+        """Test cudagraphs template configuration."""
+        backend = InductorBackend({"template": "cudagraphs"})
+        overrides = backend._build_inductor_overrides()
+        mode = backend._resolve_compile_mode()
+
+        self.assertEqual(overrides, {"triton.cudagraphs": True})
+        self.assertEqual(mode, "reduce-overhead")
+
+    def test_max_autotune_template(self):
+        """Test max_autotune template configuration."""
+        backend = InductorBackend({"template": "max_autotune"})
+        overrides = backend._build_inductor_overrides()
+        mode = backend._resolve_compile_mode()
+
+        self.assertEqual(
+            overrides,
+            {
+                "max_autotune": True,
+                "max_autotune_gemm": True,
+                "coordinate_descent_tuning": True,
+                "epilogue_fusion": True,
+            },
+        )
+        self.assertEqual(mode, "max-autotune")
+
+    def test_freezing_template(self):
+        """Test freezing template configuration."""
+        backend = InductorBackend({"template": "freezing"})
+        overrides = backend._build_inductor_overrides()
+        mode = backend._resolve_compile_mode()
+
+        self.assertEqual(overrides, {"freezing": True})
+        self.assertEqual(mode, "default")
+
+    def test_tma_template(self):
+        """Test TMA template configuration.
+
+        Note: This test verifies the config is accepted. On GPUs without
+        TMA support (e.g., A100), Inductor will gracefully fall back
+        to non-TMA persistent kernels. The config itself is valid regardless
+        of the underlying hardware.
+        """
+        backend = InductorBackend({"template": "tma"})
+        overrides = backend._build_inductor_overrides()
+        mode = backend._resolve_compile_mode()
+
+        self.assertEqual(overrides, {"triton.enable_persistent_tma_matmul": True})
+        self.assertEqual(mode, "default")
+
+    def test_mode_override(self):
+        """Test explicit mode override."""
+        backend = InductorBackend({"template": "cudagraphs", "mode": "max-autotune"})
+        mode = backend._resolve_compile_mode()
+
+        # Explicit mode should take precedence
+        self.assertEqual(mode, "max-autotune")
+
+    def test_freezing_override(self):
+        """Test explicit freezing override."""
+        backend = InductorBackend({"template": "max_autotune", "freezing": False})
+        overrides = backend._build_inductor_overrides()
+
+        # Freezing should override template defaults
+        self.assertIn("freezing", overrides)
+        self.assertEqual(overrides["freezing"], False)
+        self.assertIn("max_autotune", overrides)
+
+    def test_inductor_config_override(self):
+        """Test inductor_config overrides take highest priority."""
+        backend = InductorBackend(
+            {
+                "template": "triton",
+                "inductor_config": {"cpp_wrapper": True, "triton.cudagraphs": True},
+            }
+        )
+        overrides = backend._build_inductor_overrides()
+
+        # inductor_config overrides should be applied
+        self.assertIn("cpp_wrapper", overrides)
+        self.assertIn("triton.cudagraphs", overrides)
+
+    def test_invalid_template_raises_error(self):
+        """Test invalid template raises ValueError."""
+        with self.assertRaises(ValueError) as context:
+            backend = InductorBackend({"template": "invalid_template"})
+            backend._build_inductor_overrides()
+
+        self.assertIn("Unknown Inductor config template", str(context.exception))
+        self.assertIn("invalid_template", str(context.exception))
+
+    def test_empty_config(self):
+        """Test empty config produces no overrides."""
+        backend = InductorBackend({})
+        overrides = backend._build_inductor_overrides()
+        mode = backend._resolve_compile_mode()
+
+        self.assertEqual(overrides, {})
+        self.assertEqual(mode, "default")
+
+    def test_template_to_mode_mapping(self):
+        """Test template to mode mapping."""
+        self.assertEqual(
+            _TEMPLATE_TO_COMPILE_MODE,
+            {
+                "cudagraphs": "reduce-overhead",
+                "max_autotune": "max-autotune",
+            },
+        )
+
+
+@unittest.skipIf(not TORCH_AVAILABLE, "PyTorch not available")
+class TestInductorConfigValidation(unittest.TestCase):
+    """Test that all config overrides reference valid torch._inductor.config attributes."""
+
+    def _check_config_key_exists(self, key):
+        """Check if a config key (possibly nested) exists in torch._inductor.config."""
+        parts = key.split(".")
+        obj = inductor_config
+        try:
+            for part in parts:
+                obj = getattr(obj, part)
+            return True
+        except AttributeError:
+            return False
+
+    def test_cpp_wrapper_config_exists(self):
+        """Test cpp_wrapper config exists."""
+        self.assertTrue(self._check_config_key_exists("cpp_wrapper"))
+
+    def test_max_autotune_config_exists(self):
+        """Test max_autotune config exists."""
+        self.assertTrue(self._check_config_key_exists("max_autotune"))
+
+    def test_max_autotune_gemm_config_exists(self):
+        """Test max_autotune_gemm config exists."""
+        self.assertTrue(self._check_config_key_exists("max_autotune_gemm"))
+
+    def test_epilogue_fusion_config_exists(self):
+        """Test epilogue_fusion config exists."""
+        self.assertTrue(self._check_config_key_exists("epilogue_fusion"))
+
+    def test_coordinate_descent_tuning_config_exists(self):
+        """Test coordinate_descent_tuning config exists."""
+        self.assertTrue(self._check_config_key_exists("coordinate_descent_tuning"))
+
+    def test_freezing_config_exists(self):
+        """Test freezing config exists."""
+        self.assertTrue(self._check_config_key_exists("freezing"))
+
+    def test_enable_persistent_tma_matmul_config_exists(self):
+        """Test triton.enable_persistent_tma_matmul config exists."""
+        self.assertTrue(
+            self._check_config_key_exists("triton.enable_persistent_tma_matmul")
+        )
+
+    def test_autotune_fallback_to_aten_config_exists(self):
+        """Test autotune_fallback_to_aten config exists."""
+        self.assertTrue(self._check_config_key_exists("autotune_fallback_to_aten"))
+
+    def test_triton_cudagraphs_config_exists(self):
+        """Test triton.cudagraphs config exists."""
+        self.assertTrue(self._check_config_key_exists("triton.cudagraphs"))
+
+    def test_all_template_configs_exist(self):
+        """Test all configs from templates exist in torch._inductor.config."""
+        missing_configs = []
+        for template_name, template_config in _INDUCTOR_CONFIG_TEMPLATES.items():
+            for key in template_config.keys():
+                if not self._check_config_key_exists(key):
+                    missing_configs.append(f"{template_name}.{key}")
+
+        if missing_configs:
+            self.fail(f"Missing config keys: {missing_configs}")
+
+    @unittest.skipIf(not TORCH_AVAILABLE, "PyTorch not available")
+    def test_tma_fallback_on_non_tma_gpu(self):
+        """Test TMA config gracefully falls back on non-TMA GPUs.
+
+        This verifies that even on GPUs without TMA support (like A100),
+        the TMA config doesn't cause errors - it just falls back to
+        non-TMA persistent kernels.
+        """
+        backend = InductorBackend({"template": "tma"})
+
+        # On non-TMA GPUs, this should not raise an error
+        # (Inductor handles the fallback internally)
+        try:
+            import torch._inductor.config as cfg
+            from graph_net_bench.torch.backend.inductor_backend import _set_nested_attr
+
+            # This is what __call__ does - should not fail
+            for key, value in backend._build_inductor_overrides().items():
+                _set_nested_attr(cfg, key, value)
+
+            # If we get here, config was accepted successfully
+            # (regardless of actual TMA support on the GPU)
+            self.assertTrue(True)
+        except Exception as e:
+            # Should not fail even on non-TMA GPU
+            self.fail(f"TMA config should be accepted on non-TMA GPU: {e}")
+
+
+class TestInductorBackendIntegration(unittest.TestCase):
+    """Integration tests for InductorBackend."""
+
+    def test_backend_initialization(self):
+        """Test backend can be initialized with various configs."""
+        configs = [
+            {},
+            {"template": "triton"},
+            {"template": "max_autotune", "mode": "default"},
+            {"template": "cudagraphs", "freezing": True},
+        ]
+
+        for config in configs:
+            backend = InductorBackend(config)
+            self.assertIsNotNone(backend)
+
+    def test_build_overrides_priority(self):
+        """Test override priority: template < freezing < inductor_config."""
+        backend = InductorBackend(
+            {
+                "template": "freezing",
+                "freezing": False,
+                "inductor_config": {
+                    "freezing": True,
+                    "max_autotune": True,
+                },
+            }
+        )
+        overrides = backend._build_inductor_overrides()
+
+        # inductor_config has highest priority
+        self.assertTrue(overrides["freezing"])
+        self.assertTrue(overrides["max_autotune"])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Overview

This PR introduces configuration for PyTorch Inductor backend,
allowing users to select predefined config templates that set groups of
`torch._inductor.config` overrides. This provides an extension to PyTorch's
official "mode" concept while maintaining full compatibility with existing
`test_compiler.py` framework.

## Motivation

Previously, `InductorBackend` accepted only basic config parameters through
individual `inductor_config` dictionary entries. Users could not easily enable
common combinations of Inductor options such as:

- **CUTLASS-based GEMM kernels** - For optimal GEMM performance on modern GPUs
- **CUDA Graphs** - To reduce kernel launch overhead for small batch inference
- **Model freezing** - To inline weights as constants for deployment optimization
- **TMA (Tensor Memory Accelerator)** - For H100+ GPUs with hardware acceleration

This PR addresses these limitations by introducing **config templates** - pre-defined,
well-tested combinations of `torch._inductor.config` options that users can select
by name. Templates, mode, and options are mutually exclusive, providing clear
separation of concerns.

## Changes Summary

### 1. Inductor Backend Configuration Templates

**File**: `graph_net_bench/torch/backend/inductor_backend.py`

#### Features

- **`_INDUCTOR_CONFIG_TEMPLATES`** dictionary with 6 predefined templates
- Parameter: `graph_net_inductor_config_template` - select template by name
- Mutual exclusivity: exactly one of template/mode/options can be specified
- No global state mutation: uses torch.compile's `options` parameter directly

#### Supported Templates

| Template | Description | Config Overrides |
|----------|-------------|-----------------|
| `triton` | Default Triton backend | `cpp_wrapper: False` |
| `cpp_wrapper` | C++ wrapper for kernels | `cpp_wrapper: True` |
| `cudagraphs` | CUDA Graphs | `triton.cudagraphs: True` |
| `max_autotune` | Comprehensive autotuning | 4 autotune options |
| `freezing` | Model freezing | `freezing: True` |
| `tma` | TMA persistent matmul | `triton.enable_persistent_tma_matmul: True` |

Note that the TMA template works universally across GPU architectures:
- **H100+ (CC >= 9.0)**: Enables TMA persistent kernels
- **A100 or other GPUs**: Enables non-TMA persistent kernels as fallback

No runtime error occurs on GPUs without TMA support.

### 2. CUDA Graphs Compatibility Fix

**File**: `graph_net_bench/torch/test_compiler.py`

When CUDA Graphs is enabled, output tensor pointers are recorded to CUDA Graph buffers.
Subsequent model calls overwrite these buffers, causing errors when accessing compiled
output after eager run. Fixed by cloning outputs immediately:

```python
if isinstance(outs, torch.Tensor):
    outs = outs.clone()
elif isinstance(outs, tuple):
    outs = tuple(t.clone() if isinstance(t, torch.Tensor) else t for t in outs)
```

**Note**: `eval_backend_perf.py` and `eval_backend_diff.py` are unaffected
(torch.save/torch.load creates independent copies).

### 3. Test

**File**: `test/inductor_backend_test.py` (new file, ~290 lines)

**Test Coverage**:
- Template validation: 11 tests
- Parameter handling: 5 tests
- Config validation: 9 tests
- Integration: 1 test
- **Total: 26 tests**

## Usage

```bash
# Schema: exactly one of template/mode/options can be specified
--config '{"graph_net_inductor_config_template": "<template_name>"}'    # template
--config '{"mode": "<mode_name>"}'                                    # mode
--config '{"options": {...}}'                                          # custom

# Example: use max-autotune template
python -m graph_net_bench.torch.test_compiler \
    --compiler inductor \
    --model-path samples/torchvision/alexnet \
    --config "$(echo '{"graph_net_inductor_config_template": "max_autotune"}' | base64 -w0)" \
    --trials 5 --warmup 3
```

## Documentation References

All configuration keys verified against PyTorch source code:

- **Config File**: https://github.com/pytorch/pytorch/blob/main/torch/_inductor/config.py
- **Compile API**: https://pytorch.org/docs/stable/generated/torch.compile.html
