### PR TITLE
Agent: fix success count logic in extraction scripts to match actual log markers

### DIFF
--- a/graph_net/agent/scripts/analyze_extraction_log.sh
+++ b/graph_net/agent/scripts/analyze_extraction_log.sh
@@ -76,13 +76,13 @@ echo ""
 # 1. 总体统计
 echo "--- 一、总体统计 ---"
 # 使用日志中实际的标记格式统计：
-# 成功: [CPU X] OK model_name 或 [GPU X] OK model_name
-# 失败: [CPU X] FAIL model_name 或 [GPU X] FAIL model_name
-# 注：同时支持 CPU-only 模式和 GPU 模式的日志
+# 成功: "Graph extracted to:"（主要成功路径）
+# 失败: "Extraction failed for"
+# 注：部分旧日志可能用 "Successfully extracted"，但当前代码主要输出 "Graph extracted to"
 # 部分日志含二进制数据，用 grep -a 强制按文本处理
 TOTAL=$(grep -ac "Starting extraction for model:" "$LOG_FILE" 2>/dev/null || echo 0)
-SUCCESS=$(grep -aoE '\[(CPU|GPU) [0-9]+\] OK [^ ]+' "$LOG_FILE" 2>/dev/null | wc -l | tr -d ' ')
-FAILED=$(grep -aoE '\[(CPU|GPU) [0-9]+\] FAIL [^ ]+' "$LOG_FILE" 2>/dev/null | wc -l | tr -d ' ')
+SUCCESS=$(grep -ac "Graph extracted to" "$LOG_FILE" 2>/dev/null || echo 0)
+FAILED=$(grep -ac "Extraction failed for" "$LOG_FILE" 2>/dev/null || echo 0)
 PROGRESS_LINES=$(grep -c "PROGRESS" "$LOG_FILE" 2>/dev/null || echo 0)
 
 echo "总尝试数: $TOTAL"
@@ -217,8 +217,9 @@ SUCCESS_LIST="/tmp/${BASE_NAME}_success.txt"
 grep "Starting extraction for model:" "$LOG_FILE" 2>/dev/null | \
     sed 's/.*Starting extraction for model: //' > "$PROCESSED"
 
-grep -aoE '\[(CPU|GPU) [0-9]+\] OK [^ ]+' "$LOG_FILE" 2>/dev/null | \
-    awk '{print $NF}' | sort -u > "$SUCCESS_LIST"
+grep -a "Graph extracted to" "$LOG_FILE" 2>/dev/null | \
+    sed 's/.*Graph extracted to: .*\//\//' | \
+    sed 's/.*samples\///' | sort -u > "$SUCCESS_LIST"
 
 echo "已处理模型列表: $PROCESSED ($(wc -l < "$PROCESSED" 2>/dev/null || echo 0) 个)"
 echo "成功模型列表:   $SUCCESS_LIST ($(wc -l < "$SUCCESS_LIST" 2>/dev/null || echo 0) 个)"

--- a/graph_net/agent/scripts/check_extraction_progress.sh
+++ b/graph_net/agent/scripts/check_extraction_progress.sh
@@ -137,8 +137,9 @@ echo ""
 echo "====== 统计汇总 ======"
 
 # 从日志统计
-TOTAL_IN_LOG=$(grep -cE "Starting extraction for|Successfully extracted|Extraction failed for" "$LOG_FILE" 2>/dev/null || echo 0)
-SUCCESS_IN_LOG=$(grep -c "Successfully extracted" "$LOG_FILE" 2>/dev/null || echo 0)
+# 注：日志中成功的主要标记是 "Graph extracted to"（而非 "Successfully extracted"）
+TOTAL_IN_LOG=$(grep -cE "Starting extraction for|Graph extracted to|Extraction failed for" "$LOG_FILE" 2>/dev/null || echo 0)
+SUCCESS_IN_LOG=$(grep -c "Graph extracted to" "$LOG_FILE" 2>/dev/null || echo 0)
 FAILED_IN_LOG=$(grep -c "Extraction failed for" "$LOG_FILE" 2>/dev/null || echo 0)
 
 # 从 PROGRESS 行提取进度


### PR DESCRIPTION
### PR Category
<!-- One of [ New Sample | Feature Enhancement | Bug Fix | Other ] -->


### Description
<!-- Describe what you’ve done -->
#### 问题描述

`analyze_extraction_log.sh` 和 `check_extraction_progress.sh` 两个辅助脚本的成功数统计逻辑与 Agent 代码实际打印的日志标记不一致，导致统计结果严重低估。

| 脚本 | 修改前 | 实际日志标记 |
|---|---|---|
| `check_extraction_progress.sh` | `"Successfully extracted"` | `"Graph extracted to"` |
| `analyze_extraction_log.sh` | `"\[CPU X\] OK"` | `"Graph extracted to"` |

Agent 代码在成功抽取后的实际日志输出是 `"Graph extracted to: /path/to/sample"`（见 `graph_net_agent.py`），旧统计方式遗漏了绝大部分成功记录。

**影响**：以 `batch7_safe_run_no_llm.log` 为例，旧逻辑统计成功数仅 **283** 个，与实际日志中的 **4,691** 个 `"Graph extracted to"` 记录严重不符。

#### 修改内容

| 脚本 | 修改项 | 修改前 | 修改后 |
|---|---|---|---|
| `check_extraction_progress.sh` | 成功数统计 | `grep -c "Successfully extracted"` | `grep -c "Graph extracted to"` |
| `check_extraction_progress.sh` | 总尝试数条件 | `"Successfully extracted"` | `"Graph extracted to"` |
| `analyze_extraction_log.sh` | 成功数统计 | `grep "\[(CPU\|GPU) [0-9]+\] OK"` | `grep -ac "Graph extracted to"` |
| `analyze_extraction_log.sh` | 成功列表生成 | 从 `"OK"` 提取 | 从 `"Graph extracted to"` 提取 |

同时更新了脚本头部注释，说明当前日志使用的实际标记格式。

#### 验证结果

```bash
# batch7_safe_run_no_llm.log
旧逻辑: 成功 283 个，成功率 1.3%
新逻辑: 成功 4,691 个，成功率 21.6%
```

与日志中 `"Graph extracted to"` 的实际出现次数（4,691）完全一致。
