### PR TITLE
fix: separate model weights from inputs in extraction output

### DIFF
--- a/graph_net/torch/extractor.py
+++ b/graph_net/torch/extractor.py
@@ -49,6 +49,7 @@ class GraphExtractor:
         mut_graph_codes=None,
         placeholder_auto_rename=False,
         workspace_path=None,
+        param_buffer_ids=None,
     ):
         self.subgraph_counter = 0
         self.name = name
@@ -64,6 +65,7 @@ class GraphExtractor:
             raise EnvironmentError(
                 "Environment variable 'GRAPH_NET_EXTRACT_WORKSPACE' is not set."
             )
+        self.param_buffer_ids = param_buffer_ids or set()
 
     def move_files(self, source_dir, target_dir):
         os.makedirs(target_dir, exist_ok=True)
@@ -150,7 +152,16 @@ class GraphExtractor:
             self.mut_graph_codes.append(base_code)
 
         # 4. Save tensor metadata
-        converted = utils.convert_state_and_inputs(params, [])
+        # Separate model weights (parameters + buffers) from real inputs in params
+        weights = {}
+        example_inputs = {}
+        for name, value in params.items():
+            if id(value) in self.param_buffer_ids:
+                weights[name] = value
+            else:
+                example_inputs[name] = value
+
+        converted = utils.convert_state_and_inputs(weights, example_inputs)
         utils.save_converted_to_text(converted, file_path=subgraph_path)
         utils.save_constraints_text(
             converted,
@@ -280,9 +291,24 @@ def extract(
         model_path = None
         if hasattr(model, "__graph_net_file_path__"):
             model_path = os.path.dirname(model.__graph_net_file_path__)
-        extractor = get_graph_extractor_maker(model_path)(
-            name, dynamic, mut_graph_codes, placeholder_auto_rename
-        )
+
+        # Collect parameter and buffer ids from the original model for distinguishing weights and inputs in __call__
+        param_buffer_ids = set()
+        for _, p in model.named_parameters():
+            param_buffer_ids.add(id(p))
+        for _, b in model.named_buffers():
+            param_buffer_ids.add(id(b))
+
+        maker = get_graph_extractor_maker(model_path)
+        if maker is GraphExtractor:
+            extractor = maker(
+                name, dynamic, mut_graph_codes, placeholder_auto_rename,
+                param_buffer_ids=param_buffer_ids,
+            )
+        else:
+            extractor = maker(
+                name, dynamic, mut_graph_codes, placeholder_auto_rename
+            )
         # return torch.compile(backend=extractor, dynamic=dynamic)
         compiled_model = torch.compile(model, backend=extractor, dynamic=dynamic)
         return compiled_model

--- a/graph_net/torch/utils.py
+++ b/graph_net/torch/utils.py
@@ -75,6 +75,8 @@ def convert_state_and_inputs_impl(state_dict, example_inputs):
         processed_inputs = process_tensor(example_inputs)
     elif isinstance(example_inputs, (list, tuple)):
         processed_inputs = [process_tensor(t) for t in example_inputs]
+    elif isinstance(example_inputs, dict):
+        processed_inputs = {k: process_tensor(v) for k, v in example_inputs.items()}
     else:
         processed_inputs = {"type": "unknown", "value": example_inputs}
 
@@ -181,13 +183,28 @@ def save_converted_to_text(converted, file_path):
         return lines
 
     input_infos = converted["input_info"]
-    if isinstance(input_infos, dict):
-        input_infos = [input_infos]
 
     input_lines = []
-    for idx, input_info in enumerate(input_infos):
-        input_info["name"] = f"input_{idx}"
-        input_lines.extend(process_tensor_info(input_info, name_prefix="Program_input"))
+    if isinstance(input_infos, dict) and input_infos:
+        # Check if it's a dict of named tensor infos (e.g., placeholder inputs)
+        first_val = next(iter(input_infos.values()))
+        if isinstance(first_val, dict) and "type" in first_val:
+            # Named inputs: {name: tensor_info}
+            for name, input_info in input_infos.items():
+                input_info["name"] = name
+                input_lines.extend(process_tensor_info(input_info, name_prefix="Program_input"))
+        else:
+            # Single input info dict (e.g., a single tensor's info)
+            input_infos = [input_infos]
+            for idx, input_info in enumerate(input_infos):
+                input_info["name"] = f"input_{idx}"
+                input_lines.extend(process_tensor_info(input_info, name_prefix="Program_input"))
+    else:
+        if isinstance(input_infos, dict):
+            input_infos = [input_infos]
+        for idx, input_info in enumerate(input_infos):
+            input_info["name"] = f"input_{idx}"
+            input_lines.extend(process_tensor_info(input_info, name_prefix="Program_input"))
 
     with open(f"{file_path}/input_meta.py", "w") as f:
         f.write("\n".join(input_lines))


### PR DESCRIPTION
## Summary

- Fix `extractor.py` to correctly separate model parameters/buffers from placeholder inputs (including SymInt symbols like `s0`, `s1`) when saving tensor metadata
- Previously, all placeholder params were passed to `convert_state_and_inputs(params, [])`, causing SymInt placeholders to appear in `weight_meta.py` as `Program_weight_tensor_meta_s0`
- Now uses object identity (`id()`) to distinguish original model params/buffers from real inputs, writing weights to `weight_meta.py` and inputs to `input_meta.py`
- Updates `utils.py` to handle dict-style `example_inputs` with named tensor infos

## Background

When `torch.compile` with FX tracing lifts model parameters and buffers into placeholder nodes, the extractor treated them identically to real model inputs. This caused:

1. SymInt symbols (`s0`, `s1`, etc.) to be written to `weight_meta.py` as fake weights
2. Model parameters and buffers to be written to `input_meta.py` instead of `weight_meta.py`
3. Downstream dimension generalization (`_get_tensor_metas`) to merge both files, propagating the redundant entries

## Changes

### `graph_net/torch/extractor.py`
- `GraphExtractor.__init__`: add `param_buffer_ids` parameter
- `wrapper()`: collect `id()` of original model's `named_parameters()` and `named_buffers()`, pass to `GraphExtractor`
- `__call__()`: split `params` into `weights` (by id match) and `example_inputs`, call `convert_state_and_inputs(weights, example_inputs)`

### `graph_net/torch/utils.py`
- `convert_state_and_inputs_impl`: support `example_inputs` as `dict` (named inputs)
- `save_converted_to_text`: handle dict-of-tensor-infos for `input_info`, preserving placeholder names

## Test Plan

- [x] No-param model: `weight_meta.py` empty, all inputs in `input_meta.py`
- [x] Nested modules: parameters correctly in `weight_meta.py`
- [x] Multi-input + buffer model: parameters and buffers in `weight_meta.py`, real inputs in `input_meta.py`
- [x] Parameter-only model (no buffer): correct split
- [x] ParameterList model: all list params in `weight_meta.py`
- [x] `s0`/`s1` SymInt symbols never appear in `weight_meta.py`