### PR TITLE
Agent: add hard timeout for snapshot_download to prevent indefinite hangs

### DIFF
--- a/graph_net/agent/model_fetcher/huggingface_fetcher.py
+++ b/graph_net/agent/model_fetcher/huggingface_fetcher.py
@@ -1,6 +1,7 @@
 """HuggingFace model fetcher implementation"""
 
 import os
+import signal
 import time
 from pathlib import Path
 from typing import Optional
@@ -16,6 +17,13 @@ from graph_net.agent.utils.exceptions import (
     GraphExtractionErrorCategory,
     ModelFetchError,
 )
+
+
+class _DownloadTimeoutError(Exception):
+    """Raised when snapshot_download exceeds the overall time budget."""
+
+    pass
+
 
 # Network-related exceptions that are worth retrying
 _RETRYABLE_ERRORS = (
@@ -133,6 +141,10 @@ class HFFetcher(BaseModelFetcher):
         """
         Download model from HuggingFace Hub with retry on network errors.
 
+        A **hard overall timeout** (signal.alarm) guards `snapshot_download` so that
+        if a single file hangs indefinitely (e.g. TCP connection stays open but no
+        data arrives), the call is aborted instead of blocking forever.
+
         Args:
             model_id: HuggingFace model ID (e.g., "bert-base-uncased")
 
@@ -148,6 +160,13 @@ class HFFetcher(BaseModelFetcher):
                 "Please install it with: pip install huggingface_hub"
             )
 
+        # Set a stricter download timeout to avoid getting stuck on large/slow files
+        # (default is 10s; we bump to 30s to accommodate slow networks while still
+        # preventing indefinite hangs).
+        os.environ["HF_HUB_DOWNLOAD_TIMEOUT"] = os.environ.get(
+            "HF_HUB_DOWNLOAD_TIMEOUT", "30"
+        )
+
         last_err = None
         for attempt in range(1, self.max_retries + 1):
             try:
@@ -155,28 +174,44 @@ class HFFetcher(BaseModelFetcher):
                 if self.endpoint:
                     os.environ["HF_ENDPOINT"] = self.endpoint
 
-                local_dir = snapshot_download(
-                    repo_id=model_id,
-                    cache_dir=str(self.cache_dir) if self.cache_dir else None,
-                    token=self.token,
-                    ignore_patterns=[
-                        "*.bin",
-                        "*.safetensors",
-                        "*.pt",
-                        "*.pth",
-                        "*.gguf",
-                        "*.ot",
-                        "*.zip",
-                        "*.tflite",
-                        "*.mlmodel",
-                        "*.onnx",
-                        "*.msgpack",
-                        "flax_model*",
-                        "tf_model*",
-                        "rust_model*",
-                    ],
-                )
-                return Path(local_dir)
+                # Hard overall timeout for the entire snapshot_download call.
+                # HF_HUB_DOWNLOAD_TIMEOUT=30 only controls individual HTTP requests;
+                # huggingface_hub's internal retry/resume logic can still loop forever
+                # when a connection stalls without raising an exception.  We therefore
+                # enforce a 120-second wall-clock ceiling on the whole operation.
+                def _alarm_handler(signum, frame):
+                    raise _DownloadTimeoutError(
+                        f"Overall download timeout (120s) exceeded for {model_id}"
+                    )
+
+                old_handler = signal.signal(signal.SIGALRM, _alarm_handler)
+                signal.alarm(120)
+                try:
+                    local_dir = snapshot_download(
+                        repo_id=model_id,
+                        cache_dir=str(self.cache_dir) if self.cache_dir else None,
+                        token=self.token,
+                        ignore_patterns=[
+                            "*.bin",
+                            "*.safetensors",
+                            "*.pt",
+                            "*.pth",
+                            "*.gguf",
+                            "*.ot",
+                            "*.zip",
+                            "*.tflite",
+                            "*.mlmodel",
+                            "*.onnx",
+                            "*.msgpack",
+                            "flax_model*",
+                            "tf_model*",
+                            "rust_model*",
+                        ],
+                    )
+                    return Path(local_dir)
+                finally:
+                    signal.alarm(0)
+                    signal.signal(signal.SIGALRM, old_handler)
 
             except _RETRYABLE_ERRORS as e:
                 last_err = e
@@ -203,6 +238,10 @@ class HFFetcher(BaseModelFetcher):
                     raise ModelFetchError(
                         f"Failed to download model {model_id} after {self.max_retries} retries: {e}"
                     ) from e
+            except _DownloadTimeoutError as e:
+                raise ModelFetchError(
+                    f"Failed to download model {model_id}: {e}"
+                ) from e
             except Exception as e:
                 raise ModelFetchError(
                     f"Failed to download model {model_id}: {e}",


### PR DESCRIPTION
### PR Category
<!-- One of [ New Sample | Feature Enhancement | Bug Fix | Other ] -->
Feature Enhancement

### Description
<!-- Describe what you’ve done -->
### 问题

`HFFetcher.download()` 调用 `snapshot_download` 下载模型文件时，可能因网络问题无限阻塞。

**典型案例**：`Frank290350/ku-typhoon-v1-merged` 的 `merges.txt` 下载卡住 13 小时，导致整个 worker 进程阻塞，pipeline 无法继续。

根因分析：
- `HF_HUB_DOWNLOAD_TIMEOUT` 默认仅 10s，且只控制**单次 HTTP 请求**超时
- `huggingface_hub` 内部的重试/恢复逻辑在 TCP 连接存活但**无数据传输**时，可能无限循环而不抛出异常
- 没有任何进程级超时保护，单个文件下载可永久挂起

### 修改内容

1. **提升单次 HTTP 超时到 30s**
   - `HF_HUB_DOWNLOAD_TIMEOUT=30`（默认 10s）
   - 兼顾慢网络，同时防止无限挂起

2. **添加 120s 硬总超时（`signal.alarm`）**
   - 为整个 `snapshot_download` 调用套上进程级 wall-clock 超时
   - 120 秒足够下载 `config.json`/`tokenizer.json` 等小文件
   - 超时后抛出 `_DownloadTimeoutError`，转为 `ModelFetchError`
   - 上层记录为"下载失败"并继续下一个模型，不再阻塞整个 pipeline

3. **自定义超时异常**
   - `_DownloadTimeoutError` 专门用于区分超时失败与其他网络错误

### 效果

- 单个文件下载最多等待 120 秒，超时后优雅失败
- Worker 不再因单个模型下载卡住而阻塞整个 pipeline
- 模型下载异常从"无限等待"变为"可控失败"