### PR TITLE
Agent: support CPU-only mode in parallel_extract.py

### DIFF
--- a/graph_net/agent/parallel_extract.py
+++ b/graph_net/agent/parallel_extract.py
@@ -102,15 +102,18 @@ def get_gpu_ids(args) -> List[int]:
 
     Returns:
         List of GPU indices if specified or detected.
-        Falls back to _get_default_gpus() if args.gpus is None, empty, or invalid.
+        Falls back to _get_default_gpus() if args.gpus is None.
+        Returns [] when --gpus is explicitly empty (CPU-only mode).
     """
     if args.gpus is not None:
         gpus_str = args.gpus.strip()
-        if gpus_str:
-            try:
-                return [int(g.strip()) for g in gpus_str.split(",") if g.strip()]
-            except ValueError:
-                print(f"[WARN] Invalid --gpus value: {args.gpus}, using default GPUs")
+        if gpus_str == "":
+            # Explicitly empty --gpus means CPU-only mode
+            return []
+        try:
+            return [int(g.strip()) for g in gpus_str.split(",") if g.strip()]
+        except ValueError:
+            print(f"[WARN] Invalid --gpus value: {args.gpus}, using default GPUs")
 
     return _get_default_gpus()
 
@@ -383,13 +386,13 @@ def _parse_args() -> argparse.Namespace:
         "--gpus",
         type=str,
         default=None,
-        help="Comma-separated GPU indices to use (GPU mode; if set, ignores --num-workers)",
+        help="Comma-separated GPU indices to use (set to '' for CPU-only mode)",
     )
     parser.add_argument(
-        "--num-workers",
+        "--cpu-workers",
         type=int,
         default=None,
-        help="Number of worker processes in CPU mode (default: CPU count)",
+        help="Number of worker processes in CPU-only mode (default: half of CPU cores)",
     )
     parser.add_argument(
         "--output",
@@ -435,18 +438,24 @@ def _resolve_config(args: argparse.Namespace):
     )
     print(f"[INFO] Workspace: {workspace}")
 
-    if get_device_type() == "cuda":
-        gpus = get_gpu_ids(args)
+    # Resolve GPU list first; --gpus "" explicitly forces CPU-only mode
+    gpus = get_gpu_ids(args)
+
+    if gpus:
         num_workers = len(gpus)
-        print(f"[INFO] GPU mode (torch fallback): {gpus}")
+        print(f"[INFO] GPU mode: {num_workers} workers on GPUs {gpus}")
         extract_timeout = (
             args.extract_timeout if args.extract_timeout is not None else 1000
         )
         verify_timeout = args.verify_timeout if args.verify_timeout is not None else 300
     else:
-        gpus = []
-        num_workers = args.num_workers if args.num_workers else 1
-        print(f"[INFO] CPU mode: {num_workers} workers")
+        # CPU-only mode: either --gpus explicitly empty or no CUDA available.
+        # Default to half of CPU cores to avoid overloading the system,
+        # since each worker is a heavy process (model loading + graph extraction).
+        num_workers = (
+            args.cpu_workers if args.cpu_workers else max(1, (os.cpu_count() or 2) // 2)
+        )
+        print(f"[INFO] CPU-only mode: {num_workers} workers")
         extract_timeout = (
             args.extract_timeout if args.extract_timeout is not None else 2000
         )
@@ -468,7 +477,10 @@ def main() -> int:
         print("[ERROR] Empty model list, nothing to do")
         return 1
 
-    print(f"[INFO] Total models: {len(model_ids)}, workers: {num_workers}")
+    if gpus:
+        print(f"[INFO] Total models: {len(model_ids)}, GPU workers: {num_workers}")
+    else:
+        print(f"[INFO] Total models: {len(model_ids)}, CPU workers: {num_workers}")
 
     # --- Populate shared task queue ---
     task_queue: multiprocessing.Queue = multiprocessing.Queue()
@@ -479,8 +491,9 @@ def main() -> int:
     result_queue: multiprocessing.Queue = multiprocessing.Queue()
 
     start_time = datetime.now()
+    worker_type = "GPU" if gpus else "CPU"
     print(
-        f"\n[START] {start_time.strftime('%Y-%m-%d %H:%M:%S')} — launching {num_workers} workers\n"
+        f"\n[START] {start_time.strftime('%Y-%m-%d %H:%M:%S')} — launching {num_workers} {worker_type} workers\n"
     )
 
     processes = []

--- a/graph_net/agent/parallel_extract.py
+++ b/graph_net/agent/parallel_extract.py
@@ -102,18 +102,15 @@ def get_gpu_ids(args) -> List[int]:
 
     Returns:
         List of GPU indices if specified or detected.
-        Falls back to _get_default_gpus() if args.gpus is None.
-        Returns [] when --gpus is explicitly empty (CPU-only mode).
+        Falls back to _get_default_gpus() if args.gpus is None, empty, or invalid.
     """
     if args.gpus is not None:
         gpus_str = args.gpus.strip()
-        if gpus_str == "":
-            # Explicitly empty --gpus means CPU-only mode
-            return []
-        try:
-            return [int(g.strip()) for g in gpus_str.split(",") if g.strip()]
-        except ValueError:
-            print(f"[WARN] Invalid --gpus value: {args.gpus}, using default GPUs")
+        if gpus_str:
+            try:
+                return [int(g.strip()) for g in gpus_str.split(",") if g.strip()]
+            except ValueError:
+                print(f"[WARN] Invalid --gpus value: {args.gpus}, using default GPUs")
 
     return _get_default_gpus()
 
@@ -386,7 +383,7 @@ def _parse_args() -> argparse.Namespace:
         "--gpus",
         type=str,
         default=None,
-        help="Comma-separated GPU indices to use (set to '' for CPU-only mode)",
+        help="Comma-separated GPU indices to use (default: auto-detect all available GPUs)",
     )
     parser.add_argument(
         "--cpu-workers",
@@ -438,20 +435,13 @@ def _resolve_config(args: argparse.Namespace):
     )
     print(f"[INFO] Workspace: {workspace}")
 
-    # Resolve GPU list first; --gpus "" explicitly forces CPU-only mode
-    gpus = get_gpu_ids(args)
-
-    if gpus:
-        num_workers = len(gpus)
-        print(f"[INFO] GPU mode: {num_workers} workers on GPUs {gpus}")
-        extract_timeout = (
-            args.extract_timeout if args.extract_timeout is not None else 1000
-        )
-        verify_timeout = args.verify_timeout if args.verify_timeout is not None else 300
-    else:
-        # CPU-only mode: either --gpus explicitly empty or no CUDA available.
-        # Default to half of CPU cores to avoid overloading the system,
-        # since each worker is a heavy process (model loading + graph extraction).
+    # Decide GPU vs CPU mode: if --cpu-workers is set, force CPU-only mode.
+    # If no CUDA available, also fall back to CPU mode.
+    if (args.cpu_workers and args.cpu_workers > 0) or get_device_type() == "cpu":
+        # CPU-only mode. Default to half of CPU cores to avoid overloading the
+        # system, since each worker is a heavy process (model loading + graph
+        # extraction).
+        gpus = []
         num_workers = (
             args.cpu_workers if args.cpu_workers else max(1, (os.cpu_count() or 2) // 2)
         )
@@ -460,6 +450,14 @@ def _resolve_config(args: argparse.Namespace):
             args.extract_timeout if args.extract_timeout is not None else 2000
         )
         verify_timeout = args.verify_timeout if args.verify_timeout is not None else 600
+    else:
+        gpus = get_gpu_ids(args)
+        num_workers = len(gpus)
+        print(f"[INFO] GPU mode: {num_workers} workers on GPUs {gpus}")
+        extract_timeout = (
+            args.extract_timeout if args.extract_timeout is not None else 1000
+        )
+        verify_timeout = args.verify_timeout if args.verify_timeout is not None else 300
 
     return workspace, gpus, num_workers, extract_timeout, verify_timeout
 


### PR DESCRIPTION
### PR Category
<!-- One of [ New Sample | Feature Enhancement | Bug Fix | Other ] -->
Feature Enhancement

### Description
<!-- Describe what you’ve done -->
### 问题

在没有这些修改的情况下，`parallel_extract.py` 可以跑 CPU，但受限制：

1. **自动触发**：只有当 `torch.cuda.is_available()` 返回 False 时（即机器没有 GPU 或 CUDA 未安装），才会自动进入 CPU 模式
2. **无法强制切换**：如果机器有 GPU，当前代码会强制使用 GPU，不能通过 `--gpus ""` 参数切换到纯 CPU 模式。因为 `get_gpu_ids()` 对空字符串的处理是 fallback 到 `_get_default_gpus()`，返回 `[0]`
3. **变通方法**：可以通过设置环境变量 `CUDA_VISIBLE_DEVICES=""` 来隐藏 GPU，让 torch 检测不到 CUDA，从而进入 CPU 模式

因此，如果需要在有 GPU 的机器上主动选择 CPU-only 模式，就必须做这些修改。

### 修改内容

- **`--cpu-workers` 触发 CPU-only 模式**：当 `--cpu-workers` 被设置时（且值 > 0），强制进入 CPU-only 模式，`--gpus` 参数不再生效
- **无 CUDA 时自动降级**：`torch.cuda.is_available()` 返回 False 时自动进入 CPU-only 模式
- **默认 worker 数取 CPU 核心数的一半**：避免打满 CPU 导致系统过载（每个 worker 是重负载进程，涉及模型加载 + 图抽取），用户可通过 `--cpu-workers` 自定义
- **重命名参数 `--num-workers` → `--cpu-workers`**：参数语义更明确，专用于 CPU-only 模式下的 worker 数量
- **修正 worker 计数和启动日志**：正确显示 CPU worker 数量，日志中区分 GPU/CPU worker 类型

### 使用方式

```bash
# CPU-only 模式（有 GPU 的机器上主动选择）
python graph_net/agent/parallel_extract.py \
    --model-list /tmp/test_one_model.txt \
    --workspace /tmp/graphnet_test_cleanup \
    --cpu-workers 1

# GPU 模式（默认行为，自动检测可用 GPU）
python graph_net/agent/parallel_extract.py \
    --model-list /tmp/test_one_model.txt \
    --workspace /tmp/graphnet_test_cleanup \
    --gpus 0,1

# 输出
[INFO] CPU-only mode: 1 workers
[INFO] Total models: 1, CPU workers: 1
[START] 2026-05-19 20:31:19 — launching 1 CPU workers
[Worker-0 CPU] Started (extract_timeout=1200s, verify_timeout=600s)
[Worker-0 CPU] OK sshleifer/tiny-gpt2 (37.4s)