### PR TITLE
feat: add profiler_device speedup metric for CUDA benchmarks

### DIFF
--- a/graph_net_bench/test_compiler_util.py
+++ b/graph_net_bench/test_compiler_util.py
@@ -239,7 +239,7 @@ def print_times_and_speedup(args, eager_stats, compiled_stats):
 
     e2e_speedup = 0
     gpu_speedup = 0
-    profiler_device_speedup = 0
+    kernel_speedup = 0
 
     eager_e2e_time_ms = eager_stats.get("e2e", {}).get("median", 0)
     compiled_e2e_time_ms = compiled_stats.get("e2e", {}).get("median", 0)
@@ -254,15 +254,11 @@ def print_times_and_speedup(args, eager_stats, compiled_stats):
         if eager_gpu_time_ms > 0 and compiled_gpu_time_ms > 0:
             gpu_speedup = eager_gpu_time_ms / compiled_gpu_time_ms
 
-        eager_profiler_device_ms = eager_stats.get("profiler_device", {}).get("mean", 0)
-        compiled_profiler_device_ms = compiled_stats.get("profiler_device", {}).get(
-            "mean", 0
-        )
+        eager_kernel_time_ms = eager_stats.get("kernel", {}).get("median", 0)
+        compiled_kernel_time_ms = compiled_stats.get("kernel", {}).get("median", 0)
 
-        if eager_profiler_device_ms > 0 and compiled_profiler_device_ms > 0:
-            profiler_device_speedup = (
-                eager_profiler_device_ms / compiled_profiler_device_ms
-            )
+        if eager_kernel_time_ms > 0 and compiled_kernel_time_ms > 0:
+            kernel_speedup = eager_kernel_time_ms / compiled_kernel_time_ms
 
     if e2e_speedup > 0:
         print_with_log_prompt("[Speedup][e2e]:", f"{e2e_speedup:.5f}", args.log_prompt)
@@ -270,10 +266,10 @@ def print_times_and_speedup(args, eager_stats, compiled_stats):
     if is_gpu_device(args.device) and gpu_speedup > 0:
         print_with_log_prompt("[Speedup][gpu]:", f"{gpu_speedup:.5f}", args.log_prompt)
 
-    if is_gpu_device(args.device) and profiler_device_speedup > 0:
+    if is_gpu_device(args.device) and kernel_speedup > 0:
         print_with_log_prompt(
-            "[Speedup][profiler_device]:",
-            f"{profiler_device_speedup:.5f}",
+            "[Speedup][kernel]:",
+            f"{kernel_speedup:.5f}",
             args.log_prompt,
         )
 

--- a/graph_net_bench/test_compiler_util.py
+++ b/graph_net_bench/test_compiler_util.py
@@ -205,6 +205,7 @@ def print_times_and_speedup(args, eager_stats, compiled_stats):
 
     e2e_speedup = 0
     gpu_speedup = 0
+    profiler_device_speedup = 0
 
     eager_e2e_time_ms = eager_stats.get("e2e", {}).get("mean", 0)
     compiled_e2e_time_ms = compiled_stats.get("e2e", {}).get("mean", 0)
@@ -219,11 +220,28 @@ def print_times_and_speedup(args, eager_stats, compiled_stats):
         if eager_gpu_time_ms > 0 and compiled_gpu_time_ms > 0:
             gpu_speedup = eager_gpu_time_ms / compiled_gpu_time_ms
 
+        eager_profiler_device_ms = eager_stats.get("profiler_device", {}).get("mean", 0)
+        compiled_profiler_device_ms = compiled_stats.get("profiler_device", {}).get(
+            "mean", 0
+        )
+
+        if eager_profiler_device_ms > 0 and compiled_profiler_device_ms > 0:
+            profiler_device_speedup = (
+                eager_profiler_device_ms / compiled_profiler_device_ms
+            )
+
     if e2e_speedup > 0:
         print_with_log_prompt("[Speedup][e2e]:", f"{e2e_speedup:.5f}", args.log_prompt)
 
     if is_gpu_device(args.device) and gpu_speedup > 0:
         print_with_log_prompt("[Speedup][gpu]:", f"{gpu_speedup:.5f}", args.log_prompt)
+
+    if is_gpu_device(args.device) and profiler_device_speedup > 0:
+        print_with_log_prompt(
+            "[Speedup][profiler_device]:",
+            f"{profiler_device_speedup:.5f}",
+            args.log_prompt,
+        )
 
 
 def check_type_match(eager_dtypes, compiled_dtypes):

--- a/graph_net_bench/torch/test_compiler.py
+++ b/graph_net_bench/torch/test_compiler.py
@@ -206,6 +206,28 @@ def measure_performance(model_call, args, compiler):
             e2e_times.append(duration_box.value)
         stats["e2e"] = test_compiler_util.get_timing_stats(e2e_times)
 
+    # Profiler device_time measurement (only when enabled and on CUDA)
+    if args.profiler_device_time and "cuda" in args.device:
+        profiler_device_times = []
+        for i in range(args.trials):
+            with torch.profiler.profile(
+                activities=[torch.profiler.ProfilerActivity.CUDA],
+            ) as prof:
+                model_call()
+            compiler.synchronize()
+            device_time_ms = (
+                sum(evt.self_device_time_total for evt in prof.key_averages()) / 1000.0
+            )
+            profiler_device_times.append(device_time_ms)
+            print(
+                f"Trial {i + 1}: profiler_device={device_time_ms:.5f} ms",
+                file=sys.stderr,
+                flush=True,
+            )
+        stats["profiler_device"] = test_compiler_util.get_timing_stats(
+            profiler_device_times
+        )
+
     return outs, stats
 
 
@@ -423,6 +445,7 @@ def test_multi_models(args):
                     f"--trials {args.trials}",
                     f"--log-prompt {args.log_prompt}",
                     f"--config {args.config}",
+                    "--profiler-device-time" if args.profiler_device_time else "",
                 ]
             )
             try:
@@ -472,6 +495,7 @@ def test_multi_models_with_prefix(args):
                 f"--trials {args.trials}",
                 f"--log-prompt {args.log_prompt}",
                 f"--config {args.config}",
+                "--profiler-device-time" if args.profiler_device_time else "",
             ]
         )
         try:
@@ -557,6 +581,12 @@ if __name__ == "__main__":
         required=False,
         default=None,
         help="base64 encode configuration json.",
+    )
+    parser.add_argument(
+        "--profiler-device-time",
+        action="store_true",
+        default=False,
+        help="Enable PyTorch Profiler device time measurement (CUDA only)",
     )
     args = parser.parse_args()
     main(args=args)

--- a/graph_net_bench/torch/test_compiler.py
+++ b/graph_net_bench/torch/test_compiler.py
@@ -206,26 +206,26 @@ def measure_performance(model_call, args, compiler):
             e2e_times.append(duration_box.value)
         stats["e2e"] = test_compiler_util.get_timing_stats(e2e_times)
 
-    # Profiler device_time measurement (only when enabled and on CUDA)
-    if args.profiler_device_time and "cuda" in args.device:
-        profiler_device_times = []
+    # Kernel-level compute time measurement (only when enabled and on CUDA)
+    if args.kernel_time and "cuda" in args.device:
+        kernel_times = []
         for i in range(args.trials):
             with torch.profiler.profile(
                 activities=[torch.profiler.ProfilerActivity.CUDA],
             ) as prof:
                 model_call()
             compiler.synchronize()
-            device_time_ms = (
+            kernel_time_ms = (
                 sum(evt.self_device_time_total for evt in prof.key_averages()) / 1000.0
             )
-            profiler_device_times.append(device_time_ms)
+            kernel_times.append(kernel_time_ms)
             print(
-                f"Trial {i + 1}: profiler_device={device_time_ms:.5f} ms",
+                f"Trial {i + 1}: kernel={kernel_time_ms:.5f} ms",
                 file=sys.stderr,
                 flush=True,
             )
-        stats["profiler_device"] = test_compiler_util.get_timing_stats(
-            profiler_device_times
+        stats["kernel"] = test_compiler_util.get_timing_stats(
+            kernel_times
         )
 
     return outs, stats
@@ -445,7 +445,7 @@ def test_multi_models(args):
                     f"--trials {args.trials}",
                     f"--log-prompt {args.log_prompt}",
                     f"--config {args.config}",
-                    "--profiler-device-time" if args.profiler_device_time else "",
+                    "--kernel-time" if args.kernel_time else "",
                 ]
             )
             try:
@@ -583,10 +583,10 @@ if __name__ == "__main__":
         help="base64 encode configuration json.",
     )
     parser.add_argument(
-        "--profiler-device-time",
+        "--kernel-time",
         action="store_true",
         default=False,
-        help="Enable PyTorch Profiler device time measurement (CUDA only)",
+        help="Enable kernel-level compute time measurement via torch.profiler (CUDA only)",
     )
     args = parser.parse_args()
     main(args=args)

--- a/graph_net_bench/torch/test_compiler.py
+++ b/graph_net_bench/torch/test_compiler.py
@@ -498,7 +498,7 @@ def test_multi_models_with_prefix(args):
                 f"--trials {args.trials}",
                 f"--log-prompt {args.log_prompt}",
                 f"--config {args.config}",
-                "--profiler-device-time" if args.profiler_device_time else "",
+                "--kernel-time" if args.profiler_device_time else "",
             ]
         )
         try:

--- a/graph_net_bench/torch/test_compiler.py
+++ b/graph_net_bench/torch/test_compiler.py
@@ -498,7 +498,7 @@ def test_multi_models_with_prefix(args):
                 f"--trials {args.trials}",
                 f"--log-prompt {args.log_prompt}",
                 f"--config {args.config}",
-                "--kernel-time" if args.profiler_device_time else "",
+                "--kernel-time" if args.kernel_time else "",
             ]
         )
         try:

--- a/graph_net_bench/torch/test_compiler.py
+++ b/graph_net_bench/torch/test_compiler.py
@@ -208,25 +208,28 @@ def measure_performance(model_call, args, compiler):
 
     # Kernel-level compute time measurement (only when enabled and on CUDA)
     if args.kernel_time and "cuda" in args.device:
-        kernel_times = []
-        for i in range(args.trials):
-            with torch.profiler.profile(
-                activities=[torch.profiler.ProfilerActivity.CUDA],
-            ) as prof:
+        with torch.profiler.profile(
+            activities=[torch.profiler.ProfilerActivity.CUDA],
+        ) as prof:
+            for _ in range(args.trials):
                 model_call()
-            compiler.synchronize()
-            kernel_time_ms = (
-                sum(evt.self_device_time_total for evt in prof.key_averages()) / 1000.0
-            )
-            kernel_times.append(kernel_time_ms)
-            print(
-                f"Trial {i + 1}: kernel={kernel_time_ms:.5f} ms",
-                file=sys.stderr,
-                flush=True,
-            )
-        stats["kernel"] = test_compiler_util.get_timing_stats(
-            kernel_times
+        compiler.synchronize()
+        kernel_time_ms = (
+            sum(evt.self_device_time_total for evt in prof.key_averages())
+            / 1000.0
+            / args.trials
         )
+        print(
+            f"kernel={kernel_time_ms:.5f} ms (avg over {args.trials} trials)",
+            file=sys.stderr,
+            flush=True,
+        )
+        stats["kernel"] = {
+            "mean": kernel_time_ms,
+            "min": kernel_time_ms,
+            "max": kernel_time_ms,
+            "median": kernel_time_ms,
+        }
 
     return outs, stats
 


### PR DESCRIPTION
### PR Category
<!-- One of [ New Sample | Feature Enhancement | Bug Fix | Other ] -->
Feature Enhancement

### Description
<!-- Describe what you’ve done -->
增加GPU时间的测量

<details>
<pre style="white-space: pre; overflow-x: auto;">
graph-net-test-compiler-log [Processing] /work/ai4c/samples/hf_subgraphs_v2/fusible_subgraphs/c4/f4/c4f4baceed0eed457d338798e78817bd018b4cfe4a762fc95022e94a742dd3f1/graphs/hf_subgraphs_v2/fusible_subgraphs/float16/7/samples/transformers-auto-model/zuppif_maskformer-swin-small-ade/_decomposed/zuppif_maskformer-swin-small-ade_start261_end269_22
graph-net-test-compiler-log [Config] model: zuppif/maskformer-swin-small-ade
graph-net-test-compiler-log [Config] device: cuda
graph-net-test-compiler-log [Config] hardware: NVIDIA A100-SXM4-80GB
graph-net-test-compiler-log [Config] compiler: inductor
graph-net-test-compiler-log [Config] warmup: 5
graph-net-test-compiler-log [Config] trials: 10
graph-net-test-compiler-log [Config] compile_framework_version: 2.9.1+cu126
[Profiling] Using device: cuda NVIDIA A100-SXM4-80GB, warm up 5, trials 10
Trial 1: e2e=0.42009 ms, gpu=0.30118 ms
Trial 2: e2e=0.34142 ms, gpu=0.26333 ms
Trial 3: e2e=0.33832 ms, gpu=0.27142 ms
Trial 4: e2e=0.32544 ms, gpu=0.25709 ms
Trial 5: e2e=0.30947 ms, gpu=0.24982 ms
Trial 6: e2e=0.33855 ms, gpu=0.27082 ms
Trial 7: e2e=0.32330 ms, gpu=0.25642 ms
Trial 8: e2e=0.31805 ms, gpu=0.25197 ms
Trial 9: e2e=0.31590 ms, gpu=0.25078 ms
Trial 10: e2e=0.31233 ms, gpu=0.25248 ms
Trial 1: profiler_device=0.04288 ms
Trial 2: profiler_device=0.04198 ms
Trial 3: profiler_device=0.04186 ms
Trial 4: profiler_device=0.04202 ms
Trial 5: profiler_device=0.04208 ms
Trial 6: profiler_device=0.04198 ms
Trial 7: profiler_device=0.04189 ms
Trial 8: profiler_device=0.04186 ms
Trial 9: profiler_device=0.04218 ms
Trial 10: profiler_device=0.04205 ms
[Profiling] Using device: cuda NVIDIA A100-SXM4-80GB, warm up 5, trials 10
Trial 1: e2e=0.35548 ms, gpu=0.27174 ms
Trial 2: e2e=0.33617 ms, gpu=0.27578 ms
Trial 3: e2e=0.29993 ms, gpu=0.24602 ms
Trial 4: e2e=0.29445 ms, gpu=0.24115 ms
Trial 5: e2e=0.30160 ms, gpu=0.24838 ms
Trial 6: e2e=0.29421 ms, gpu=0.24150 ms
Trial 7: e2e=0.28825 ms, gpu=0.23693 ms
Trial 8: e2e=0.36645 ms, gpu=0.30074 ms
Trial 9: e2e=0.32663 ms, gpu=0.26058 ms
Trial 10: e2e=0.33236 ms, gpu=0.25965 ms
Trial 1: profiler_device=0.00733 ms
Trial 2: profiler_device=0.00723 ms
Trial 3: profiler_device=0.00698 ms
Trial 4: profiler_device=0.00698 ms
Trial 5: profiler_device=0.00694 ms
Trial 6: profiler_device=0.00698 ms
Trial 7: profiler_device=0.00691 ms
Trial 8: profiler_device=0.00694 ms
Trial 9: profiler_device=0.00698 ms
Trial 10: profiler_device=0.00698 ms
graph-net-test-compiler-log [Datatype][eager]: float16 float16
graph-net-test-compiler-log [Datatype][compiled]: float16 float16
graph-net-test-compiler-log [DataType] eager:['float16', 'float16'] compiled:['float16', 'float16'] match:True
graph-net-test-compiler-log [Correctness][equal]: 1 0
graph-net-test-compiler-log [Correctness][all_close_atol_1.00E-10_rtol_1.00E-06]: 1 0
graph-net-test-compiler-log [Correctness][all_close_atol_1.00E-10_rtol_2.56E-04]: 1 0
graph-net-test-compiler-log [Correctness][all_close_atol_1.00E-10_rtol_1.69E-12]: 1 0
graph-net-test-compiler-log [Correctness][all_close_atol_1.00E-14_rtol_1.00E-14]: 1 0
graph-net-test-compiler-log [Correctness][all_close_atol_1.00E-09_rtol_3.98E-06]: 1 0
graph-net-test-compiler-log [Correctness][all_close_atol_1.00E-09_rtol_5.85E-04]: 1 0
graph-net-test-compiler-log [Correctness][all_close_atol_1.00E-09_rtol_2.54E-11]: 1 0
graph-net-test-compiler-log [Correctness][all_close_atol_2.51E-13_rtol_2.51E-13]: 1 0
graph-net-test-compiler-log [Correctness][all_close_atol_1.00E-08_rtol_1.58E-05]: 1 0
graph-net-test-compiler-log [Correctness][all_close_atol_1.00E-08_rtol_1.34E-03]: 1 0
graph-net-test-compiler-log [Correctness][all_close_atol_1.00E-08_rtol_3.82E-10]: 1 0
graph-net-test-compiler-log [Correctness][all_close_atol_6.31E-12_rtol_6.31E-12]: 1 0
graph-net-test-compiler-log [Correctness][all_close_atol_1.00E-07_rtol_6.31E-05]: 1 0
graph-net-test-compiler-log [Correctness][all_close_atol_1.00E-07_rtol_3.06E-03]: 1 0
graph-net-test-compiler-log [Correctness][all_close_atol_1.00E-07_rtol_5.75E-09]: 1 0
graph-net-test-compiler-log [Correctness][all_close_atol_1.58E-10_rtol_1.58E-10]: 1 0
graph-net-test-compiler-log [Correctness][all_close_atol_1.00E-06_rtol_2.51E-04]: 1 0
graph-net-test-compiler-log [Correctness][all_close_atol_1.00E-06_rtol_7.00E-03]: 1 0
graph-net-test-compiler-log [Correctness][all_close_atol_1.00E-06_rtol_8.65E-08]: 1 0
graph-net-test-compiler-log [Correctness][all_close_atol_3.98E-09_rtol_3.98E-09]: 1 0
graph-net-test-compiler-log [Correctness][all_close_atol_1.00E-05_rtol_1.00E-03]: 1 0
graph-net-test-compiler-log [Correctness][all_close_atol_1.00E-05_rtol_1.60E-02]: 1 0
graph-net-test-compiler-log [Correctness][all_close_atol_1.00E-05_rtol_1.30E-06]: 1 0
graph-net-test-compiler-log [Correctness][all_close_atol_1.00E-07_rtol_1.00E-07]: 1 0
graph-net-test-compiler-log [Correctness][all_close_atol_1.00E-04_rtol_3.98E-03]: 1 0
graph-net-test-compiler-log [Correctness][all_close_atol_1.00E-04_rtol_3.66E-02]: 1 0
graph-net-test-compiler-log [Correctness][all_close_atol_1.00E-04_rtol_1.96E-05]: 1 0
graph-net-test-compiler-log [Correctness][all_close_atol_2.51E-06_rtol_2.51E-06]: 1 0
graph-net-test-compiler-log [Correctness][all_close_atol_1.00E-03_rtol_1.58E-02]: 1 1
graph-net-test-compiler-log [Correctness][all_close_atol_1.00E-03_rtol_8.36E-02]: 1 1
graph-net-test-compiler-log [Correctness][all_close_atol_1.00E-03_rtol_2.94E-04]: 1 0
graph-net-test-compiler-log [Correctness][all_close_atol_6.31E-05_rtol_6.31E-05]: 1 0
graph-net-test-compiler-log [Correctness][all_close_atol_1.00E-02_rtol_6.31E-02]: 1 1
graph-net-test-compiler-log [Correctness][all_close_atol_1.00E-02_rtol_1.91E-01]: 1 1
graph-net-test-compiler-log [Correctness][all_close_atol_1.00E-02_rtol_4.42E-03]: 1 1
graph-net-test-compiler-log [Correctness][all_close_atol_1.58E-03_rtol_1.58E-03]: 1 1
graph-net-test-compiler-log [Correctness][all_close_atol_1.00E-01_rtol_2.51E-01]: 1 1
graph-net-test-compiler-log [Correctness][all_close_atol_1.00E-01_rtol_4.37E-01]: 1 1
graph-net-test-compiler-log [Correctness][all_close_atol_1.00E-01_rtol_6.65E-02]: 1 1
graph-net-test-compiler-log [Correctness][all_close_atol_3.98E-02_rtol_3.98E-02]: 1 1
graph-net-test-compiler-log [Correctness][all_close_atol_1.00E+00_rtol_1.00E+00]: 1 1
graph-net-test-compiler-log [Correctness][all_close_atol_1.00E+00_rtol_1.00E+00]: 1 1
graph-net-test-compiler-log [Correctness][all_close_atol_1.00E+00_rtol_1.00E+00]: 1 1
graph-net-test-compiler-log [Correctness][all_close_atol_1.00E+00_rtol_1.00E+00]: 1 1
graph-net-test-compiler-log [Correctness][all_close_atol_1.00E+01_rtol_3.98E+00]: 1 1
graph-net-test-compiler-log [Correctness][all_close_atol_1.00E+01_rtol_2.29E+00]: 1 1
graph-net-test-compiler-log [Correctness][all_close_atol_1.00E+01_rtol_1.50E+01]: 1 1
graph-net-test-compiler-log [Correctness][all_close_atol_2.51E+01_rtol_2.51E+01]: 1 1
graph-net-test-compiler-log [Correctness][all_close_atol_1.00E+02_rtol_1.58E+01]: 1 1
graph-net-test-compiler-log [Correctness][all_close_atol_1.00E+02_rtol_5.23E+00]: 1 1
graph-net-test-compiler-log [Correctness][all_close_atol_1.00E+02_rtol_2.26E+02]: 1 1
graph-net-test-compiler-log [Correctness][all_close_atol_6.31E+02_rtol_6.31E+02]: 1 1
graph-net-test-compiler-log [Correctness][all_close_atol_1.00E+03_rtol_6.31E+01]: 1 1
graph-net-test-compiler-log [Correctness][all_close_atol_1.00E+03_rtol_1.20E+01]: 1 1
graph-net-test-compiler-log [Correctness][all_close_atol_1.00E+03_rtol_3.40E+03]: 1 1
graph-net-test-compiler-log [Correctness][all_close_atol_1.58E+04_rtol_1.58E+04]: 1 1
graph-net-test-compiler-log [Correctness][all_close_atol_1.00E+04_rtol_2.51E+02]: 1 1
graph-net-test-compiler-log [Correctness][all_close_atol_1.00E+04_rtol_2.73E+01]: 1 1
graph-net-test-compiler-log [Correctness][all_close_atol_1.00E+04_rtol_5.11E+04]: 1 1
graph-net-test-compiler-log [Correctness][all_close_atol_3.98E+05_rtol_3.98E+05]: 1 1
graph-net-test-compiler-log [Correctness][all_close_atol_1.00E+05_rtol_1.00E+03]: 1 1
graph-net-test-compiler-log [Correctness][all_close_atol_1.00E+05_rtol_6.25E+01]: 1 1
graph-net-test-compiler-log [Correctness][all_close_atol_1.00E+05_rtol_7.69E+05]: 1 1
graph-net-test-compiler-log [Correctness][all_close_atol_1.00E+07_rtol_1.00E+07]: 1 1
graph-net-test-compiler-log [Correctness][max_diff]: 0.0 0.00390625
graph-net-test-compiler-log [Correctness][mean_diff]: 0.0 0.00014134598313830793
graph-net-test-compiler-log [Result] status: success
graph-net-test-compiler-log [Performance][eager]: {"e2e": {"mean": 0.334287, "std": 0.0305726, "min": 0.309467, "max": 0.420094}, "gpu": {"mean": 0.262531, "std": 0.0149047, "min": 0.249824, "max": 0.301184}, "profiler_device": {"mean": 0.0420766, "std": 0.000284628, "min": 0.041855, "max": 0.04288}}
graph-net-test-compiler-log [Performance][compiled]: {"e2e": {"mean": 0.319552, "std": 0.0263446, "min": 0.288248, "max": 0.366449}, "gpu": {"mean": 0.258246, "std": 0.0189105, "min": 0.236928, "max": 0.300736}, "profiler_device": {"mean": 0.007024, "std": 0.000131356, "min": 0.006912, "max": 0.007328}}
graph-net-test-compiler-log [Speedup][e2e]: 1.04611
graph-net-test-compiler-log [Speedup][gpu]: 1.01659
graph-net-test-compiler-log [Speedup][profiler_device]: 5.99040
</pre>
</details>