### PR TITLE
Agent: fix graph hash generation for multi-subgraph models and unify hash utilities

### DIFF
--- a/graph_net/agent/graph_net_agent.py
+++ b/graph_net/agent/graph_net_agent.py
@@ -332,12 +332,19 @@ class GraphNetAgent:
         self.logger.info(f"Graph extracted to: {sample_dir}")
         return sample_dir
 
+    def _get_subgraph_dirs(self, sample_dir: Path) -> list[Path]:
+        """Return list of subgraph directories.
+
+        For single-graph models, returns [sample_dir].
+        For multi-subgraph models, returns [subgraph_0, subgraph_1, ...] sorted.
+        """
+        subgraph_dirs = sorted(sample_dir.glob("subgraph_*/"))
+        return subgraph_dirs if subgraph_dirs else [sample_dir]
+
     def _fix_model_name(self, sample_dir: Path, model_id: str) -> None:
         """Update model_name in graph_net.json to the original HuggingFace model_id (org/model)."""
-        for json_path in [
-            sample_dir / "graph_net.json",
-            *sample_dir.glob("subgraph_*/graph_net.json"),
-        ]:
+        for target_dir in self._get_subgraph_dirs(sample_dir):
+            json_path = target_dir / "graph_net.json"
             if not json_path.exists():
                 continue
             try:
@@ -349,47 +356,20 @@ class GraphNetAgent:
                 self.logger.warning(f"Failed to fix model_name in {json_path}: {e}")
 
     def _generate_graph_hash(self, sample_dir: Path) -> None:
-        """Generate graph_hash.txt from model.py.
-
-        - Single-graph: hash root model.py → sample_dir/graph_hash.txt
-        - Multi-subgraph: hash each subgraph_N/model.py → subgraph_N/graph_hash.txt
-          (no top-level graph_hash.txt for multi-subgraph models)
-        """
-        root_model = sample_dir / "model.py"
-        if root_model.exists():
-            # Single-graph model
-            graph_hash_path = sample_dir / "graph_hash.txt"
-            if graph_hash_path.exists():
-                return
+        """Generate graph_hash.txt from model.py for each subgraph."""
+        for target_dir in self._get_subgraph_dirs(sample_dir):
+            model_py = target_dir / "model.py"
+            hash_path = target_dir / "graph_hash.txt"
+            if hash_path.exists() or not model_py.exists():
+                continue
             try:
-                graph_hash = get_sha256_hash(root_model.read_text())
-                graph_hash_path.write_text(graph_hash)
-                self.logger.info(f"Generated graph_hash.txt: {graph_hash[:16]}...")
+                graph_hash = get_sha256_hash(model_py.read_text())
+                hash_path.write_text(graph_hash)
+                rel = hash_path.relative_to(sample_dir)
+                self.logger.info(f"Generated {rel}: {graph_hash[:16]}...")
             except (OSError, IOError) as e:
-                self.logger.warning(f"Failed to generate graph_hash.txt: {e}")
-        else:
-            # Multi-subgraph model: generate per-subgraph hashes
-            subgraph_dirs = sorted(sample_dir.glob("subgraph_*"))
-            if not subgraph_dirs:
-                self.logger.warning(
-                    f"No model.py or subgraph dirs found in {sample_dir}"
-                )
-                return
-            for subgraph_dir in subgraph_dirs:
-                model_py = subgraph_dir / "model.py"
-                hash_path = subgraph_dir / "graph_hash.txt"
-                if hash_path.exists() or not model_py.exists():
-                    continue
-                try:
-                    graph_hash = get_sha256_hash(model_py.read_text())
-                    hash_path.write_text(graph_hash)
-                    self.logger.info(
-                        f"Generated {subgraph_dir.name}/graph_hash.txt: {graph_hash[:16]}..."
-                    )
-                except (OSError, IOError) as e:
-                    self.logger.warning(
-                        f"Failed to generate graph_hash.txt for {subgraph_dir}: {e}"
-                    )
+                rel = hash_path.relative_to(sample_dir)
+                self.logger.warning(f"Failed to generate {rel}: {e}")
 
     def _move_sample(self, sample_dir: Path, dest_parent: Path) -> Path:
         """Move sample_dir into dest_parent/, overwriting if destination exists"""
@@ -403,59 +383,39 @@ class GraphNetAgent:
     def is_duplicate_sample(self, sample_dir: Path) -> bool:
         """Check if the extracted sample is a duplicate of an existing sample.
 
-        - Single-graph: compare root graph_hash.txt against existing root hashes.
-        - Multi-subgraph: compare frozenset of all subgraph_*/graph_hash.txt hashes.
+        Collects all subgraph graph_hash.txt hashes into a frozenset and compares
+        against existing samples. Works for both single-graph and multi-subgraph.
         """
+
+        def _collect_hashes(path: Path) -> frozenset[str]:
+            hashes = set()
+            for target_dir in self._get_subgraph_dirs(path):
+                hash_path = target_dir / "graph_hash.txt"
+                if hash_path.exists():
+                    try:
+                        hashes.add(hash_path.read_text().strip())
+                    except (OSError, IOError):
+                        pass
+            return frozenset(hashes)
+
         try:
-            root_model = sample_dir / "model.py"
-            if root_model.exists():
-                # Single-graph
-                graph_hash_path = sample_dir / "graph_hash.txt"
-                if not graph_hash_path.exists():
-                    return False
-                current_hash = graph_hash_path.read_text().strip()
-                for search_root in [
-                    self.workspace.success_dir,
-                    self.workspace.samples_dir,
-                ]:
-                    if not search_root.exists():
+            current_hashes = _collect_hashes(sample_dir)
+            if not current_hashes:
+                return False
+
+            for search_root in [
+                self.workspace.success_dir,
+                self.workspace.samples_dir,
+            ]:
+                if not search_root.exists():
+                    continue
+                for existing_dir in search_root.iterdir():
+                    if not existing_dir.is_dir() or existing_dir == sample_dir:
                         continue
-                    for existing_dir in search_root.iterdir():
-                        if not existing_dir.is_dir() or existing_dir == sample_dir:
-                            continue
-                        hash_file = existing_dir / "graph_hash.txt"
-                        if not hash_file.exists():
-                            continue
-                        try:
-                            if hash_file.read_text().strip() == current_hash:
-                                self.logger.info(f"Duplicate found: {existing_dir}")
-                                return True
-                        except (OSError, IOError):
-                            continue
-            else:
-                # Multi-subgraph: compare the set of subgraph hashes
-                current_hashes = frozenset(
-                    h.read_text().strip()
-                    for h in sample_dir.glob("subgraph_*/graph_hash.txt")
-                )
-                if not current_hashes:
-                    return False
-                for search_root in [
-                    self.workspace.success_dir,
-                    self.workspace.samples_dir,
-                ]:
-                    if not search_root.exists():
-                        continue
-                    for existing_dir in search_root.iterdir():
-                        if not existing_dir.is_dir() or existing_dir == sample_dir:
-                            continue
-                        existing_hashes = frozenset(
-                            h.read_text().strip()
-                            for h in existing_dir.glob("subgraph_*/graph_hash.txt")
-                        )
-                        if existing_hashes and existing_hashes == current_hashes:
-                            self.logger.info(f"Duplicate found: {existing_dir}")
-                            return True
+                    existing_hashes = _collect_hashes(existing_dir)
+                    if existing_hashes and existing_hashes == current_hashes:
+                        self.logger.info(f"Duplicate found: {existing_dir}")
+                        return True
         except (OSError, IOError) as e:
             self.logger.warning(f"Failed to check duplicate: {e}")
         return False

--- a/graph_net/agent/graph_net_agent.py
+++ b/graph_net/agent/graph_net_agent.py
@@ -349,24 +349,47 @@ class GraphNetAgent:
                 self.logger.warning(f"Failed to fix model_name in {json_path}: {e}")
 
     def _generate_graph_hash(self, sample_dir: Path) -> None:
-        """Generate graph_hash.txt from model.py if it doesn't exist"""
-        graph_hash_path = sample_dir / "graph_hash.txt"
-        model_py_path = sample_dir / "model.py"
+        """Generate graph_hash.txt from model.py.
 
-        if graph_hash_path.exists():
-            return
-
-        if not model_py_path.exists():
-            self.logger.warning(f"model.py not found at {model_py_path}")
-            return
-
-        try:
-            model_code = model_py_path.read_text()
-            graph_hash = get_sha256_hash(model_code)
-            graph_hash_path.write_text(graph_hash)
-            self.logger.info(f"Generated graph_hash.txt: {graph_hash[:16]}...")
-        except (OSError, IOError) as e:
-            self.logger.warning(f"Failed to generate graph_hash.txt: {e}")
+        - Single-graph: hash root model.py → sample_dir/graph_hash.txt
+        - Multi-subgraph: hash each subgraph_N/model.py → subgraph_N/graph_hash.txt
+          (no top-level graph_hash.txt for multi-subgraph models)
+        """
+        root_model = sample_dir / "model.py"
+        if root_model.exists():
+            # Single-graph model
+            graph_hash_path = sample_dir / "graph_hash.txt"
+            if graph_hash_path.exists():
+                return
+            try:
+                graph_hash = get_sha256_hash(root_model.read_text())
+                graph_hash_path.write_text(graph_hash)
+                self.logger.info(f"Generated graph_hash.txt: {graph_hash[:16]}...")
+            except (OSError, IOError) as e:
+                self.logger.warning(f"Failed to generate graph_hash.txt: {e}")
+        else:
+            # Multi-subgraph model: generate per-subgraph hashes
+            subgraph_dirs = sorted(sample_dir.glob("subgraph_*"))
+            if not subgraph_dirs:
+                self.logger.warning(
+                    f"No model.py or subgraph dirs found in {sample_dir}"
+                )
+                return
+            for subgraph_dir in subgraph_dirs:
+                model_py = subgraph_dir / "model.py"
+                hash_path = subgraph_dir / "graph_hash.txt"
+                if hash_path.exists() or not model_py.exists():
+                    continue
+                try:
+                    graph_hash = get_sha256_hash(model_py.read_text())
+                    hash_path.write_text(graph_hash)
+                    self.logger.info(
+                        f"Generated {subgraph_dir.name}/graph_hash.txt: {graph_hash[:16]}..."
+                    )
+                except (OSError, IOError) as e:
+                    self.logger.warning(
+                        f"Failed to generate graph_hash.txt for {subgraph_dir}: {e}"
+                    )
 
     def _move_sample(self, sample_dir: Path, dest_parent: Path) -> Path:
         """Move sample_dir into dest_parent/, overwriting if destination exists"""
@@ -378,31 +401,61 @@ class GraphNetAgent:
         return dest
 
     def is_duplicate_sample(self, sample_dir: Path) -> bool:
-        """Check if the extracted sample is a duplicate of an existing sample"""
-        graph_hash_path = sample_dir / "graph_hash.txt"
+        """Check if the extracted sample is a duplicate of an existing sample.
 
-        if not graph_hash_path.exists():
-            return False
-
+        - Single-graph: compare root graph_hash.txt against existing root hashes.
+        - Multi-subgraph: compare frozenset of all subgraph_*/graph_hash.txt hashes.
+        """
         try:
-            current_hash = graph_hash_path.read_text().strip()
-
-            # Search for duplicates in success_dir (where past successful samples live)
-            for search_root in [self.workspace.success_dir, self.workspace.samples_dir]:
-                if not search_root.exists():
-                    continue
-                for hash_file in search_root.rglob("graph_hash.txt"):
-                    if hash_file == graph_hash_path:
+            root_model = sample_dir / "model.py"
+            if root_model.exists():
+                # Single-graph
+                graph_hash_path = sample_dir / "graph_hash.txt"
+                if not graph_hash_path.exists():
+                    return False
+                current_hash = graph_hash_path.read_text().strip()
+                for search_root in [
+                    self.workspace.success_dir,
+                    self.workspace.samples_dir,
+                ]:
+                    if not search_root.exists():
                         continue
-                    try:
-                        existing_hash = hash_file.read_text().strip()
-                        if existing_hash == current_hash:
-                            self.logger.info(f"Duplicate found: {hash_file.parent}")
+                    for existing_dir in search_root.iterdir():
+                        if not existing_dir.is_dir() or existing_dir == sample_dir:
+                            continue
+                        hash_file = existing_dir / "graph_hash.txt"
+                        if not hash_file.exists():
+                            continue
+                        try:
+                            if hash_file.read_text().strip() == current_hash:
+                                self.logger.info(f"Duplicate found: {existing_dir}")
+                                return True
+                        except (OSError, IOError):
+                            continue
+            else:
+                # Multi-subgraph: compare the set of subgraph hashes
+                current_hashes = frozenset(
+                    h.read_text().strip()
+                    for h in sample_dir.glob("subgraph_*/graph_hash.txt")
+                )
+                if not current_hashes:
+                    return False
+                for search_root in [
+                    self.workspace.success_dir,
+                    self.workspace.samples_dir,
+                ]:
+                    if not search_root.exists():
+                        continue
+                    for existing_dir in search_root.iterdir():
+                        if not existing_dir.is_dir() or existing_dir == sample_dir:
+                            continue
+                        existing_hashes = frozenset(
+                            h.read_text().strip()
+                            for h in existing_dir.glob("subgraph_*/graph_hash.txt")
+                        )
+                        if existing_hashes and existing_hashes == current_hashes:
+                            self.logger.info(f"Duplicate found: {existing_dir}")
                             return True
-                    except (OSError, IOError):
-                        continue
-
-            return False
         except (OSError, IOError) as e:
             self.logger.warning(f"Failed to check duplicate: {e}")
-            return False
+        return False

--- a/graph_net/agent/scripts/gen_hash_and_dedup.py
+++ b/graph_net/agent/scripts/gen_hash_and_dedup.py
@@ -57,16 +57,17 @@
 # 依赖：Python 3.6+
 # =============================================================================
 
-import hashlib
 import os
 import sys
 from collections import defaultdict
 
+# Ensure graph_net is importable when running this script standalone
+_SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+_GRAPHNET_ROOT = os.path.join(_SCRIPT_DIR, "..", "..", "..")
+if _GRAPHNET_ROOT not in sys.path:
+    sys.path.insert(0, _GRAPHNET_ROOT)
 
-def get_sha256_hash(content):
-    m = hashlib.sha256()
-    m.update(content.encode("utf-8"))
-    return m.hexdigest()
+from graph_net.hash_util import get_sha256_hash  # noqa: E402
 
 
 def find_model_files(workspace):


### PR DESCRIPTION
### PR Category
<!-- One of [ New Sample | Feature Enhancement | Bug Fix | Other ] -->
Feature Enhancement

### Description
<!-- Describe what you’ve done -->
### 背景

原 `_generate_graph_hash` 只处理单图模型（根目录下有 `model.py`），对多子图模型（目录结构为 `subgraph_0/`, `subgraph_1/`, ...）直接跳过，导致 `graph_hash.txt` 始终无法生成。具体影响：

- 多子图模型缺少 `graph_hash.txt`
- `is_duplicate_sample()` 依赖 `graph_hash.txt` 做去重，缺失时直接返回 `False`，相同计算图结构会被重复抽取
- 对 fine-tune 变体（共用同一 base 架构）浪费大量计算资源

同时，子图去重脚本 `gen_hash_and_dedup.py` 内联实现了 SHA256 哈希计算，与库内统一的 `graph_net.hash_util.get_sha256_hash` 不一致，不利于维护。

### 修改内容

#### 1. 修复多子图模型的 hash 生成与去重 (`graph_net_agent.py`)

- **单/多子图统一处理**：新增 `_get_subgraph_dirs()` 辅助方法
  - 单图模型：返回 `[sample_dir]`
  - 多子图模型：返回 `[subgraph_0, subgraph_1, ...]` 排序后的列表
  - 消除所有 `subgraph_xxx` hardcoded glob

- **`_generate_graph_hash`**：基于 `_get_subgraph_dirs` 统一循环处理
  - 每个子图目录独立计算 `model.py` 的 sha256，生成对应目录下的 `graph_hash.txt`
  - 单图模型即循环一次，逻辑自然兼容

- **`is_duplicate_sample`**：基于 `_get_subgraph_dirs` 统一收集 hash
  - 定义内部 `_collect_hashes()` 函数，遍历所有子图目录收集 `graph_hash.txt`
  - 单图/多子图统一使用 `frozenset` 比对，消除重复分支

- **`_fix_model_name`**：同样复用 `_get_subgraph_dirs`，消除硬编码 glob

#### 2. 统一 hash 工具 (`gen_hash_and_dedup.py`)

- 删除内联的 `get_sha256_hash` 实现
- 复用 `graph_net.hash_util.get_sha256_hash`，与 Agent 抽取流程及其他模块保持一致

### 验证结果

对历史成功样本 `/home/luotao02/workspace/success_backup_20260519` 运行去重分析：

```bash
python graph_net/agent/scripts/gen_hash_and_dedup.py /path/to/workspace
```
输出：
```
Found 24430 model.py files under /path/to/workspace
Step 1 - Generate graph_hash.txt:
  Total model.py: 24430
  Generated/Updated: 24430
  Failed: 0
Step 2 - Deduplication analysis:
  Total subgraphs: 24430
  Unique graphs: 503
  Duplicate groups: 344
  Subgraphs involved in duplication: 24271
  Can be removed (keeping one per group): 23927
```