### PR TITLE
Agent: reorganize workspace directory structure

### DIFF
--- a/graph_net/agent/graph_extractor/subprocess_graph_extractor.py
+++ b/graph_net/agent/graph_extractor/subprocess_graph_extractor.py
@@ -112,9 +112,13 @@ class SubprocessGraphExtractor(BaseGraphExtractor):
             else:
                 env["PYTHONPATH"] = str(graphnet_root)
 
-            # Ensure GRAPH_NET_EXTRACT_WORKSPACE points to our workspace
-            if "GRAPH_NET_EXTRACT_WORKSPACE" not in env:
-                env["GRAPH_NET_EXTRACT_WORKSPACE"] = str(self.workspace)
+            # Ensure GRAPH_NET_EXTRACT_WORKSPACE points to samples dir
+            # so extraction output goes to workspace/samples/ instead of root
+            samples_dir = self.workspace / "samples"
+            samples_dir.mkdir(parents=True, exist_ok=True)
+            env["GRAPH_NET_EXTRACT_WORKSPACE"] = str(samples_dir)
+            # Also set in current process env so _get_workspace_path() can find it
+            os.environ["GRAPH_NET_EXTRACT_WORKSPACE"] = str(samples_dir)
 
             # Run script in subprocess via Popen so we can kill on timeout
             proc = subprocess.Popen(
@@ -225,7 +229,12 @@ class SubprocessGraphExtractor(BaseGraphExtractor):
     def _get_workspace_path(self) -> Optional[Path]:
         """Get workspace path from environment or instance variable"""
         workspace_env = os.environ.get("GRAPH_NET_EXTRACT_WORKSPACE")
-        return Path(workspace_env) if workspace_env else self.workspace
+        if workspace_env:
+            return Path(workspace_env)
+        # Default to samples/ subdir to avoid cluttering workspace root
+        samples_dir = self.workspace / "samples"
+        samples_dir.mkdir(parents=True, exist_ok=True)
+        return samples_dir
 
     def _find_dir_by_pattern(
         self, workspace_path: Path, model_id: str, safe_model_id: str

--- a/graph_net/agent/graph_net_agent.py
+++ b/graph_net/agent/graph_net_agent.py
@@ -192,6 +192,17 @@ class GraphNetAgent:
                 self._move_sample(sample_dir, self.workspace.failed_dir)
             return ExtractionStatus.ERROR
 
+    @staticmethod
+    def _is_llm_fixable_error(err: GraphExtractionError) -> bool:
+        """Decide whether an extraction error is worth retrying with LLM.
+
+        Only allow LLM retry for script logic errors (non-zero return code).
+        All other categories (timeout, infrastructure, missing model, etc.)
+        are not fixable by rewriting the script.
+        """
+        category = GraphExtractionErrorClassifier.classify_from_exception(err)
+        return category == GraphExtractionErrorCategory.SCRIPT_EXECUTION_FAILED
+
     def _llm_retry(
         self,
         first_err: GraphExtractionError,

--- a/graph_net/agent/graph_net_agent.py
+++ b/graph_net/agent/graph_net_agent.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import shutil
 from enum import Enum
 from pathlib import Path
 from typing import Optional
@@ -118,6 +119,7 @@ class GraphNetAgent:
             ExtractionStatus.ERROR           – unexpected error
         """
         self.last_timeout_success = False
+        sample_dir: Optional[Path] = None
         try:
             self.logger.info(f"Starting extraction for model: {model_id}")
 
@@ -144,6 +146,7 @@ class GraphNetAgent:
 
             if self.is_duplicate_sample(sample_dir):
                 self.logger.info("Duplicate sample detected, skipping verification")
+                self._move_sample(sample_dir, self.workspace.success_dir)
                 return ExtractionStatus.OK
 
             if not self.sample_verifier.verify(sample_dir):
@@ -152,6 +155,7 @@ class GraphNetAgent:
                     model_id,
                     Exception("Sample verification failed"),
                 )
+                self._move_sample(sample_dir, self.workspace.failed_dir)
                 return ExtractionStatus.VERIFY_FAILED
 
             if getattr(self.sample_verifier, "last_timeout_success", False):
@@ -160,12 +164,15 @@ class GraphNetAgent:
                     f"Sample verification for {model_id} passed via timeout skip"
                 )
 
+            self._move_sample(sample_dir, self.workspace.success_dir)
             self.logger.info(f"Successfully extracted sample for {model_id}")
             return ExtractionStatus.OK
 
         except SampleVerificationError as e:
             self.logger.error(f"Extraction failed for {model_id}: {e}")
             self.error_classifier.classify_and_record(model_id, e)
+            if sample_dir and sample_dir.exists():
+                self._move_sample(sample_dir, self.workspace.failed_dir)
             return ExtractionStatus.VERIFY_FAILED
         except (
             ModelFetchError,
@@ -175,22 +182,15 @@ class GraphNetAgent:
         ) as e:
             self.logger.error(f"Extraction failed for {model_id}: {e}")
             self.error_classifier.classify_and_record(model_id, e)
+            if sample_dir and sample_dir.exists():
+                self._move_sample(sample_dir, self.workspace.failed_dir)
             return ExtractionStatus.EXTRACT_FAILED
         except Exception as e:
             self.logger.error(f"Unexpected error for {model_id}: {e}", exc_info=True)
             self.error_classifier.classify_and_record(model_id, e)
+            if sample_dir and sample_dir.exists():
+                self._move_sample(sample_dir, self.workspace.failed_dir)
             return ExtractionStatus.ERROR
-
-    @staticmethod
-    def _is_llm_fixable_error(err: GraphExtractionError) -> bool:
-        """Decide whether an extraction error is worth retrying with LLM.
-
-        Only allow LLM retry for script logic errors (non-zero return code).
-        All other categories (timeout, infrastructure, missing model, etc.)
-        are not fixable by rewriting the script.
-        """
-        category = GraphExtractionErrorClassifier.classify_from_exception(err)
-        return category == GraphExtractionErrorCategory.SCRIPT_EXECUTION_FAILED
 
     def _llm_retry(
         self,
@@ -357,6 +357,15 @@ class GraphNetAgent:
         except (OSError, IOError) as e:
             self.logger.warning(f"Failed to generate graph_hash.txt: {e}")
 
+    def _move_sample(self, sample_dir: Path, dest_parent: Path) -> Path:
+        """Move sample_dir into dest_parent/, overwriting if destination exists"""
+        dest = dest_parent / sample_dir.name
+        if dest.exists():
+            shutil.rmtree(dest)
+        shutil.move(str(sample_dir), str(dest))
+        self.logger.info(f"Moved sample to: {dest}")
+        return dest
+
     def is_duplicate_sample(self, sample_dir: Path) -> bool:
         """Check if the extracted sample is a duplicate of an existing sample"""
         graph_hash_path = sample_dir / "graph_hash.txt"
@@ -366,21 +375,21 @@ class GraphNetAgent:
 
         try:
             current_hash = graph_hash_path.read_text().strip()
-            samples_root = self.workspace.samples_dir
 
-            if not samples_root.exists():
-                return False
-
-            for hash_file in samples_root.rglob("graph_hash.txt"):
-                if hash_file == graph_hash_path:
+            # Search for duplicates in success_dir (where past successful samples live)
+            for search_root in [self.workspace.success_dir, self.workspace.samples_dir]:
+                if not search_root.exists():
                     continue
-                try:
-                    existing_hash = hash_file.read_text().strip()
-                    if existing_hash == current_hash:
-                        self.logger.info(f"Duplicate found: {hash_file.parent}")
-                        return True
-                except (OSError, IOError):
-                    continue
+                for hash_file in search_root.rglob("graph_hash.txt"):
+                    if hash_file == graph_hash_path:
+                        continue
+                    try:
+                        existing_hash = hash_file.read_text().strip()
+                        if existing_hash == current_hash:
+                            self.logger.info(f"Duplicate found: {hash_file.parent}")
+                            return True
+                    except (OSError, IOError):
+                        continue
 
             return False
         except (OSError, IOError) as e:

--- a/graph_net/agent/parallel_extract.py
+++ b/graph_net/agent/parallel_extract.py
@@ -573,8 +573,14 @@ def main() -> int:
         )
 
     # --- Save results ---
-    output_file = (
-        args.output or f"parallel_extract_{start_time.strftime('%Y%m%d_%H%M%S')}.json"
+    from graph_net.agent.utils.workspace_manager import (
+        WorkspaceManager as _WorkspaceManager,
+    )
+
+    _ws = _WorkspaceManager(workspace)
+    output_file = args.output or str(
+        _ws.logs_and_lists_dir
+        / f"parallel_extract_{start_time.strftime('%Y%m%d_%H%M%S')}.json"
     )
     _save_results(results, output_file)
 

--- a/graph_net/agent/utils/workspace_manager.py
+++ b/graph_net/agent/utils/workspace_manager.py
@@ -22,6 +22,9 @@ class WorkspaceManager:
             self.generated_dir,
             self.samples_dir,
             self.logs_dir,
+            self.success_dir,
+            self.failed_dir,
+            self.logs_and_lists_dir,
         ]
         for dir_path in dirs:
             dir_path.mkdir(parents=True, exist_ok=True)
@@ -45,6 +48,21 @@ class WorkspaceManager:
     def logs_dir(self) -> Path:
         """Directory for logs"""
         return self.workspace_root / "logs"
+
+    @property
+    def success_dir(self) -> Path:
+        """Directory for successfully extracted samples"""
+        return self.workspace_root / "success"
+
+    @property
+    def failed_dir(self) -> Path:
+        """Directory for failed extraction artifacts"""
+        return self.workspace_root / "failed"
+
+    @property
+    def logs_and_lists_dir(self) -> Path:
+        """Directory for result JSONs, model lists, and run logs"""
+        return self.workspace_root / "logs_and_lists"
 
     def get_model_dir(self, model_id: str) -> Path:
         """Get directory path for a specific model"""


### PR DESCRIPTION
### PR Category
<!-- One of [ New Sample | Feature Enhancement | Bug Fix | Other ] -->
Feature Enhancement

### Description
<!-- Describe what you’ve done -->
### Agent: 整理 workspace 目录结构

#### 背景

批量抽取运行后，模型目录和结果文件混杂在 workspace 根目录：
- 成功和失败的模型目录混在一起
- 结果 JSON 散落在各处
- 子图输出 clutter 根目录

这给后续分析、重跑和文件管理带来不便。

#### 变更内容

##### 1. `graph_net/agent/utils/workspace_manager.py`

新增三个目录属性：
- `success_dir` — `workspace/success/`，存放抽取成功的模型样本
- `failed_dir` — `workspace/failed/`，存放抽取失败的模型目录
- `logs_and_lists_dir` — `workspace/logs_and_lists/`，存放结果 JSON 和模型列表

`_ensure_directories()` 初始化时自动创建以上三个目录。

##### 2. `graph_net/agent/graph_net_agent.py`

- `extract_sample()` 中跟踪 `sample_dir`，提取完成后自动 move 到对应目录：
  - 验证通过 / 去重命中 → `success/`
  - 验证失败 / 异常退出 → `failed/`（如目录已存在则覆盖）
- 新增 `_move_sample()` 辅助方法，封装 `shutil.move` 及覆盖逻辑
- `is_duplicate_sample()` 改为同时扫描 `success_dir` 和 `samples_dir`，确保历史成功样本能正确命中去重检查
- 保留 `_is_llm_fixable_error()` 方法用于判断是否值得 LLM 重试

##### 3. `graph_net/agent/parallel_extract.py`

批量抽取结果 JSON 默认输出路径从 workspace 根改为：
```
workspace/logs_and_lists/parallel_extract_<时间戳>.json
```

结果文件统一归档，无需手动整理。

##### 4. `graph_net/agent/graph_extractor/subprocess_graph_extractor.py`

隔离抽取输出到 `samples/` 子目录：
- 设置 `GRAPH_NET_EXTRACT_WORKSPACE=workspace/samples/`，避免结果散落在 workspace 根目录
- `_get_workspace_path()` 默认返回 `samples/` 子目录
- 解决多次抽取后 workspace 根目录产生大量冗余模型目录的问题

#### 验证

使用单个模型（`sshleifer/tiny-gpt2`）在 CPU 模式下测试：

```
workspace/
├── failed/           ← 空（无失败）
├── generated/        ← 生成的 run_model.py 脚本
├── logs/             ← Agent 日志
├── logs_and_lists/   ← 结果 JSON
├── models/           ← 下载的模型文件
├── samples/          ← 抽取输出（临时）
└── success/          ← 最终成功样本
    └── sshleifer_tiny-gpt2
```

结果：1 个模型，成功率 100%，样本正确移动到 `success/`。
